### PR TITLE
Symmetric client verification and cross-machine coordination lease

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.6.0] - 2026-07-30
+
+### Added
+
+- Client-binary resolution for verification tooling
+  (`synthesis-agent-conformance/scripts/client_binaries.py` and matching
+  installer shell helpers): explicit `SYNTHESIS_CLAUDE_BIN` /
+  `SYNTHESIS_CODEX_BIN` overrides (a set-but-empty override means absent),
+  then `PATH`, then documented stable install locations, so conformance,
+  doctors, and plugin detection give the same answer from either client's
+  shell, cron, or CI.
+- An opt-in git-backed coordination lease (`lease.json` beside the board):
+  every board mutation publishes through an atomic git ref compare-and-swap
+  on a shared remote, with bounded retry on concurrent advance, fail-closed
+  behavior on unreachable remotes, mirror refresh in `status`, and sync
+  verification in `doctor`. Enables safe same-resource coordination across
+  machines; `synthesis-project-management` v1.7.0.
+
+### Fixed
+
+- `conformance.py runtime` no longer crashes with an unhandled traceback when
+  a client CLI is missing; every runtime check reports a structured failure
+  and the remaining check groups still run.
+- Coordination claim overlap detection now normalizes `~`, absolute, and
+  repository-relative claim spellings onto path segments, so two spellings of
+  one real path conflict instead of passing silently; ambiguous alignments
+  are treated as conflicts.
+- Plugin inventory checks validate JSON shape and count only enabled
+  installations for both clients.
+
 ## [4.5.0] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   are treated as conflicts.
 - Plugin inventory checks validate JSON shape and count only enabled
   installations for both clients.
+- The `day-end` launcher resolves its agent CLI through the same override /
+  PATH / known-locations order, honors `DAY_END_AGENT_CMD` as a documented
+  executable path, and no longer silently degrades "auto" to whichever client
+  happens to be on the terminal's PATH.
 
 ## [4.5.0] - 2026-07-30
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Proven AI agent skills for code review, content creation, project management, an
 
 ## What's new
 
+**Symmetric verification and cross-machine coordination (July 2026).**
+Conformance checks, doctors, and installers now resolve the Claude and Codex
+CLIs through overrides, `PATH`, and documented install locations, so the same
+verification runs from either client's shell. `synthesis-project-management`
+**v1.7.0** adds an opt-in git-backed coordination lease — an atomic ref
+compare-and-swap on a shared remote — for safe same-resource sessions across
+machines, and claim-overlap detection now matches mixed absolute, `~`, and
+relative claim spellings. See the [4.6.0 release notes](CHANGELOG.md).
+
 **A stable inbox engine across native clients (July 2026).**
 `synthesis-inbox-cleanup` **v1.4.0** installs verified, immutable engine
 releases under `~/.synthesis/inbox-cleanup/engine/`. Claude Code and Codex

--- a/install.sh
+++ b/install.sh
@@ -52,16 +52,71 @@ detect_targets() {
     echo "$TARGETS"
 }
 
+# Each client's own shell puts its CLI on PATH, but other shells (the other
+# client, cron, CI) usually do not — the Codex CLI ships inside the ChatGPT
+# desktop app on macOS. Resolve through an explicit override first (a set but
+# empty override means "treat as absent"), then PATH, then documented stable
+# install locations, so plugin detection gives the same answer from every
+# shell instead of silently reverting to direct-copy installs.
+resolve_claude_bin() {
+    if [ "${SYNTHESIS_CLAUDE_BIN+set}" = "set" ]; then
+        if [ -n "$SYNTHESIS_CLAUDE_BIN" ] && [ -x "$SYNTHESIS_CLAUDE_BIN" ]; then
+            printf '%s\n' "$SYNTHESIS_CLAUDE_BIN"
+        fi
+        return 0
+    fi
+    if command -v claude >/dev/null 2>&1; then
+        command -v claude
+        return 0
+    fi
+    for CLIENT_BIN_CANDIDATE in \
+        "$HOME/.local/bin/claude" \
+        /opt/homebrew/bin/claude \
+        /usr/local/bin/claude; do
+        if [ -x "$CLIENT_BIN_CANDIDATE" ]; then
+            printf '%s\n' "$CLIENT_BIN_CANDIDATE"
+            return 0
+        fi
+    done
+    return 0
+}
+
+resolve_codex_bin() {
+    if [ "${SYNTHESIS_CODEX_BIN+set}" = "set" ]; then
+        if [ -n "$SYNTHESIS_CODEX_BIN" ] && [ -x "$SYNTHESIS_CODEX_BIN" ]; then
+            printf '%s\n' "$SYNTHESIS_CODEX_BIN"
+        fi
+        return 0
+    fi
+    if command -v codex >/dev/null 2>&1; then
+        command -v codex
+        return 0
+    fi
+    for CLIENT_BIN_CANDIDATE in \
+        "$HOME/.local/bin/codex" \
+        /opt/homebrew/bin/codex \
+        /usr/local/bin/codex \
+        "/Applications/ChatGPT.app/Contents/Resources/codex"; do
+        if [ -x "$CLIENT_BIN_CANDIDATE" ]; then
+            printf '%s\n' "$CLIENT_BIN_CANDIDATE"
+            return 0
+        fi
+    done
+    return 0
+}
+
 claude_plugin_installed() {
-    command -v claude >/dev/null 2>&1 || return 1
-    claude plugin list --json 2>/dev/null |
+    CLAUDE_CLIENT_BIN=$(resolve_claude_bin)
+    [ -n "$CLAUDE_CLIENT_BIN" ] || return 1
+    "$CLAUDE_CLIENT_BIN" plugin list --json 2>/dev/null |
         tr '\n' ' ' |
         grep -Eq '\{[^{}]*"id"[[:space:]]*:[[:space:]]*"synthesis-skills@[^"]*"[^{}]*"enabled"[[:space:]]*:[[:space:]]*true'
 }
 
 codex_plugin_installed() {
-    command -v codex >/dev/null 2>&1 || return 1
-    codex plugin list --json 2>/dev/null |
+    CODEX_CLIENT_BIN=$(resolve_codex_bin)
+    [ -n "$CODEX_CLIENT_BIN" ] || return 1
+    "$CODEX_CLIENT_BIN" plugin list --json 2>/dev/null |
         tr '\n' ' ' |
         grep -Eq '\{[^{}]*"name"[[:space:]]*:[[:space:]]*"synthesis-skills"[^{}]*"enabled"[[:space:]]*:[[:space:]]*true'
 }

