### PR TITLE
Small fixes

### DIFF
--- a/skills/synthesis-agent-conformance/scripts/session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/session_context.py
@@ -30,7 +30,25 @@ def next_actions(context: str) -> list[str]:
     )
     if not match:
         return []
-    return [line.strip() for line in match.group(1).splitlines() if line.strip()][:5]
+    lines = [line.strip() for line in match.group(1).splitlines()]
+    checklist = re.compile(r"^(?:[-*]|\d+\.)\s+\[([ xX])\]\s+")
+    items: list[tuple[bool, list[str]]] = []
+    current: tuple[bool, list[str]] | None = None
+    for line in lines:
+        item = checklist.match(line)
+        if item:
+            if current is not None:
+                items.append(current)
+            current = (item.group(1).lower() == "x", [line])
+        elif current is not None and line:
+            current[1].append(line)
+    if current is not None:
+        items.append(current)
+
+    pending = [" ".join(parts) for done, parts in items if not done]
+    if pending:
+        return pending[:5]
+    return [line for line in lines if line][:5]
 
 
 def active_session_ids(board: Path) -> list[str]:

--- a/skills/synthesis-agent-conformance/scripts/test_session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/test_session_context.py
@@ -13,6 +13,23 @@ sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
 
 
+def test_next_actions_prefers_unchecked_items() -> None:
+    context = (
+        "# Context\n\n"
+        "## What's Next — Prioritized\n\n"
+        "1. [x] Finished first.\n"
+        "2. [x] Finished second.\n"
+        "3. [ ] Resume live conformance and run\n"
+        "   the complete installed-state doctor.\n"
+        "4. [ ] Verify handoff.\n"
+    )
+
+    assert MODULE.next_actions(context) == [
+        "3. [ ] Resume live conformance and run the complete installed-state doctor.",
+        "4. [ ] Verify handoff.",
+    ]
+
+
 def test_build_includes_active_coordination(tmp_path: Path) -> None:
     board = tmp_path / "active-sessions.md"
     board.write_text(


### PR DESCRIPTION
## Summary

- make shared SessionStart context prefer unchecked project actions
- preserve wrapped checklist text as one action
- cover completed, pending, and multiline project-state rows

## Verification

- agent-conformance tests passed (9)
- active-project handoff checks passed
- live Codex, Claude, and text hook payloads named the same Phase 8 project and pending work