### PR TITLE
feat: add code-audit, preflight, review-triage skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [2.2.0] - 2026-04-09
+
+### Added
+- **`synthesis-code-audit`** v1.0.0 — 10-dimension diff-based quality framework with PASS/WARNING/FAIL scoring, PR review mode cross-referencing, and context isolation principle
+- **`synthesis-preflight`** v1.0.0 — pre-merge quality gate framework with 6 orthogonal dimensions, temporary considerations pattern for tracking workarounds, and mechanical go/no-go verdict
+- **`synthesis-review-triage`** v1.0.0 — PR prioritization methodology with weighted scoring (review gap, CI, age, size, labels), author-response detection, queue classification, and prior-review gate
+
+### Changed
+- **`synthesis-pr-review`** — expanded "Where This Fits" table from 4 to 8 engineering skills covering the full development lifecycle; added code-audit cross-reference section
+- **`synthesis-implementation-integrity`** — expanded "Where This Fits" table to include code-audit and preflight in the verification chain
+- **`synthesis-codebase-review`** — expanded "Relationship to Other Verification Skills" to include code-audit and preflight
+- **README** — added 3 new skills to Engineering table, updated skill count to 29
+
 ## [2.1.0] - 2026-03-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Proven AI agent skills for code review, content creation, project management, an
 
 ## Install
 
