### PR TITLE
Add dual-runtime skill interfaces and agent-neutral automation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,7 @@ jobs:
       - run: python -m pytest skills/synthesis-agent-conformance/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-project-management/scripts/test_coordination.py -q
       - run: python -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
+      - run: python -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py -q
       - run: sh -n install.sh tests/test_installer.sh
       - run: ./tests/test_installer.sh
       - run: python -m compileall -q skills

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
       - run: python -m pytest skills/synthesis-agent-conformance/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-project-management/scripts/test_coordination.py -q
       - run: python -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
-      - run: python -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py -q
+      - run: python -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py -q
       - run: sh -n install.sh tests/test_installer.sh
       - run: ./tests/test_installer.sh
       - run: python -m compileall -q skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.3.0] - 2026-07-29
+
+### Added
+
+- Codex `agents/openai.yaml` interfaces for every public synthesis skill, with
+  source conformance that requires the interface, invocation token, and a
+  correctly sized short description.
+- An agent-neutral day-end installer that atomically places the launcher and
+  nudge under `~/.synthesis/day-end/`, refuses symlinked runtime roots, and
+  supports persisted `auto`, `codex`, or `claude` selection.
+- Dual-client message-guard diagnosis: every installed Claude Code and Codex
+  hook configuration must independently gate the complete correspondence tool
+  family.
+- Regression coverage for day-end source survival, Codex-first auto selection,
+  symlink refusal, both client hook shapes, and client-bound runtime paths.
+
+### Changed
+
+- `synthesis-daily-rituals` v2.16.0 uses the stable synthesis runtime for its
+  background automation instead of a client-owned skill cache.
+- `synthesis-slack-sync` v3.3.1 resolves its checker from the active skill root.
+- `synthesis-inbox-cleanup` v1.3.2 and `synthesis-git-hooks` v2.1.1 make native
+  Codex and Claude Code plugins their primary setup path.
+- `synthesis-message-guard` v1.1.0 treats an unwired installed client as an
+  unhealthy protection layer.
+
 ## [4.2.0] - 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   family.
 - Regression coverage for day-end source survival, Codex-first auto selection,
   symlink refusal, both client hook shapes, and client-bound runtime paths.
+- Commit-hook calibration for exact canonical-file copies: unchanged committed
+  content is not reclassified as newly introduced, while a paired control proves
+  genuinely new sensitive lines still block.
 
 ### Changed
 
 - `synthesis-daily-rituals` v2.16.0 uses the stable synthesis runtime for its
   background automation instead of a client-owned skill cache.
 - `synthesis-slack-sync` v3.3.1 resolves its checker from the active skill root.
-- `synthesis-inbox-cleanup` v1.3.2 and `synthesis-git-hooks` v2.1.1 make native
+- `synthesis-inbox-cleanup` v1.3.2 and `synthesis-git-hooks` v2.1.2 make native
   Codex and Claude Code plugins their primary setup path.
 - `synthesis-message-guard` v1.1.0 treats an unwired installed client as an
   unhealthy protection layer.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Proven AI agent skills for code review, content creation, project management, an
 
 ## What's new
 
+**First-class Codex interfaces and agent-neutral automation (July 2026).**
+Every public skill now carries a Codex interface with an explicit invocation
+prompt. Day-end automation installs under stable `~/.synthesis/` ownership and
+can launch Codex or Claude Code from one configuration, while the
+correspondence safety doctor validates both clients independently. Source
+conformance rejects client-bound runtime paths before they ship. See the
+[4.3.0 release notes](CHANGELOG.md).
+
 **One knowledge-base contract across agents (July 2026).** New
 `synthesis-kb-edit` reads `.agents/knowledge-base.yaml` for editable and
 generated paths, topic routing, the one frontmatter schema, confidentiality
@@ -20,7 +28,7 @@ without tool-owned workflow copies or date-field drift. See the
 
 **Google's Open Knowledge Format, validated and converted (July 2026).** New skill `synthesis-okf` **v1.0.0** fills the one gap Google's own OKF repo leaves open: a conformance validator and an idempotent frontmatter converter for OKF v0.1 (announced 2026-06-12 by Google Cloud's Sam McVeety and Amir Hormati). `okf_validate.py` checks the spec's three hard rules plus soft-guidance warnings and link-checking; `okf_convert.py` backfills frontmatter onto an existing markdown corpus without ever overwriting what's already there. Proven across several real conversions, from a small public reference repo up to a 72-doc personal knowledge base. See the [3.15.0 release notes](CHANGELOG.md).
 
-**Day-end that survives tired evenings (July 2026).** `synthesis-daily-rituals` **v2.14.0** adds a two-speed day-end: full mode stays, and a new ~10-minute **Quick Close** keeps only the three moments that need a human — send-or-release on decay-tagged drafts, keep/drop on the day's lesson candidates, and a closure read-back. The weekly loose-ends review becomes owed-weekly (it runs at the first ritual on/after Friday instead of living inside the most-skipped one), time-sensitive drafts carry explicit `Decays:` dates from creation, and a state file plus a notification-only nudge make skipped evenings visible instead of silent. The shipped `day-end` script is a launcher, not a runner — the ritual always executes inside the agentic coding session. See the [3.11.0 release notes](CHANGELOG.md).
+**Day-end that survives tired evenings (July 2026).** `synthesis-daily-rituals` **v2.16.0** provides full and Quick Close modes, owed-weekly loose-ends review, explicit `Decays:` dates, and a state-aware notification. Its launcher and nudge live under `~/.synthesis/day-end/`, independent of client skill caches, and the launcher can open Codex or Claude Code. See the [4.3.0 release notes](CHANGELOG.md).
 
 **Autonomous execution as a mode (July 2026).** New skill `synthesis-autopilot` **v1.0.0** encodes the delegation contract users otherwise retype per task: one explicit phrase ("take care of this for me," "autopilot this," "handle this end to end") engages a mode that sequences the existing stack — thinking framework for decisions, plan file + context lifecycle + checkpoint for compaction survival, anti-shortcuts for quality, implementation integrity before "done." Strict trigger discipline (explicit delegation only — ambiguity resolves to not engaging), batched user-only questions at checkpoints instead of blocking, and an explicit rule that standing gates survive autonomy: delegating a task never delegates authority the user has reserved. See the [3.10.0 release notes](CHANGELOG.md).
 

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -153,13 +153,22 @@ def source_checks(source_root: Path) -> list[Check]:
             add(checks, f"source.skill.{skill_dir.name}", valid, f"declared={declared}")
             names.append(declared)
             interface = skill_dir / "agents" / "openai.yaml"
-            if interface.is_file():
+            if not interface.is_file():
+                add(
+                    checks,
+                    f"source.skill-ui.{skill_dir.name}",
+                    False,
+                    f"missing {interface.relative_to(source_root)}",
+                )
+            else:
                 try:
                     ui = yaml.safe_load(interface.read_text(encoding="utf-8"))
                     prompt = ui["interface"]["default_prompt"]
+                    short_description = ui["interface"]["short_description"]
                     ui_ok = (
                         isinstance(ui["interface"]["display_name"], str)
-                        and isinstance(ui["interface"]["short_description"], str)
+                        and isinstance(short_description, str)
+                        and 25 <= len(short_description) <= 64
                         and isinstance(prompt, str)
                         and f"${declared}" in prompt
                     )
@@ -185,8 +194,9 @@ def source_checks(source_root: Path) -> list[Check]:
     add(checks, "source.no-root-skills", not root_skills, ", ".join(root_skills) or "none")
 
     stale_patterns = {
-        "source.no-codex-copy-paths": re.compile(r"~/.codex/skills/synthesis-"),
-        "source.no-claude-copy-paths": re.compile(r"~/.claude/skills/synthesis-"),
+        "source.no-client-copy-paths": re.compile(
+            r"(?:~|\$HOME)/\.(?:codex|claude|agents)/skills/synthesis-"
+        ),
         "source.no-old-source-layout": re.compile(r"synthesis-skills/synthesis-"),
     }
     text_files = [
@@ -196,6 +206,7 @@ def source_checks(source_root: Path) -> list[Check]:
         and ".git" not in path.parts
         and ".claude" not in path.parts
         and path.resolve() != SCRIPT_PATH
+        and path.resolve() != SCRIPT_PATH.with_name("test_conformance.py")
         and path.suffix in {".md", ".py", ".sh", ".yaml", ".yml", ".json"}
     ]
     for name, pattern in stale_patterns.items():
@@ -207,6 +218,25 @@ def source_checks(source_root: Path) -> list[Check]:
             except UnicodeDecodeError:
                 continue
         add(checks, name, not matches, ", ".join(matches) or "none")
+
+    skill_local_npx = re.compile(
+        r"npx\s+skills\s+add\s+synthesisengineering/synthesis-skills"
+    )
+    matches = []
+    for path in text_files:
+        if skills_root not in path.parents:
+            continue
+        try:
+            if skill_local_npx.search(path.read_text(encoding="utf-8")):
+                matches.append(str(path.relative_to(source_root)))
+        except UnicodeDecodeError:
+            continue
+    add(
+        checks,
+        "source.no-skill-local-fallback-installs",
+        not matches,
+        ", ".join(matches) or "none",
+    )
     return checks
 
 

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -21,6 +21,15 @@ def write_skill(root: Path, name: str) -> None:
         f"---\nname: {name}\ndescription: Test skill.\n---\n\n# Test\n",
         encoding="utf-8",
     )
