### PR TITLE
Stabilize inbox cleanup runtime

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.4.4",
+  "version": "4.5.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.4.4",
+  "version": "4.5.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,3 +26,4 @@ jobs:
       - run: python -m compileall -q skills
       - run: python skills/synthesis-inbox-cleanup/tests/run_poisoned.py
       - run: python skills/synthesis-inbox-cleanup/tests/run_resolver.py
+      - run: sh skills/synthesis-inbox-cleanup/tests/test_runtime_installer.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ sh -n install.sh tests/test_installer.sh
 python3 -m compileall -q skills
 python3 skills/synthesis-inbox-cleanup/tests/run_poisoned.py
 python3 skills/synthesis-inbox-cleanup/tests/run_resolver.py
+sh skills/synthesis-inbox-cleanup/tests/test_runtime_installer.sh
 ```
 
 For a cross-client release, also run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.5.0] - 2026-07-30
+
+### Added
+
+- A content-addressed inbox-cleanup engine runtime under
+  `~/.synthesis/inbox-cleanup/engine/`, with an atomic `current` link shared by
+  Claude Code, Codex, and direct Agent Skills clients.
+- Installer regression coverage that proves the source tree and working
+  directory survive installation, repeated installs are idempotent, and
+  drifted immutable releases fail closed.
+
+### Changed
+
+- `synthesis-inbox-cleanup` v1.4.0 no longer requires operational scripts to
+  resolve a client-owned, version-numbered plugin cache.
+- The installer recognizes both regular Git checkouts and linked worktrees,
+  and provenance replaces the obsolete hardcoded fallback list during
+  source-free uninstall.
+
 ## [4.4.4] - 2026-07-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Proven AI agent skills for code review, content creation, project management, an
 
 ## What's new
 
+**A stable inbox engine across native clients (July 2026).**
+`synthesis-inbox-cleanup` **v1.4.0** installs verified, immutable engine
+releases under `~/.synthesis/inbox-cleanup/engine/`. Claude Code and Codex
+private workflows now share `engine/current` instead of depending on either
+client's version-numbered plugin cache. See the
+[4.5.0 release notes](CHANGELOG.md).
+
 **Clean handoff after project completion (July 2026).** A completed synthesis
 project now emits no pending actions during activation or SessionStart; checked
 items are never relabeled as future work. See the

--- a/install.sh
+++ b/install.sh
@@ -134,8 +134,12 @@ our_skill_names() {
 }
 
 # Get current git commit hash from cache
+git_source_available() {
+    git -C "$CACHE_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
 get_source_commit() {
-    if [ -d "$CACHE_DIR/.git" ]; then
+    if git_source_available; then
         git -C "$CACHE_DIR" rev-parse HEAD
     else
         echo "unknown"
@@ -205,7 +209,7 @@ do_install() {
     # Clone or update cache
     if [ "$SOURCE_MODE" = "local" ]; then
         echo "Using local source: $CACHE_DIR"
-    elif [ -d "$CACHE_DIR/.git" ]; then
+    elif git_source_available; then
         echo "Updating cached repo..."
         git -C "$CACHE_DIR" pull --quiet
     else
@@ -434,7 +438,7 @@ do_update() {
         do_install
         return
     fi
-    if [ ! -d "$CACHE_DIR/.git" ]; then
+    if ! git_source_available; then
         echo "No existing installation found. Running install instead."
         do_install
         return
@@ -470,7 +474,7 @@ do_status() {
         STATUS_SKILLS_DIR="$SKILLS_DIR"
     elif [ -d "$SCRIPT_SKILLS_DIR" ]; then
         STATUS_SKILLS_DIR="$SCRIPT_SKILLS_DIR"
-    elif [ -d "$CACHE_DIR/.git" ]; then
+    elif git_source_available; then
         if ! git -C "$CACHE_DIR" pull --quiet; then
             echo "ERROR: could not refresh cached source: $CACHE_DIR" >&2
             return 1
@@ -579,22 +583,31 @@ do_status() {
 do_uninstall() {
     echo "Uninstalling Synthesis Skills..."
 
-    if [ ! -d "$CACHE_DIR/.git" ]; then
-        echo "No cached repo found. Scanning for installed skills..."
-    fi
-
     TARGETS=$(detect_targets)
     REMOVED=0
+    SOURCE_SKILL_NAMES=""
 
-    # Get our skill names from cache (or scan known names)
-    if [ -d "$CACHE_DIR/.git" ]; then
-        SKILL_NAMES=$(our_skill_names)
+    if git_source_available; then
+        SOURCE_SKILL_NAMES=$(our_skill_names)
     else
-        # Fallback: list of known synthesis-skills names
-        SKILL_NAMES="synthesis-article-writing synthesis-blog-refresh synthesis-clean-text synthesis-code-audit synthesis-code-integration synthesis-code-planning synthesis-codebase-review synthesis-concise-messaging synthesis-content-distribution synthesis-content-framing synthesis-content-quality synthesis-context-lifecycle synthesis-creative-writer synthesis-fact-checking synthesis-implementation-integrity synthesis-link-research synthesis-llm-setup synthesis-mac-sync synthesis-preflight synthesis-pr-review synthesis-project-management synthesis-response-merger synthesis-review-triage synthesis-skills-manager synthesis-slack-sync synthesis-technical-advisor synthesis-thinking-framework synthesis-tree-of-thought synthesis-voice-profiler"
+        echo "No source repository found. Scanning install provenance..."
     fi
 
     for target in $TARGETS; do
+        SKILL_NAMES="$SOURCE_SKILL_NAMES"
+        if [ -z "$SKILL_NAMES" ] && [ -d "$target" ]; then
+            SKILL_NAMES=$(
+                find "$target" -mindepth 2 -maxdepth 2 \
+                    -name .source.json -type f |
+                while IFS= read -r source_json; do
+                    if grep -q \
+                        "\"source_repo\": \"${SOURCE_REPO}\"" \
+                        "$source_json"; then
+                        basename "$(dirname "$source_json")"
+                    fi
+                done
+            )
+        fi
         for skill_name in $SKILL_NAMES; do
             if [ -d "${target}/${skill_name}" ]; then
                 rm -rf "${target}/${skill_name}"

--- a/skills/synthesis-inbox-cleanup/SKILL.md
+++ b/skills/synthesis-inbox-cleanup/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.3.2"
+  version: "1.4.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
   platform: "macOS (Apple Silicon and Intel)"
@@ -17,12 +17,13 @@ A manifest-driven email cleanup engine that scales the same human-curated rules 
 
 The engine is deterministic. Email content does not change rules at runtime. When an LLM is invoked — for new-sender categorization or for higher-risk paths like body-reading digests — sanitization defenses run first. The skill ships adversarial test fixtures so prompt-injection regressions surface in CI rather than in production.
 
-## v1.3.2 — Native dual-runtime setup
+## v1.4.0 — Stable cross-client engine runtime
 
-v1.3.2 (2026-07-29) makes the repository's native plugin the primary setup
-path for Codex and Claude Code. The engine continues to install its private
-runtime and rules under `~/.synthesis/inbox-cleanup/`, independent of either
-client's skill cache.
+v1.4.0 (2026-07-30) installs an immutable engine release under
+`~/.synthesis/inbox-cleanup/engine/releases/` and atomically points
+`engine/current` at it. Operational scripts use that stable path instead of a
+Claude Code or Codex plugin cache. Updating either client can no longer remove
+the engine path used by private workflows.
 
 ## Architecture: public engine, private rules
 
@@ -35,6 +36,9 @@ client's skill cache.
   └── tests/poisoned/                      ← adversarial fixtures
 
 ~/.synthesis/inbox-cleanup/                 ← private (per-user, not in git)
+  ├── engine/
+  │   ├── current → releases/<digest>/     ← stable client-neutral runtime
+  │   └── releases/<digest>/               ← immutable verified engine
   ├── config.yaml                          ← account list, host, user candidates
   ├── rules.yaml                           ← sender rules, never_touch, subject_rules
   └── imap.secret                          ← optional credential fallback
@@ -262,8 +266,8 @@ claude plugin install synthesis-skills@synthesis-engineering
 security add-generic-password -s inbox-cleanup-imap -a "$USER" -w
 # (paste the password when prompted; never in shell history)
 
-# 6. Sanity-check
-cd <synthesis-inbox-cleanup-root>/scripts
+# 6. Sanity-check from the stable runtime
+cd ~/.synthesis/inbox-cleanup/engine/current
 python3 icloud_census.py
 ```
 

