### PR TITLE
install.sh: whole-directory drift detection, pre-overwrite backups, named drift warnings (repo 3.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [3.19.0] - 2026-07-21
+
+### Changed
+
+- **`install.sh` drift handling: whole-directory detection, pre-overwrite backups, named warnings.** Three changes to how the bootstrap installer treats an installed skill copy that differs from source. (1) Drift detection now checksums the entire skill directory (excluding installer-written `.source.json` and Finder `.DS_Store`) instead of `SKILL.md` alone — a modified script, reference file, or data table (e.g. `tiers.yaml`) now registers as drift instead of being silently replaced. (2) Every drifted copy is saved to `${XDG_CACHE_HOME:-~/.cache}/synthesis-skills-backups/<UTC-run-stamp>/<target>/<skill>/` before the overwrite, including same-name directories that carry no install provenance; backups sit beside the cache directory rather than inside it, so recloning or uninstalling never deletes them, and the newest 10 runs are retained. (3) The end-of-run warning now lists each drifted skill by name, distinguishes unique skills from per-location copies, points at the backup directory, and no longer asserts "local modifications" — a checksum mismatch can equally be an installed copy that is merely older than freshly pulled source, and the installer cannot tell the difference. Motivating incident (2026-07-21): an update run piped through `tail` preserved only the count line — "3 skill(s) had local modifications" — while the per-skill DRIFT lines above it were cut off, and with no backups there was no way to reconstruct which copies had been replaced or what they contained. Investigation showed the count itself was misleading: one skill, one commit behind source, counted once per install location. The summary block now carries the names, so even a truncated tail answers the question, and the backups make it recoverable either way. `synthesis-skills-manager` bumped to v1.1.1 — its bootstrap-installer paragraph now describes the whole-directory drift coverage and backup behavior.
+
 ## [3.18.0] - 2026-07-21
 
 ### Added

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,10 @@ set -e
 REPO_URL="https://github.com/synthesisengineering/synthesis-skills.git"
 REPO_NAME="synthesis-skills"
 CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/synthesis-skills"
+# Backups live BESIDE the cache, not inside it: the cache dir is deleted on
+# reclone and on uninstall, and backups must survive both.
+BACKUP_ROOT="${CACHE_DIR}-backups"
+BACKUP_KEEP_RUNS=10
 SOURCE_REPO="github.com/synthesisengineering/synthesis-skills"
 SOURCE_TYPE="public"
 
@@ -70,16 +74,43 @@ write_source_json() {
 ENDJSON
 }
 
-# Compute checksum of SKILL.md content (portable across macOS and Linux)
-skill_checksum() {
-    if command -v shasum >/dev/null 2>&1; then
-        shasum -a 256 "$1" | cut -d' ' -f1
-    elif command -v sha256sum >/dev/null 2>&1; then
-        sha256sum "$1" | cut -d' ' -f1
-    else
-        # Fallback: use cksum
-        cksum "$1" | cut -d' ' -f1
-    fi
+# Checksum tooling (portable across macOS and Linux).
+# Word-split on use is intentional; do not quote $CHECKSUM_TOOL.
+if command -v shasum >/dev/null 2>&1; then
+    CHECKSUM_TOOL="shasum -a 256"
+elif command -v sha256sum >/dev/null 2>&1; then
+    CHECKSUM_TOOL="sha256sum"
+else
+    # Fallback: cksum is POSIX
+    CHECKSUM_TOOL="cksum"
+fi
+
+checksum_stdin() {
+    $CHECKSUM_TOOL | cut -d' ' -f1
+}
+
+# Checksum of an entire skill directory: every file except installer-written
+# provenance (.source.json) and Finder noise (.DS_Store), keyed by relative
+# path so an installed copy and its source dir compare equal. Whole-directory
+# coverage matters: drift in scripts/, references/, or data tables
+# (e.g. tiers.yaml) must be detected, not just drift in SKILL.md.
+skill_dir_checksum() {
+    (cd "$1" 2>/dev/null || exit 0
+     find . -type f ! -name '.source.json' ! -name '.DS_Store' -print0 \
+        | LC_ALL=C sort -z \
+        | xargs -0 $CHECKSUM_TOOL 2>/dev/null) | checksum_stdin
+}
+
+# Drop backup runs beyond the newest BACKUP_KEEP_RUNS. Run-stamp dirs are
+# UTC timestamps, so lexicographic order is chronological order.
+prune_backups() {
+    [ -d "$BACKUP_ROOT" ] || return 0
+    total=$(ls -1 "$BACKUP_ROOT" 2>/dev/null | wc -l | tr -d ' ')
+    [ "$total" -gt "$BACKUP_KEEP_RUNS" ] || return 0
+    ls -1 "$BACKUP_ROOT" | LC_ALL=C sort | head -n $((total - BACKUP_KEEP_RUNS)) \
+        | while IFS= read -r old_run; do
+            rm -rf "${BACKUP_ROOT:?}/${old_run}"
+        done
 }
 
 do_install() {
@@ -99,6 +130,9 @@ do_install() {
     TARGETS=$(detect_targets)
     SKILL_COUNT=0
     DRIFT_COUNT=0
+    DRIFT_NAMES=""
+    RUN_STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+    BACKUP_DIR="${BACKUP_ROOT}/${RUN_STAMP}"
 
     for target in $TARGETS; do
         mkdir -p "$target"
@@ -111,16 +145,25 @@ do_install() {
 
             installed_dir="${target}/${skill_name}"
 
-            # Check for drift before overwriting
-            if [ -f "${installed_dir}/SKILL.md" ] && [ -f "${skill_dir}/SKILL.md" ]; then
-                installed_sum=$(skill_checksum "${installed_dir}/SKILL.md")
-                source_sum=$(skill_checksum "${skill_dir}/SKILL.md")
+            # Check for drift before overwriting. Any existing directory that
+            # differs from source — whatever the reason: a local edit, an
+            # installed copy older than source, or a same-name directory this
+            # installer never wrote — is backed up before it is replaced.
+            if [ -d "$installed_dir" ]; then
+                installed_sum=$(skill_dir_checksum "$installed_dir")
+                source_sum=$(skill_dir_checksum "$skill_dir")
                 if [ "$installed_sum" != "$source_sum" ]; then
-                    # Check if this was from our repo
+                    target_tag=$(printf '%s' "$target" | sed "s|^${HOME}/||; s|^\.||; s|/|-|g")
+                    mkdir -p "${BACKUP_DIR}/${target_tag}"
+                    cp -R "$installed_dir" "${BACKUP_DIR}/${target_tag}/${skill_name}"
+                    DRIFT_COUNT=$((DRIFT_COUNT + 1))
+                    DRIFT_NAMES="$DRIFT_NAMES $skill_name"
                     if [ -f "${installed_dir}/.source.json" ]; then
-                        echo "  DRIFT: ${skill_name} — installed copy differs from source"
-                        DRIFT_COUNT=$((DRIFT_COUNT + 1))
+                        echo "  DRIFT: ${skill_name} in ${target} — installed copy differs from source"
+                    else
+                        echo "  DRIFT: ${skill_name} in ${target} — same-name directory without install provenance differs from source"
                     fi
+                    echo "         pre-overwrite copy saved: ${BACKUP_DIR}/${target_tag}/${skill_name}"
                 fi
             fi
 
@@ -138,9 +181,16 @@ do_install() {
     echo ""
     echo "Done. $UNIQUE_SKILLS skills installed to $(echo $TARGETS | wc -w | tr -d ' ') locations."
     if [ "$DRIFT_COUNT" -gt 0 ]; then
-        echo "WARNING: $DRIFT_COUNT skill(s) had local modifications that were overwritten."
-        echo "  Use './install.sh status' before install to review drift."
+        # Word-split $DRIFT_NAMES on purpose: one name per list entry.
+        DRIFTED_SKILLS=$(printf '%s\n' $DRIFT_NAMES | LC_ALL=C sort -u)
+        DRIFTED_SKILL_COUNT=$(printf '%s\n' "$DRIFTED_SKILLS" | grep -c .)
+        echo "WARNING: $DRIFTED_SKILL_COUNT skill(s) differed from source and were overwritten ($DRIFT_COUNT installed copies):"
+        printf '%s\n' "$DRIFTED_SKILLS" | sed 's/^/  - /'
+        echo "  Pre-overwrite copies saved under: $BACKUP_DIR"
+        echo "  A difference can be a local edit or an installed copy older than source."
+        echo "  Use './install.sh status' before install/update to review drift first."
     fi
+    prune_backups
     echo "Restart your AI assistant to pick up the new skills."
 
     # Validate dependencies in the first target directory
@@ -336,15 +386,13 @@ do_status() {
 
             INSTALLED=$((INSTALLED + 1))
 
-            if [ -f "${installed_dir}/SKILL.md" ] && [ -f "${skill_dir}/SKILL.md" ]; then
-                installed_sum=$(skill_checksum "${installed_dir}/SKILL.md")
-                source_sum=$(skill_checksum "${skill_dir}/SKILL.md")
-                if [ "$installed_sum" != "$source_sum" ]; then
-                    echo "  DRIFT:   $skill_name"
-                    DRIFTED=$((DRIFTED + 1))
-                else
-                    echo "  OK:      $skill_name"
-                fi
+            installed_sum=$(skill_dir_checksum "$installed_dir")
+            source_sum=$(skill_dir_checksum "$skill_dir")
+            if [ "$installed_sum" != "$source_sum" ]; then
+                echo "  DRIFT:   $skill_name"
+                DRIFTED=$((DRIFTED + 1))
+            else
+                echo "  OK:      $skill_name"
             fi
         done
 

--- a/synthesis-skills-manager/SKILL.md
+++ b/synthesis-skills-manager/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.1.0"
+  version: "1.1.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -214,7 +214,7 @@ User: "Update my skills"
 
 This skill is designed to be executed by an AI agent (Claude Code, Cursor, etc.), not as a shell script. The agent reads files, compares content, understands methodology structure, and makes merge decisions that a text-based tool cannot.
 
-The `install.sh` scripts in each repo serve as bootstrap/fallback installers for environments without an AI agent. They handle the mechanical parts (copy, provenance, checksums) but cannot do synthesis merge — they overwrite on conflict with a drift warning.
+The `install.sh` scripts in each repo serve as bootstrap/fallback installers for environments without an AI agent. They handle the mechanical parts (copy, provenance, checksums) but cannot do synthesis merge — they overwrite on conflict. Drift detection covers the whole skill directory (scripts, references, data tables — not just SKILL.md); every drifted copy is saved to `${XDG_CACHE_HOME:-~/.cache}/<repo-name>-backups/<UTC-run-stamp>/<target>/<skill>/` before overwrite, and the end-of-run warning names each drifted skill and the backup path. Backups are pruned to the 10 most recent runs.
 
 ## Source Update Protocol (NON-NEGOTIABLE)
 


### PR DESCRIPTION
## Summary

Three changes to how the bootstrap installer treats an installed skill copy that differs from source:

1. **Whole-directory drift detection** — checksums the entire skill directory (excluding installer-written `.source.json` and Finder `.DS_Store`) instead of `SKILL.md` alone. A modified script, reference file, or data table (e.g. `tiers.yaml`) now registers as drift instead of being silently replaced.
2. **Pre-overwrite backups** — every drifted copy (including same-name directories without install provenance) is saved to `${XDG_CACHE_HOME:-~/.cache}/synthesis-skills-backups/<UTC-run-stamp>/<target>/<skill>/` before overwrite. The backup root sits beside the cache directory rather than inside it, so recloning or uninstalling never deletes it. Retention: newest 10 runs.
3. **Named drift warnings** — the end-of-run warning lists each drifted skill by name, distinguishes unique skills from per-location copies, prints the backup path, and no longer asserts "local modifications" (a checksum mismatch can equally be an installed copy that is merely older than freshly pulled source).

`do_status` uses the same whole-directory checksum, so status and install agree on what drift means. `synthesis-skills-manager` bumped to v1.1.1 — its bootstrap-installer paragraph now describes the new behavior.

## Motivation

An update run piped through `tail` preserved only the count line — "3 skill(s) had local modifications" — while the per-skill DRIFT lines above it were cut off. With no backups, there was no way to reconstruct which copies were replaced or what they contained. Investigation showed the count was misleading (one skill, one commit behind source, counted once per install location). The summary block now carries the names, so even a truncated tail answers the question, and the backups make it recoverable either way.

## Testing

Sandbox-tested end to end with an isolated `$HOME` and pre-seeded cache clone:
- Fresh install: 43 skills × 3 targets, no spurious drift
- Clean re-update: zero drift, no warning, no backup directory created
- Three drift variants: `SKILL.md` edit, non-`SKILL.md` edit (`tiers.yaml`), and same-name directory without provenance — all detected, all backed up with content verified, correct wording per variant
- Warning block survives `| tail -8` truncation with names visible
- `status` detects non-`SKILL.md` drift in exactly the seeded target
- Pruning: 14 backup runs reduced to the 10 lexicographically newest
- `sh -n` syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)