+    interface = skill / "agents"
+    interface.mkdir()
+    (interface / "openai.yaml").write_text(
+        "interface:\n"
+        f'  display_name: "{name}"\n'
+        '  short_description: "Apply this synthesis workflow"\n'
+        f'  default_prompt: "Use ${name} for this task."\n',
+        encoding="utf-8",
+    )
 
 
 def write_manifests(root: Path) -> None:
@@ -52,6 +61,35 @@ def test_source_checks_accept_dual_manifest(tmp_path: Path) -> None:
     write_skill(tmp_path, "synthesis-test")
     checks = MODULE.source_checks(tmp_path)
     assert all(check.ok for check in checks)
+
+
+def test_source_checks_require_openai_interface(tmp_path: Path) -> None:
+    write_manifests(tmp_path)
+    write_skill(tmp_path, "synthesis-test")
+    (tmp_path / "skills" / "synthesis-test" / "agents" / "openai.yaml").unlink()
+
+    checks = MODULE.source_checks(tmp_path)
+
+    interface = next(
+        check for check in checks if check.name == "source.skill-ui.synthesis-test"
+    )
+    assert not interface.ok
+
+
+def test_source_checks_reject_client_bound_runtime_path(tmp_path: Path) -> None:
+    write_manifests(tmp_path)
+    write_skill(tmp_path, "synthesis-test")
+    (tmp_path / "skills" / "synthesis-test" / "runtime.sh").write_text(
+        'exec "$HOME/.claude/skills/synthesis-test/run.sh"\n',
+        encoding="utf-8",
+    )
+
+    checks = MODULE.source_checks(tmp_path)
+
+    stale = next(
+        check for check in checks if check.name == "source.no-client-copy-paths"
+    )
+    assert not stale.ok
 
 
 def test_instruction_adapter(tmp_path: Path) -> None:

--- a/skills/synthesis-anti-shortcuts/agents/openai.yaml
+++ b/skills/synthesis-anti-shortcuts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Anti Shortcuts"
+  short_description: "Apply the anti shortcuts synthesis workflow"
+  default_prompt: "Use $synthesis-anti-shortcuts to apply this workflow to the current task."

--- a/skills/synthesis-article-refresh/agents/openai.yaml
+++ b/skills/synthesis-article-refresh/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Article Refresh"
+  short_description: "Apply the article refresh synthesis workflow"
+  default_prompt: "Use $synthesis-article-refresh to apply this workflow to the current task."

--- a/skills/synthesis-article-writing/agents/openai.yaml
+++ b/skills/synthesis-article-writing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Article Writing"
+  short_description: "Apply the article writing synthesis workflow"
+  default_prompt: "Use $synthesis-article-writing to apply this workflow to the current task."

--- a/skills/synthesis-autopilot/agents/openai.yaml
+++ b/skills/synthesis-autopilot/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Autopilot"
+  short_description: "Apply the autopilot synthesis workflow"
+  default_prompt: "Use $synthesis-autopilot to apply this workflow to the current task."

--- a/skills/synthesis-bitbucket/agents/openai.yaml
+++ b/skills/synthesis-bitbucket/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Bitbucket"
+  short_description: "Apply the bitbucket synthesis workflow"
+  default_prompt: "Use $synthesis-bitbucket to apply this workflow to the current task."

--- a/skills/synthesis-catchup-ledger/agents/openai.yaml
+++ b/skills/synthesis-catchup-ledger/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Catchup Ledger"
+  short_description: "Apply the catchup ledger synthesis workflow"
+  default_prompt: "Use $synthesis-catchup-ledger to apply this workflow to the current task."

--- a/skills/synthesis-checkpoint/agents/openai.yaml
+++ b/skills/synthesis-checkpoint/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Checkpoint"
+  short_description: "Apply the checkpoint synthesis workflow"
+  default_prompt: "Use $synthesis-checkpoint to apply this workflow to the current task."

--- a/skills/synthesis-chief-of-staff/agents/openai.yaml
+++ b/skills/synthesis-chief-of-staff/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Chief Of Staff"
+  short_description: "Apply the chief of staff synthesis workflow"
+  default_prompt: "Use $synthesis-chief-of-staff to apply this workflow to the current task."

--- a/skills/synthesis-clean-text/agents/openai.yaml
+++ b/skills/synthesis-clean-text/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Clean Text"
+  short_description: "Apply the clean text synthesis workflow"
+  default_prompt: "Use $synthesis-clean-text to apply this workflow to the current task."

--- a/skills/synthesis-code-audit/agents/openai.yaml
+++ b/skills/synthesis-code-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Code Audit"
+  short_description: "Apply the code audit synthesis workflow"
+  default_prompt: "Use $synthesis-code-audit to apply this workflow to the current task."

--- a/skills/synthesis-code-integration/agents/openai.yaml
+++ b/skills/synthesis-code-integration/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Code Integration"
+  short_description: "Apply the code integration synthesis workflow"
+  default_prompt: "Use $synthesis-code-integration to apply this workflow to the current task."

--- a/skills/synthesis-code-planning/agents/openai.yaml
+++ b/skills/synthesis-code-planning/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Code Planning"
+  short_description: "Apply the code planning synthesis workflow"
+  default_prompt: "Use $synthesis-code-planning to apply this workflow to the current task."

--- a/skills/synthesis-codebase-review/agents/openai.yaml
+++ b/skills/synthesis-codebase-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Codebase Review"
+  short_description: "Apply the codebase review synthesis workflow"
+  default_prompt: "Use $synthesis-codebase-review to apply this workflow to the current task."

--- a/skills/synthesis-concise-messaging/agents/openai.yaml
+++ b/skills/synthesis-concise-messaging/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Concise Messaging"
+  short_description: "Apply the concise messaging synthesis workflow"
+  default_prompt: "Use $synthesis-concise-messaging to apply this workflow to the current task."

--- a/skills/synthesis-content-distribution/agents/openai.yaml
+++ b/skills/synthesis-content-distribution/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Content Distribution"
+  short_description: "Apply the content distribution synthesis workflow"
+  default_prompt: "Use $synthesis-content-distribution to apply this workflow to the current task."

--- a/skills/synthesis-content-framing/agents/openai.yaml
+++ b/skills/synthesis-content-framing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Content Framing"
+  short_description: "Apply the content framing synthesis workflow"
+  default_prompt: "Use $synthesis-content-framing to apply this workflow to the current task."