-**One command — installs all 26 skills to every AI agent on your machine:**
+**One command — installs all 29 skills to every AI agent on your machine:**
 
 ```bash
 npx skills add rajivpant/synthesis-skills --global --all --copy
@@ -47,9 +47,12 @@ All skills are prefixed with `synthesis-` to prevent namespace collisions with s
 | Skill | Description |
 |-------|-------------|
 | `synthesis-codebase-review` | Enterprise-scale codebase audit with tiered review system |
+| `synthesis-code-audit` | 10-dimension quality scan of code diffs with scored PASS/WARNING/FAIL verdicts |
 | `synthesis-pr-review` | Delta review methodology with security scanning and AI-analysis verification |
+| `synthesis-review-triage` | PR queue prioritization: scoring, author-response detection, and review routing |
 | `synthesis-code-integration` | Adopt-and-adapt pattern for integrating multi-contributor code with cherry-pick safety |
 | `synthesis-code-planning` | Structured multi-approach evaluation before coding |
+| `synthesis-preflight` | Pre-merge quality gate: tests, types, audit, commit hygiene, go/no-go verdict |
 | `synthesis-implementation-integrity` | Adversarial self-review: verify implementations are genuinely complete before shipping |
 
 ### Content Creation

--- a/install.sh
+++ b/install.sh
@@ -358,7 +358,7 @@ do_uninstall() {
         SKILL_NAMES=$(our_skill_names)
     else
         # Fallback: list of known synthesis-skills names
-        SKILL_NAMES="synthesis-article-writing synthesis-blog-refresh synthesis-clean-text synthesis-code-integration synthesis-code-planning synthesis-codebase-review synthesis-concise-messaging synthesis-content-distribution synthesis-content-framing synthesis-content-quality synthesis-context-lifecycle synthesis-creative-writer synthesis-fact-checking synthesis-link-research synthesis-llm-setup synthesis-mac-sync synthesis-pr-review synthesis-project-management synthesis-response-merger synthesis-technical-advisor synthesis-thinking-framework synthesis-tree-of-thought"
+        SKILL_NAMES="synthesis-article-writing synthesis-blog-refresh synthesis-clean-text synthesis-code-audit synthesis-code-integration synthesis-code-planning synthesis-codebase-review synthesis-concise-messaging synthesis-content-distribution synthesis-content-framing synthesis-content-quality synthesis-context-lifecycle synthesis-creative-writer synthesis-fact-checking synthesis-implementation-integrity synthesis-link-research synthesis-llm-setup synthesis-mac-sync synthesis-preflight synthesis-pr-review synthesis-project-management synthesis-response-merger synthesis-review-triage synthesis-skills-manager synthesis-slack-sync synthesis-technical-advisor synthesis-thinking-framework synthesis-tree-of-thought synthesis-voice-profiler"
     fi
 
     for target in $TARGETS; do

--- a/synthesis-code-audit/SKILL.md
+++ b/synthesis-code-audit/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: synthesis-code-audit
+description: >
+  Systematic 10-dimension quality scan of code diffs, producing scored
+  PASS/WARNING/FAIL verdicts per dimension with a machine-readable overall
+  result. Includes PR review mode for cross-referencing findings against
+  existing reviewer comments. Use when asked to: code audit, audit my changes,
+  quality check, review the diff, check this code, audit my code, scan for
+  issues, code quality scan, diff review.
+license: "CC0-1.0"
+depends_on: []
+metadata:
+  author: "Emil Peñaló"
+  version: "1.0.0"
+  source_repo: "github.com/rajivpant/synthesis-skills"
+  source_type: "public"
+---
+
+# Synthesis Code Audit
+
+A code audit is a systematic quality measurement of a diff. It is not a judgment call about whether a change should merge — that is the reviewer's job (see synthesis-pr-review). An audit produces a scored report across 10 orthogonal dimensions, each graded independently. The report tells you *where the quality problems are*; the reviewer decides *what to do about them*.
+
+---
+
+## Where This Fits
+
+Three engineering skills evaluate code at different scopes:
+
+| Skill | Scope | When to use |
+|-------|-------|-------------|
+| **code-audit** (this one) | Quality scan of a diff | After implementation, standalone or as input to preflight/pr-review |
+| **pr-review** | Judgment-based delta review | Every PR, before peer approval or lead integration |
+| **codebase-review** | Full system audit (16 categories, tiered) | Periodic health check or major milestone |
+
+Code-audit produces findings. PR-review produces a verdict that may consume those findings. Codebase-review catches systemic patterns that no single diff reveals.
+
+---
+
+## Principles
+
+1. **Fresh base branch.** Compare against an up-to-date base ref. Stale base branches cause false positives (flagging code already addressed upstream) and false negatives (missing new context on the base that changes interpretation).
+
+2. **Read files in full, not just diff hunks.** A diff hunk shows what changed. The surrounding file shows whether the change makes sense in context. Always read changed files in their entirety.
+
+3. **Context isolation.** The best audit comes from fresh eyes. If possible, evaluate the diff without prior knowledge of the planning decisions, trade-offs, or rationale that produced it. Confirmation bias is the default mode — you see what you expect to see. An isolated audit overrides that.
+
+4. **Grade only what changed.** If a serious pre-existing issue is discovered in unchanged code (security vulnerability, data loss risk, race condition), note it as informational but do not let it affect the dimension's grade for this diff.
+
+---
+
+## Diff Scope Detection
+
+Determine what to audit:
+
+- **Uncommitted changes exist** — audit staged and unstaged changes against HEAD.
+- **Branch has commits ahead of base** — audit the range from base to HEAD.
+- **Nothing to diff** — report that and stop.
+
+**Large diffs (40+ files):** Prioritize files with logic changes (source code, tests) over config, generated, and lock files. If the diff exceeds practical single-pass review scope, note this in the report and focus depth on the highest-risk changes.
+
+---
+
+## The 10-Dimension Framework
+
+For each dimension, evaluate the changed code and assign one of:
+
+- **PASS** — no issues, or only trivial stylistic preferences
+- **WARNING** — potential problem that deserves attention but does not block shipping (missing edge-case test, minor inconsistency, could-be-better pattern)
+- **FAIL** — concrete defect, security hole, convention violation, or missing coverage that should be fixed before merge
+
+### 1. Project Convention Compliance
+
+Read the project's convention documentation (style guides, architectural decision records, contribution guidelines). Check every changed file against the conventions that apply to it. Flag violations with a reference to the specific convention.
+
+If the project has no documented conventions, skip this dimension and note it as N/A.
+
+### 2. Code Reuse — Existing Before New
+
+When the diff introduces a new component, utility, hook, or abstraction, search the codebase for existing implementations that serve the same purpose. If one exists, flag the new code and recommend using the existing implementation.
+
+When the diff introduces a behavioral pattern (overlay management, keyboard navigation, positioning logic, state machine, API wrapper, error handling), search the broader codebase for functionally similar implementations — different code serving the same purpose is still duplication.
+
+When multiple implementations of the same pattern are found, recommend extracting a shared primitive and migrating callers.
+
+For any shared primitive — existing, introduced in this diff, or recommended for extraction — check whether the project's conventions document it. Undocumented shared primitives will be re-implemented by contributors who do not know they exist.
+
+### 3. Consistency with Existing Patterns
+
+Read 2-3 neighboring files in the same directory or module as each changed file. Note their naming conventions, file structure, export style, error handling approach, and architectural patterns.
+
+Compare the diff against those observed patterns. Flag divergences that are not justified by the change's purpose.
+
+### 4. Security
+
+- Auth checks on all new endpoints
+- No injection vectors (SQL injection, XSS, command injection)
+- Input validation at system boundaries
+- No secrets, credentials, or sensitive data in code, logs, or error messages
+- ORM queries preferred over raw SQL (unless justified)
+
+### 5. Scalability & Enterprise Readiness
+
+- Efficient database queries (proper indexes, no N+1, pagination)
+- Async patterns used correctly
+- Proper logging for observability
+- Resource cleanup (connections, file handles, subscriptions)
+
+### 6. Future-Proofing (Without Over-Engineering)
+
+- Extensible where extension is likely
+- Migration-safe database changes
+- Clean interfaces that do not leak implementation details
+- No abstractions for hypothetical requirements
+
+### 7. Code Quality
+
+- DRY — no literal code duplication (copy-pasted blocks, repeated logic). Semantic duplication (different code serving the same purpose) belongs to Dimension 2.
+- Single responsibility
+- Readable and self-documenting
+- Proper error handling at boundaries
+- Type safety
+
+### 8. Test Coverage
+
+- New behavior has corresponding test additions or updates (or a clear reason why not)
+- Existing test files were not removed or gutted without replacement
+- Edge cases and error paths have test coverage
+
+### 9. Documentation & Comments
+
+- No project-management artifacts in code comments (plan phases, ticket numbers, sprint references)
+- No stale comments from refactoring
+- Complex logic has a "why" comment
+
+### 10. Cleanup
+
+- No dead code, unused imports, or leftover debug statements
+- No TODO comments without context
+- No commented-out code blocks
+- Consistent formatting
+
+---
+
+## Reporting
+
+Present findings as a table:
+
+| # | Dimension | Result | Notes |
+|---|-----------|--------|-------|
+| 1 | Project Convention Compliance | PASS/WARNING/FAIL | details |
+| 2 | Code Reuse | PASS/WARNING/FAIL | details |
+| ... | ... | ... | ... |
+
+Below the table, add a one-line verdict:
+
+- **"Clean"** — all dimensions PASS
+- **"Has warnings"** — one or more WARNING, no FAIL
+- **"Has blockers"** — one or more FAIL
+
+Then list actionable findings with file and line references. For each issue, state what is wrong and how to fix it.
+
+---
+
+## PR Review Mode (Cross-Referencing)
+
+When invoked as part of a PR review workflow, existing reviewer comments may be available as context — a list of entries with reviewer, file path, line number, and comment body.
+
+After completing all 10 dimensions, cross-reference each finding:
+
+1. **File + Line match** — Is there an existing reviewer comment on the same file within +/-10 lines?
+2. **Semantic match** — Does an existing comment raise the same category of concern (both flagging missing auth, both noting duplication)?
+3. **Annotate each finding:**
+   - `[Already noted by @reviewer]` — same or very similar concern at the same location
+   - `[Related to @reviewer's comment on file:line]` — similar concern, different location
+   - `[New finding]` — not covered by any existing reviewer
+
+End with a **Cross-Reference Summary**: count of new findings vs. already-covered findings.
+
+This mode does not change which dimensions are checked or how issues are evaluated — it only adds overlap annotations so the reviewer knows where their review adds new value vs. confirms existing feedback.
+
+---
+
+## Rules
+
+- Always compare against a fresh base ref — never compare against a stale local ref
+- Read changed files in full, not just diff hunks — context matters
+- Check project convention documentation and apply project-specific rules explicitly
+- Do not flag style nits in code that was not changed by this diff
+- Pre-existing issues in unchanged code are informational only — they do not affect dimension grades
+- If the audit is invoked by another workflow (preflight, PR review), return findings to that workflow for decision-making

--- a/synthesis-codebase-review/SKILL.md
+++ b/synthesis-codebase-review/SKILL.md
@@ -242,12 +242,14 @@ reviews/
 
 ## Relationship to Other Verification Skills
 
-This skill evaluates the **entire system**. Two companion skills cover narrower scopes:
+This skill evaluates the **entire system**. Four companion skills cover narrower scopes:
 
 - **synthesis-implementation-integrity** — verifies a single change is genuinely complete (self-review, run after every implementation)
+- **synthesis-code-audit** — systematic 10-dimension quality scan of a diff (run after implementation, as input to preflight or pr-review)
+- **synthesis-preflight** — branch readiness gate that orchestrates tests, types, audit, and commit hygiene into a go/no-go verdict (run before creating a PR)
 - **synthesis-pr-review** — evaluates a change proposed for merge (peer review, run on every PR)
 
-Together these three skills form a verification trio: implementation-integrity catches change-level gaps, pr-review catches what the implementer missed, and this skill catches systemic patterns that no single change reveals.
+Together these five skills form a verification chain: implementation-integrity catches change-level gaps, code-audit measures quality across 10 dimensions, preflight gates the branch before it becomes a PR, pr-review catches what earlier checks missed through judgment-based evaluation, and this skill catches systemic patterns that no single change reveals.
 
 ---
 

--- a/synthesis-implementation-integrity/SKILL.md
+++ b/synthesis-implementation-integrity/SKILL.md
@@ -36,17 +36,19 @@ Skip for trivial changes (typo fixes, comment updates, single-line config edits)
 
 ---
 
-## Where This Fits — Three Verification Scopes
+## Where This Fits — Verification Chain
 
-Three complementary skills cover verification at different scopes. Each has a distinct purpose and cadence:
+Five complementary skills cover verification at different scopes and lifecycle phases:
 
 | Skill | Scope | Cadence | Core question |
 |-------|-------|---------|---------------|
 | **synthesis-implementation-integrity** (this one) | A single change | After every non-trivial implementation | "Is this change genuinely complete?" |
+| **synthesis-code-audit** | A diff (changed code) | After implementation, before or during review | "Does this diff meet quality standards?" |
+| **synthesis-preflight** | A branch | Before creating a PR | "Is this branch ready to merge?" |
 | **synthesis-pr-review** | A change proposed for merge | Every pull request | "Should this change enter the codebase?" |
 | **synthesis-codebase-review** | The entire system | Periodic or at milestones | "Is this system healthy?" |
 
-**The natural flow:** Implement → self-verify (this skill) → peer review (pr-review) → periodic health check (codebase-review).
+**The natural flow:** Implement → self-verify (this skill) → quality scan (code-audit) → branch gate (preflight) → peer review (pr-review) → periodic health check (codebase-review).
 
 **When to use both this skill and codebase-review:** After a major feature that touches many system layers. Run this skill to verify the feature itself is complete. Then run relevant sections of codebase-review (security, architecture, testing) to verify the feature doesn't degrade overall system health.
 
@@ -359,15 +361,17 @@ Compilation checks syntax and type safety. It does not check that the right data
 
 ## Relationship to Other Skills
 
-This skill forms a verification trio with two others. Together they cover all three scopes of code quality:
+This skill is part of a verification chain. Together these skills cover code quality from implementation through system health:
 
 | Skill | Scope | Who runs it | Analogy |
 |-------|-------|-------------|---------|
 | **implementation-integrity** (this) | Single change | The implementer, on their own work | A pilot's pre-flight checklist |
+| **synthesis-code-audit** | A diff (changed code) | The implementer or reviewer | An instrument panel reading |
+| **synthesis-preflight** | A branch | The implementer, before PR | A pre-departure clearance |
 | **synthesis-pr-review** | Change proposed for merge | A peer reviewer | An inspector's acceptance test |
 | **synthesis-codebase-review** | Entire system | An auditor or lead | An annual structural inspection |
 
-**The handoff:** Run this skill before creating a PR. It catches the issues you'd be embarrassed to have a peer find. Then pr-review catches what you missed from an external perspective. Codebase-review catches systemic patterns that no single change reveals.
+**The handoff:** Run this skill after implementing. Then code-audit provides a systematic quality scan across 10 dimensions. Preflight gates the branch (tests, types, audit, commit hygiene). pr-review catches what you missed from an external perspective. Codebase-review catches systemic patterns that no single change reveals.
 
 Other related skills:
 
@@ -375,5 +379,6 @@ Other related skills:
 |-------|-------------|
 | **synthesis-code-planning** | Plans the approach before implementation; this skill verifies the result after |
 | **synthesis-code-integration** | Verifies the merge is safe; this skill verifies the implementation is complete before merge |
+| **synthesis-review-triage** | Prioritizes which PR to review next; upstream of pr-review in the review workflow |
 
 This skill is the bridge between "I wrote the code" and "I'd stake my reputation on it." Run it before the code leaves your hands.

--- a/synthesis-pr-review/SKILL.md
+++ b/synthesis-pr-review/SKILL.md
@@ -18,16 +18,20 @@ A pull request in a synthesis-coded project is not just "does the code work?" It
 
 ## Where This Fits
 
-Three related skills cover different scopes:
+Seven related engineering skills cover different scopes and lifecycle phases:
 
 | Skill | Scope | When to use |
 |-------|-------|-------------|
-| **codebase-review** | Full codebase audit (16 categories, tiered) | New engagement, periodic health check, or major milestone |
-| **implementation-integrity** | Self-verification of a single implementation | After completing work, before creating a PR |
-| **synthesis-code-integration** | Integration workflow (adopt-and-adapt pattern, quality gates) | When merging contributor work into main |
+| **code-planning** | Approach selection for a task | Before writing code — evaluate alternatives, pick the best approach |
+| **implementation-integrity** | Self-verification of a single implementation | After completing work — "Is my code genuinely complete?" |
+| **code-audit** | 10-dimension quality scan of a diff | After implementation — systematic quality measurement |
+| **preflight** | Branch readiness gate | Before creating a PR — tests, types, audit, commit hygiene |
+| **review-triage** | PR queue prioritization | Before starting review — which PR to review next |
 | **pr-review** (this one) | Delta review of a single change | Every PR, before peer approval or lead integration |
+| **code-integration** | Integration workflow (adopt-and-adapt pattern, quality gates) | When merging contributor work into main |
+| **codebase-review** | Full codebase audit (16 categories, tiered) | Periodic health check or major milestone |
 
-PR review is the **most frequent** of the three. It happens on every change. The quality gates from the synthesis-code-integration skill apply here, but this skill operationalizes them as specific review steps.
+PR review is the most frequent *review* skill. It happens on every change. The synthesis-code-audit skill provides systematic quality data that feeds into reviews; this skill provides the judgment-based evaluation and communication. The quality gates from synthesis-code-integration apply here, but this skill operationalizes them as specific review steps.
 
 ---
 
@@ -325,3 +329,16 @@ The synthesis-codebase-review skill has 16 categories with tiered checks. Not al
 | Error handling | Observability (if logging/monitoring is affected) |
 
 The synthesis-codebase-review skill is the reference catalog. This PR review skill tells you which items to pull from it for a given change.
+
+---
+
+## Using the Code Audit Skill Alongside PR Review
+
+The synthesis-code-audit skill provides a 10-dimension scored quality scan of a diff. When used alongside this skill, code-audit provides systematic data; this skill provides judgment-based evaluation. The two are complementary:
+
+- **Code-audit** measures: convention compliance, code reuse, pattern consistency, security, scalability, future-proofing, code quality, test coverage, documentation, cleanup. It produces a PASS/WARNING/FAIL table.
+- **PR-review** evaluates: scope, root cause, regression risk, architectural consistency, completeness, security, data integrity. It produces a review verdict with severity-tiered findings.
+
+Some subject matter overlaps (security appears in both; consistency appears in both), but the purpose differs. Code-audit asks "does this code meet standards?" PR-review asks "should this change enter the codebase?" A diff can pass all 10 audit dimensions and still warrant a request-changes verdict because the approach is wrong, the root cause is misidentified, or the solution is incomplete.
+
+The audit findings feed into the review, but the review verdict considers factors the audit does not measure.

--- a/synthesis-preflight/SKILL.md
+++ b/synthesis-preflight/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: synthesis-preflight
+description: >
+  Pre-merge quality gate framework with six orthogonal dimensions: branch
+  hygiene, clean tree, tests and types, code audit, temporary considerations,
+  and commit history. Produces a mechanical go/no-go verdict. Use when asked
+  to: preflight, pre-merge check, ready to merge, can I ship this, branch
+  ready, quality gate, merge readiness, pre-PR check.
+license: "CC0-1.0"
+depends_on: ["synthesis-code-audit"]
+metadata:
+  author: "Emil Peñaló"
+  version: "1.0.0"
+  source_repo: "github.com/rajivpant/synthesis-skills"
+  source_type: "public"
+---
+
+# Synthesis Preflight
+
+Preflight is a branch readiness gate. It does not evaluate whether your code is correct — that is the job of synthesis-implementation-integrity (self-review) and synthesis-code-audit (quality scan). Preflight asks a different question: *is this branch mechanically ready to become a PR?*
+
+A branch can contain perfectly good code and still fail preflight: tests broken, uncommitted changes left behind, vague commit messages, a stale workaround that should have been removed. Preflight catches the things that fall between "the code works" and "the branch is ready."
+
+---
+
+## Where This Fits
+
+| Skill | Scope | When to use |
+|-------|-------|-------------|
+| **implementation-integrity** | Self-verification of a single implementation | After completing work — "Is my code genuinely complete?" |
+| **code-audit** | 10-dimension quality scan of a diff | After implementation — systematic quality measurement |
+| **preflight** (this one) | Branch readiness gate | Before creating a PR — "Is this branch ready?" |
+
+**The natural flow:** Implement → self-verify (implementation-integrity) → quality scan (code-audit) → branch gate (preflight) → create PR → peer review (pr-review).
+
+Preflight assumes implementation-integrity was already run during development. It does not re-check whether the code is complete — it checks whether the *branch* is ready to leave your machine.
+
+---
+
+## The Quality Gate Framework
+
+Preflight evaluates six orthogonal dimensions. Each is graded independently:
+
+- **Pass** — no issues
+- **Warning** — potential concern, does not block
+- **Fail** — blocks the PR until resolved
+
+A single FAIL in any dimension means the branch is NOT READY. The verdict is mechanical — no human override of FAIL dimensions. Warnings are surfaced for awareness but do not block.
+
+---
+
+## Quality Dimensions
+
+### 1. Branch Verification
+
+- Confirm you are on a feature, fix, or working branch — not on the default branch (main, master, or whatever the project designates as protected). Refuse to proceed if on a protected branch.
+- Count commits ahead of the base branch. If the branch is behind the base, warn that a sync may be needed before PR creation.
+
+### 2. Clean Working Tree
+
+- Check for uncommitted changes. If any exist, warn that they will not be included in the PR.
+- If there are unstaged changes, surface them explicitly so the developer can decide whether to commit or discard before proceeding.
+- The goal is awareness, not enforcement — uncommitted work may be intentional (unrelated experiments, local config).
+
+### 3. Test & Type Verification
+
+- Run the project's full test suite. Report pass/fail summary.
+- If the project uses a type checker (TypeScript, mypy, pyright, or equivalent), run it. Report any type errors.
+- These are binary gates. If tests fail or types do not check, the branch is not ready.
+
+### 4. Code Audit
+
+- Run the synthesis-code-audit methodology against the full branch diff (base to HEAD).
+- Any FAIL dimension in the audit = preflight FAIL for this gate.
+- WARNING dimensions are surfaced in the preflight report but do not block.
+- A "Clean" audit verdict = PASS for this gate.
+
+### 5. Temporary Considerations
+
+Check whether the project tracks temporary workarounds, known issues, or time-limited technical debt.
+
+For each tracked entry:
+
+1. **Run its resolution verification check.** Each temporary consideration should define criteria for when it can be removed (a flag is deleted, a migration is complete, a dependency is upgraded).
+2. **Resolved entries** — remove them from tracking. Report the resolution in the preflight output.
+3. **Still-active entries** — list them in the preflight output. Ensure other preflight checks (audit, test runs) respect any exclusions described in active entries.
+
+If the project does not track temporary considerations, grade this dimension as N/A.
+
+### 6. Commit History
+
+Review the commits on this branch (from the base branch to HEAD):
+
+- **Secrets or credentials in commit messages** — FAIL. Even if the secret is not in the code, its presence in a commit message means it will persist in git history.
+- **Vague messages** — WARNING for messages like "fix," "update," "wip," or single-word subjects that give no context. These should be reworded or squashed before PR.
+- **Convention compliance** — check that commit messages follow the project's documented format (conventional commits, imperative mood, character limits, or whatever the project specifies). Flag violations.
+
+---
+
+## Verdict
+
+Present findings as a status report:
+
+```
+PREFLIGHT REPORT — {branch-name}
+
+Branch:           pass/warning/fail (details)
+Clean tree:       pass/warning/fail (details)
+Tests & types:    pass/warning/fail (X passed, Y failed)
+Code audit:       pass/warning/fail (X issues: N FAIL, N WARNING)
+Temp items:       pass/skipped (N resolved, N still active)
+Commit history:   pass/warning/fail (details)
+
+VERDICT: READY / NOT READY (with blockers listed)
+```
+
+**READY** — all dimensions pass. Warnings are acceptable and listed for awareness.
+
+**NOT READY** — one or more FAIL. List blockers in priority order. For each blocker, state what is wrong and what needs to happen to resolve it.
+
+---
+
+## The Temporary Considerations Pattern
+
+This pattern is worth explaining because most projects do not formalize it, and workarounds accumulate silently as a result.
+
+### What to Track
+
+- Workarounds for known bugs in dependencies or infrastructure
+- Feature flags that were meant to be temporary
+- Hardcoded values that should come from configuration after a specific migration
+- Compatibility shims for deprecated APIs
+- Any code with an implicit expiration date
+
+### Entry Format
+
+Each tracked consideration should include:
+
+- **Description** — what the workaround does and why it exists
+- **Reason it is temporary** — what event or change will make it unnecessary
+- **Resolution verification** — a concrete, checkable condition (a file is deleted, a config key exists, a dependency version is above X, a feature flag is removed)
+- **Exclusions** — if the workaround causes known test failures or audit warnings, document them so preflight does not double-count the issue
+
+### Why Preflight Checks This
+
+Workarounds that are not tracked and not checked tend to become permanent. Preflight auto-cleaning resolved entries prevents accumulation. The developer who resolves the underlying issue may not remember every workaround it affects — preflight remembers for them.
+
+---
+
+## Rules
+
+- Never skip a dimension. If a check cannot run (no test suite, no type checker), grade it as N/A with explanation — not as PASS.
+- The verdict is mechanical. If any dimension is FAIL, the verdict is NOT READY. No exceptions.
+- Warnings are informational. They surface concerns but do not block.
+- If preflight is invoked by another workflow (a shipping or CI pipeline), return the full report to that workflow for decision-making.
+- Do not re-run checks that were already run in the current session. If a code audit was just completed, reference its results rather than running a second audit.

--- a/synthesis-review-triage/SKILL.md
+++ b/synthesis-review-triage/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: synthesis-review-triage
+description: >
+  PR queue prioritization methodology with weighted scoring across review gap,
+  CI status, age, size, and labels. Includes author-response detection, queue
+  classification, and prior-review gate for deciding full audit vs. delta-only
+  vs. skip. Use when asked to: triage PRs, which PR should I review, review
+  queue, prioritize reviews, PR backlog, review priority, what needs review,
+  PR triage, review workload.
+license: "CC0-1.0"
+depends_on: []
+metadata:
+  author: "Emil Peñaló"
+  version: "1.0.0"
+  source_repo: "github.com/rajivpant/synthesis-skills"
+  source_type: "public"
+---
+
+# Synthesis Review Triage
+
+Review triage decides *which* PR to review next. It does not evaluate code — that is the job of synthesis-pr-review and synthesis-code-audit. Triage is a routing and scheduling methodology: classify the queue, score each item by urgency, and direct review effort where it has the most impact.
+
+The most common failure in code review is not low-quality reviews — it is reviewing the wrong thing at the wrong time. A team that reviews the newest PR first while a merge-ready PR sits waiting for one more approval is wasting reviewer capacity. Triage prevents this.
+
+---
+
+## Where This Fits
+
+| Skill | Scope | When to use |
+|-------|-------|-------------|
+| **review-triage** (this one) | PR queue prioritization | Before starting a review session — decide which PR to review next |
+| **pr-review** | Delta review of a single change | Every PR, before peer approval or lead integration |
+| **code-audit** | 10-dimension quality scan of a diff | During review, as systematic input alongside judgment-based evaluation |
+
+Triage is upstream of everything in the review path. Run it before opening any PR.
+
+---
+
+## Queue Classification
+
+Every open PR belongs to exactly one of three categories:
+
+### 1. Reviewable
+
+PRs that need your review action. This is the working queue — everything you score and prioritize comes from here.
+
+### 2. Waiting on Author
+
+PRs that are genuinely blocked on the author. Changes were requested or a blocker was raised, and the author has not responded. These are visible for awareness but not actionable by the reviewer.
+
+### 3. Blocked
+
+PRs held by external factors — labels like "blocked" or "do not merge," dependency on another PR, or infrastructure holds. Shown for awareness, not actionable.
+
+---
+
+## Exclusion Rules
+
+Before scoring, remove PRs that should not be in your queue:
+
+- **Self-authored** — you do not review your own PRs.
+- **Drafts** — the author has not marked the PR ready for review.
+- **Already approved by you** — your review work is done. This includes dismissed approvals that were positive in nature (contained "LGTM," "looks good," or similar signals with no blockers). A dismissed approval after a force-push does not mean the reviewer's assessment was wrong — it means the platform reset the review state.
+- **Already reviewed by you with no new code commits** — you have seen this code. If the most recent commit on the PR predates your last review, there is nothing new to evaluate.
+
+### Classifying Post-Review Commits
+
+When a PR has new commits since your last review, classify them before deciding what to do:
+
+- **Merge-only commits** (all new commits have 2+ parents, or messages begin with "Merge branch") — likely no code changes. Flag as "rebase/merge since your last review — verify manually." These rarely warrant a full re-review.
+- **Code commits** (at least one new commit with 1 parent and a substantive message) — actual changes since your review. Flag as "new code commits since your last review — delta review needed." Boost priority.
+
+---
+
+## Author-Response Detection
+
+This is the single most important classification decision in triage. Get it wrong and review-ready PRs hide in the "waiting on author" bucket.
+
+**The insight:** A PR with changes requested + new commits pushed after the review is not blocked on the author. The author already responded. It is blocked on the *reviewer* to re-review.
+
+**How to determine this:**
+
+1. Find the timestamp of the most recent changes-requested review (or blocker comment).
+2. Find the timestamp of the latest commit on the PR.
+3. Compare:
+   - **Latest commit is after the review** — the author likely addressed feedback. Move to the **Reviewable** queue with flag: "Author pushed changes after review — re-review needed." Boost priority.
+   - **No new commits since the review** — genuinely **Waiting on Author**.
+
+Apply the same logic to inline blocker comments (comments containing "blocker," "must fix before merge," "do not merge," or similar signals). If commits arrived after the blocker was posted, the author may have addressed it.
+
+**Why this matters:** Teams that classify all "changes requested" PRs as "waiting on author" create invisible review debt. The author did their part. The reviewer is now the bottleneck but does not know it.
+
+---
+
+## Scoring Dimensions
+
+Score each reviewable PR across these dimensions. The goal: maximize the impact of your review time.
+
+### Review Gap — weight: highest
+
+How far is the PR from its approval threshold?
+
+| State | Urgency |
+|-------|---------|
+| 1 approval, CI passing, no conflicts | **Critical** — your review unblocks merge |
+| 0 reviews | **High** — nobody has looked at it |
+| Has review comments but 0 approvals | **High** — reviewed but not approved |
+| Already meets approval threshold | **Low** — threshold met, your review is additive |
+
+This is the most impactful dimension because it directly connects your review to an unblock event.
+
+### CI Status — weight: medium
+
+| Status | Effect |
+|--------|--------|
+| All passing | Boost — PR is actionable right now |
+| Some failing | Neutral — may still be worth reviewing |
+| All failing | Deprioritize — author needs to fix CI first |
+
+### Age & Staleness — weight: medium
+
+- Days since PR opened
+- Days since last activity (commits, comments, reviews)
+- Open > 7 days with no review = review debt — boost priority
+- Updated in last 24h = actively being worked on — slight boost
+
+Review debt compounds. A PR that has waited a week is more urgent than one opened an hour ago, all else being equal.
+
+### Size — weight: low-medium
+
+| Lines changed | Tag | Effect |
+|---------------|-----|--------|
+| < 50 | S | Quick review — slight boost (fast to unblock) |
+| 50–200 | M | Standard |
+| 200–500 | L | Significant — no automatic effect |
+| > 500 | XL | Flag for possible split — not buried, but noted |
+
+Smaller PRs get a slight boost because they are faster to unblock. XL PRs are flagged but not deprioritized — they may block the most downstream work.
+
+### Labels — weight: override
+
+Labels like "priority," "urgent," "critical," "hotfix," or "blocker" push the PR to the top regardless of other scores. These represent explicit team decisions about urgency.
+
+### Updated Since Last Review
+
+If a PR has reviews AND commits pushed after the most recent review, flag it: "New commits since last review — delta review needed." Boost priority. The author addressed feedback and is waiting for re-review.
+
+---
+
+## Tier Assignment
+
+Group scored PRs into tiers:
+
+| Tier | Criteria |
+|------|----------|
+| **Critical** | 1 approval + CI passing + no conflicts. Your review unblocks merge. |
+| **High** | 0 reviews + CI passing. Or: updated since last review (author responded to feedback). |
+| **Medium** | Reviewable but not urgent — CI mixed, very recently opened, or already has non-blocking reviews. |
+| **Waiting on Author** | Changes requested with no author response since the blocking review. |
+
+Review in tier order. Within a tier, use the scoring dimensions as tiebreakers.
+
+---
+
+## Prior-Review Gate
+
+Before investing time in a PR you have already reviewed, run this decision gate:
+
+### Step 1: Summarize Prior Review
+
+State your prior review's outcome (approved, changes requested, commented), when it happened, and a one-line summary of what you covered.
+
+### Step 2: Classify New Activity
+
+Determine what changed since your last review:
+
+- **Merge-only commits** — branch was rebased or merged from base. Likely no code changes.
+- **Code commits** — actual new code since your review. Count them and note their scope.
+- **New reviewer comments** — other reviewers may have covered ground you would duplicate.
+
+### Step 3: Decide
+
+| Situation | Action |
+|-----------|--------|
+| Merge-only commits, no code changes | **Skip** or quick manual verify |
+| Small code commits addressing your feedback | **Delta review** — diff only new commits, check if feedback was addressed |
+| Large code commits or significant new work | **Full review** — treat as a fresh evaluation |
+| Other reviewers covered your concerns | **Skip** — your review adds no new value |
+
+**Why this gate exists:** A rebase or merge-of-base produces "new commits since your last review" but often changes nothing in the PR's own code. Running a full review wastes time and produces identical findings. The prior-review gate prevents this wasted effort.
+
+---
+
+## Rules
+
+- **Triage is routing, not evaluation.** Do not assess code quality during triage. That is what pr-review and code-audit are for.
+- **The scoring is a framework, not a formula.** Adapt weights to your team's context. A team with a strict SLA on review turnaround might weight age higher. A team with frequent CI flakiness might weight CI status lower.
+- **Author-response detection prevents misclassification.** Always check for post-review commits before labeling a PR as "waiting on author."
+- **"Already reviewed" does not mean "already approved."** Distinguish carefully — a commented review with no verdict is not a completed review.
+- **Respect explicit team signals.** Priority labels, blocker tags, and team conventions override the scoring framework.


### PR DESCRIPTION
## What

Three new engineering methodology skills that fill gaps in the verification chain between "I wrote the code" and "this PR is merged."

**synthesis-code-audit** is a systematic 10-dimension quality scan of a diff. The repo already has three code evaluation skills, each at a different scope: codebase-review audits the entire system periodically, pr-review is a reviewer's judgment-based evaluation of a proposed change, and implementation-integrity is a self-verification protocol for completeness. Code-audit occupies a distinct role: it produces a scored PASS/WARNING/FAIL report across 10 measurable dimensions (convention compliance, code reuse, pattern consistency, security, scalability, future-proofing, code quality, test coverage, documentation, cleanup). It does not produce a review verdict or decide whether a change should merge. Instead, it generates structured quality data that other workflows consume. Preflight uses it as one of its quality gates. PR reviewers can use it alongside pr-review, where code-audit provides the systematic measurement and pr-review provides the judgment (scope governance, root cause analysis, regression risk, completeness) that no automated scan can replace. A diff can pass all 10 audit dimensions and still warrant a request-changes verdict because the approach is wrong or the solution is incomplete.

**synthesis-preflight** is a pre-merge branch readiness gate with 6 orthogonal dimensions: branch verification, clean working tree, test and type checking, code audit, temporary considerations, and commit history review. Each dimension is graded independently and a single FAIL produces a NOT READY verdict. The skill also introduces the temporary considerations pattern, a formalized approach to tracking workarounds and time-limited technical debt with explicit resolution criteria. Preflight auto-cleans resolved entries during each run, preventing workaround accumulation.

**synthesis-review-triage** is a PR prioritization methodology that decides which PR to review next before any evaluation begins. It classifies the queue into three categories (reviewable, waiting on author, blocked), scores reviewable PRs across five weighted dimensions (review gap, CI status, age/staleness, size, labels), and assigns urgency tiers. Its most important contribution is author-response detection: recognizing that a PR with changes requested but new commits pushed after the review is waiting on the reviewer to re-review, not on the author. Teams that miss this classification create invisible review debt where authors have done their part but nobody knows it.

## Changes

- **synthesis-code-audit** v1.0.0: 10-dimension diff quality framework with PASS/WARNING/FAIL scoring and PR review mode cross-referencing
- **synthesis-preflight** v1.0.0: 6 orthogonal quality gates with temporary considerations pattern and mechanical go/no-go verdict
- **synthesis-review-triage** v1.0.0: weighted scoring, author-response detection, queue classification, prior-review gate
- **synthesis-pr-review**: expanded "Where This Fits" table from 4 to 8 skills covering the full development lifecycle; added code-audit cross-reference section
- **synthesis-implementation-integrity**: expanded verification chain from 3 to 5 skills in both ecosystem sections
- **synthesis-codebase-review**: expanded relationship section from 2 to 4 companion skills
- **install.sh**: updated fallback SKILL_NAMES list with all 7 missing skills (4 pre-existing + 3 new)
- **README**: skill count 26 to 29, 3 new Engineering table entries
- **CHANGELOG**: v2.2.0 entry

## Context

These skills formalize the engineering verification lifecycle: plan, implement, self-verify, quality scan, branch gate, triage, peer review, integrate, system audit. Each skill is pure methodology (no platform-specific commands or orchestration) following the repo's conventions. The install.sh fix addresses a pre-existing gap where 4 previously added skills were also missing from the uninstall fallback list.