### PR TITLE
Add shared repository instructions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,6 +16,7 @@ jobs:
           python-version: "3.12"
       - run: python -m pip install pytest pyyaml
       - run: python skills/synthesis-agent-conformance/scripts/conformance.py source
+      - run: python skills/synthesis-agent-conformance/scripts/conformance.py instructions --repo-root .
       - run: python -m pytest skills/synthesis-agent-conformance/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-project-management/scripts/test_coordination.py -q
       - run: python -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# Repository Instructions: Synthesis Skills
+
+## Purpose
+
+This public repository is the canonical source for portable synthesis
+engineering skills. It is packaged as one native plugin for OpenAI Codex and
+Claude Code while remaining compatible with the Agent Skills standard.
+
+## Canonical Sources
+
+- `skills/` owns every public skill, script, reference, asset, license, and
+  Codex interface.
+- `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json` own the two
+  client manifests. Their versions must match.
+- `.agents/plugins/marketplace.json` and
+  `.claude-plugin/marketplace.json` own marketplace discovery.
+- `hooks/hooks.json` owns shared lifecycle-hook registration.
+- `install.sh` supports direct-copy fallbacks and the transition to native
+  plugins. Native plugins are the primary installation path.
+
+Never edit installed plugin caches or user-level skill copies. Make the change
+here, verify it, merge it to `main`, then update the installed plugins.
+
+## Implementation Rules
+
+1. Search the existing skills and scripts before adding behavior.
+2. Keep shared behavior agent-neutral. Put client-specific metadata and event
+   translation in the corresponding adapter.
+3. Give each skill one canonical directory under `skills/`.
+4. Keep `SKILL.md` below 500 lines; move detailed material into `references/`.
+5. Keep executable behavior in version-controlled scripts with deterministic
+   tests.
+6. Protective checks fail closed when required state or dependencies cannot be
+   verified.
+7. Do not add compatibility shims unless the task explicitly requires them.
+8. Do not include credentials, private organization names, personal paths, or
+   client-confidential examples in this public repository.
+
+## Cross-Client Contract
+
+- Every public skill requires `SKILL.md`, `LICENSE`, and
+  `agents/openai.yaml`.
+- Claude Code and Codex must load the same skill source and shared scripts.
+- `AGENTS.md` is the tracked repository instruction source.
+- `CLAUDE.md` is only the Claude Code import adapter: `@AGENTS.md`.
+- Plugin-relative paths are required; absolute paths to a local checkout are
+  forbidden.
+- Runtime conformance must verify enabled plugin state, duplicate direct
+  copies, hooks, and project handoff behavior.
+
+## Verification
+
+Run the same checks required by CI:
+
+```bash
+python3 skills/synthesis-agent-conformance/scripts/conformance.py source
+python3 skills/synthesis-agent-conformance/scripts/conformance.py instructions --repo-root .
+python3 -m pytest skills/synthesis-agent-conformance/scripts/test_*.py -q
+python3 -m pytest skills/synthesis-project-management/scripts/test_coordination.py -q
+python3 -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
+python3 -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py -q
+sh -n install.sh tests/test_installer.sh
+./tests/test_installer.sh
+python3 -m compileall -q skills
+python3 skills/synthesis-inbox-cleanup/tests/run_poisoned.py
+python3 skills/synthesis-inbox-cleanup/tests/run_resolver.py
+```
+
+For a cross-client release, also run:
+
+```bash
+python3 skills/synthesis-agent-conformance/scripts/conformance.py runtime
+python3 skills/synthesis-agent-conformance/scripts/conformance.py coordination
+```
+
+## Releases
+
+- Use semantic versioning and keep both plugin manifests in parity.
+- Record user-visible changes in `CHANGELOG.md`.
+- Update the concise release note in `README.md`.
+- Use a feature branch and a review request for non-trivial changes.
+- Merge only after every required check passes.
+- Update both installed marketplaces from committed `main` and rerun runtime
+  conformance.
+
+See `CONTRIBUTING.md` for contribution structure and licensing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.4.3] - 2026-07-30
+
+### Added
+
+- Tracked, agent-neutral repository instructions for contributors working in
+  Codex, Claude Code, or another `AGENTS.md`-aware client.
+- A one-line Claude Code import adapter that keeps both clients on the same
+  repository rules.
+
+### Changed
+
+- CI now rejects missing or divergent repository instruction adapters.
+
 ## [4.4.2] - 2026-07-30
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Proven AI agent skills for code review, content creation, project management, an
 
 ## What's new
 
+**One repository contract for every agent (July 2026).** The public source now
+tracks its own `AGENTS.md`, with Claude Code importing that same contract
+through a one-line adapter. CI verifies both files so contributors using Codex
+and Claude Code receive the same repository rules. See the
+[4.4.3 release notes](CHANGELOG.md).
+
 **Trustworthy native-plugin status (July 2026).** Installer status now reads
 the checked-out or plugin-packaged skill tree directly, verifies that the
 Claude Code and Codex plugins are enabled, and fails clearly when no

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:asyncio


### PR DESCRIPTION
## Summary

- add one tracked repository contract for Codex and other AGENTS.md-aware clients
- import the same contract into Claude Code
- require instruction conformance in CI
- keep local test runs free of unrelated async-plugin warnings

## Verification

- 111 source-conformance checks
- repository instruction conformance
- 39 Python tests
- installer, compilation, and adversarial inbox tests