--- a/skills/synthesis-content-quality/agents/openai.yaml
+++ b/skills/synthesis-content-quality/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Content Quality"
+  short_description: "Apply the content quality synthesis workflow"
+  default_prompt: "Use $synthesis-content-quality to apply this workflow to the current task."

--- a/skills/synthesis-context-lifecycle/agents/openai.yaml
+++ b/skills/synthesis-context-lifecycle/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Context Lifecycle"
+  short_description: "Apply the context lifecycle synthesis workflow"
+  default_prompt: "Use $synthesis-context-lifecycle to apply this workflow to the current task."

--- a/skills/synthesis-creative-writer/agents/openai.yaml
+++ b/skills/synthesis-creative-writer/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Creative Writer"
+  short_description: "Apply the creative writer synthesis workflow"
+  default_prompt: "Use $synthesis-creative-writer to apply this workflow to the current task."

--- a/skills/synthesis-daily-rituals/SKILL.md
+++ b/skills/synthesis-daily-rituals/SKILL.md
@@ -10,7 +10,7 @@ depends_on:
   - synthesis-checkpoint
 metadata:
   author: "Rajiv Pant"
-  version: "2.14.0"
+  version: "2.16.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -18,6 +18,16 @@ metadata:
 # Daily Rituals — Global Checklists
 
 Standard day-start and day-end rituals for synthesis engineering projects. These are the global (per-person) checklists. Each project may have a project-specific supplement that extends these with channel-specific sync, repo-specific checks, and stakeholder-specific communications.
+
+## v2.16.0 — Agent-neutral day-end runtime
+
+v2.16.0 (2026-07-29) installs the launcher and macOS nudge under
+`~/.synthesis/day-end/`, a stable runtime owned by synthesis rather than by one
+agent client's skill cache. The launcher can open Codex or Claude Code; `auto`
+prefers Codex when both CLIs are present, and `--agent codex|claude` persists an
+explicit choice. The installer atomically writes exact files, refuses
+symlinked runtime roots, never removes the runtime tree, and verifies source
+survival in its tests.
 
 ## v2.15.1 — Message-guard doctor joins Day-Start Step 1
 
@@ -48,7 +58,7 @@ v2.14.0 (2026-07-08) redesigns the day-end around the observed failure mode: on 
    ```
 
    `streak_day_end` = consecutive workdays with a completed day-end, computed from history at write time. Consumers: the synthesis-console day-end chip, the nudge's suppression check, and the day-start brief line ("day-end: ran Mon ✓ quick · skipped Tue").
-7. **Launcher + nudge ship in `scripts/`.** The ritual is an Agent Skill and always runs INSIDE an agentic coding session — nothing here changes that. `scripts/day-end` is a *launcher, not a runner*: it opens an agent session (Claude Code by default; `DAY_END_AGENT_CMD` overrides) with the ritual invocation as the first prompt, purely to remove cold-start friction at the end of the day. `scripts/day-end-nudge.sh` + `scripts/com.synthesis.day-end-nudge.plist` show one generic macOS banner at 16:55 on weekdays unless the state file says today's day-end already ran — notification only, never a mutation, generic fixed text (see the alert-confidentiality rule below). Install steps follow.
+7. **Launcher + nudge ship in `scripts/`.** The ritual is an Agent Skill and always runs INSIDE an agentic coding session — nothing here changes that. `scripts/day-end` is a *launcher, not a runner*: it opens Codex or Claude Code with the ritual invocation as the first prompt, purely to remove cold-start friction at the end of the day. `DAY_END_AGENT_CMD` selects a CLI for one run; the installed `agent-cli` file persists `auto`, `codex`, or `claude`. `scripts/day-end-nudge.sh` shows one generic macOS banner at 16:55 on weekdays unless the state file says today's day-end already ran — notification only, never a mutation, generic fixed text (see the alert-confidentiality rule below). Install steps follow.
 8. **Audio-alert section aligned with alert confidentiality.** Spoken alerts and banners carry zero identifying content and honor the `~/.synthesis/quiet-audio` mute flag — matching the synthesis-repo-guard v2 alert model. The old `say "[user], [task description] is complete"` pattern is retired: task descriptions can name clients, repos, or people, and speakers/screen-shares leak.
 
 **Consumer coupling:** synthesis-console renders `state.json` (day-end chip) and `**Decays:**` lines (draft badges). Producer-grammar changes here require the console's `docs/cockpit-design.md` to change in the same wave — the document-as-contract rule.
@@ -56,15 +66,20 @@ v2.14.0 (2026-07-08) redesigns the day-end around the observed failure mode: on 
 ### Installing the launcher and nudge (macOS)
 
 ```bash
-# Launcher on PATH (point the symlink at any PATH dir you use)
-ln -sf <synthesis-daily-rituals-root>/scripts/day-end ~/.local/bin/day-end
+# Auto-select Codex first when both supported clients are available
+python3 <synthesis-daily-rituals-root>/scripts/install_day_end.py
 
-# Nudge LaunchAgent (16:55 weekdays, state-aware, notification-only)
-cp <synthesis-daily-rituals-root>/scripts/com.synthesis.day-end-nudge.plist ~/Library/LaunchAgents/
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.synthesis.day-end-nudge.plist
+# Or persist one client explicitly
+python3 <synthesis-daily-rituals-root>/scripts/install_day_end.py --agent codex
+python3 <synthesis-daily-rituals-root>/scripts/install_day_end.py --agent claude
 ```
 
-The plist resolves the nudge script through `$HOME/.claude/skills/.../scripts/` — the installed copy — so ordinary skill reinstalls keep it current without touching launchd. After changing the plist itself: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.synthesis.day-end-nudge.plist`, then re-`bootstrap`.
+The installer copies the launcher and nudge into
+`~/.synthesis/day-end/bin/`, links `~/.local/bin/day-end` to that stable
+runtime, writes the LaunchAgent with an absolute program path, and reloads it.
+Re-run the installer after the skill changes. Use `--no-launchctl` only for CI
+or an installation audit that should write and verify artifacts without
+loading the LaunchAgent.
 
 ## v2.13.0 — Per-workspace `repos.yaml` is the machine-readable repo list
 

--- a/skills/synthesis-daily-rituals/agents/openai.yaml
+++ b/skills/synthesis-daily-rituals/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Daily Rituals"
+  short_description: "Apply the daily rituals synthesis workflow"
+  default_prompt: "Use $synthesis-daily-rituals to apply this workflow to the current task."

--- a/skills/synthesis-daily-rituals/scripts/com.synthesis.day-end-nudge.plist
+++ b/skills/synthesis-daily-rituals/scripts/com.synthesis.day-end-nudge.plist
@@ -8,7 +8,7 @@
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>exec "$HOME/.claude/skills/synthesis-daily-rituals/scripts/day-end-nudge.sh"</string>
+    <string>exec "$HOME/.synthesis/day-end/bin/day-end-nudge.sh"</string>
   </array>
   <key>StartCalendarInterval</key>
   <array>

--- a/skills/synthesis-daily-rituals/scripts/day-end
+++ b/skills/synthesis-daily-rituals/scripts/day-end
@@ -2,15 +2,65 @@
 # day-end — launcher for the synthesis-daily-rituals Day-End ritual.
 #
 # The ritual is an Agent Skill and always runs INSIDE an agentic coding
-# session (Claude Code by default). This script is a launcher, not a
-# runner: it only removes cold-start friction by opening such a session
-# with the ritual invocation as the first prompt. Inside an already-open
-# session, invoke the skill directly and ignore this launcher.
+# session. This script is a launcher, not a runner: it only removes
+# cold-start friction by opening Codex or Claude Code with the ritual
+# invocation as the first prompt. Inside an already-open session, invoke
+# the skill directly and ignore this launcher.
 #
 # Usage: day-end [-f|-q|-o]
 #   -f full · -q quick close · -o observer · default: the session asks.
