### PR TITLE
Small fixes

### DIFF
--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -53,10 +53,16 @@ def run(command: list[str], timeout: int = 30) -> subprocess.CompletedProcess[st
 
 
 def json_from_output(output: str) -> object:
-    starts = [pos for pos in (output.find("{"), output.find("[")) if pos >= 0]
-    if not starts:
-        raise ValueError("command returned no JSON")
-    return json.loads(output[min(starts) :])
+    decoder = json.JSONDecoder()
+    for position, character in enumerate(output):
+        if character not in "[{":
+            continue
+        try:
+            value, _ = decoder.raw_decode(output, position)
+        except json.JSONDecodeError:
+            continue
+        return value
+    raise ValueError("command returned no JSON")
 
 
 def file_digest(path: Path) -> str:
@@ -284,7 +290,7 @@ def runtime_checks() -> list[Check]:
 
     doctor = run(["codex", "doctor", "--json"])
     try:
-        data = json_from_output(doctor.stdout)
+        data = json_from_output(doctor.stdout + "\n" + doctor.stderr)
         provider = data["checks"]["network.provider_reachability"]["status"] == "ok"
         websocket = data["checks"]["network.websocket_reachability"]["status"] == "ok"
         add(checks, "runtime.codex-provider", provider, "HTTP reachability")

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -56,6 +56,18 @@ def write_manifests(root: Path) -> None:
         configuration.write_text("{}\n", encoding="utf-8")
 
 
+def test_json_from_output_accepts_cli_diagnostics_around_json() -> None:
+    output = (
+        "WARNING: [aliases] could not be refreshed\n"
+        '{"installed": [{"name": "synthesis-skills"}]}\n'
+        "WARNING: proceeding with cached aliases\n"
+    )
+
+    assert MODULE.json_from_output(output) == {
+        "installed": [{"name": "synthesis-skills"}]
+    }
+
+
 def test_source_checks_accept_dual_manifest(tmp_path: Path) -> None:
     write_manifests(tmp_path)
     write_skill(tmp_path, "synthesis-test")


### PR DESCRIPTION
## Summary

- accept structured CLI output when operational diagnostics appear before or after the JSON payload
- include both output streams when reading client health results
- cover the mixed-output case with a regression test

## Verification

- installer tests passed
- agent-conformance tests passed (8)
- coordination tests passed (3)
- knowledge-base and OKF tests passed (8)
- daily-ritual, message-guard, and git-hook tests passed (8)
- source conformance passed for all 49 skills