--- a/skills/synthesis-agent-conformance/scripts/client_binaries.py
+++ b/skills/synthesis-agent-conformance/scripts/client_binaries.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Locate installed Claude Code and Codex CLI binaries.
+
+Cross-client verification must run from either client's shell, from cron, or
+from CI. Each client's own shell puts its binary on PATH, but the other
+client's shell usually does not — the Codex CLI ships inside the ChatGPT
+desktop app on macOS and is injected only into Codex-managed shells. Checks
+that spawn a client binary therefore resolve it in this order:
+
+1. An explicit environment override (``SYNTHESIS_CODEX_BIN`` or
+   ``SYNTHESIS_CLAUDE_BIN``). A set override is authoritative: an empty
+   value means "treat the client as absent" (used by hermetic tests), and a
+   value that does not point at an executable file resolves to nothing
+   rather than falling through, so a misconfigured override fails closed
+   instead of silently testing a different installation.
+2. ``PATH`` via :func:`shutil.which`.
+3. Documented stable install locations. These are vendor install paths, not
+   version-numbered plugin caches, so consulting them as fallbacks does not
+   create a dependency on client-owned cache layout.
+
+Callers treat ``None`` as "binary unavailable" and report a structured check
+failure; they never let ``FileNotFoundError`` escape as a crash.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+ENV_OVERRIDES = {
+    "claude": "SYNTHESIS_CLAUDE_BIN",
+    "codex": "SYNTHESIS_CODEX_BIN",
+}
+
+WELL_KNOWN_LOCATIONS = {
+    "claude": (
+        "~/.local/bin/claude",
+        "/opt/homebrew/bin/claude",
+        "/usr/local/bin/claude",
+    ),
+    "codex": (
+        "~/.local/bin/codex",
+        "/opt/homebrew/bin/codex",
+        "/usr/local/bin/codex",
+        "/Applications/ChatGPT.app/Contents/Resources/codex",
+    ),
+}
+
+
+def _executable(path: Path) -> bool:
+    return path.is_file() and os.access(path, os.X_OK)
+
+
+def resolve_client_binary(name: str) -> str | None:
+    """Return an executable path for ``name`` (``claude`` or ``codex``)."""
+    override_key = ENV_OVERRIDES.get(name, "")
+    if override_key and override_key in os.environ:
+        override = os.environ[override_key]
+        if not override:
+            return None
+        path = Path(override).expanduser()
+        return str(path) if _executable(path) else None
+    found = shutil.which(name)
+    if found:
+        return found
+    for candidate in WELL_KNOWN_LOCATIONS.get(name, ()):
+        path = Path(candidate).expanduser()
+        if _executable(path):
+            return str(path)
+    return None
+
+
+def missing_binary_detail(name: str) -> str:
+    """Uniform detail string for a structured check failure."""
+    override_key = ENV_OVERRIDES.get(name, f"SYNTHESIS_{name.upper()}_BIN")
+    return (
+        f"{name} binary not found on PATH or in documented install locations; "
+        f"set {override_key} to the CLI path if it is installed elsewhere"
+    )

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -26,6 +26,7 @@ SCRIPTS_DIR = SCRIPT_PATH.parent
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
+from client_binaries import missing_binary_detail, resolve_client_binary
 from project_context import next_actions
 
 DEFAULT_SOURCE_ROOT = SCRIPT_PATH.parents[3]
@@ -258,9 +259,12 @@ def source_checks(source_root: Path) -> list[Check]:
     return checks
 
 
-def plugin_inventory(command: list[str], client: str) -> tuple[bool, str]:
+def plugin_inventory(client: str) -> tuple[bool, str]:
+    binary = resolve_client_binary(client)
+    if not binary:
+        return False, missing_binary_detail(client)
     try:
-        result = run(command)
+        result = run([binary, "plugin", "list", "--json"])
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         return False, str(exc)
     if result.returncode != 0:
@@ -270,14 +274,24 @@ def plugin_inventory(command: list[str], client: str) -> tuple[bool, str]:
     except Exception as exc:
         return False, f"invalid JSON: {exc}"
     if client == "claude":
-        found = [item for item in data if item.get("id", "").startswith("synthesis-skills@")]
-    else:
+        items = data if isinstance(data, list) else []
         found = [
             item
-            for item in data.get("installed", [])
-            if item.get("name") == "synthesis-skills" and item.get("enabled")
+            for item in items
+            if isinstance(item, dict)
+            and str(item.get("id", "")).startswith("synthesis-skills@")
+            and item.get("enabled", True)
         ]
-    return len(found) == 1, f"{len(found)} enabled installation(s)"
+    else:
+        installed = data.get("installed", []) if isinstance(data, dict) else []
+        found = [
+            item
+            for item in installed
+            if isinstance(item, dict)
+            and item.get("name") == "synthesis-skills"
+            and item.get("enabled")
+        ]
+    return len(found) == 1, f"{len(found)} enabled installation(s) via {binary}"
 
 
 def direct_public_copies(home: Path) -> list[str]:
@@ -296,9 +310,9 @@ def direct_public_copies(home: Path) -> list[str]:
 
 def runtime_checks() -> list[Check]:
     checks: list[Check] = []
-    ok, detail = plugin_inventory(["claude", "plugin", "list", "--json"], "claude")
+    ok, detail = plugin_inventory("claude")
     add(checks, "runtime.claude-plugin", ok, detail)
-    ok, detail = plugin_inventory(["codex", "plugin", "list", "--json"], "codex")
+    ok, detail = plugin_inventory("codex")
     add(checks, "runtime.codex-plugin", ok, detail)
 
     home = Path.home()
@@ -310,12 +324,16 @@ def runtime_checks() -> list[Check]:
         ", ".join(duplicates) or "none",
     )
 
-    doctor = run(["codex", "doctor", "--json"])
+    codex_binary = resolve_client_binary("codex")
+    if not codex_binary:
+        add(checks, "runtime.codex-doctor", False, missing_binary_detail("codex"))
+        return checks
     try:
+        doctor = run([codex_binary, "doctor", "--json"])
         data = json_from_output(doctor.stdout + "\n" + doctor.stderr)
         provider = data["checks"]["network.provider_reachability"]["status"] == "ok"
         websocket = data["checks"]["network.websocket_reachability"]["status"] == "ok"
-        add(checks, "runtime.codex-provider", provider, "HTTP reachability")
+        add(checks, "runtime.codex-provider", provider, f"HTTP reachability via {codex_binary}")
         add(checks, "runtime.codex-websocket", websocket, "Responses WebSocket")
     except Exception as exc:
         add(checks, "runtime.codex-doctor", False, str(exc))