-# Override the agent CLI with DAY_END_AGENT_CMD (default: claude).
+# Selection order:
+#   1. DAY_END_AGENT_CMD
+#   2. <runtime-root>/agent-cli (auto|codex|claude)
+#   3. auto (Codex first, then Claude Code)
 set -euo pipefail
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$SOURCE_DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
+RUNTIME_ROOT="$(cd -P "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
+
+configured_agent() {
+  if [ -n "${DAY_END_AGENT_CMD:-}" ]; then
+    printf '%s\n' "$DAY_END_AGENT_CMD"
+    return
+  fi
+  if [ -f "$RUNTIME_ROOT/agent-cli" ]; then
+    IFS= read -r selection < "$RUNTIME_ROOT/agent-cli"
+    printf '%s\n' "${selection:-auto}"
+    return
+  fi
+  printf '%s\n' "auto"
+}
+
+AGENT="$(configured_agent)"
+case "$AGENT" in
+  auto)
+    if command -v codex >/dev/null 2>&1; then
+      AGENT="codex"
+    elif command -v claude >/dev/null 2>&1; then
+      AGENT="claude"
+    else
+      echo "day-end: neither codex nor claude is available on PATH" >&2
+      exit 127
+    fi
+    ;;
+  codex|claude) ;;
+  *)
+    echo "day-end: agent-cli must be auto, codex, or claude (got: $AGENT)" >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v "$AGENT" >/dev/null 2>&1; then
+  echo "day-end: configured agent CLI is unavailable: $AGENT" >&2
+  exit 127
+fi
+
 MODE_LINE="Ask me the one-letter mode question (f = full, q = quick close, o = observer) before starting."
 case "${1:-}" in
   -f) MODE_LINE="Mode: full." ;;
@@ -20,4 +70,4 @@ case "${1:-}" in
   *) echo "usage: day-end [-f|-q|-o]" >&2; exit 2 ;;
 esac
 PROMPT="Please name this session day-end-$(date +%Y-%m-%d). Run the synthesis-daily-rituals Day-End ritual now. ${MODE_LINE}"
-exec "${DAY_END_AGENT_CMD:-claude}" "$PROMPT"
+exec "$AGENT" "$PROMPT"

