### PR TITLE
Trustworthy resumption, lease self-declaration, and safe worktree retirement

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.7.0] - 2026-07-30
+
+### Added
+
+- Record-freshness verification: `conformance.py` activation and handoff, and
+  the shared SessionStart context, now compare the local project record with
+  its last-fetched upstream and flag how many upstream commits touching the
+  project subtree are missing locally. A stale checkout can no longer report
+  phase, status, and plan with silent confidence; activation refuses to write
+  a pointer from a stale record.
+- Payload-parity handoff check: `handoff` runs the shared SessionStart script
+  in both client envelope formats against the live pointer and verifies the
+  enveloped context is identical, without needing either client binary.
+- Lease self-declaration (`synthesis-project-management` v1.8.0): a
+  lease-managed board carries a `Lease: <remote>` header line that travels
+  with the board content. A lease-aware helper on a machine whose
+  `lease.json` has not arrived (or was lost) refuses to mutate instead of
+  writing a local-only change that the next lease refetch would drop. The
+  `lease-disable` command retires a lease sanctionedly — publishing the
+  undeclared board through the compare-and-swap path and moving the local
+  config to a timestamped `.disabled-` file — with `--local-only` reserved
+  for unreachable-remote recovery; the doctor flags declared-but-unconfigured
+  boards.
+- `retire_worktree.py`: fail-closed retirement of merged feature worktrees.
+  Takes the repository explicitly (never inferred from the working
+  directory), refuses main worktrees, dirty trees, detached heads, branch
+  mismatches, and a working directory inside the target; verifies branch
+  ancestry against the freshly fetched remote base before removing anything;
+  deletes local branches with safe delete only and remote branches only on
+  request.
+
 ## [4.6.0] - 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Proven AI agent skills for code review, content creation, project management, an
 
 ## What's new
 
+**Trustworthy resumption and safe retirement (July 2026).**
+Activation, handoff, and SessionStart context now detect stale project
+checkouts by comparing the record with its fetched upstream, and handoff
+verifies that both client envelope formats carry identical context.
+`synthesis-project-management` **v1.8.0** makes lease-managed boards
+self-declaring — a machine without the lease config refuses to write rather
+than losing changes silently, with a sanctioned `lease-disable` path — and
+adds `retire_worktree.py` for fail-closed, remote-verified retirement of
+merged worktrees. See the [4.7.0 release notes](CHANGELOG.md).
+
 **Symmetric verification and cross-machine coordination (July 2026).**
 Conformance checks, doctors, and installers now resolve the Claude and Codex
 CLIs through overrides, `PATH`, and documented install locations, so the same

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -27,7 +27,7 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from client_binaries import missing_binary_detail, resolve_client_binary
-from project_context import next_actions
+from project_context import next_actions, record_freshness
 
 DEFAULT_SOURCE_ROOT = SCRIPT_PATH.parents[3]
 DEFAULT_ACTIVE_PROJECT = Path.home() / ".synthesis" / "active-project.json"
@@ -55,13 +55,16 @@ def add(checks: list[Check], name: str, ok: bool, detail: str, required: bool = 
     checks.append(Check(name=name, ok=ok, detail=detail, required=required))
 
 
-def run(command: list[str], timeout: int = 30) -> subprocess.CompletedProcess[str]:
+def run(
+    command: list[str], timeout: int = 30, input_text: str | None = None
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         command,
         capture_output=True,
         text=True,
         timeout=timeout,
         check=False,
+        input=input_text,
     )
 
 
@@ -439,6 +442,8 @@ def project_summary(project: Path) -> tuple[dict[str, object], list[Check]]:
     add(checks, "handoff.context", context.is_file(), str(context))
     add(checks, "handoff.reference", reference.is_file(), str(reference))
     add(checks, "handoff.sessions", sessions.is_dir(), str(sessions))
+    fresh, detail = record_freshness(project)
+    add(checks, "handoff.record-freshness", fresh, detail)
 
     summary: dict[str, object] = {"project": str(project.resolve())}
     if context.is_file():
@@ -479,6 +484,64 @@ def activate(project: Path, pointer: Path) -> list[Check]:
     return checks
 
 
+TIMESTAMP_LINE = re.compile(r"^Verified local time: .*$", re.MULTILINE)
+
+
+def payload_parity(pointer: Path) -> tuple[bool, str]:
+    """Both client formats of the SessionStart payload must carry one context.
+
+    The claude and codex wrappers are native envelopes around the same
+    message; this runs the shared script in both formats against the live
+    pointer and compares the enveloped context after normalizing the
+    timestamp line. No client binary is required — the script itself is the
+    shared implementation both clients invoke.
+    """
+    script = SCRIPTS_DIR / "session_context.py"
+    contexts: dict[str, str] = {}
+    for client_format in ("claude", "codex"):
+        result = run(
+            [
+                sys.executable,
+                str(script),
+                "--format",
+                client_format,
+                "--active-project-file",
+                str(pointer),
+            ],
+            input_text="{}",
+        )
+        if result.returncode != 0:
+            return False, (
+                f"{client_format} payload failed: "
+                + (result.stderr.strip() or f"exit {result.returncode}")
+            )
+        try:
+            envelope = json.loads(result.stdout)
+            contexts[client_format] = envelope["hookSpecificOutput"][
+                "additionalContext"
+            ]
+        except Exception as exc:
+            return False, f"{client_format} payload is not a valid envelope: {exc}"
+    normalized = {
+        client_format: TIMESTAMP_LINE.sub("Verified local time: <normalized>", text)
+        for client_format, text in contexts.items()
+    }
+    if normalized["claude"] == normalized["codex"]:
+        return True, "claude and codex envelopes carry identical context"
+    difference = next(
+        (
+            f"claude={left!r} codex={right!r}"
+            for left, right in zip(
+                normalized["claude"].splitlines(),
+                normalized["codex"].splitlines(),
+            )
+            if left != right
+        ),
+        "payloads differ in length",
+    )
+    return False, f"client payloads diverge: {difference}"
+
+
 def handoff_checks(project: Path, pointer: Path) -> list[Check]:
     summary, checks = project_summary(project)
     try:
@@ -492,6 +555,8 @@ def handoff_checks(project: Path, pointer: Path) -> list[Check]:
                 active.get(key) == summary.get(key),
                 f"active={active.get(key)!r}; project={summary.get(key)!r}",
             )