--- a/skills/synthesis-inbox-cleanup/scripts/install.sh
+++ b/skills/synthesis-inbox-cleanup/scripts/install.sh
@@ -3,8 +3,10 @@
 # synthesis-inbox-cleanup installer.
 #
 # Idempotent. Run multiple times safely. Creates ~/.synthesis/inbox-cleanup/,
-# seeds config.yaml and rules.yaml from the bundled templates (only if no
-# existing files — does not overwrite), and prints next-step instructions.
+# installs an immutable engine release behind a stable `engine/current`
+# symlink, seeds config.yaml and rules.yaml from the bundled templates (only
+# if no existing files — does not overwrite), and prints next-step
+# instructions.
 #
 # Usage:
 #   <synthesis-inbox-cleanup-root>/scripts/install.sh
@@ -18,16 +20,112 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 SKILL_DIR="$(dirname "$SCRIPT_DIR")"
 TEMPLATES_DIR="$SKILL_DIR/templates"
 
-TARGET_DIR="$HOME/.synthesis/inbox-cleanup"
+TARGET_DIR="${SYNTHESIS_INBOX_HOME:-$HOME/.synthesis/inbox-cleanup}"
 CONFIG_PATH="$TARGET_DIR/config.yaml"
 RULES_PATH="$TARGET_DIR/rules.yaml"