--- a/skills/synthesis-daily-rituals/scripts/install_day_end.py
+++ b/skills/synthesis-daily-rituals/scripts/install_day_end.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Install the agent-neutral day-end launcher and macOS nudge runtime."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import NoReturn
+
+
+LABEL = "com.synthesis.day-end-nudge"
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def fail(message: str) -> NoReturn:
+    raise RuntimeError(message)
+
+
+def ensure_safe_root(home: Path, runtime_root: Path) -> None:
+    expected = home / ".synthesis" / "day-end"
+    if runtime_root != expected:
+        fail(f"runtime root must be exactly {expected}, got {runtime_root}")
+    if runtime_root in {Path("/"), home, Path.cwd()}:
+        fail(f"refusing protected runtime root: {runtime_root}")
+
+    cursor = home
+    for part in (".synthesis", "day-end"):
+        cursor = cursor / part
+        if cursor.is_symlink():
+            fail(f"refusing symlinked runtime path: {cursor}")
+
+
+def atomic_write(path: Path, payload: bytes, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        fail(f"refusing to replace symlinked runtime file: {path}")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.chmod(mode)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def install_symlink(link: Path, target: Path) -> None:
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if link.exists() and not link.is_symlink():
+        fail(f"refusing to replace non-symlink launcher: {link}")
+    if link.is_symlink() and link.resolve(strict=False) == target:
+        return
+    temporary = link.with_name(f".{link.name}.new-{os.getpid()}")
+    temporary.unlink(missing_ok=True)
+    temporary.symlink_to(target)
+    os.replace(temporary, link)
+
+
+def plist_payload(nudge_script: Path) -> bytes:
+    payload = plistlib.loads(
+        (SCRIPT_DIR / f"{LABEL}.plist").read_bytes()
+    )
+    if payload.get("Label") != LABEL:
+        fail("LaunchAgent template label does not match the installer")
+    payload["ProgramArguments"] = [str(nudge_script)]
+    return plistlib.dumps(payload, sort_keys=False)
+
+
+def run_launchctl(plist: Path) -> None:
+    domain = f"gui/{os.getuid()}"
+    subprocess.run(
+        ["launchctl", "bootout", domain, str(plist)],
+        capture_output=True,
+        check=False,
+    )
+    completed = subprocess.run(
+        ["launchctl", "bootstrap", domain, str(plist)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode:
+        fail(
+            "launchctl bootstrap failed: "
+            + (completed.stderr.strip() or completed.stdout.strip())
+        )
+
+
+def install(agent: str | None, no_launchctl: bool) -> None:
+    home = Path.home()
+    runtime_root = home / ".synthesis" / "day-end"
+    ensure_safe_root(home, runtime_root)
+
+    launcher = runtime_root / "bin" / "day-end"
+    nudge = runtime_root / "bin" / "day-end-nudge.sh"
+    atomic_write(launcher, (SCRIPT_DIR / "day-end").read_bytes(), 0o755)
+    atomic_write(nudge, (SCRIPT_DIR / "day-end-nudge.sh").read_bytes(), 0o755)
+
+    selection_file = runtime_root / "agent-cli"
+    if agent is not None or not selection_file.exists():
+        atomic_write(selection_file, f"{agent or 'auto'}\n".encode(), 0o600)
+
+    install_symlink(home / ".local" / "bin" / "day-end", launcher)
+
+    launch_agent = home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+    atomic_write(launch_agent, plist_payload(nudge), 0o644)
+
+    if not no_launchctl:
+        if sys.platform != "darwin" or shutil.which("launchctl") is None:
+            fail("launchctl is required unless --no-launchctl is supplied")
+        run_launchctl(launch_agent)
+
+    print(f"installed day-end runtime: {runtime_root}")
+    print(f"agent selection: {selection_file.read_text().strip()}")
+    print(f"launcher: {home / '.local' / 'bin' / 'day-end'}")
+    print(f"nudge: {launch_agent}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--agent",
+        choices=("auto", "codex", "claude"),
+        help="persist the preferred launcher; existing choice is preserved if omitted",
+    )
+    parser.add_argument(
+        "--no-launchctl",
+        action="store_true",
+        help="write and verify artifacts without loading the LaunchAgent",
+    )
+    args = parser.parse_args()
+    try:
+        install(args.agent, args.no_launchctl)
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        print(f"day-end install failed: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/synthesis-daily-rituals/scripts/test_install_day_end.py
+++ b/skills/synthesis-daily-rituals/scripts/test_install_day_end.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+INSTALLER = SCRIPT_DIR / "install_day_end.py"
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def run_installer(home: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    environment = dict(os.environ)
+    environment["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, str(INSTALLER), "--no-launchctl", *arguments],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+    )
+
+
+def fake_cli(path: Path, name: str) -> None:
+    executable = path / name
+    executable.write_text(
+        "#!/bin/sh\nprintf '%s\\n' \"$0|$*\" > \"$DAY_END_TEST_RECORD\"\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+
+
+def test_installer_uses_stable_runtime_and_preserves_source(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    source_digests = {
+        name: digest(SCRIPT_DIR / name)
+        for name in ("day-end", "day-end-nudge.sh")
+    }
+
+    completed = run_installer(home)
+    assert completed.returncode == 0, completed.stderr
+
+    runtime = home / ".synthesis" / "day-end"
+    assert (runtime / "agent-cli").read_text() == "auto\n"
+    assert (home / ".local" / "bin" / "day-end").resolve() == runtime / "bin" / "day-end"
+
+    plist_path = home / "Library" / "LaunchAgents" / "com.synthesis.day-end-nudge.plist"
+    with plist_path.open("rb") as handle:
+        plist = plistlib.load(handle)
+    assert plist["ProgramArguments"] == [str(runtime / "bin" / "day-end-nudge.sh")]
+    assert ".claude" not in plist_path.read_text(encoding="utf-8")
+    assert ".codex" not in plist_path.read_text(encoding="utf-8")
+
+    for name, before in source_digests.items():
+        assert digest(SCRIPT_DIR / name) == before
+
+
+def test_launcher_auto_prefers_codex_and_honors_selection(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    assert run_installer(home).returncode == 0
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_cli(fake_bin, "codex")
+    fake_cli(fake_bin, "claude")
+    record = tmp_path / "record"
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "HOME": str(home),
+            "PATH": str(fake_bin) + os.pathsep + os.environ["PATH"],
+            "DAY_END_TEST_RECORD": str(record),
+        }
+    )
+    launcher = home / ".local" / "bin" / "day-end"
+
+    completed = subprocess.run(
+        [str(launcher), "-q"], env=environment, capture_output=True, text=True, check=False
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert record.read_text().startswith(str(fake_bin / "codex") + "|")
+
+    assert run_installer(home, "--agent", "claude").returncode == 0
+    completed = subprocess.run(
+        [str(launcher), "-f"], env=environment, capture_output=True, text=True, check=False
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert record.read_text().startswith(str(fake_bin / "claude") + "|")
+
+
+def test_installer_refuses_symlinked_runtime_root(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    synthesis = home / ".synthesis"
+    synthesis.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (synthesis / "day-end").symlink_to(elsewhere, target_is_directory=True)
+
+    completed = run_installer(home)
+    assert completed.returncode == 2
+    assert "symlinked runtime path" in completed.stderr
+    assert list(elsewhere.iterdir()) == []

--- a/skills/synthesis-fact-checking/agents/openai.yaml
+++ b/skills/synthesis-fact-checking/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Fact Checking"
+  short_description: "Apply the fact checking synthesis workflow"
+  default_prompt: "Use $synthesis-fact-checking to apply this workflow to the current task."

--- a/skills/synthesis-git-hooks/SKILL.md
+++ b/skills/synthesis-git-hooks/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.1.0"
+  version: "2.1.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -15,6 +15,13 @@ metadata:
 A YAML-driven pre-commit policy engine. Part of the synthesis-engineering operational layer — deterministic enforcement that catches credential leaks and exposure-sensitive content at the commit boundary, before the diff persists.
 
 The engine is small (one bash script + one Python sidecar). The policy is data — a YAML file at `~/.synthesis/git-hook-config.yaml` that anyone adopting synthesis engineering fills in with their own personal-remote patterns, client names, and internal URLs.
+
+## v2.1.1 — Native dual-runtime setup
+
+v2.1.1 (2026-07-29) makes the native synthesis plugin the primary skill setup
+for Codex and Claude Code. The enforcement runtime remains agent-neutral under
+`~/.synthesis/git-hooks/`; both clients invoke and diagnose the same installed
+engine.
 
 ## v2.0.0 — fail closed, zero dependencies, self-diagnosing
 
@@ -50,8 +57,13 @@ The classification is derived from `git remote -v` on every commit — no per-re
 ## Install
 
 ```bash
-# 1. Install this skill into ~/.claude/skills/ (or equivalent for your agent)
-npx skills add synthesisengineering/synthesis-skills --skill synthesis-git-hooks --copy
+# 1. Install the native plugin in the client you use
+codex plugin marketplace add synthesisengineering/synthesis-skills
+codex plugin add synthesis-skills@synthesis-engineering
+
+# Claude Code equivalent
+claude plugin marketplace add synthesisengineering/synthesis-skills
+claude plugin install synthesis-skills@synthesis-engineering
 
 # 2. Run the install script — copies the engine to ~/.synthesis/git-hooks/,
 #    sets git's core.hooksPath, and seeds an initial config from the template.

--- a/skills/synthesis-git-hooks/SKILL.md
+++ b/skills/synthesis-git-hooks/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.1.1"
+  version: "2.1.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -15,6 +15,14 @@ metadata:
 A YAML-driven pre-commit policy engine. Part of the synthesis-engineering operational layer — deterministic enforcement that catches credential leaks and exposure-sensitive content at the commit boundary, before the diff persists.
 
 The engine is small (one bash script + one Python sidecar). The policy is data — a YAML file at `~/.synthesis/git-hook-config.yaml` that anyone adopting synthesis engineering fills in with their own personal-remote patterns, client names, and internal URLs.
+
+## v2.1.2 — Exact-copy migration calibration
+
+v2.1.2 (2026-07-30) recognizes exact copies from already-committed files before
+scanning added lines. Canonical instruction migrations such as
+`CLAUDE.md` to `AGENTS.md` therefore scan the new adapter and any actual edits
+without treating the unchanged historical instruction body as a fresh leak.
+Genuinely new sensitive lines still block, covered by a paired regression.
 
 ## v2.1.1 — Native dual-runtime setup
 

--- a/skills/synthesis-git-hooks/agents/openai.yaml
+++ b/skills/synthesis-git-hooks/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Git Hooks"
+  short_description: "Apply the git hooks synthesis workflow"
+  default_prompt: "Use $synthesis-git-hooks to apply this workflow to the current task."

--- a/skills/synthesis-git-hooks/scripts/pre-commit
+++ b/skills/synthesis-git-hooks/scripts/pre-commit
@@ -87,14 +87,19 @@ eval "$SIDECAR_OUT"
 # Determine which files to scan. Always exclude files that contain pattern
 # definitions by design — adding a name to the policy is the opposite of
 # leaking it, but the diff still matches.
-CHANGED_FILES=$(git diff --cached --name-only --diff-filter=AM 2>/dev/null || true)
+# Detect exact copies from already-committed files. A canonical-file migration
+# (for example CLAUDE.md -> AGENTS.md plus a one-line adapter) must not rescan
+# hundreds of unchanged historical lines as newly introduced content. Copy
+# targets receive status C and are excluded by AM; genuinely new or modified
+# lines remain in scope.
+CHANGED_FILES=$(git diff --cached -C --find-copies-harder --name-only --diff-filter=AM 2>/dev/null || true)
 if [ -n "${DIFF_EXCLUDE_REGEX:-}" ] && [ -n "$CHANGED_FILES" ]; then
     CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v -E "$DIFF_EXCLUDE_REGEX" || true)
 fi
 
 MATCHES=""
 if [ -n "$CHANGED_FILES" ]; then
-    DIFF=$(echo "$CHANGED_FILES" | xargs git diff --cached --diff-filter=AM -U0 -- 2>/dev/null || true)
+    DIFF=$(echo "$CHANGED_FILES" | xargs git diff --cached -C --find-copies-harder --diff-filter=AM -U0 -- 2>/dev/null || true)
     if [ -n "$DIFF" ]; then
         # Stage 1: collect added lines that hit the active regex. Validate the
         # regex against an empty string first — if grep rejects the pattern

--- a/skills/synthesis-git-hooks/scripts/test_pre_commit.py
+++ b/skills/synthesis-git-hooks/scripts/test_pre_commit.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+HOOK = SCRIPT_DIR / "pre-commit"
+
+
+def run(repository: Path, *command: str, env: dict[str, str] | None = None):
+    return subprocess.run(
+        command,
+        cwd=repository,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def policy(path: Path) -> None:
+    path.write_text(
+        """\
+config_version: 1
+personal_remote_patterns:
+  - '[:/]never-matches/'
+tier_0_always:
+  credentials:
+    - 'AKIA[0-9A-Z]{16}'
+tier_1_strict_only:
+  confidentiality:
+    - 'confidential'
+check_commit_message: false
+""",
+        encoding="utf-8",
+    )
+
+
+def repository(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    root = tmp_path / "repo"
+    root.mkdir()
+    assert run(root, "git", "init").returncode == 0
+    assert run(root, "git", "config", "user.name", "Test").returncode == 0
+    assert run(root, "git", "config", "user.email", "test@example.com").returncode == 0
+    assert (
+        run(
+            root,
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/public-repo.git",
+        ).returncode
+        == 0
+    )
+    (root / "CLAUDE.md").write_text(
+        "# Rules\n\nDo not add confidential material.\n",
+        encoding="utf-8",
+    )
+    assert run(root, "git", "add", "CLAUDE.md").returncode == 0
+    assert (
+        run(
+            root,
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "commit",
+            "-m",
+            "Initial",
+        ).returncode
+        == 0
+    )
+    config = tmp_path / "policy.yaml"
+    policy(config)
+    environment = dict(os.environ)
+    environment["SYNTHESIS_GIT_HOOK_CONFIG"] = str(config)
+    return root, environment
+
+
+def test_exact_instruction_copy_is_not_rescanned(tmp_path: Path) -> None:
+    root, environment = repository(tmp_path)
+    (root / "AGENTS.md").write_bytes((root / "CLAUDE.md").read_bytes())
+    (root / "CLAUDE.md").write_text("@AGENTS.md\n", encoding="utf-8")
+    assert run(root, "git", "add", "AGENTS.md", "CLAUDE.md").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_genuinely_new_sensitive_line_still_blocks(tmp_path: Path) -> None:
+    root, environment = repository(tmp_path)
+    (root / "NEW.md").write_text("New confidential material.\n", encoding="utf-8")
+    assert run(root, "git", "add", "NEW.md").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1
+    assert "SENSITIVE PATTERN DETECTED" in completed.stdout

--- a/skills/synthesis-implementation-integrity/agents/openai.yaml
+++ b/skills/synthesis-implementation-integrity/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Implementation Integrity"
+  short_description: "Apply the implementation integrity synthesis workflow"
+  default_prompt: "Use $synthesis-implementation-integrity to apply this workflow to the current task."

--- a/skills/synthesis-inbox-cleanup/SKILL.md
+++ b/skills/synthesis-inbox-cleanup/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.3.1"
+  version: "1.3.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
   platform: "macOS (Apple Silicon and Intel)"
@@ -16,6 +16,13 @@ metadata:
 A manifest-driven email cleanup engine that scales the same human-curated rules across three account tool stacks on macOS: iCloud / generic IMAP, Microsoft 365 / outlook.com via Mail.app AppleScript, and Gmail via the workspace-mcp Gmail API (with optional native server-side filters).
 
 The engine is deterministic. Email content does not change rules at runtime. When an LLM is invoked — for new-sender categorization or for higher-risk paths like body-reading digests — sanitization defenses run first. The skill ships adversarial test fixtures so prompt-injection regressions surface in CI rather than in production.
+
+## v1.3.2 — Native dual-runtime setup
+
+v1.3.2 (2026-07-29) makes the repository's native plugin the primary setup
+path for Codex and Claude Code. The engine continues to install its private
+runtime and rules under `~/.synthesis/inbox-cleanup/`, independent of either
+client's skill cache.
 
 ## Architecture: public engine, private rules
 
@@ -237,8 +244,13 @@ The IMAP substring pitfall and the circumstantial-inference pitfall are document
 ## Setup
 
 ```bash
-# 1. Install the skill (Claude Code shown; same idea for Codex)
-npx skills add synthesisengineering/synthesis-skills --skill synthesis-inbox-cleanup --copy
+# 1. Install the native plugin in the client you use
+codex plugin marketplace add synthesisengineering/synthesis-skills
+codex plugin add synthesis-skills@synthesis-engineering
+
+# Claude Code equivalent
+claude plugin marketplace add synthesisengineering/synthesis-skills
+claude plugin install synthesis-skills@synthesis-engineering
 
 # 2. Run the installer — creates ~/.synthesis/inbox-cleanup/ with seed config + rules
 <synthesis-inbox-cleanup-root>/scripts/install.sh

--- a/skills/synthesis-inbox-cleanup/agents/openai.yaml
+++ b/skills/synthesis-inbox-cleanup/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Inbox Cleanup"
+  short_description: "Apply the inbox cleanup synthesis workflow"
+  default_prompt: "Use $synthesis-inbox-cleanup to apply this workflow to the current task."

--- a/skills/synthesis-link-research/agents/openai.yaml
+++ b/skills/synthesis-link-research/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Link Research"
+  short_description: "Apply the link research synthesis workflow"
+  default_prompt: "Use $synthesis-link-research to apply this workflow to the current task."

--- a/skills/synthesis-llm-setup/agents/openai.yaml
+++ b/skills/synthesis-llm-setup/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis LLM Setup"
+  short_description: "Apply the llm setup synthesis workflow"
+  default_prompt: "Use $synthesis-llm-setup to apply this workflow to the current task."

--- a/skills/synthesis-mac-sync/agents/openai.yaml
+++ b/skills/synthesis-mac-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Mac Sync"
+  short_description: "Apply the mac sync synthesis workflow"
+  default_prompt: "Use $synthesis-mac-sync to apply this workflow to the current task."

--- a/skills/synthesis-meeting-transcripts/agents/openai.yaml
+++ b/skills/synthesis-meeting-transcripts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Meeting Transcripts"
+  short_description: "Apply the meeting transcripts synthesis workflow"
+  default_prompt: "Use $synthesis-meeting-transcripts to apply this workflow to the current task."

--- a/skills/synthesis-message-guard/SKILL.md
+++ b/skills/synthesis-message-guard/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: synthesis-message-guard
 description: Fail-closed pre-send enforcement for agent-drafted correspondence. A PreToolUse hook blocks every message-sending or draft-creating tool call unless the outgoing text passes a deterministic register scan AND a fresh, single-use grounding ledger — sha256-bound to the exact message — attests that the composing agent read the full thread, searched prior correspondence, and mapped every factual claim to a source. Use when setting up, debugging, or composing under the guard; when a send is blocked; or when asked about message grounding, voice enforcement, or pre-send gates.
+license: "Apache-2.0"
+metadata:
+  author: "Rajiv Pant"
+  version: "1.1.0"
+  source_repo: "github.com/synthesisengineering/synthesis-skills"
+  source_type: "public"
 ---
 
 # Message Guard
 
-**Version 1.0.0** (2026-07-29)
+**Version 1.1.0** (2026-07-29)
 
 Prose rules do not survive contact with a model under load. This skill is the
 enforcement layer for correspondence the way commit hooks are the enforcement
@@ -55,8 +61,10 @@ composing agent                      engine (stdlib python, fail closed)
 - **Ledger:** `~/.synthesis/message-guard/ledger.json` — written per message,
   consumed on use (single-shot; no reuse across messages). Passed sends are
   appended to `log.jsonl` with the full ledger for audit.
-- **Wiring:** a `PreToolUse` entry in `~/.claude/settings.json` matching the
-  send/draft tool family across all MCP servers by name pattern.
+- **Wiring:** equivalent `PreToolUse` entries in Claude Code's
+  `~/.claude/settings.json` and Codex's `~/.codex/hooks.json`, each matching
+  the send/draft tool family across all MCP servers by name pattern. The doctor
+  requires every installed client to carry the guard.
 
 ## The ledger contract
 
@@ -86,7 +94,7 @@ message_guard.py --gate            # hook mode (stdin: tool-call JSON)
 message_guard.py --scan  < draft   # pre-check wording; exit 2 on block hits
 message_guard.py --sha   < draft   # sha256 for the ledger
 message_guard.py --ledger-template # skeleton
-message_guard.py --doctor          # config, controls, wiring, state dir
+message_guard.py --doctor          # config, controls, all client wiring, state dir
 message_guard.py --test            # behavioral suite (12 cases)
 ```
 
@@ -103,9 +111,10 @@ message_guard.py --test            # behavioral suite (12 cases)
    messages and BLOCK the incident drafts. Re-run calibration whenever
    patterns change; a guard that blocks the principal's own voice is
    miscalibrated, not strict.
-4. **Monitored.** The doctor runs in the day-start ritual (synthesis-daily-
-   rituals Step 1) alongside the commit-hook doctor. A guard nobody monitors
-   is already broken.
+4. **Monitored across clients.** The doctor runs in the day-start ritual
+   (synthesis-daily-rituals Step 1) alongside the commit-hook doctor. It checks
+   Claude Code and Codex independently whenever each client is installed; one
+   healthy client cannot hide an unwired peer.
 
 ## Known limits — stated, not hidden
 

--- a/skills/synthesis-message-guard/agents/openai.yaml
+++ b/skills/synthesis-message-guard/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Message Guard"
+  short_description: "Apply the message guard synthesis workflow"
+  default_prompt: "Use $synthesis-message-guard to apply this workflow to the current task."

--- a/skills/synthesis-message-guard/scripts/message_guard.py
+++ b/skills/synthesis-message-guard/scripts/message_guard.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """synthesis-message-guard — fail-closed pre-send gate for agent-drafted correspondence.
 
-v1.0.0 (2026-07-29)
+v1.1.0 (2026-07-29)
 
 A PreToolUse hook engine that blocks message-sending and draft-creating tool
 calls unless (a) the outgoing text passes a deterministic register scan against
@@ -27,27 +27,31 @@ Modes:
   --scan            read message text on stdin, print scan findings, exit 2 if
                     any block-tier hit. Lets an agent pre-check wording.
   --ledger-template print a skeleton ledger JSON.
-  --doctor          self-check; exit 0 HEALTHY / 2 UNHEALTHY.
+  --doctor          self-check, including every active client hook config;
+                    exit 0 HEALTHY / 2 UNHEALTHY.
   --test            behavioral test suite; exit 0 all pass / 2 failures.
 
 Environment overrides (used by --test; safe to leave unset):
   MESSAGE_GUARD_CONFIG     path to patterns/config JSON
                            (default ~/.synthesis/message-guard/patterns.json)
   MESSAGE_GUARD_STATE_DIR  ledger/log dir (default ~/.synthesis/message-guard)
-  MESSAGE_GUARD_SETTINGS   settings.json to inspect in --doctor
-                           (default ~/.claude/settings.json)
+  MESSAGE_GUARD_CLAUDE_SETTINGS  Claude Code hooks to inspect in --doctor
+                                 (default ~/.claude/settings.json)
+  MESSAGE_GUARD_CODEX_HOOKS      Codex hooks to inspect in --doctor
+                                 (default ~/.codex/hooks.json)
 """
 
 import hashlib
 import json
 import os
 import re
+import shutil
 import sys
 import tempfile
 import time
 from datetime import datetime, timezone
 
-ENGINE_VERSION = "1.0.0"
+ENGINE_VERSION = "1.1.0"
 
 
 def config_path():
@@ -304,6 +308,26 @@ POSITIVE_CONTROL_CLEAN = ("Thank you for writing this up properly. The step "
                           "you and I will make one of them work.")
 
 
+def hook_config_covers(path, sample_tools):
+    """Return whether a Claude Code or Codex hook config gates every sample."""
+    with open(path, "r", encoding="utf-8") as fh:
+        settings = json.load(fh)
+    for entry in settings.get("hooks", {}).get("PreToolUse", []):
+        matcher = entry.get("matcher", "")
+        guard_present = any(
+            "message_guard.py" in hook.get("command", "")
+            for hook in entry.get("hooks", [])
+        )
+        if not guard_present:
+            continue
+        try:
+            if matcher and all(re.search(matcher, tool) for tool in sample_tools):
+                return True
+        except re.error:
+            return False
+    return False
+
+
 def run_doctor():
     ok = True
 
@@ -338,11 +362,13 @@ def run_doctor():
     sample_tools = [
         "mcp__abc123__slack_send_message",
         "mcp__abc123__slack_send_message_draft",
+        "mcp__abc123__slack_schedule_message",
         "mcp__workspace-mcp__draft_gmail_message",
         "mcp__workspace-mcp__send_gmail_message",
         "mcp__d01c__create_draft",
         "mcp__d01c__update_draft",
         "mcp__apple-mail__send_email",
+        "mcp__mail__send_message",
     ]
     missed = [t for t in sample_tools if not any(rx.search(t) for rx in gated)]
     report(not missed, "gated patterns cover the send/draft tool family",
@@ -350,24 +376,43 @@ def run_doctor():
     report(any(rx.search("mcp__ccd_session_mgmt__send_message") for rx in exempt),
            "inter-session messaging is exempted")
 
-    settings_file = os.environ.get(
-        "MESSAGE_GUARD_SETTINGS", os.path.expanduser("~/.claude/settings.json"))
-    try:
-        with open(settings_file, "r", encoding="utf-8") as fh:
-            settings = json.load(fh)
-        wired = False
-        for entry in settings.get("hooks", {}).get("PreToolUse", []):
-            for h in entry.get("hooks", []):
-                if "message_guard.py" in h.get("command", ""):
-                    matcher = entry.get("matcher", "")
-                    try:
-                        wired = all(
-                            re.search(matcher, t) for t in sample_tools)
-                    except re.error:
-                        wired = False
-        report(wired, "settings.json PreToolUse wiring covers the tool family")
-    except Exception as exc:
-        report(False, "settings.json readable", str(exc))
+    client_configs = [
+        (
+            "Claude Code",
+            "claude",
+            "MESSAGE_GUARD_CLAUDE_SETTINGS",
+            os.path.expanduser("~/.claude/settings.json"),
+        ),
+        (
+            "Codex",
+            "codex",
+            "MESSAGE_GUARD_CODEX_HOOKS",
+            os.path.expanduser("~/.codex/hooks.json"),
+        ),
+    ]
+    active_clients = 0
+    for label, executable, environment_key, default_path in client_configs:
+        config_file = os.environ.get(environment_key, default_path)
+        explicitly_configured = environment_key in os.environ
+        active = (
+            explicitly_configured
+            or os.path.exists(config_file)
+            or shutil.which(executable) is not None
+        )
+        if not active:
+            print("  ok  %s hook wiring: client is not installed" % label)
+            continue
+        active_clients += 1
+        try:
+            wired = hook_config_covers(config_file, sample_tools)
+            report(
+                wired,
+                "%s PreToolUse wiring covers the tool family" % label,
+                config_file,
+            )
+        except Exception as exc:
+            report(False, "%s hook config readable" % label, str(exc))
+    report(active_clients > 0, "at least one supported agent client is active")
 
     try:
         os.makedirs(state_dir(), exist_ok=True)

--- a/skills/synthesis-message-guard/scripts/test_message_guard.py
+++ b/skills/synthesis-message-guard/scripts/test_message_guard.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("message_guard.py")
+SPEC = importlib.util.spec_from_file_location("message_guard", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+SAMPLE_TOOLS = [
+    "mcp__abc__slack_send_message",
+    "mcp__abc__slack_send_message_draft",
+    "mcp__abc__slack_schedule_message",
+    "mcp__workspace__draft_gmail_message",
+    "mcp__workspace__send_gmail_message",
+    "mcp__mail__create_draft",
+    "mcp__mail__update_draft",
+    "mcp__apple-mail__send_email",
+    "mcp__mail__send_message",
+]
+MATCHER = (
+    "mcp__.*__(slack_send_message|slack_send_message_draft|"
+    "slack_schedule_message|draft_gmail_message|send_gmail_message|"
+    "create_draft|update_draft|send_email|send_message)$"
+)
+
+
+def write_hooks(path: Path, matcher: str, command: str) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": matcher,
+                            "hooks": [{"type": "command", "command": command}],
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_hook_config_accepts_claude_and_codex_shape(tmp_path: Path) -> None:
+    for filename in ("settings.json", "hooks.json"):
+        path = tmp_path / filename
+        write_hooks(path, MATCHER, "python3 message_guard.py --gate")
+        assert MODULE.hook_config_covers(path, SAMPLE_TOOLS)
+
+
+def test_hook_config_rejects_partial_matcher(tmp_path: Path) -> None:
+    path = tmp_path / "hooks.json"
+    write_hooks(
+        path,
+        "mcp__.*__slack_send_message$",
+        "python3 message_guard.py --gate",
+    )
+    assert not MODULE.hook_config_covers(path, SAMPLE_TOOLS)
+
+
+def test_hook_config_rejects_missing_guard(tmp_path: Path) -> None:
+    path = tmp_path / "hooks.json"
+    write_hooks(path, MATCHER, "python3 another_guard.py --gate")
+    assert not MODULE.hook_config_covers(path, SAMPLE_TOOLS)

--- a/skills/synthesis-model-tiers/agents/openai.yaml
+++ b/skills/synthesis-model-tiers/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Model Tiers"
+  short_description: "Apply the model tiers synthesis workflow"
+  default_prompt: "Use $synthesis-model-tiers to apply this workflow to the current task."

--- a/skills/synthesis-pr-review/agents/openai.yaml
+++ b/skills/synthesis-pr-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis PR Review"
+  short_description: "Apply the pr review synthesis workflow"
+  default_prompt: "Use $synthesis-pr-review to apply this workflow to the current task."

--- a/skills/synthesis-preflight/agents/openai.yaml
+++ b/skills/synthesis-preflight/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Preflight"
+  short_description: "Apply the preflight synthesis workflow"
+  default_prompt: "Use $synthesis-preflight to apply this workflow to the current task."

--- a/skills/synthesis-project-management/agents/openai.yaml
+++ b/skills/synthesis-project-management/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Project Management"
+  short_description: "Apply the project management synthesis workflow"
+  default_prompt: "Use $synthesis-project-management to apply this workflow to the current task."

--- a/skills/synthesis-reader-briefing/agents/openai.yaml
+++ b/skills/synthesis-reader-briefing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Reader Briefing"
+  short_description: "Apply the reader briefing synthesis workflow"
+  default_prompt: "Use $synthesis-reader-briefing to apply this workflow to the current task."

--- a/skills/synthesis-repo-guard/agents/openai.yaml
+++ b/skills/synthesis-repo-guard/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Repo Guard"
+  short_description: "Apply the repo guard synthesis workflow"
+  default_prompt: "Use $synthesis-repo-guard to apply this workflow to the current task."

--- a/skills/synthesis-response-merger/agents/openai.yaml
+++ b/skills/synthesis-response-merger/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Response Merger"
+  short_description: "Apply the response merger synthesis workflow"
+  default_prompt: "Use $synthesis-response-merger to apply this workflow to the current task."

--- a/skills/synthesis-review-triage/agents/openai.yaml
+++ b/skills/synthesis-review-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Review Triage"
+  short_description: "Apply the review triage synthesis workflow"
+  default_prompt: "Use $synthesis-review-triage to apply this workflow to the current task."

--- a/skills/synthesis-skills-manager/agents/openai.yaml
+++ b/skills/synthesis-skills-manager/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Skills Manager"
+  short_description: "Apply the skills manager synthesis workflow"
+  default_prompt: "Use $synthesis-skills-manager to apply this workflow to the current task."

--- a/skills/synthesis-slack-sync/SKILL.md
+++ b/skills/synthesis-slack-sync/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 metadata:
   depends_on: "synthesis-daily-rituals, synthesis-project-management"
   author: "Rajiv Pant"
-  version: "3.3.0"
+  version: "3.3.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -15,6 +15,13 @@ metadata:
 A protocol for syncing Slack channels and threads to local transcript files using Slack MCP. Designed for AI-assisted workflows where an agent reads Slack on behalf of a user, saves transcripts locally, and updates a daily action plan.
 
 This skill provides the **protocol** — the sync methodology, thread re-reading discipline, transcript format, and action plan update rules. A per-project **config file** provides the specifics: which channels, which paths, which DMs. Prefer `.agents/slack-sync.yaml`; existing `.claude/slack-sync.yaml` configs remain supported.
+
+## v3.3.1 — Runtime-resolved checker
+
+v3.3.1 (2026-07-29) invokes the thread checker relative to the skill root
+resolved by the active plugin runtime. The protocol no longer binds Slack sync
+to an `.agents` copy, so Codex and Claude Code execute the same checker from the
+same committed skill version.
 
 ## v3.3.0 — Two-Tier Draft Block: Templates Move into Files
 
@@ -229,9 +236,9 @@ Every sync — whether day-start, mid-day, or day-end — follows these steps. N
 Before doing anything else, run the thread checker script on each transcript file that exists for today:
 
 ```bash
-python3 ~/.agents/skills/synthesis-slack-sync/thread_checker.py {transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/<channel>.md [action_plan_file]
-python3 ~/.agents/skills/synthesis-slack-sync/thread_checker.py {transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/_dms.md [action_plan_file]
-python3 ~/.agents/skills/synthesis-slack-sync/thread_checker.py {transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/_group-dms.md [action_plan_file]
+python3 <synthesis-slack-sync-root>/thread_checker.py {transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/<channel>.md [action_plan_file]
+python3 <synthesis-slack-sync-root>/thread_checker.py {transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/_dms.md [action_plan_file]
+python3 <synthesis-slack-sync-root>/thread_checker.py {transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/_group-dms.md [action_plan_file]
 ```
 
 Skip any file that does not yet exist (e.g., no DMs synced today). Combine the output from all runs into a single checklist. You MUST re-read every thread listed during Step 2. The script exists because manually deciding which threads to re-read has repeatedly failed — threads get skipped and messages get missed.

--- a/skills/synthesis-slack-sync/agents/openai.yaml
+++ b/skills/synthesis-slack-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Slack Sync"
+  short_description: "Apply the slack sync synthesis workflow"
+  default_prompt: "Use $synthesis-slack-sync to apply this workflow to the current task."

--- a/skills/synthesis-technical-advisor/agents/openai.yaml
+++ b/skills/synthesis-technical-advisor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Technical Advisor"
+  short_description: "Apply the technical advisor synthesis workflow"
+  default_prompt: "Use $synthesis-technical-advisor to apply this workflow to the current task."

--- a/skills/synthesis-thinking-framework/agents/openai.yaml
+++ b/skills/synthesis-thinking-framework/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Thinking Framework"
+  short_description: "Apply the thinking framework synthesis workflow"
+  default_prompt: "Use $synthesis-thinking-framework to apply this workflow to the current task."

--- a/skills/synthesis-tree-of-thought/agents/openai.yaml
+++ b/skills/synthesis-tree-of-thought/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Tree Of Thought"
+  short_description: "Apply the tree of thought synthesis workflow"
+  default_prompt: "Use $synthesis-tree-of-thought to apply this workflow to the current task."

--- a/skills/synthesis-voice-profiler/agents/openai.yaml
+++ b/skills/synthesis-voice-profiler/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Voice Profiler"
+  short_description: "Apply the voice profiler synthesis workflow"
+  default_prompt: "Use $synthesis-voice-profiler to apply this workflow to the current task."

--- a/skills/synthesis-writing-craft/agents/openai.yaml
+++ b/skills/synthesis-writing-craft/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Writing Craft"
+  short_description: "Apply the writing craft synthesis workflow"
+  default_prompt: "Use $synthesis-writing-craft to apply this workflow to the current task."

--- a/skills/synthesis-writing-pitfalls/agents/openai.yaml
+++ b/skills/synthesis-writing-pitfalls/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Writing Pitfalls"
+  short_description: "Apply the writing pitfalls synthesis workflow"
+  default_prompt: "Use $synthesis-writing-pitfalls to apply this workflow to the current task."


### PR DESCRIPTION
## Summary

- add explicit Codex interfaces for all 49 public skills and require them in source conformance
- move day-end automation to a stable synthesis-owned runtime with Codex or Claude Code selection
- verify correspondence hook wiring independently for every installed agent client
- remove client-bound runtime paths from Slack, inbox, and commit-protection workflows
- calibrate commit scanning so exact canonical-file copies are not misclassified as newly introduced content

## Verification

- 111 source conformance checks
- agent-conformance, coordination, knowledge-base, OKF, day-end, message-guard, and commit-guard test suites
- message-guard behavioral controls
- installer, compile, adversarial inbox, and resolver suites