--- a/skills/synthesis-agent-conformance/scripts/test_client_binaries.py
+++ b/skills/synthesis-agent-conformance/scripts/test_client_binaries.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("client_binaries.py")
+SPEC = importlib.util.spec_from_file_location("client_binaries", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def fake_binary(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def test_env_override_wins_over_path(tmp_path: Path, monkeypatch) -> None:
+    override = fake_binary(tmp_path / "custom" / "codex")
+    monkeypatch.setenv("SYNTHESIS_CODEX_BIN", str(override))
+    monkeypatch.setattr(MODULE.shutil, "which", lambda name: "/elsewhere/codex")
+    assert MODULE.resolve_client_binary("codex") == str(override)
+
+
+def test_env_override_set_but_empty_means_absent(monkeypatch) -> None:
+    monkeypatch.setenv("SYNTHESIS_CODEX_BIN", "")
+    monkeypatch.setattr(MODULE.shutil, "which", lambda name: "/elsewhere/codex")
+    assert MODULE.resolve_client_binary("codex") is None
+
+
+def test_env_override_pointing_nowhere_fails_closed(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("SYNTHESIS_CLAUDE_BIN", str(tmp_path / "missing"))
+    monkeypatch.setattr(MODULE.shutil, "which", lambda name: "/elsewhere/claude")
+    assert MODULE.resolve_client_binary("claude") is None
+
+
+def test_path_resolution(monkeypatch) -> None:
+    monkeypatch.delenv("SYNTHESIS_CODEX_BIN", raising=False)
+    monkeypatch.setattr(MODULE.shutil, "which", lambda name: f"/on/path/{name}")
+    assert MODULE.resolve_client_binary("codex") == "/on/path/codex"
+
+
+def test_well_known_fallback(tmp_path: Path, monkeypatch) -> None:
+    fallback = fake_binary(tmp_path / "bundle" / "codex")
+    monkeypatch.delenv("SYNTHESIS_CODEX_BIN", raising=False)
+    monkeypatch.setattr(MODULE.shutil, "which", lambda name: None)
+    monkeypatch.setitem(MODULE.WELL_KNOWN_LOCATIONS, "codex", (str(fallback),))
+    assert MODULE.resolve_client_binary("codex") == str(fallback)
+
+
+def test_absent_everywhere_returns_none(monkeypatch) -> None:
+    monkeypatch.delenv("SYNTHESIS_CODEX_BIN", raising=False)
+    monkeypatch.setattr(MODULE.shutil, "which", lambda name: None)
+    monkeypatch.setitem(MODULE.WELL_KNOWN_LOCATIONS, "codex", ())
+    assert MODULE.resolve_client_binary("codex") is None
+
+
+def test_missing_binary_detail_names_override() -> None:
+    detail = MODULE.missing_binary_detail("codex")
+    assert "SYNTHESIS_CODEX_BIN" in detail
+    assert "codex" in detail
+
+
+def test_unknown_client_has_no_well_known_locations(monkeypatch) -> None:
+    monkeypatch.setattr(MODULE.shutil, "which", lambda name: None)
+    assert MODULE.resolve_client_binary("unknown-client") is None

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -198,3 +198,55 @@ def test_activate_and_handoff(tmp_path: Path) -> None:
     ]
     handoff = MODULE.handoff_checks(project, pointer)
     assert all(check.ok for check in handoff if check.required)
+
+
+def test_runtime_checks_fail_structurally_when_binaries_absent(monkeypatch) -> None:
+    monkeypatch.setattr(MODULE, "resolve_client_binary", lambda name: None)
+
+    checks = MODULE.runtime_checks()
+
+    named = {check.name: check for check in checks}
+    assert not named["runtime.claude-plugin"].ok
+    assert "SYNTHESIS_CLAUDE_BIN" in named["runtime.claude-plugin"].detail
+    assert not named["runtime.codex-plugin"].ok
+    assert not named["runtime.codex-doctor"].ok
+    assert "SYNTHESIS_CODEX_BIN" in named["runtime.codex-doctor"].detail
+
+
+def test_runtime_checks_survive_vanishing_binary(monkeypatch) -> None:
+    monkeypatch.setattr(
+        MODULE, "resolve_client_binary", lambda name: f"/gone/{name}"
+    )
+
+    def raising_run(command, timeout=30):
+        raise FileNotFoundError(command[0])
+
+    monkeypatch.setattr(MODULE, "run", raising_run)
+
+    checks = MODULE.runtime_checks()
+
+    named = {check.name: check for check in checks}
+    assert not named["runtime.claude-plugin"].ok
+    assert not named["runtime.codex-plugin"].ok
+    assert not named["runtime.codex-doctor"].ok
+
+
+def test_plugin_inventory_rejects_unexpected_json_shapes(monkeypatch) -> None:
+    monkeypatch.setattr(
+        MODULE, "resolve_client_binary", lambda name: f"/fake/{name}"
+    )
+
+    class Result:
+        returncode = 0
+        stdout = '{"unexpected": "shape"}'
+        stderr = ""
+
+    monkeypatch.setattr(MODULE, "run", lambda command, timeout=30: Result())
+
+    ok, detail = MODULE.plugin_inventory("claude")
+    assert not ok
+    assert "0 enabled" in detail
+
+    ok, detail = MODULE.plugin_inventory("codex")
+    assert not ok
+    assert "0 enabled" in detail

--- a/skills/synthesis-daily-rituals/scripts/day-end
+++ b/skills/synthesis-daily-rituals/scripts/day-end
@@ -37,29 +37,85 @@ configured_agent() {
   printf '%s\n' "auto"
 }
 
+# Resolve a client CLI the way synthesis-agent-conformance does: an explicit
+# SYNTHESIS_CODEX_BIN / SYNTHESIS_CLAUDE_BIN override (set but empty means
+# "treat as absent"), then PATH, then documented stable install locations. A
+# plain terminal has neither agent shell's PATH additions — the Codex CLI
+# ships inside the ChatGPT desktop app on macOS — and without the fallbacks
+# "auto" silently degrades to whichever client happens to be on PATH.
+find_agent_cli() {
+  case "$1" in
+    codex) override="${SYNTHESIS_CODEX_BIN-__unset__}" ;;
+    claude) override="${SYNTHESIS_CLAUDE_BIN-__unset__}" ;;
+    *) override="__unset__" ;;
+  esac
+  if [ "$override" != "__unset__" ]; then
+    if [ -n "$override" ] && [ -x "$override" ]; then
+      printf '%s\n' "$override"
+      return 0
+    fi
+    return 1
+  fi
+  if command -v "$1" >/dev/null 2>&1; then
+    command -v "$1"
+    return 0
+  fi
+  case "$1" in
+    codex)
+      set -- codex \
+        "$HOME/.local/bin/codex" \
+        /opt/homebrew/bin/codex \
+        /usr/local/bin/codex \
+        "/Applications/ChatGPT.app/Contents/Resources/codex"
+      ;;
+    claude)
+      set -- claude \
+        "$HOME/.local/bin/claude" \
+        /opt/homebrew/bin/claude \
+        /usr/local/bin/claude
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  shift
+  for candidate in "$@"; do
+    if [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
 AGENT="$(configured_agent)"
+AGENT_CLI=""
 case "$AGENT" in
   auto)