+ENGINE_ROOT="$TARGET_DIR/engine"
+ENGINE_RELEASES="$ENGINE_ROOT/releases"
+ENGINE_CURRENT="$ENGINE_ROOT/current"
 
+validate_runtime_root() {
+    case "$TARGET_DIR" in
+        /|"$HOME")
+            echo "ERROR: refusing unsafe inbox runtime root: $TARGET_DIR" >&2
+            return 1
+            ;;
+    esac
+    for path in "$TARGET_DIR" "$ENGINE_ROOT" "$ENGINE_RELEASES"; do
+        if [ -L "$path" ]; then
+            echo "ERROR: refusing symlinked inbox runtime path: $path" >&2
+            return 1
+        fi
+    done
+    if [ -e "$TARGET_DIR" ] && [ ! -d "$TARGET_DIR" ]; then
+        echo "ERROR: refusing non-directory inbox runtime root: $TARGET_DIR" >&2
+        return 1
+    fi
+}
+
+engine_digest() {
+    directory="$1"
+    (
+        cd "$directory"
+        for file in *.py *.applescript; do
+            [ -f "$file" ] || continue
+            printf '%s  ' "$file"
+            shasum -a 256 "$file"
+        done
+    ) | shasum -a 256 | awk '{print $1}'
+}
+
+install_engine_runtime() {
+    source_digest="$(engine_digest "$SCRIPT_DIR")"
+    release_dir="$ENGINE_RELEASES/$source_digest"
+
+    mkdir -p "$ENGINE_RELEASES"
+    chmod 700 "$ENGINE_ROOT" "$ENGINE_RELEASES"
+
+    if [ -L "$release_dir" ]; then
+        echo "ERROR: refusing symlinked engine release: $release_dir" >&2
+        return 1
+    fi
+
+    if [ -d "$release_dir" ]; then
+        installed_digest="$(engine_digest "$release_dir")"
+        if [ "$installed_digest" != "$source_digest" ]; then
+            echo "ERROR: engine release content does not match its digest: $release_dir" >&2
+            return 1
+        fi
+    else
+        stage_dir="$(mktemp -d "$ENGINE_ROOT/.engine-stage.XXXXXX")"
+        for source in "$SCRIPT_DIR"/*.py "$SCRIPT_DIR"/*.applescript; do
+            [ -f "$source" ] || continue
+            cp -p "$source" "$stage_dir/"
+        done
+        if [ ! -f "$stage_dir/_lib.py" ] || [ ! -f "$stage_dir/icloud_plan.py" ]; then
+            echo "ERROR: staged engine is incomplete: $stage_dir" >&2
+            return 1
+        fi
+        staged_digest="$(engine_digest "$stage_dir")"
+        if [ "$staged_digest" != "$source_digest" ]; then
+            echo "ERROR: staged engine failed digest verification: $stage_dir" >&2
+            return 1
+        fi
+        chmod 700 "$stage_dir"
+        mv "$stage_dir" "$release_dir"
+    fi
+
+    if [ -e "$ENGINE_CURRENT" ] && [ ! -L "$ENGINE_CURRENT" ]; then
+        echo "ERROR: refusing non-symlink engine/current: $ENGINE_CURRENT" >&2
+        return 1
+    fi
+
+    link_stage="$ENGINE_ROOT/.current.$$.tmp"
+    if [ -e "$link_stage" ] || [ -L "$link_stage" ]; then
+        echo "ERROR: temporary current-link path already exists: $link_stage" >&2
+        return 1
+    fi
+    ln -s "releases/$source_digest" "$link_stage"
+    mv -f "$link_stage" "$ENGINE_CURRENT"
+
+    resolved_current="$(cd "$ENGINE_CURRENT" && pwd -P)"
+    resolved_release="$(cd "$release_dir" && pwd -P)"
+    if [ "$resolved_current" != "$resolved_release" ]; then
+        echo "ERROR: engine/current did not resolve to the installed release" >&2
+        return 1
+    fi
+    echo "✓ Stable engine runtime: $ENGINE_CURRENT"
+}
+
+validate_runtime_root
 mkdir -p "$TARGET_DIR"
 chmod 700 "$TARGET_DIR"   # private dir: rules.yaml/config.yaml/imap.secret live here
 
 echo "→ Skill location:  $SKILL_DIR"
 echo "→ Private rules:   $TARGET_DIR"
 echo ""
+
+install_engine_runtime
 
 # config.yaml — account + behavior configuration
 if [ -f "$CONFIG_PATH" ]; then
@@ -96,7 +194,7 @@ echo "    1. Edit $CONFIG_PATH"
 echo "    2. Edit $RULES_PATH"
 echo "    3. Store the IMAP password in Keychain (see above)"
 echo "    4. Sanity-check:"
-echo "         cd $SCRIPT_DIR"
+echo "         cd $ENGINE_CURRENT"
 echo "         python3 icloud_census.py"
 echo ""
 echo "  Adversarial fixture tests (verify defenses):"

--- a/skills/synthesis-inbox-cleanup/tests/test_runtime_installer.sh
+++ b/skills/synthesis-inbox-cleanup/tests/test_runtime_installer.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+SKILL_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TEST_ROOT=$(mktemp -d)
+SOURCE_SENTINEL="$SKILL_ROOT/.runtime-installer-source-sentinel"
+CWD_SENTINEL="$TEST_ROOT/cwd-sentinel"
+
+cleanup() {
+    if [ -d "$TEST_ROOT" ]; then
+        rm -rf "$TEST_ROOT"
+    fi
+    if [ -f "$SOURCE_SENTINEL" ]; then
+        rm -f "$SOURCE_SENTINEL"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+touch "$SOURCE_SENTINEL" "$CWD_SENTINEL"
+
+(
+    cd "$TEST_ROOT"
+    SYNTHESIS_INBOX_HOME="$TEST_ROOT/runtime" \
+        "$SKILL_ROOT/scripts/install.sh" >/dev/null
+)
+
+test -f "$SOURCE_SENTINEL"
+test -f "$CWD_SENTINEL"
+test -L "$TEST_ROOT/runtime/engine/current"
+test -f "$TEST_ROOT/runtime/engine/current/_lib.py"
+test -f "$TEST_ROOT/runtime/engine/current/icloud_plan.py"
+
+FIRST_TARGET=$(readlink "$TEST_ROOT/runtime/engine/current")
+(
+    cd "$SKILL_ROOT"
+    SYNTHESIS_INBOX_HOME="$TEST_ROOT/runtime" \
+        "$SKILL_ROOT/scripts/install.sh" >/dev/null
+)
+SECOND_TARGET=$(readlink "$TEST_ROOT/runtime/engine/current")
+
+test "$FIRST_TARGET" = "$SECOND_TARGET"
+test -f "$SOURCE_SENTINEL"
+test -f "$CWD_SENTINEL"
+
+SYMLINK_TARGET="$TEST_ROOT/symlink-target"
+SYMLINK_RUNTIME="$TEST_ROOT/symlink-runtime"
+mkdir -p "$SYMLINK_TARGET"
+touch "$SYMLINK_TARGET/preserved"
+ln -s "$SYMLINK_TARGET" "$SYMLINK_RUNTIME"
+if SYNTHESIS_INBOX_HOME="$SYMLINK_RUNTIME" \
+    "$SKILL_ROOT/scripts/install.sh" >/dev/null 2>&1; then
+    echo "runtime installer accepted a symlinked runtime root" >&2
+    exit 1
+fi
+test -f "$SYMLINK_TARGET/preserved"
+
+release_dir="$TEST_ROOT/runtime/engine/$FIRST_TARGET"
+printf '\nDRIFT\n' >> "$release_dir/_lib.py"
+if SYNTHESIS_INBOX_HOME="$TEST_ROOT/runtime" \
+    "$SKILL_ROOT/scripts/install.sh" >/dev/null 2>&1; then
+    echo "runtime installer accepted a drifted immutable release" >&2
+    exit 1
+fi
+
+test -f "$SOURCE_SENTINEL"
+test -f "$CWD_SENTINEL"
+echo "inbox runtime installer tests passed"

--- a/tests/test_installer.sh
+++ b/tests/test_installer.sh
@@ -4,8 +4,12 @@ set -eu
 REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 TEST_ROOT=$(mktemp -d)
 TARGET="${TEST_ROOT}/installed"
+GIT_FILE_SOURCE="${TEST_ROOT}/git-file-source"
 
 cleanup() {
+    if [ -e "$GIT_FILE_SOURCE/.git" ]; then
+        git -C "$REPO_ROOT" worktree remove "$GIT_FILE_SOURCE" >/dev/null 2>&1 || true
+    fi
     rm -rf "$TEST_ROOT"
 }
 trap cleanup EXIT INT TERM
@@ -47,6 +51,32 @@ SYNTHESIS_SKILLS_TARGETS="$TARGET" \
     "$REPO_ROOT/install.sh" uninstall >/dev/null
 
 [ ! -d "$TARGET/synthesis-agent-conformance" ]
+[ -z "$(find "$TARGET" -mindepth 1 -maxdepth 1 -type d -name 'synthesis-*' -print -quit)" ]
+
+git -C "$REPO_ROOT" worktree add --detach "$GIT_FILE_SOURCE" HEAD >/dev/null
+test -f "$GIT_FILE_SOURCE/.git"
+WORKTREE_TARGET="${TEST_ROOT}/worktree-installed"
+SYNTHESIS_SKILLS_HOME="$TEST_ROOT" \
+SYNTHESIS_SKILLS_SOURCE_DIR="$GIT_FILE_SOURCE" \
+SYNTHESIS_SKILLS_TARGETS="$WORKTREE_TARGET" \
+    "$REPO_ROOT/install.sh" install >/dev/null
+SYNTHESIS_SKILLS_HOME="$TEST_ROOT" \
+SYNTHESIS_SKILLS_SOURCE_DIR="$GIT_FILE_SOURCE" \
+SYNTHESIS_SKILLS_TARGETS="$WORKTREE_TARGET" \
+    "$REPO_ROOT/install.sh" uninstall >/dev/null
+[ -z "$(find "$WORKTREE_TARGET" -mindepth 1 -maxdepth 1 -type d -name 'synthesis-*' -print -quit)" ]
+git -C "$REPO_ROOT" worktree remove "$GIT_FILE_SOURCE" >/dev/null
+
+PROVENANCE_TARGET="${TEST_ROOT}/provenance-installed"
+SYNTHESIS_SKILLS_HOME="$TEST_ROOT" \
+SYNTHESIS_SKILLS_SOURCE_DIR="$REPO_ROOT" \
+SYNTHESIS_SKILLS_TARGETS="$PROVENANCE_TARGET" \
+    "$REPO_ROOT/install.sh" install >/dev/null
+XDG_CACHE_HOME="${TEST_ROOT}/empty-cache" \
+SYNTHESIS_SKILLS_HOME="$TEST_ROOT" \
+SYNTHESIS_SKILLS_TARGETS="$PROVENANCE_TARGET" \
+    "$REPO_ROOT/install.sh" uninstall >/dev/null
+[ -z "$(find "$PROVENANCE_TARGET" -mindepth 1 -maxdepth 1 -type d -name 'synthesis-*' -print -quit)" ]
 
 PLUGIN_HOME="${TEST_ROOT}/plugin-home"
 PLUGIN_BIN="${TEST_ROOT}/plugin-bin"


### PR DESCRIPTION
Installs the inbox-cleanup engine into a content-addressed synthesis-owned runtime instead of requiring operational scripts to use client plugin caches. Adds fail-closed installer coverage for source and working-directory survival, symlink refusal, immutable-release drift, linked Git worktrees, and provenance-based uninstall. Bumps the dual-runtime plugin to 4.5.0 and the inbox skill to 1.4.0.