### PR TITLE
Correct native plugin status checks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.4.2] - 2026-07-30
+
+### Fixed
+
+- Installer status now resolves its authoritative skill tree from the current
+  source checkout or native plugin before consulting the legacy cache.
+- Claude Code and Codex plugin checks require the plugin to be enabled and
+  report each client's state explicitly.
+- A stale or unavailable cache now fails with a clear diagnosis instead of
+  emitting filesystem errors followed by a false pass.
+
 ## [4.4.1] - 2026-07-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Proven AI agent skills for code review, content creation, project management, an
 
 ## What's new
 
+**Trustworthy native-plugin status (July 2026).** Installer status now reads
+the checked-out or plugin-packaged skill tree directly, verifies that the
+Claude Code and Codex plugins are enabled, and fails clearly when no
+authoritative source is available. A stale legacy cache can no longer produce
+filesystem errors followed by a false pass. See the
+[4.4.2 release notes](CHANGELOG.md).
+
 **Accurate cross-client project recovery (July 2026).** Active-project
 activation and SessionStart now share one parser that selects pending,
 multiline project actions. See the [4.4.1 release notes](CHANGELOG.md).

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,8 @@ set -e
 REPO_URL="https://github.com/synthesisengineering/synthesis-skills.git"
 REPO_NAME="synthesis-skills"
 USER_HOME="${SYNTHESIS_SKILLS_HOME:-$HOME}"
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" 2>/dev/null && pwd || true)
+SCRIPT_SKILLS_DIR="${SCRIPT_DIR}/skills"
 SOURCE_MODE="remote"
 if [ -n "${SYNTHESIS_SKILLS_SOURCE_DIR:-}" ]; then
     CACHE_DIR=$(cd "$SYNTHESIS_SKILLS_SOURCE_DIR" && pwd)