+        parity, detail = payload_parity(pointer)
+        add(checks, "handoff.payload-parity", parity, detail)
     except Exception as exc:
         add(checks, "handoff.pointer", False, f"{pointer}: {exc}")
     return checks

--- a/skills/synthesis-agent-conformance/scripts/project_context.py
+++ b/skills/synthesis-agent-conformance/scripts/project_context.py
@@ -4,9 +4,54 @@
 from __future__ import annotations
 
 import re
+import subprocess
+from pathlib import Path
 
 
 CHECKLIST = re.compile(r"^(?:[-*]|\d+\.)\s+\[([ xX])\]\s+")
+
+
+def _git(project: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(project), *arguments],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def record_freshness(project: Path) -> tuple[bool, str]:
+    """Compare the local project record with its last-fetched upstream.
+
+    A checkout left behind by another machine or session reports a stale
+    phase, status, and plan with full confidence; both clients resume from
+    whatever the record file says. This counts upstream commits that touch
+    the project subtree but are absent locally. It never touches the
+    network — the comparison is against the already-fetched remote-tracking
+    ref, so run `git fetch` first when currency matters.
+    """
+    inside = _git(project, "rev-parse", "--show-toplevel")
+    if inside.returncode != 0:
+        return False, inside.stderr.strip() or "not inside a git repository"
+    upstream = _git(
+        project, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"
+    )
+    if upstream.returncode != 0:
+        return True, "no upstream configured; freshness not comparable"
+    upstream_name = upstream.stdout.strip()
+    behind = _git(
+        project, "rev-list", "--count", f"HEAD..{upstream_name}", "--", str(project)
+    )
+    if behind.returncode != 0:
+        return False, behind.stderr.strip() or "freshness comparison failed"
+    count = int(behind.stdout.strip() or "0")
+    if count == 0:
+        return True, f"record current with fetched {upstream_name}"
+    return False, (
+        f"project record is {count} commit(s) behind fetched {upstream_name}; "
+        "pull the checkout before trusting phase, status, or plan"
+    )
 
 
 def extract(context: str, key: str) -> str:

--- a/skills/synthesis-agent-conformance/scripts/session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/session_context.py
@@ -14,7 +14,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-from project_context import extract, next_actions
+from project_context import extract, next_actions, record_freshness
 
 
 DEFAULT_POINTER = Path.home() / ".synthesis" / "active-project.json"
@@ -91,6 +91,9 @@ def build(pointer: Path, coordination_board: Path = DEFAULT_COORDINATION_BOARD) 
             f"Controlling plan: {plan}.",
         ]
     )
+    fresh, freshness_detail = record_freshness(project)
+    if not fresh:
+        lines.append(f"RECORD STALENESS WARNING: {freshness_detail}.")
     actions = next_actions(context)
     if actions:
         lines.append("Recorded next actions:")

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -198,6 +198,105 @@ def test_activate_and_handoff(tmp_path: Path) -> None:
     ]
     handoff = MODULE.handoff_checks(project, pointer)
     assert all(check.ok for check in handoff if check.required)
+    named = {check.name: check for check in handoff}
+    assert named["handoff.payload-parity"].ok
+    assert "identical context" in named["handoff.payload-parity"].detail
+    assert named["handoff.record-freshness"].ok
+
+
+def clone_pair_with_project(tmp_path: Path) -> tuple[Path, Path]:
+    """Two clones of one remote; the project lives in both, one goes stale."""
+    subprocess = __import__("subprocess")
+
+    def git(cwd: Path, *arguments: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(cwd), *arguments], check=True, capture_output=True
+        )
+
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", "--quiet", "--initial-branch", "main", str(remote)],
+        check=True,
+        capture_output=True,
+    )
+    clones = []
+    for name in ("writer", "reader"):
+        clone = tmp_path / name
+        subprocess.run(
+            ["git", "clone", "--quiet", str(remote), str(clone)],
+            check=True,
+            capture_output=True,
+        )
+        git(clone, "config", "user.email", "test@example.com")
+        git(clone, "config", "user.name", "Test")
+        clones.append(clone)
+    writer, reader = clones
+    project = writer / "projects" / "demo"
+    project.mkdir(parents=True)
+    (project / "CONTEXT.md").write_text("**Phase:** 1\n", encoding="utf-8")
+    git(writer, "add", "projects")
+    git(writer, "commit", "--quiet", "-m", "seed")
+    git(writer, "push", "--quiet", "origin", "main")
+    git(reader, "pull", "--quiet")
+
+    (project / "CONTEXT.md").write_text("**Phase:** 2\n", encoding="utf-8")
+    git(writer, "commit", "--quiet", "-am", "advance")
+    git(writer, "push", "--quiet", "origin", "main")
+    git(reader, "fetch", "--quiet", "origin")
+    return writer / "projects" / "demo", reader / "projects" / "demo"
+
+
+def test_record_freshness_flags_stale_checkout(tmp_path: Path) -> None:
+    current, stale = clone_pair_with_project(tmp_path)
+
+    fresh, detail = MODULE.record_freshness(current)
+    assert fresh, detail
+
+    fresh, detail = MODULE.record_freshness(stale)
+    assert not fresh
+    assert "1 commit(s) behind" in detail
+
+    subprocess = __import__("subprocess")
+    subprocess.run(
+        ["git", "-C", str(stale.parents[1]), "pull", "--quiet"],
+        check=True,
+        capture_output=True,
+    )
+    fresh, detail = MODULE.record_freshness(stale)
+    assert fresh, detail
+
+
+def test_record_freshness_without_upstream_is_not_comparable(tmp_path: Path) -> None:
+    subprocess = __import__("subprocess")
+    project = tmp_path / "local-only"
+    project.mkdir()
+    subprocess.run(["git", "init", str(project)], check=True, capture_output=True)
+    fresh, detail = MODULE.record_freshness(project)
+    assert fresh
+    assert "not comparable" in detail
+
+
+def test_activate_refuses_stale_record(tmp_path: Path) -> None:
+    _, stale = clone_pair_with_project(tmp_path)
+    (stale / "REFERENCE.md").write_text("# Reference\n", encoding="utf-8")
+    (stale / "sessions").mkdir()
+
+    pointer = tmp_path / "active.json"
+    checks = MODULE.activate(stale, pointer)
+    named = {check.name: check for check in checks}
+    assert not named["handoff.record-freshness"].ok
+    assert not pointer.exists()
+
+
+def test_payload_parity_reports_broken_pointer(tmp_path: Path) -> None:
+    pointer = tmp_path / "active.json"
+    pointer.write_text(
+        json.dumps({"project": str(tmp_path / "missing-project")}),
+        encoding="utf-8",
+    )
+    ok, detail = MODULE.payload_parity(pointer)
+    assert not ok
+    assert "payload failed" in detail
 
 
 def test_runtime_checks_fail_structurally_when_binaries_absent(monkeypatch) -> None:

--- a/skills/synthesis-agent-conformance/scripts/test_session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/test_session_context.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -61,3 +62,31 @@ def test_build_includes_active_coordination(tmp_path: Path) -> None:
     assert "session(s): A" in message
     assert "B" not in message
     assert "verify claims before writes" in message
+
+
+def test_build_warns_when_project_record_is_stale(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "CONTEXT.md").write_text(
+        "**Phase:** 2\n**Status:** Active\n", encoding="utf-8"
+    )
+    pointer = tmp_path / "active.json"
+    pointer.write_text(
+        json.dumps({"project": str(project), "plan": "unknown"}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        MODULE,
+        "record_freshness",
+        lambda path: (False, "project record is 3 commit(s) behind fetched origin/main"),
+    )
+    message = MODULE.build(pointer, tmp_path / "no-board.md")
+    assert "RECORD STALENESS WARNING" in message
+    assert "3 commit(s) behind" in message
+
+    monkeypatch.setattr(
+        MODULE, "record_freshness", lambda path: (True, "record current")
+    )
+    message = MODULE.build(pointer, tmp_path / "no-board.md")
+    assert "RECORD STALENESS WARNING" not in message

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -368,13 +368,21 @@ through an atomic ref compare-and-swap on a shared git remote
 the local board file becomes a mirror of the leased ref, mutations retry on
 concurrent advance, and an unreachable remote fails closed instead of falling
 back to local-only writes. `status` refreshes the mirror; `doctor` verifies
-remote sync. Without a lease, simultaneous cross-machine writes to the same
-resources remain prohibited — file-sync conflict resolution is not a
-distributed lock. See
+remote sync. A leased board declares itself in its header (`Lease: <remote>`),
+and a machine that sees the declaration without a local `lease.json` refuses
+to mutate rather than writing a change the next refetch would drop;
+`lease-disable` is the sanctioned retirement path. Without a lease,
+simultaneous cross-machine writes to the same resources remain prohibited —
+file-sync conflict resolution is not a distributed lock.
+
+Retire merged feature worktrees with `scripts/retire_worktree.py`
+(explicit repository argument, fetch-then-verify remote ancestry, fail-closed
+on dirty or unmerged state) instead of hand-run git sequences. See
 [`references/active-sessions-template.md`](references/active-sessions-template.md)
 for the canonical file shape and
 [`references/parallel-agent-protocol.md`](references/parallel-agent-protocol.md)
-for operating patterns across different and shared projects.
+for the quickstart, digest convention, administrative release, lease
+bootstrap/retirement, and worktree-retirement details.
 
 ### Cross-Agent Handoff
 

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.7.0"
+  version: "1.8.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-project-management/references/parallel-agent-protocol.md
+++ b/skills/synthesis-project-management/references/parallel-agent-protocol.md
@@ -4,6 +4,41 @@ Synthesis project management supports independent Claude Code, OpenAI Codex,
 Cursor, and other root sessions without making any client the owner of project
 memory.
 
+## Quickstart — many agents, projects, and computers
+
+The order of operations for every root session, in any client, on any
+machine:
+
+1. **Anchor.** Verify the date, then run `coordination.py status` — it
+   refreshes the lease mirror when one is configured — and read your
+   project's `CONTEXT.md`, `REFERENCE.md`, latest session entry, and
+   controlling plan. Trust `git log`, not cached prose; a
+   `handoff.record-freshness` failure or a SessionStart staleness warning
+   means pull the checkout before believing anything the record says.
+2. **Claim.** Register an unused session id with your exact machine,
+   project, worktree/branch, resource claims, and context role — owner for
+   the project's canonical context, contributor for a bounded slice.
+3. **Isolate.** Create worktrees only after the claim, always naming the
+   repository explicitly (a `cd`-dependent worktree command in the wrong
+   directory creates a worktree of the wrong repository).
+4. **Work.** Heartbeat at checkpoints; keep the plan file current at phase
+   boundaries — it is the artifact that survives a crash (see "Digests").
+5. **Close.** Commit and push durable state, message affected sessions,
+   release the claim, and retire merged worktrees with
+   `retire_worktree.py`, never by hand.
+
+## Digests — what survives a crash
+
+Semantic continuity does not come from copying chat transcripts. The durable
+digest of a session is the controlling plan file updated at every phase
+boundary (decisions, evidence, open loops, approval gates, user
+instructions), plus the session-log entry written at close. A session that
+dies mid-flight loses at most the work since its last plan-file update —
+which is why the update belongs at every phase boundary, not at the end.
+Contributor sessions get the same protection from their contribution
+artifact. No separate digest artifact exists, deliberately: a second place
+to record decisions is a second place for the record to drift.
+
 ## Different projects
 
 Different projects may run at the same time. Each session:
@@ -105,6 +140,23 @@ Heartbeats make abandoned sessions visible, but a stale timestamp never
 transfers ownership automatically. Another session may take over only after the
 user or the owning session explicitly releases or reassigns the claim.
 
+### Administrative release
+
+When a session is genuinely gone — a crashed client, a closed laptop, a chat
+that will never resume — its `active` row keeps blocking overlapping claims
+by design. The release decision belongs to the user, not to elapsed time and
+not to another agent's judgment. The user (or a session acting on the user's
+explicit direction, recorded in that session's log) runs:
+
+```bash
+python3 <root>/scripts/coordination.py release --id <stale-id>
+```
+
+`release` marks the row released without touching its history; nothing else
+on the board changes. An agent must never administratively release a peer on
+its own initiative — route the request through the board's message log or
+the user, exactly as with any other overlap.
+
 ## Cross-machine boundary
 
 Git carries durable project state and contribution artifacts between machines.
@@ -120,17 +172,67 @@ git-backed lease by writing `lease.json` beside it:
 ```
 
 Optional keys: `ref` (default `refs/synthesis/coordination-board`) and
-`repository` (the local bare mirror, default `.lease-repo` beside the board).
-Every mutating command then performs an atomic compare-and-swap ref update on
-the shared remote — the server-side ref transaction is the mutual exclusion —
-and rewrites the local board as a mirror of the accepted state. Concurrent
-advances trigger a bounded refetch-and-retry against fresh content; an
-unreachable remote fails the mutation closed rather than falling back to a
-local-only write. `status` refreshes the mirror from the remote and reports a
-refresh failure as a problem (strict mode fails); `doctor` fails when the
-mirror and remote differ. The remote must be one both machines can push to;
-enable the lease on every machine that writes the board, or its writes bypass
-the shared exclusion.
+`repository` (the local bare mirror, default `.lease-repo` beside the board;
+point it at a non-synced location such as `~/.cache/...` when the board
+directory itself is file-synced, so replication carries only the static
+config, never git-object churn). Every mutating command then performs an
+atomic compare-and-swap ref update on the shared remote — the server-side
+ref transaction is the mutual exclusion — and rewrites the local board as a
+mirror of the accepted state. Concurrent advances trigger a bounded
+refetch-and-retry against fresh content; an unreachable remote fails the
+mutation closed rather than falling back to a local-only write. `status`
+refreshes the mirror from the remote and reports a refresh failure as a
+problem (strict mode fails); `doctor` fails when the mirror and remote
+differ.
+
+A leased board **declares itself**: mutations keep a `Lease: <remote>` line
+in the board header, and the declaration travels with the board content —
+through file sync, mirrors, and the leased ref. A lease-aware helper that
+finds the declaration without a local `lease.json` refuses to mutate, which
+turns the silent-loss scenario (a machine writing local-only changes that
+the next lease refetch would drop) into a loud, actionable error.
+
+### Bootstrapping another machine
+
+1. Let the file-synced board directory replicate `lease.json` (or copy it),
+   including its `remote`; adjust `repository` to a machine-local path.
+2. Confirm the machine can push to the lease remote with its existing
+   credentials.
+3. Run `coordination.py status` — the mirror refreshes from the remote — and
+   then claim normally. If a mutation is refused with the
+   declared-but-unconfigured error, the config has not arrived yet; copy it
+   rather than working around the refusal.
+
+Use a helper at least as new as the lease feature for every board write; an
+older helper writes the local file directly and its change is dropped at the
+next lease refetch.
+
+### Retiring a lease
+
+`coordination.py lease-disable` removes the declaration and publishes the
+undeclared board through the compare-and-swap path, then moves the local
+`lease.json` to a timestamped `.disabled-` file; remove the config from the
+other machines before their next board write, or their mutation re-enables
+the lease. `lease-disable --local-only` exists solely for a lease whose
+remote is permanently unreachable; with a working remote the published path
+is the only sanctioned one.
 
 Without a configured lease, simultaneous cross-machine writes to the same
 resources remain prohibited.
+
+## Worktree retirement
+
+Retire merged feature worktrees with the fail-closed helper instead of raw
+git:
+
+```bash
+python3 <root>/scripts/retire_worktree.py \
+  --repository /path/to/repo --worktree /path/to/worktree --delete-remote
+```
+
+It takes the repository explicitly (never the current directory), fetches
+before verifying, requires the branch to be fully contained in the remote
+base, refuses main worktrees, dirty trees, detached heads, and a working
+directory inside the target, and deletes branches with safe delete only.
+"Merged on the remote" is the retirement bar — a stale local ref proving
+nothing.

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -505,7 +505,41 @@ def lease_publish(
     return False, pushed.stderr.strip()
 
 
-def lease_update(board: Path, config: dict, operation) -> None:
+LEASE_DECLARATION = re.compile(r"(?m)^Lease: (\S+)[ \t]*$")
+
+
+def declared_lease(content: str) -> str | None:
+    """The remote a board says it is leased to, from its header declaration.
+
+    The declaration travels IN the board content, so it replicates with the
+    board (file sync, mirrors, the leased ref itself). A machine whose
+    `lease.json` has not arrived yet — or that lost it — then refuses to
+    mutate a lease-managed board instead of writing a local-only change that
+    the next lease refetch would silently drop.
+    """
+    match = LEASE_DECLARATION.search(content)
+    return match.group(1) if match else None
+
+
+def ensure_lease_declaration(content: str, remote: str) -> str:
+    existing = declared_lease(content)
+    if existing == remote:
+        return content
+    if existing is not None:
+        return LEASE_DECLARATION.sub(f"Lease: {remote}", content, count=1)
+    schema = re.search(r"(?m)^Schema:\s*v\d+[ \t]*$", content)
+    if schema is None:
+        return f"Lease: {remote}\n" + content
+    return content[: schema.end()] + f"\nLease: {remote}" + content[schema.end() :]
+
+
+def remove_lease_declaration(content: str) -> str:
+    return re.sub(r"(?m)^Lease: \S+[ \t]*\n?", "", content, count=1)
+
+
+def lease_update(
+    board: Path, config: dict, operation, *, declare: bool = True
+) -> None:
     failure = ""
     for _ in range(LEASE_RETRIES):
         sha, content = lease_fetch(config)
@@ -514,6 +548,8 @@ def lease_update(board: Path, config: dict, operation) -> None:
                 board.read_text(encoding="utf-8") if board.exists() else template()
             )
         updated = operation(content)
+        if declare:
+            updated = ensure_lease_declaration(updated, config["remote"])
         published, failure = lease_publish(config, board.name, updated, sha)
         if published:
             write_board(board, updated)
@@ -553,6 +589,15 @@ def locked_update(board: Path, operation) -> None:
             lease_update(board, config, operation)
             return
         content = board.read_text(encoding="utf-8") if board.exists() else template()
+        declared = declared_lease(content)
+        if declared is not None:
+            raise RuntimeError(
+                f"board declares a coordination lease ({declared}) but "
+                f"{board.parent / LEASE_CONFIG_NAME} is missing on this "
+                "machine; copy the lease configuration here, or run "
+                "'lease-disable --local-only' only if the lease is being "
+                "retired everywhere"
+            )
         write_board(board, operation(content))
 
 
@@ -783,6 +828,66 @@ def command_migrate(args) -> int:
     return 0
 
 
+def command_lease_disable(args) -> int:
+    board = args.board
+    board.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = board.parent / ".active-sessions.lock"
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            config = lease_configuration(board)
+        except RuntimeError as exc:
+            print(f"coordination lease-disable failed: {exc}", file=sys.stderr)
+            return 10
+        if args.local_only:
+            if config is not None:
+                print(
+                    "coordination lease-disable refused: lease.json is present, "
+                    "so the sanctioned path is 'lease-disable' without "
+                    "--local-only (it retires the lease on the remote too)",
+                    file=sys.stderr,
+                )
+                return 10
+            if not board.is_file():
+                print(f"No coordination board: {board}", file=sys.stderr)
+                return 10
+            content = board.read_text(encoding="utf-8")
+            if declared_lease(content) is None:
+                print("Board declares no lease; nothing to disable.")
+                return 0
+            write_board(board, remove_lease_declaration(content))
+            print(
+                "Lease declaration removed from the local board only. If the "
+                "lease remote still exists, machines with lease.json will "
+                "republish it; this path is for retiring an unreachable lease."
+            )
+            return 0
+        if config is None:
+            print(
+                "coordination lease-disable failed: no lease.json beside the "
+                "board; use --local-only only when retiring a lease whose "
+                "remote is gone",
+                file=sys.stderr,
+            )
+            return 10
+        try:
+            lease_update(board, config, remove_lease_declaration, declare=False)
+        except RuntimeError as exc:
+            print(f"coordination lease-disable failed: {exc}", file=sys.stderr)
+            return 10
+        retired = board.parent / (
+            f"{LEASE_CONFIG_NAME}.disabled-{datetime.now().strftime('%Y%m%dT%H%M%S')}"
+        )
+        os.replace(board.parent / LEASE_CONFIG_NAME, retired)
+        print(
+            "Lease declaration removed and published to the remote. Local "
+            f"lease config moved to {retired}. Remove lease.json on every "
+            "other machine before its next board write, or it will "
+            "re-enable the lease."
+        )
+    return 0
+
+
 def command_doctor(args) -> int:
     if not args.board.is_file():
         print(f"FAIL coordination.board: missing {args.board}", file=sys.stderr)
@@ -797,6 +902,13 @@ def command_doctor(args) -> int:
     lease_line = ""
     try:
         lease = lease_configuration(args.board)
+        if lease is None and declared_lease(content) is not None:
+            problems.append(
+                f"board declares a coordination lease "
+                f"({declared_lease(content)}) but lease.json is missing "
+                "beside it; mutations will refuse until the configuration "
+                "is copied here or the lease is retired"
+            )
         if lease is not None:
             sha, remote_content = lease_fetch(lease)
             if remote_content is None:
@@ -867,6 +979,12 @@ def parser() -> argparse.ArgumentParser:
     message.add_argument("--text")
     commands.add_parser("migrate")
     commands.add_parser("doctor")
+    lease_disable = commands.add_parser(
+        "lease-disable",
+        help="Retire the board's lease declaration (CAS-published by default; "
+        "--local-only is the unreachable-remote escape).",
+    )
+    lease_disable.add_argument("--local-only", action="store_true")
     return result
 
 
@@ -885,6 +1003,8 @@ def main() -> int:
         return command_message(args)
     if args.command == "migrate":
         return command_migrate(args)
+    if args.command == "lease-disable":
+        return command_lease_disable(args)
     return command_doctor(args)
 
 

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -128,9 +128,12 @@ def split_values(value: str) -> list[str]:
     clean = plain(value)
     if not clean or clean.lower().startswith("released"):
         return []
+    # Semicolons appear in hand-migrated rows; treating them as content would
+    # fuse several claims into one unmatchable string and silently disable
+    # overlap detection for that row.
     return [
         item.strip()
-        for item in re.split(r",|<br\s*/?>", clean)
+        for item in re.split(r"[,;]|<br\s*/?>", clean)
         if item.strip()
     ]
 

--- a/skills/synthesis-project-management/scripts/retire_worktree.py
+++ b/skills/synthesis-project-management/scripts/retire_worktree.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Retire a merged feature worktree and its branches, fail-closed.
+
+Parallel sessions create isolated worktrees constantly, and retiring them by
+hand repeats the same risky sequence: verify the work reached the remote,
+remove the worktree, delete the local branch, delete the remote branch. Done
+manually it depends on the shell's current directory being the right
+repository — the exact dependency behind repeated wrong-repo worktree
+mistakes — and nothing stops removal of a dirty tree or an unmerged branch.
+
+This helper takes the repository EXPLICITLY, never trusts the working
+directory, and refuses every unsafe state:
+
+- the repository path must be a git worktree's real toplevel, not a symlink;
+- the target must be a linked worktree of that repository, never its main
+  worktree, and never a directory containing the current working directory;
+- the worktree must be completely clean (tracked and untracked);
+- the checked-out branch must be an ancestor of the verification base
+  (default: the remote's fetched main) — by default after a fresh fetch, so
+  "merged" means merged on the REMOTE, not in a stale local ref;
+- the local branch is deleted with git's safe delete only, and the remote
+  branch only when --delete-remote is passed.
+
+Nothing here ever uses --force variants, and nothing is removed before its
+verification passes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(
+    repository: Path, *arguments: str, timeout: int = 60
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def fail(message: str) -> int:
+    print(f"retire-worktree refused: {message}", file=sys.stderr)
+    return 2
+
+
+def worktree_entries(repository: Path) -> list[dict[str, str]]:
+    listing = run(repository, "worktree", "list", "--porcelain")
+    if listing.returncode != 0:
+        raise RuntimeError(listing.stderr.strip() or "git worktree list failed")
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in listing.stdout.splitlines():
+        if not line.strip():
+            if current:
+                entries.append(current)
+                current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    if current:
+        entries.append(current)
+    return entries
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repository",
+        required=True,
+        type=Path,
+        help="The repository the worktree belongs to (explicit — the current "
+        "directory is never used to pick a repository).",
+    )
+    parser.add_argument("--worktree", required=True, type=Path)
+    parser.add_argument(
+        "--branch",
+        help="Expected branch; must match the worktree's checkout when given.",
+    )
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Verification base ref (default: <remote>/HEAD, falling back to "
+        "<remote>/main).",
+    )
+    parser.add_argument("--remote", default="origin")
+    parser.add_argument(
+        "--no-fetch",
+        action="store_true",
+        help="Skip the pre-verification fetch (verification then runs against "
+        "the last-fetched state).",
+    )
+    parser.add_argument(
+        "--delete-remote",
+        action="store_true",
+        help="Also delete the branch on the remote after ancestry passes.",
+    )
+    args = parser.parse_args()
+
+    repository = args.repository.expanduser()
+    if repository.is_symlink():
+        return fail(f"repository path is a symlink: {repository}")
+    repository = repository.absolute()
+    toplevel = run(repository, "rev-parse", "--show-toplevel")
+    if toplevel.returncode != 0:
+        return fail(f"not a git repository: {repository}")
+    if Path(toplevel.stdout.strip()).resolve() != repository.resolve():
+        return fail(
+            f"repository must be the worktree toplevel, got {repository} "
+            f"inside {toplevel.stdout.strip()}"
+        )
+
+    worktree = args.worktree.expanduser().absolute()
+    try:
+        entries = worktree_entries(repository)
+    except RuntimeError as exc:
+        return fail(str(exc))
+    if not entries:
+        return fail("git reported no worktrees")
+    main_worktree = Path(entries[0]["worktree"]).resolve()
+    match = next(
+        (
+            entry
+            for entry in entries
+            if Path(entry["worktree"]).resolve() == worktree.resolve()
+        ),
+        None,
+    )
+    if match is None:
+        return fail(f"{worktree} is not a worktree of {repository}")
+    if Path(match["worktree"]).resolve() == main_worktree:
+        return fail("refusing to retire the repository's main worktree")
+
+    cwd = Path.cwd().resolve()
+    if cwd == worktree.resolve() or worktree.resolve() in cwd.parents:
+        return fail(
+            "the current directory is inside the target worktree; leave it "
+            "first"
+        )
+
+    status = run(worktree, "status", "--porcelain")
+    if status.returncode != 0:
+        return fail(status.stderr.strip() or "status failed in the worktree")
+    if status.stdout.strip():
+        return fail(
+            "worktree is not clean; commit, stash, or inspect before retiring:"
+            f"\n{status.stdout.strip()}"
+        )
+
+    branch_ref = match.get("branch", "")
+    if not branch_ref.startswith("refs/heads/"):
+        return fail(f"worktree is not on a local branch: {branch_ref or 'detached'}")
+    branch = branch_ref[len("refs/heads/") :]
+    if args.branch and args.branch != branch:
+        return fail(f"worktree is on {branch}, not the expected {args.branch}")
+
+    if not args.no_fetch:
+        fetched = run(repository, "fetch", "--quiet", "--prune", args.remote)
+        if fetched.returncode != 0:
+            return fail(
+                f"fetch from {args.remote} failed (pass --no-fetch only to "
+                "verify against last-fetched state): "
+                + fetched.stderr.strip()
+            )
+
+    base = args.base
+    if base is None:
+        for candidate in (f"{args.remote}/HEAD", f"{args.remote}/main"):
+            resolved = run(repository, "rev-parse", "--verify", "--quiet", candidate)
+            if resolved.returncode == 0:
+                base = candidate
+                break
+    if base is None:
+        return fail(
+            f"could not resolve a verification base under {args.remote}; "
+            "pass --base explicitly"
+        )
+    base_check = run(repository, "rev-parse", "--verify", "--quiet", base)
+    if base_check.returncode != 0:
+        return fail(f"verification base does not resolve: {base}")
+
+    ancestry = run(repository, "merge-base", "--is-ancestor", branch, base)
+    if ancestry.returncode != 0:
+        return fail(
+            f"branch {branch} is not fully contained in {base}; its commits "
+            "have not been verified on the remote"
+        )
+
+    removed = run(repository, "worktree", "remove", str(worktree))
+    if removed.returncode != 0:
+        return fail(removed.stderr.strip() or "git worktree remove failed")
+    print(f"Removed worktree {worktree}")
+
+    deleted = run(repository, "branch", "-d", branch)
+    if deleted.returncode != 0:
+        print(
+            f"retire-worktree: local branch kept: "
+            + (deleted.stderr.strip() or f"could not delete {branch}"),
+            file=sys.stderr,
+        )
+    else:
+        print(f"Deleted local branch {branch}")
+
+    if args.delete_remote:
+        listed = run(repository, "ls-remote", "--heads", args.remote, branch)
+        if listed.returncode != 0:
+            return fail(f"could not query {args.remote}: {listed.stderr.strip()}")
+        if not listed.stdout.strip():
+            print(f"Remote branch {args.remote}/{branch} already absent")
+        else:
+            pushed = run(repository, "push", args.remote, "--delete", branch)
+            if pushed.returncode != 0:
+                return fail(
+                    f"remote branch deletion failed: {pushed.stderr.strip()}"
+                )
+            print(f"Deleted remote branch {args.remote}/{branch}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -674,3 +674,26 @@ def test_lease_disable_local_only_requires_absent_config(tmp_path: Path) -> None
         area="/repos/other/**",
     )
     assert MODULE.command_claim(follow_up) == 0
+
+
+def test_semicolon_separated_claims_still_conflict(tmp_path: Path) -> None:
+    board = tmp_path / "coordination" / "active-sessions.md"
+    legacy = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="repo-one/notes/**; repo-two/daily/**",
+    )
+    assert MODULE.command_claim(legacy) == 0
+    parsed = MODULE.rows(board.read_text(encoding="utf-8"))[0]
+    assert len(parsed.claims) == 2
+
+    overlapping = claim_args(
+        board,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="/home/user/workspaces/demo/repo-two/daily/plan.md",
+    )
+    assert MODULE.command_claim(overlapping) == 10

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -559,3 +559,118 @@ def test_lease_doctor_verifies_remote_sync(tmp_path: Path, capsys) -> None:
         == 0
     )
     assert MODULE.command_doctor(args(machine1)) == 0
+
+
+def test_lease_declares_itself_in_board_content(tmp_path: Path) -> None:
+    machine1, machine2 = lease_machines(tmp_path)
+    request = claim_args(
+        machine1,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="/repos/shared/**",
+    )
+    assert MODULE.command_claim(request) == 0
+    remote = str(tmp_path / "remote.git")
+    assert MODULE.declared_lease(machine1.read_text(encoding="utf-8")) == remote
+
+    follower = claim_args(
+        machine2,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="/repos/other/**",
+    )
+    assert MODULE.command_claim(follower) == 0
+    assert MODULE.declared_lease(machine2.read_text(encoding="utf-8")) == remote
+
+
+def test_declared_board_without_config_refuses_mutation(tmp_path: Path) -> None:
+    machine1, _ = lease_machines(tmp_path)
+    request = claim_args(
+        machine1,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="/repos/shared/**",
+    )
+    assert MODULE.command_claim(request) == 0
+
+    (machine1.parent / "lease.json").unlink()
+    late = claim_args(
+        machine1,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="/repos/other/**",
+    )
+    assert MODULE.command_claim(late) == 10
+    table = MODULE.rows(machine1.read_text(encoding="utf-8"))
+    assert {row.id for row in table} == {"A"}
+
+    assert MODULE.command_doctor(args(machine1)) == 1
+
+
+def test_lease_disable_publishes_and_retires_config(tmp_path: Path) -> None:
+    machine1, machine2 = lease_machines(tmp_path)
+    request = claim_args(
+        machine1,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="/repos/shared/**",
+    )
+    assert MODULE.command_claim(request) == 0
+
+    assert MODULE.command_lease_disable(args(machine1, local_only=False)) == 0
+    assert not (machine1.parent / "lease.json").exists()
+    assert any(
+        candidate.name.startswith("lease.json.disabled-")
+        for candidate in machine1.parent.iterdir()
+    )
+    assert MODULE.declared_lease(machine1.read_text(encoding="utf-8")) is None
+
+    unleased = claim_args(
+        machine1,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="/repos/other/**",
+    )
+    assert MODULE.command_claim(unleased) == 0
+
+    refreshed = MODULE.lease_fetch(
+        {
+            "remote": str(tmp_path / "remote.git"),
+            "ref": MODULE.LEASE_DEFAULT_REF,
+            "repository": machine2.parent / ".lease-repo",
+        }
+    )
+    assert refreshed[1] is not None
+    assert MODULE.declared_lease(refreshed[1]) is None
+
+
+def test_lease_disable_local_only_requires_absent_config(tmp_path: Path) -> None:
+    machine1, _ = lease_machines(tmp_path)
+    request = claim_args(
+        machine1,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="/repos/shared/**",
+    )
+    assert MODULE.command_claim(request) == 0
+
+    assert MODULE.command_lease_disable(args(machine1, local_only=True)) == 10
+
+    (machine1.parent / "lease.json").unlink()
+    assert MODULE.command_lease_disable(args(machine1, local_only=True)) == 0
+    assert MODULE.declared_lease(machine1.read_text(encoding="utf-8")) is None
+    follow_up = claim_args(
+        machine1,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="/repos/other/**",
+    )
+    assert MODULE.command_claim(follow_up) == 0

--- a/skills/synthesis-project-management/scripts/test_retire_worktree.py
+++ b/skills/synthesis-project-management/scripts/test_retire_worktree.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("retire_worktree.py")
+
+
+def git(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *arguments],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def retire(*arguments: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=str(cwd) if cwd else None,
+    )
+
+
+def build_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """A clone with an origin bare remote and one commit on main."""
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", "--quiet", "--initial-branch", "main", str(remote)],
+        check=True,
+        capture_output=True,
+    )
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "--quiet", str(remote), str(clone)],
+        check=True,
+        capture_output=True,
+    )
+    git(clone, "config", "user.email", "test@example.com")
+    git(clone, "config", "user.name", "Test")
+    (clone / "seed.txt").write_text("seed\n", encoding="utf-8")
+    git(clone, "add", "seed.txt")
+    git(clone, "commit", "--quiet", "-m", "seed")
+    git(clone, "push", "--quiet", "origin", "main")
+    return remote, clone
+
+
+def add_feature_worktree(
+    tmp_path: Path, clone: Path, name: str = "feature/demo"
+) -> Path:
+    worktree = tmp_path / "worktrees" / name.replace("/", "-")
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    git(clone, "worktree", "add", str(worktree), "-b", name)
+    git(worktree, "config", "user.email", "test@example.com")
+    git(worktree, "config", "user.name", "Test")
+    return worktree
+
+
+def commit_and_merge(clone: Path, worktree: Path, branch: str = "feature/demo") -> None:
+    (worktree / "change.txt").write_text("change\n", encoding="utf-8")
+    git(worktree, "add", "change.txt")
+    git(worktree, "commit", "--quiet", "-m", "change")
+    git(worktree, "push", "--quiet", "-u", "origin", branch)
+    git(clone, "merge", "--quiet", "--no-edit", branch)
+    git(clone, "push", "--quiet", "origin", "main")
+
+
+def test_retires_merged_worktree_and_branches(tmp_path: Path) -> None:
+    remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+
+    result = retire(
+        "--repository",
+        str(clone),
+        "--worktree",
+        str(worktree),
+        "--delete-remote",
+    )
+    assert result.returncode == 0, result.stderr
+    assert not worktree.exists()
+    branches = git(clone, "branch", "--list", "feature/demo").stdout
+    assert not branches.strip()
+    remote_heads = git(clone, "ls-remote", "--heads", "origin", "feature/demo").stdout
+    assert not remote_heads.strip()
+
+
+def test_refuses_unmerged_branch(tmp_path: Path) -> None:
+    remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    (worktree / "unmerged.txt").write_text("pending\n", encoding="utf-8")
+    git(worktree, "add", "unmerged.txt")
+    git(worktree, "commit", "--quiet", "-m", "pending")
+
+    result = retire("--repository", str(clone), "--worktree", str(worktree))
+    assert result.returncode == 2
+    assert "not fully contained" in result.stderr
+    assert worktree.exists()
+
+
+def test_refuses_dirty_worktree(tmp_path: Path) -> None:
+    remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+    (worktree / "loose.txt").write_text("uncommitted\n", encoding="utf-8")
+
+    result = retire("--repository", str(clone), "--worktree", str(worktree))
+    assert result.returncode == 2
+    assert "not clean" in result.stderr
+    assert worktree.exists()
+
+
+def test_refuses_main_worktree_and_wrong_repository(tmp_path: Path) -> None:
+    remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+
+    result = retire("--repository", str(clone), "--worktree", str(clone))
+    assert result.returncode == 2
+    assert "main worktree" in result.stderr
+
+    other_remote, other_clone = build_repo(tmp_path / "other")
+    result = retire("--repository", str(other_clone), "--worktree", str(worktree))
+    assert result.returncode == 2
+    assert "not a worktree of" in result.stderr
+
+
+def test_refuses_when_cwd_is_inside_target(tmp_path: Path) -> None:
+    remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+
+    result = retire(
+        "--repository",
+        str(clone),
+        "--worktree",
+        str(worktree),
+        cwd=worktree,
+    )
+    assert result.returncode == 2
+    assert "current directory" in result.stderr
+    assert worktree.exists()
+
+
+def test_branch_mismatch_and_detached_head_refuse(tmp_path: Path) -> None:
+    remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+
+    result = retire(
+        "--repository",
+        str(clone),
+        "--worktree",
+        str(worktree),
+        "--branch",
+        "feature/other",
+    )
+    assert result.returncode == 2
+    assert "not the expected" in result.stderr
+
+    git(worktree, "checkout", "--quiet", "--detach")
+    result = retire("--repository", str(clone), "--worktree", str(worktree))
+    assert result.returncode == 2
+    assert "not on a local branch" in result.stderr
+
+
+def test_no_fetch_verifies_against_last_fetched_state(tmp_path: Path) -> None:
+    remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+
+    result = retire(
+        "--repository",
+        str(clone),
+        "--worktree",
+        str(worktree),
+        "--no-fetch",
+    )
+    assert result.returncode == 0, result.stderr
+    assert not worktree.exists()


### PR DESCRIPTION
## Summary

Follow-on improvement cycle over the v4.6.0 coordination and verification layers, driven by live evidence from this week's cross-client sessions.

- **Record-freshness verification (new `handoff.record-freshness`).** Two consecutive sessions had to hand-verify that a project checkout was behind origin before trusting its record. `project_context.record_freshness` compares the record with its last-fetched upstream, counting only commits that touch the project subtree; activation refuses to write a pointer from a stale record, handoff reports it, and the shared SessionStart context emits a `RECORD STALENESS WARNING`. Live fire: the check correctly reports the real primary checkout as 6 commits behind while a current clone passes.
- **Payload-parity handoff check (new `handoff.payload-parity`).** Cross-client envelope parity was previously verified by hand; `handoff` now runs the shared SessionStart script in both client formats against the live pointer and compares the enveloped context after timestamp normalization — no client binaries involved. Passes live.
- **Lease self-declaration (`synthesis-project-management` v1.8.0).** A leased board now carries `Lease: <remote>` in its header, traveling with the board content. A lease-aware helper that sees the declaration without a local `lease.json` refuses to mutate — closing the silent-loss window where a machine whose config had not replicated wrote local-only changes doomed to be dropped at the next refetch. `lease-disable` retires a lease through the CAS path and moves the config to a timestamped `.disabled-` file (`--local-only` reserved for unreachable remotes); the doctor flags declared-but-unconfigured boards.
- **Fail-closed worktree retirement (`retire_worktree.py`).** Manual retirement sequences were cd-dependent and unguarded — this cycle reproduced the wrong-repo worktree mistake a third time. The helper takes the repository explicitly, fetches then requires branch containment in the remote base, refuses main worktrees / dirty trees / detached heads / a cwd inside the target, safe-deletes only, and deletes remote branches only on request.
- **Protocol documentation.** New quickstart (many agents/projects/computers), digest convention (plan file at phase boundaries is the crash-surviving digest — deliberately no second artifact), administrative release authority, lease bootstrap on another machine, lease retirement, and retirement guidance.
- v4.7.0 in both manifests; changelog and README notes.

## Test plan

- [x] Conformance suites 28 passed (new: freshness stale/fresh/no-upstream, activation refusal, parity broken-pointer, SessionStart warning)
- [x] Coordination + retirement suites 33 passed (new: declaration propagation across machines, declared-without-config refusal, lease-disable publish + config retirement, --local-only semantics, 7 bare-remote retirement scenarios)
- [x] Full validation matrix: 111 source checks, 81 tests across suites, installers, compileall, inbox checks
- [x] Live fire from a real stale checkout (fails correctly) and live pointer parity (passes)

Do not merge without fresh authorization — opened by the follow-on improvement cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)