-    if command -v codex >/dev/null 2>&1; then
-      AGENT="codex"
-    elif command -v claude >/dev/null 2>&1; then
-      AGENT="claude"
+    if AGENT_CLI="$(find_agent_cli codex)"; then
+      :
+    elif AGENT_CLI="$(find_agent_cli claude)"; then
+      :
     else
-      echo "day-end: neither codex nor claude is available on PATH" >&2
+      echo "day-end: neither codex nor claude is available on PATH or in known install locations" >&2
       exit 127
     fi
     ;;
-  codex|claude) ;;
+  codex|claude)
+    if ! AGENT_CLI="$(find_agent_cli "$AGENT")"; then
+      echo "day-end: configured agent CLI is unavailable: $AGENT" >&2
+      exit 127
+    fi
+    ;;
   *)
-    echo "day-end: agent-cli must be auto, codex, or claude (got: $AGENT)" >&2
-    exit 2
+    if [ -x "$AGENT" ]; then
+      AGENT_CLI="$AGENT"
+    else
+      echo "day-end: agent-cli must be auto, codex, claude, or an executable path (got: $AGENT)" >&2
+      exit 2
+    fi
     ;;
 esac
-
-if ! command -v "$AGENT" >/dev/null 2>&1; then
-  echo "day-end: configured agent CLI is unavailable: $AGENT" >&2
-  exit 127
-fi
 
 MODE_LINE="Ask me the one-letter mode question (f = full, q = quick close, o = observer) before starting."
 case "${1:-}" in
@@ -70,4 +126,4 @@ case "${1:-}" in
   *) echo "usage: day-end [-f|-q|-o]" >&2; exit 2 ;;
 esac
 PROMPT="Please name this session day-end-$(date +%Y-%m-%d). Run the synthesis-daily-rituals Day-End ritual now. ${MODE_LINE}"
-exec "$AGENT" "$PROMPT"
+exec "$AGENT_CLI" "$PROMPT"

--- a/skills/synthesis-daily-rituals/scripts/test_install_day_end.py
+++ b/skills/synthesis-daily-rituals/scripts/test_install_day_end.py
@@ -110,3 +110,75 @@ def test_installer_refuses_symlinked_runtime_root(tmp_path: Path) -> None:
     assert completed.returncode == 2
     assert "symlinked runtime path" in completed.stderr
     assert list(elsewhere.iterdir()) == []