@@ -53,13 +55,15 @@ detect_targets() {
 claude_plugin_installed() {
     command -v claude >/dev/null 2>&1 || return 1
     claude plugin list --json 2>/dev/null |
-        grep -Eq '"id"[[:space:]]*:[[:space:]]*"synthesis-skills@'
+        tr '\n' ' ' |
+        grep -Eq '\{[^{}]*"id"[[:space:]]*:[[:space:]]*"synthesis-skills@[^"]*"[^{}]*"enabled"[[:space:]]*:[[:space:]]*true'
 }
 
 codex_plugin_installed() {
     command -v codex >/dev/null 2>&1 || return 1
     codex plugin list --json 2>/dev/null |
-        grep -Eq '"name"[[:space:]]*:[[:space:]]*"synthesis-skills"'
+        tr '\n' ' ' |
+        grep -Eq '\{[^{}]*"name"[[:space:]]*:[[:space:]]*"synthesis-skills"[^{}]*"enabled"[[:space:]]*:[[:space:]]*true'
 }
 
 retirement_target_allowed() {
@@ -446,21 +450,47 @@ do_status() {
     echo "======================"
     echo ""
 
-    # Update cache if present
+    CLAUDE_PLUGIN="not installed or disabled"
+    CODEX_PLUGIN="not installed or disabled"
+    if claude_plugin_installed; then
+        CLAUDE_PLUGIN="installed and enabled"
+    fi
+    if codex_plugin_installed; then
+        CODEX_PLUGIN="installed and enabled"
+    fi
+    echo "Claude Code plugin: $CLAUDE_PLUGIN"
+    echo "Codex plugin:       $CODEX_PLUGIN"
+    echo ""
+
+    # Resolve the authoritative source tree. A checked-out repository or
+    # installed native plugin is self-contained and must not depend on a
+    # separate legacy cache. Only a standalone downloaded script uses cache.
+    STATUS_SKILLS_DIR=""
     if [ "$SOURCE_MODE" = "local" ]; then
-        :
+        STATUS_SKILLS_DIR="$SKILLS_DIR"
+    elif [ -d "$SCRIPT_SKILLS_DIR" ]; then
+        STATUS_SKILLS_DIR="$SCRIPT_SKILLS_DIR"
     elif [ -d "$CACHE_DIR/.git" ]; then
-        git -C "$CACHE_DIR" pull --quiet 2>/dev/null || true
+        if ! git -C "$CACHE_DIR" pull --quiet; then
+            echo "ERROR: could not refresh cached source: $CACHE_DIR" >&2
+            return 1
+        fi
+        STATUS_SKILLS_DIR="${CACHE_DIR}/skills"
     else
-        echo "No cached repo. Run './install.sh install' first."
-        return
+        echo "ERROR: no authoritative skill source is available." >&2
+        echo "Run './install.sh install' or execute status from a source checkout or native plugin." >&2
+        return 1
+    fi
+    if [ ! -d "$STATUS_SKILLS_DIR" ]; then
+        echo "ERROR: authoritative skill directory is missing: $STATUS_SKILLS_DIR" >&2
+        return 1
     fi
 
     TARGETS=$(detect_targets)
     STATUS_FAILURES=0
 
     if claude_plugin_installed; then
-        for skill_dir in $(list_skills "$SKILLS_DIR"); do
+        for skill_dir in $(list_skills "$STATUS_SKILLS_DIR"); do
             skill_name=$(basename "$skill_dir")
             if [ -d "$USER_HOME/.claude/skills/$skill_name" ]; then
                 echo "  DUPLICATE: $USER_HOME/.claude/skills/$skill_name"
@@ -470,7 +500,7 @@ do_status() {
     fi
     if codex_plugin_installed; then
         for target in "$USER_HOME/.agents/skills" "$USER_HOME/.codex/skills"; do
-            for skill_dir in $(list_skills "$SKILLS_DIR"); do
+            for skill_dir in $(list_skills "$STATUS_SKILLS_DIR"); do
                 skill_name=$(basename "$skill_dir")
                 if [ -d "$target/$skill_name" ]; then
                     echo "  DUPLICATE: $target/$skill_name"
@@ -490,7 +520,7 @@ do_status() {
         DRIFTED=0
         ORPHANED=0
 
-        for skill_dir in $(list_skills "$SKILLS_DIR"); do
+        for skill_dir in $(list_skills "$STATUS_SKILLS_DIR"); do
             skill_name=$(basename "$skill_dir")
             case "$skill_name" in
                 .git|node_modules|.github) continue ;;
@@ -522,7 +552,7 @@ do_status() {
             for installed_dir in "$target"/synthesis-*; do
                 [ -d "$installed_dir" ] || continue
                 skill_name=$(basename "$installed_dir")
-                if [ ! -d "${SKILLS_DIR}/${skill_name}" ]; then
+                if [ ! -d "${STATUS_SKILLS_DIR}/${skill_name}" ]; then
                     if [ -f "${installed_dir}/.source.json" ]; then
                         other_repo=$(grep '"source_repo"' "${installed_dir}/.source.json" 2>/dev/null | sed 's/.*: *"//;s/".*//' || echo "unknown")
                         echo "  OTHER:   $skill_name (from $other_repo)"

--- a/tests/test_installer.sh
+++ b/tests/test_installer.sh
@@ -73,6 +73,32 @@ SYNTHESIS_SKILLS_SOURCE_DIR="$REPO_ROOT" \
 XDG_CACHE_HOME="$TEST_ROOT/plugin-cache" \
     "$REPO_ROOT/install.sh" install >/dev/null
 
+PLUGIN_STATUS=$(
+    PATH="$PLUGIN_BIN:$PATH" \
+    SYNTHESIS_SKILLS_HOME="$PLUGIN_HOME" \
+    XDG_CACHE_HOME="$TEST_ROOT/stale-plugin-cache" \
+        "$REPO_ROOT/install.sh" status 2>&1
+)
+printf '%s\n' "$PLUGIN_STATUS" | grep -q 'Claude Code plugin: installed and enabled'
+printf '%s\n' "$PLUGIN_STATUS" | grep -q 'Codex plugin:       installed and enabled'
+if printf '%s\n' "$PLUGIN_STATUS" | grep -q '^find:'; then
+    echo "plugin-native status tried to read a missing cache skill tree" >&2
+    exit 1
+fi
+
+printf '%s\n' '#!/bin/sh' 'printf '\''[{"id":"synthesis-skills@test","enabled":false}]\n'\''' \
+    > "$PLUGIN_BIN/claude"
+printf '%s\n' '#!/bin/sh' 'printf '\''{"installed":[{"name":"synthesis-skills","enabled":false}]}\n'\''' \
+    > "$PLUGIN_BIN/codex"
+DISABLED_STATUS=$(
+    PATH="$PLUGIN_BIN:$PATH" \
+    SYNTHESIS_SKILLS_HOME="$PLUGIN_HOME" \
+    SYNTHESIS_SKILLS_TARGETS="$TEST_ROOT/disabled-target" \
+        "$REPO_ROOT/install.sh" status 2>&1 || true
+)
+printf '%s\n' "$DISABLED_STATUS" | grep -q 'Claude Code plugin: not installed or disabled'
+printf '%s\n' "$DISABLED_STATUS" | grep -q 'Codex plugin:       not installed or disabled'
+
 for plugin_target in \
     "$PLUGIN_HOME/.claude/skills" \
     "$PLUGIN_HOME/.agents/skills" \


### PR DESCRIPTION
## Summary

- resolve status from the checked-out or plugin-packaged skill tree before the legacy cache
- require Claude Code and Codex plugins to be enabled
- fail clearly when no authoritative source is available
- add coverage for cache-independent plugin status and disabled plugins

## Verification

- 111 source-conformance checks
- 39 Python tests
- installer syntax and behavior tests