+
+
+def run_launcher(environment: dict[str, str], *arguments: str):
+    return subprocess.run(
+        ["bash", str(SCRIPT_DIR / "day-end"), *arguments],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+    )
+
+
+def fake_agent(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('#!/bin/sh\nprintf "%s" "$1"\n', encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def test_day_end_launcher_accepts_explicit_command_path(tmp_path: Path) -> None:
+    agent = fake_agent(tmp_path / "fake-agent")
+    completed = run_launcher(
+        {**os.environ, "DAY_END_AGENT_CMD": str(agent)}, "-q"
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "Quick Close" in completed.stdout
+
+
+def test_day_end_launcher_resolves_named_agent_from_known_locations(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    fake_agent(home / ".local" / "bin" / "codex")
+    completed = run_launcher(
+        {
+            "PATH": "/usr/bin:/bin",
+            "HOME": str(home),
+            "DAY_END_AGENT_CMD": "codex",
+        }
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "Day-End ritual" in completed.stdout
+
+
+def test_day_end_launcher_fails_closed_when_no_agent_exists(tmp_path: Path) -> None:
+    home = tmp_path / "empty-home"
+    home.mkdir()
+    completed = run_launcher(
+        {
+            "PATH": "/usr/bin:/bin",
+            "HOME": str(home),
+            "DAY_END_AGENT_CMD": "codex",
+            "SYNTHESIS_CODEX_BIN": "",
+        }
+    )
+    assert completed.returncode == 127
+    assert "unavailable" in completed.stderr
+
+
+def test_day_end_launcher_honors_binary_override(tmp_path: Path) -> None:
+    agent = fake_agent(tmp_path / "custom" / "codex")
+    completed = run_launcher(
+        {
+            "PATH": "/usr/bin:/bin",
+            "HOME": str(tmp_path / "home"),
+            "DAY_END_AGENT_CMD": "codex",
+            "SYNTHESIS_CODEX_BIN": str(agent),
+        },
+        "-o",
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "observer" in completed.stdout

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.6.0"
+  version: "1.7.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -355,7 +355,22 @@ Rules:
 The script uses an OS file lock, verified backups, and atomic replacement for
 board mutations. It refuses overlapping source areas, shared worktrees or
 branches, two context owners for the same project, and canonical-context claims
-from contributor sessions. See
+from contributor sessions. Claim overlap is compared on normalized path
+segments, so absolute, `~`-prefixed, and repository-relative spellings of the
+same real path still conflict; ambiguous relative-vs-absolute alignments are
+treated as conflicts rather than clearances.
+
+The OS file lock is authoritative only among processes sharing one
+filesystem. For simultaneous sessions on different machines, a `lease.json`
+beside the board opts it into a git-backed lease: every mutation is published
+through an atomic ref compare-and-swap on a shared git remote
+(`{"remote": "<url-or-path>", "ref": "refs/synthesis/coordination-board"}`),
+the local board file becomes a mirror of the leased ref, mutations retry on
+concurrent advance, and an unreachable remote fails closed instead of falling
+back to local-only writes. `status` refreshes the mirror; `doctor` verifies
+remote sync. Without a lease, simultaneous cross-machine writes to the same
+resources remain prohibited — file-sync conflict resolution is not a
+distributed lock. See
 [`references/active-sessions-template.md`](references/active-sessions-template.md)
 for the canonical file shape and
 [`references/parallel-agent-protocol.md`](references/parallel-agent-protocol.md)

--- a/skills/synthesis-project-management/references/parallel-agent-protocol.md
+++ b/skills/synthesis-project-management/references/parallel-agent-protocol.md
@@ -109,7 +109,28 @@ user or the owning session explicitly releases or reassigns the claim.
 
 Git carries durable project state and contribution artifacts between machines.
 The default live board uses an OS file lock, which is authoritative among
-processes sharing that filesystem. Simultaneous cross-machine writes to the
-same resources are prohibited until a distributed compare-and-swap coordination
-backend is configured and conformance-verified. File-sync conflict resolution
-is not a distributed lock.
+processes sharing that filesystem. File-sync conflict resolution is not a
+distributed lock.
+
+For simultaneous sessions on different machines, opt the board into the
+git-backed lease by writing `lease.json` beside it:
+
+```json
+{"remote": "git@example.com:owner/coordination.git"}
+```
+
+Optional keys: `ref` (default `refs/synthesis/coordination-board`) and
+`repository` (the local bare mirror, default `.lease-repo` beside the board).
+Every mutating command then performs an atomic compare-and-swap ref update on
+the shared remote — the server-side ref transaction is the mutual exclusion —
+and rewrites the local board as a mirror of the accepted state. Concurrent
+advances trigger a bounded refetch-and-retry against fresh content; an
+unreachable remote fails the mutation closed rather than falling back to a
+local-only write. `status` refreshes the mirror from the remote and reports a
+refresh failure as a problem (strict mode fails); `doctor` fails when the
+mirror and remote differ. The remote must be one both machines can push to;
+enable the lease on every machine that writes the board, or its writes bypass
+the shared exclusion.
+
+Without a configured lease, simultaneous cross-machine writes to the same
+resources remain prohibited.

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -10,6 +10,7 @@ import os
 import re
 import shutil
 import socket
+import subprocess
 import sys
 import tempfile
 from dataclasses import asdict, dataclass
@@ -143,16 +144,44 @@ def claim_prefix(claim: str) -> str:
     return claim[:marker].rstrip("/")
 
 
+def claim_segments(claim: str) -> tuple[bool, list[str]]:
+    prefix = claim_prefix(claim)
+    if not prefix:
+        return True, []
+    expanded = os.path.expanduser(prefix)
+    absolute = expanded.startswith("/")
+    segments = [part for part in expanded.strip("/").split("/") if part]
+    return absolute, segments
+
+
 def overlaps(left: str, right: str) -> bool:
-    left_prefix = claim_prefix(left)
-    right_prefix = claim_prefix(right)
-    if not left_prefix or not right_prefix:
+    """Conflict test for two claim globs.
+
+    Claims arrive in mixed spellings — absolute, ``~``-prefixed, and
+    repository-relative — and two spellings of one real path must still
+    conflict. Same-form claims overlap on segment-boundary containment.
+    A relative claim overlaps an absolute one when its segment run aligns
+    anywhere inside the absolute claim through the end of either claim;
+    that alignment can flag unrelated trees that share segment names, and
+    the protocol prefers that false conflict (resolved by re-scoping to
+    absolute claims) over silently missing a real one.
+    """
+    left_absolute, left_segments = claim_segments(left)
+    right_absolute, right_segments = claim_segments(right)
+    if not left_segments or not right_segments:
         return True
-    return (
-        left_prefix == right_prefix
-        or left_prefix.startswith(right_prefix + "/")
-        or right_prefix.startswith(left_prefix + "/")
-    )
+    if left_absolute == right_absolute:
+        shorter, longer = sorted(
+            (left_segments, right_segments), key=len
+        )
+        return longer[: len(shorter)] == shorter
+    absolute_segments = left_segments if left_absolute else right_segments
+    relative_segments = right_segments if left_absolute else left_segments
+    for start in range(len(absolute_segments)):
+        length = min(len(relative_segments), len(absolute_segments) - start)
+        if absolute_segments[start : start + length] == relative_segments[:length]:
+            return True
+    return False
 
 
 def workspace_parts(workspace: str) -> tuple[str, str]:
@@ -326,11 +355,203 @@ def write_board(board: Path, content: str) -> None:
         raise
 
 
+LEASE_CONFIG_NAME = "lease.json"
+LEASE_DEFAULT_REF = "refs/synthesis/coordination-board"
+LEASE_RETRIES = 3
+LEASE_GIT_TIMEOUT = 30
+LEASE_IDENTITY = {
+    "GIT_AUTHOR_NAME": "synthesis-coordination",
+    "GIT_AUTHOR_EMAIL": "coordination@localhost",
+    "GIT_COMMITTER_NAME": "synthesis-coordination",
+    "GIT_COMMITTER_EMAIL": "coordination@localhost",
+}
+
+
+def lease_configuration(board: Path) -> dict | None:
+    """Read the opt-in lease config that lives beside the board.
+
+    The OS file lock serializes sessions that share one filesystem. File-sync
+    services replicate the board but provide no mutual exclusion, so
+    same-resource writes from two machines need a real compare-and-swap. A
+    ``lease.json`` beside the board opts that board into publishing every
+    mutation through an atomic git ref update on a shared remote; the local
+    board file becomes a mirror of the leased ref.
+    """
+    path = board.parent / LEASE_CONFIG_NAME
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise RuntimeError(f"coordination lease config unreadable: {path}: {exc}")
+    remote = data.get("remote")
+    if not isinstance(remote, str) or not remote:
+        raise RuntimeError(f"coordination lease config lacks a remote: {path}")
+    ref = data.get("ref", LEASE_DEFAULT_REF)
+    if not isinstance(ref, str) or not ref.startswith("refs/"):
+        raise RuntimeError(f"coordination lease ref must live under refs/: {path}")
+    repository = Path(
+        str(data.get("repository", board.parent / ".lease-repo"))
+    ).expanduser()
+    return {"remote": remote, "ref": ref, "repository": repository}
+
+
+def git_lease(repository: Path, *arguments: str, input_text: str | None = None):
+    try:
+        return subprocess.run(
+            ["git", "--git-dir", str(repository), *arguments],
+            capture_output=True,
+            text=True,
+            timeout=LEASE_GIT_TIMEOUT,
+            check=False,
+            input=input_text,
+            env={**os.environ, **LEASE_IDENTITY},
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(
+            f"coordination lease git call timed out: git {' '.join(arguments[:2])}"
+        )
+    except FileNotFoundError:
+        raise RuntimeError("coordination lease requires git on PATH")
+
+
+def lease_repository(config: dict) -> Path:
+    repository = config["repository"]
+    if not (repository / "HEAD").is_file():
+        repository.mkdir(parents=True, exist_ok=True)
+        created = subprocess.run(
+            ["git", "init", "--bare", "--quiet", str(repository)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if created.returncode != 0:
+            raise RuntimeError(
+                f"coordination lease repository init failed: {created.stderr.strip()}"
+            )
+    return repository
+
+
+def lease_fetch(config: dict) -> tuple[str, str | None]:
+    """Return the remote ref tip and board content, or ("", None) pre-bootstrap."""
+    repository = lease_repository(config)
+    listed = git_lease(repository, "ls-remote", config["remote"], config["ref"])
+    if listed.returncode != 0:
+        raise RuntimeError(
+            f"coordination lease remote unreachable: {listed.stderr.strip()}"
+        )
+    if not listed.stdout.strip():
+        return "", None
+    fetched = git_lease(
+        repository,
+        "fetch",
+        "--quiet",
+        config["remote"],
+        f"+{config['ref']}:refs/lease/current",
+    )
+    if fetched.returncode != 0:
+        raise RuntimeError(
+            f"coordination lease fetch failed: {fetched.stderr.strip()}"
+        )
+    sha = git_lease(repository, "rev-parse", "refs/lease/current").stdout.strip()
+    names = git_lease(
+        repository, "ls-tree", "--name-only", "refs/lease/current"
+    ).stdout.split()
+    if len(names) != 1:
+        raise RuntimeError(
+            "coordination lease ref must contain exactly one board file, found: "
+            + (", ".join(names) or "none")
+        )
+    shown = git_lease(repository, "show", f"refs/lease/current:{names[0]}")
+    if shown.returncode != 0:
+        raise RuntimeError(
+            f"coordination lease board unreadable: {shown.stderr.strip()}"
+        )
+    return sha, shown.stdout
+
+
+def lease_publish(
+    config: dict, board_name: str, content: str, expected_sha: str
+) -> tuple[bool, str]:
+    repository = lease_repository(config)
+    blob = git_lease(repository, "hash-object", "-w", "--stdin", input_text=content)
+    if blob.returncode != 0:
+        raise RuntimeError(f"coordination lease blob write failed: {blob.stderr.strip()}")
+    tree = git_lease(
+        repository,
+        "mktree",
+        input_text=f"100644 blob {blob.stdout.strip()}\t{board_name}\n",
+    )
+    if tree.returncode != 0:
+        raise RuntimeError(f"coordination lease tree write failed: {tree.stderr.strip()}")
+    commit_arguments = ["commit-tree", tree.stdout.strip(), "-m", "Update coordination board"]
+    if expected_sha:
+        commit_arguments.extend(["-p", expected_sha])
+    committed = git_lease(repository, *commit_arguments)
+    if committed.returncode != 0:
+        raise RuntimeError(
+            f"coordination lease commit failed: {committed.stderr.strip()}"
+        )
+    pushed = git_lease(
+        repository,
+        "push",
+        "--quiet",
+        config["remote"],
+        f"{committed.stdout.strip()}:{config['ref']}",
+        f"--force-with-lease={config['ref']}:{expected_sha}",
+    )
+    if pushed.returncode == 0:
+        return True, ""
+    return False, pushed.stderr.strip()
+
+
+def lease_update(board: Path, config: dict, operation) -> None:
+    failure = ""
+    for _ in range(LEASE_RETRIES):
+        sha, content = lease_fetch(config)
+        if content is None:
+            content = (
+                board.read_text(encoding="utf-8") if board.exists() else template()
+            )
+        updated = operation(content)
+        published, failure = lease_publish(config, board.name, updated, sha)
+        if published:
+            write_board(board, updated)
+            return
+    raise RuntimeError(
+        "coordination lease compare-and-swap failed after "
+        f"{LEASE_RETRIES} attempts: {failure}"
+    )
+
+
+def lease_refresh(board: Path) -> dict:
+    """Best-effort mirror refresh for read paths; reports instead of raising."""
+    try:
+        config = lease_configuration(board)
+    except RuntimeError as exc:
+        return {"configured": True, "refreshed": False, "error": str(exc)}
+    if config is None:
+        return {"configured": False}
+    try:
+        sha, content = lease_fetch(config)
+    except RuntimeError as exc:
+        return {"configured": True, "refreshed": False, "error": str(exc)}
+    if content is not None and (
+        not board.exists() or board.read_text(encoding="utf-8") != content
+    ):
+        write_board(board, content)
+    return {"configured": True, "refreshed": True, "sha": sha}
+
+
 def locked_update(board: Path, operation) -> None:
     board.parent.mkdir(parents=True, exist_ok=True)
     lock_path = board.parent / ".active-sessions.lock"
     with lock_path.open("a+", encoding="utf-8") as lock:
         fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        config = lease_configuration(board)
+        if config is not None:
+            lease_update(board, config, operation)
+            return
         content = board.read_text(encoding="utf-8") if board.exists() else template()
         write_board(board, operation(content))
 
@@ -383,14 +604,24 @@ def validate_sessions(sessions: list[Session]) -> list[str]:
 
 
 def command_status(args) -> int:
+    lease = lease_refresh(args.board)
     if not args.board.is_file():
+        if lease.get("error"):
+            print(f"COORDINATION ERROR: {lease['error']}", file=sys.stderr)
+            return 10 if args.strict else 0
         print(f"No coordination board: {args.board}")
         return 0
     content = args.board.read_text(encoding="utf-8")
     sessions = rows(content)
+    problems = validate_sessions(sessions)
+    if lease.get("error"):
+        problems.append(
+            f"lease refresh failed; local mirror may be stale: {lease['error']}"
+        )
     payload = {
         "schema_version": SCHEMA_VERSION,
         "board": str(args.board),
+        "lease": lease,
         "sessions": [
             {
                 **asdict(session),
@@ -398,7 +629,7 @@ def command_status(args) -> int:
             }
             for session in sessions
         ],
-        "problems": validate_sessions(sessions),
+        "problems": problems,
     }
     if args.json:
         print(json.dumps(payload, indent=2))
@@ -543,7 +774,11 @@ def command_migrate(args) -> int:
         migrated = rows(content)
         return replace_table(content, migrated)
 
-    locked_update(args.board, operation)
+    try:
+        locked_update(args.board, operation)
+    except RuntimeError as exc:
+        print(f"coordination migrate failed: {exc}", file=sys.stderr)
+        return 10
     print(f"Migrated {args.board} to schema v{SCHEMA_VERSION}.")
     return 0
 
@@ -559,6 +794,25 @@ def command_doctor(args) -> int:
     except Exception as exc:
         print(f"FAIL coordination.board: {exc}", file=sys.stderr)
         return 1
+    lease_line = ""
+    try:
+        lease = lease_configuration(args.board)
+        if lease is not None:
+            sha, remote_content = lease_fetch(lease)
+            if remote_content is None:
+                problems.append(
+                    "lease is configured but the remote ref has never been "
+                    "published; run any mutating command to bootstrap it"
+                )
+            elif remote_content != content:
+                problems.append(
+                    "local board mirror differs from the lease remote; run "
+                    "status to refresh the mirror"
+                )
+            else:
+                lease_line = f", lease in sync at {sha[:12]}"
+    except RuntimeError as exc:
+        problems.append(str(exc))
     required = ("## Active sessions", "## Messages", "## Protocol")
     missing = [heading for heading in required if heading not in content]
     if missing:
@@ -571,7 +825,7 @@ def command_doctor(args) -> int:
         return 1
     print(
         f"PASS coordination: schema v{SCHEMA_VERSION}, "
-        f"{len(sessions)} session(s)"
+        f"{len(sessions)} session(s){lease_line}"
     )
     return 0
 

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -279,3 +279,283 @@ def test_message_accepts_annotated_protocol_heading(tmp_path: Path) -> None:
     text = board.read_text(encoding="utf-8")
     assert "Sequencing update." in text
     assert "## Protocol (formalized)" in text
+
+
+def test_overlap_detects_relative_and_absolute_spellings_of_one_path() -> None:
+    assert MODULE.overlaps(
+        "ai-knowledge-demo/projects/index.yaml",
+        "/home/user/workspaces/demo/ai-knowledge-demo/projects/index.yaml",
+    )
+    assert MODULE.overlaps(
+        "/home/user/workspaces/demo/ai-knowledge-demo/projects/**",
+        "ai-knowledge-demo/projects/index.yaml",
+    )
+    assert MODULE.overlaps(
+        "ai-knowledge-demo/projects/demo-project/sessions/2026-07.md",
+        "/home/user/workspaces/demo/ai-knowledge-demo/projects/**",
+    )
+
+
+def test_overlap_expands_home_prefixed_claims() -> None:
+    home = Path.home()
+    assert MODULE.overlaps(
+        "~/.claude/skills/**",
+        f"{home}/.claude/skills/demo-skill/SKILL.md",
+    )
+
+
+def test_overlap_keeps_distinct_subtrees_apart() -> None:
+    assert not MODULE.overlaps(
+        "ai-knowledge-demo/daily-plans/**",
+        "/home/user/workspaces/demo/ai-knowledge-demo/projects/**",
+    )
+    assert not MODULE.overlaps(
+        "/repos/alpha/**",
+        "/repos/beta/**",
+    )
+    assert not MODULE.overlaps("/repos/alpha/**", "/repos/alphabet/**")
+    assert not MODULE.overlaps("repo/docs/**", "repo/does-not-share/**")
+
+
+def test_overlap_same_form_containment_still_holds() -> None:
+    assert MODULE.overlaps("repo/**", "repo/file.md")
+    assert MODULE.overlaps("/repos/alpha/**", "/repos/alpha/docs/**")
+    assert MODULE.overlaps("bare-glob-**", "bare-glob-**")
+
+
+def test_mixed_spelling_claims_conflict_on_the_board(tmp_path: Path) -> None:
+    board = tmp_path / "coordination" / "active-sessions.md"
+    first = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="ai-knowledge-demo/projects/index.yaml",
+    )
+    assert MODULE.command_claim(first) == 0
+
+    second = claim_args(
+        board,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="/home/user/workspaces/demo/ai-knowledge-demo/projects/index.yaml",
+    )
+    assert MODULE.command_claim(second) == 10
+
+
+def lease_machines(tmp_path: Path, count: int = 2) -> list[Path]:
+    """Simulate machines sharing one lease remote but no filesystem board."""
+    subprocess = __import__("subprocess")
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", "--quiet", str(remote)],
+        check=True,
+        capture_output=True,
+    )
+    boards = []
+    for index in range(1, count + 1):
+        directory = tmp_path / f"machine{index}"
+        directory.mkdir()
+        (directory / "lease.json").write_text(
+            json.dumps({"remote": str(remote)}), encoding="utf-8"
+        )
+        boards.append(directory / "active-sessions.md")
+    return boards
+
+
+def test_lease_shares_claims_across_machines(tmp_path: Path) -> None:
+    machine1, machine2 = lease_machines(tmp_path)
+    first = claim_args(
+        machine1,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="/repos/shared/docs/**",
+    )
+    assert MODULE.command_claim(first) == 0
+
+    conflicting = claim_args(
+        machine2,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="/repos/shared/docs/guide.md",
+    )
+    assert MODULE.command_claim(conflicting) == 10
+
+    disjoint = claim_args(
+        machine2,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="/repos/other/**",
+    )
+    assert MODULE.command_claim(disjoint) == 0
+
+    assert MODULE.command_release(args(machine1, id="A")) == 0
+    retried = claim_args(
+        machine2,
+        session_id="C",
+        project="project-c",
+        workspace="/tmp/worktree-c @ feature/c",
+        area="/repos/shared/docs/guide.md",
+    )
+    assert MODULE.command_claim(retried) == 0
+
+    table = MODULE.rows(machine2.read_text(encoding="utf-8"))
+    by_id = {row.id: row for row in table}
+    assert by_id["A"].status == "released"
+    assert by_id["B"].status == "active"
+    assert by_id["C"].status == "active"
+
+
+def test_lease_compare_and_swap_retries_after_concurrent_advance(
+    tmp_path: Path, monkeypatch
+) -> None:
+    machine1, machine2 = lease_machines(tmp_path)
+    original_publish = MODULE.lease_publish
+    state = {"raced": False}
+
+    def racing_publish(config, board_name, content, expected_sha):
+        if not state["raced"]:
+            state["raced"] = True
+            competing = claim_args(
+                machine2,
+                session_id="X",
+                project="project-x",
+                workspace="/tmp/worktree-x @ feature/x",
+                area="/repos/unrelated/**",
+            )
+            assert MODULE.command_claim(competing) == 0
+        return original_publish(config, board_name, content, expected_sha)
+
+    monkeypatch.setattr(MODULE, "lease_publish", racing_publish)
+    first = claim_args(
+        machine1,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="/repos/shared/**",
+    )
+    assert MODULE.command_claim(first) == 0
+
+    table = MODULE.rows(machine1.read_text(encoding="utf-8"))
+    identifiers = {row.id for row in table}
+    assert identifiers == {"A", "X"}
+
+
+def test_lease_unreachable_remote_fails_closed(tmp_path: Path) -> None:
+    directory = tmp_path / "machine1"
+    directory.mkdir()
+    (directory / "lease.json").write_text(
+        json.dumps({"remote": str(tmp_path / "missing-remote.git")}),
+        encoding="utf-8",
+    )
+    board = directory / "active-sessions.md"
+    request = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="/repos/shared/**",
+    )
+    assert MODULE.command_claim(request) == 10
+    assert not board.exists()
+
+
+def test_lease_bootstrap_publishes_existing_local_board(tmp_path: Path) -> None:
+    machine1, machine2 = lease_machines(tmp_path)
+    (machine1.parent / "lease.json").unlink()
+    local_only = claim_args(
+        machine1,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="/repos/shared/**",
+    )
+    assert MODULE.command_claim(local_only) == 0
+
+    (machine1.parent / "lease.json").write_text(
+        json.dumps({"remote": str(tmp_path / "remote.git")}), encoding="utf-8"
+    )
+    second = claim_args(
+        machine1,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="/repos/other/**",
+    )
+    assert MODULE.command_claim(second) == 0
+
+    conflicting = claim_args(
+        machine2,
+        session_id="C",
+        project="project-c",
+        workspace="/tmp/worktree-c @ feature/c",
+        area="/repos/shared/inner/**",
+    )
+    assert MODULE.command_claim(conflicting) == 10
+
+
+def test_lease_status_reports_refresh_failure_in_strict_mode(
+    tmp_path: Path, capsys
+) -> None:
+    machine1, _ = lease_machines(tmp_path)
+    request = claim_args(
+        machine1,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="/repos/shared/**",
+    )
+    assert MODULE.command_claim(request) == 0
+
+    (machine1.parent / "lease.json").write_text(
+        json.dumps({"remote": str(tmp_path / "now-gone.git")}), encoding="utf-8"
+    )
+    capsys.readouterr()
+    exit_code = MODULE.command_status(
+        args(machine1, json=True, strict=True, stale_after_minutes=240)
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 10
+    assert payload["lease"]["configured"] is True
+    assert payload["lease"]["refreshed"] is False
+    assert any("lease refresh failed" in problem for problem in payload["problems"])
+
+
+def test_lease_doctor_verifies_remote_sync(tmp_path: Path, capsys) -> None:
+    machine1, machine2 = lease_machines(tmp_path)
+    request = claim_args(
+        machine1,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="/repos/shared/**",
+    )
+    assert MODULE.command_claim(request) == 0
+    assert MODULE.command_doctor(args(machine1)) == 0
+    captured = capsys.readouterr()
+    assert "lease in sync" in captured.out
+
+    advance = claim_args(
+        machine2,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="/repos/other/**",
+    )
+    assert MODULE.command_claim(advance) == 0
+    assert MODULE.command_doctor(args(machine1)) == 1
+    captured = capsys.readouterr()
+    assert "differs from the lease remote" in captured.err
+
+    assert (
+        MODULE.command_status(
+            args(machine1, json=False, strict=False, stale_after_minutes=240)
+        )
+        == 0
+    )
+    assert MODULE.command_doctor(args(machine1)) == 0

--- a/tests/test_installer.sh
+++ b/tests/test_installer.sh
@@ -138,4 +138,32 @@ done
 find "$TEST_ROOT/plugin-cache/synthesis-skills-backups" \
     -path '*/retired-*/*/SKILL.md' -type f | grep -q .
 
+# Binary overrides must detect plugins without the client CLIs on PATH — the
+# situation every non-Codex shell is in for codex — and a set-but-empty
+# override must be authoritative even when a CLI is findable.
+printf '%s\n' '#!/bin/sh' 'printf '\''[{"id":"synthesis-skills@test","enabled":true}]\n'\''' \
+    > "$PLUGIN_BIN/claude"
+printf '%s\n' '#!/bin/sh' 'printf '\''{"installed":[{"name":"synthesis-skills","enabled":true}]}\n'\''' \
+    > "$PLUGIN_BIN/codex"
+OVERRIDE_STATUS=$(
+    SYNTHESIS_CLAUDE_BIN="$PLUGIN_BIN/claude" \
+    SYNTHESIS_CODEX_BIN="$PLUGIN_BIN/codex" \
+    SYNTHESIS_SKILLS_HOME="$PLUGIN_HOME" \
+    XDG_CACHE_HOME="$TEST_ROOT/override-cache" \
+        "$REPO_ROOT/install.sh" status 2>&1
+)
+printf '%s\n' "$OVERRIDE_STATUS" | grep -q 'Claude Code plugin: installed and enabled'
+printf '%s\n' "$OVERRIDE_STATUS" | grep -q 'Codex plugin:       installed and enabled'
+
+EMPTY_OVERRIDE_STATUS=$(
+    PATH="$PLUGIN_BIN:$PATH" \
+    SYNTHESIS_CLAUDE_BIN= \
+    SYNTHESIS_CODEX_BIN= \
+    SYNTHESIS_SKILLS_HOME="$PLUGIN_HOME" \
+    SYNTHESIS_SKILLS_TARGETS="$TEST_ROOT/empty-override-target" \
+        "$REPO_ROOT/install.sh" status 2>&1 || true
+)
+printf '%s\n' "$EMPTY_OVERRIDE_STATUS" | grep -q 'Claude Code plugin: not installed or disabled'
+printf '%s\n' "$EMPTY_OVERRIDE_STATUS" | grep -q 'Codex plugin:       not installed or disabled'
+
 echo "installer tests passed"


### PR DESCRIPTION
## Summary

Independent peer-review pass over the dual-runtime verification and coordination layers, from a Claude Code shell — the environment the suite had not yet been executed from.

- **Fix a runtime-conformance crash.** `conformance.py runtime` invoked `codex doctor` without exception handling; a missing client CLI aborted the whole `all` report with a traceback instead of structured failures. All runtime checks now report structured results and the remaining check groups still run.
- **Resolve client binaries symmetrically.** Each client's shell puts only its own CLI on PATH (the Codex CLI ships inside the ChatGPT desktop app on macOS), so verification was only runnable from Codex. A shared resolver (`client_binaries.py`, mirrored in `install.sh`) tries `SYNTHESIS_CLAUDE_BIN` / `SYNTHESIS_CODEX_BIN` overrides (set-but-empty means absent), then PATH, then documented stable install locations. Plugin detection in the installer no longer silently reverts to direct-copy fallbacks from the other client's shell.
- **Normalize coordination claim overlap.** `overlaps()` compared raw textual prefixes, so absolute, `~`, and repository-relative spellings of one real path never conflicted — the fail-closed check failed open on mixed-format boards. Claims now compare on normalized path segments; ambiguous relative-vs-absolute alignments count as conflicts.
- **Add an opt-in git-backed coordination lease** (`synthesis-project-management` v1.7.0). A `lease.json` beside the board publishes every mutation through an atomic git ref compare-and-swap on a shared remote: bounded retry on concurrent advance, fail-closed on unreachable remotes, mirror refresh in `status`, sync verification in `doctor`. This closes the documented cross-machine boundary — file-sync replication is not mutual exclusion — with server-side ref transactions as the ownership decision.
- Version 4.6.0 in both plugin manifests, changelog, and README note.

## Test plan

- [x] `conformance.py source` 111/111; `instructions` 2/2; `runtime` 5/5 and `all` 133/133 from a Claude Code shell (previously crashed)
- [x] `pytest` conformance suites: 23 passed (new: resolver semantics, structured runtime failures, JSON-shape guards)
- [x] `pytest` coordination suite: 22 passed (new: mixed-spelling conflicts, two-machine lease sharing, CAS retry under concurrent advance, unreachable-remote fail-closed, bootstrap publish, strict-status refresh failure, doctor sync)
- [x] `sh -n` + `./tests/test_installer.sh` including new override-detection and empty-override scenarios
- [x] kb-edit, okf, daily-rituals, message-guard, git-hooks suites; `compileall`; inbox poisoned/resolver/runtime-installer checks
- [x] Live board doctor passes against the real coordination board with the stricter comparator

🤖 Generated with [Claude Code](https://claude.com/claude-code)