### PR TITLE
Disclosure governance by precedent; publication-surface enforcement

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.8.0] - 2026-07-30
+
+### Added
+
+- `synthesis-disclosure-policy`: two-category disclosure governance for
+  people who publish under their own name while handling sensitive
+  client work. Published-precedent facts (deliberately public biography, recorded
+  in an evidence-cited ledger) are restatable; unapproved disclosures —
+  anything learned from private context, negative statements, operational
+  detail, identifying descriptions, aggregation — stay closed. Ships the
+  ledger schema, five decision tests, surface-class model, and an adoption
+  quickstart with a ledger template.
+- `synthesis-git-hooks` v2.2.0: publication-surface classification.
+  `strict_repo_patterns` pins public OSS repos strict regardless of
+  remotes; `public_surface_patterns` classifies author-published site
+  repos as `public-surface` — full Tier 1 enforcement (previously these
+  either skipped Tier 1 entirely under personal remotes or blocked the
+  author's own published biography under strict), minus only the exact
+  name patterns the `disclosure_ledger` records as published precedent.
+  Evidence-free ledger entries, missing ledgers, and unparsable ledgers
+  fail closed; the doctor validates ledger allowances against the policy
+  and flags stale ones; commit-message scanning now also covers
+  public-surface repos.
+
 ## [4.7.0] - 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Proven AI agent skills for code review, content creation, project management, an
 
 ## What's new
 
+**Disclosure governance by precedent, not blacklist (July 2026).**
+`synthesis-disclosure-policy` distinguishes the names you deliberately
+publish in your own biography from disclosures nobody approved, backed by
+an evidence-cited precedent ledger. `synthesis-git-hooks` **v2.2.0**
+enforces it by publication surface: your site repos get full protection
+minus your ledgered names, public OSS repos stay pinned strict, and a
+missing or unverifiable ledger fails closed. See the
+[4.8.0 release notes](CHANGELOG.md).
+
+
 **Trustworthy resumption and safe retirement (July 2026).**
 Activation, handoff, and SessionStart context now detect stale project
 checkouts by comparing the record with its fetched upstream, and handoff

--- a/skills/synthesis-disclosure-policy/SKILL.md
+++ b/skills/synthesis-disclosure-policy/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: synthesis-disclosure-policy
+description: "Two-category disclosure governance for people who publish under their own name while handling confidential work. Distinguishes published-precedent facts (deliberately public biography an agent may restate) from unapproved disclosures (anything learned from private context), with a precedent ledger, surface classes, five decision tests, and git-hook enforcement. Use when asked about: disclosure policy, confidentiality guardrails, can I name this company, precedent ledger, public bio names, publication surface, unapproved disclosure, name allowlist."
+license: "Apache-2.0"
+depends_on: []
+metadata:
+  author: "Rajiv Pant"
+  version: "1.0.0"
+  source_repo: "github.com/synthesisengineering/synthesis-skills"
+  source_type: "public"
+---
+
+# Synthesis Disclosure Policy
+
+A name blacklist models the wrong thing. Professionals who publish under
+their own name deliberately say who they work for, who they have worked
+for, and who they work with — on their sites, in their bios, in their
+articles. That is conscious, career-positive disclosure. The same
+professionals also carry genuinely confidential material: client work,
+internal decisions, private conversations, things an AI collaborator reads
+in private context every day. A guardrail that treats the NAME as the
+secret blocks the first category (over-blocking the person's own published
+biography) while under-protecting the second (a leak rarely needs the
+blacklisted spelling).
+
+This skill governs disclosure on the axis that matters: **approval and
+provenance**. What the person deliberately published is precedent and may
+be restated. What they did not approve stays closed — no matter how the
+reference is spelled.
+
+## The three disclosure classes
+
+**Class P — published precedent.** A fact the person personally published
+on a public surface they author: their sites, bios, articles, social
+profiles. Restating a Class-P fact in the same register — biography:
+relationship, role, era, public work — on their public surfaces is
+allowed. Precedent covers the FACT, not the entity: an employer named in a
+bio does not make any other statement about that employer public.
+
+**Class A — approval required.** Any new naming or newly identifying
+disclosure without precedent: a first-time name, a new kind of fact about
+a ledgered entity, praise of a named colleague never published before, a
+case study touching real parties. Default deny. Each approval then BECOMES
+precedent: it is appended to the ledger with evidence, so the same
+question is never asked twice.
+
+**Class X — protected.** Not published even with casual approval; a
+request to publish gets an explicit challenge naming the risk before
+proceeding. Contents: negative or critical statements about named or
+identifiable parties; operational and business specifics — deals, numbers,
+finances, personnel matters, incidents, unreleased plans, security
+details, internal decisions — even about Class-P entities; material under
+NDA or equivalent obligation; other people's private information; and
+anything sourced from private context with no independent public
+counterpart.
+
+## The five tests
+
+Apply to any draft, edit, or publication that names or could identify a
+real party. When any test is uncertain, the answer is Class A or X — ask,
+never assume.
+
+1. **Precedent.** Is this exact kind of fact about this entity already on
+   a surface the person authors publicly? Cite the ledger entry. No entry,
+   no pass.
+2. **Provenance.** Where did the agent learn this? Private context —
+   messages, transcripts, private repositories, meetings — means Class X
+   until an independent public counterpart is cited. An agent's knowledge
+   of a fact is not evidence the fact is public.
+3. **Negativity.** Would the named party read the statement as anything
+   other than positive or neutral? Any doubt fails the test. Published
+   references to real parties stay positive or neutral; criticism is not
+   published under this policy at all without the explicit Class-X
+   challenge.
+4. **Identification.** Could an outsider, an insider, or a motivated
+   adversary narrow an unnamed reference to the real party? Identifying
+   descriptions are governed exactly like names — "a major metropolitan
+   newspaper where I ran engineering" identifies, and passes or fails the
+   same tests the name would.
+5. **Aggregation.** Do individually public facts combine into a
+   disclosure none of them makes alone? Judge the combination. A public
+   role plus a public timeline plus a new anecdote can identify a
+   confidential situation precisely.
+
+## The precedent ledger
+
+The machine-readable record of Class-P facts. Source-controlled, deployed
+to a stable local path, read by both agents and enforcement hooks.
+
+```yaml
+ledger_version: 1
+entities:
+  example-corp:
+    kind: organization
+    relationship: former employer
+    registers:
+      - biography
+    hook_patterns:
+      - 'example-corp'
+    evidence:
+      - 'personal-site/src/config/site.ts: author bio names example-corp as former employer'
+      - 'https://example.com/about/'
+```
+
+Rules:
+
+- **No entry without evidence.** Every entity cites where the person
+  published the fact. Enforcement refuses an evidence-free entry.
+- **`registers` scope the precedent.** `biography` covers relationship,
+  role, era, and public work. Operational detail is never a register.
+- **`hook_patterns` are exact strings.** Each must textually equal a
+  pattern in the git-hook policy's name tier; that is what the hook stops
+  enforcing on public-surface repositories. Exact equality keeps every
+  allowance auditable; the hook doctor flags stale allowances.
+- **Approvals append.** When the person approves a new disclosure, add
+  the entity (or extend its registers) with the approval date and
+  evidence. The ledger is the memory that turns approval into precedent.
+
+## Surface classes
+
+Enforcement follows the PUBLICATION SURFACE, not repository visibility. A
+private repository that publishes a website is a public surface; a public
+OSS repository is not a place for anyone's biography.
+
+| Class | Meaning | Credential tier | Sensitive tier | Ledger allowance |
+|-------|---------|-----------------|----------------|------------------|
+| `personal` | Only the author reads it | always | off | n/a |
+| `public-surface` | Author-published sites | always | on | Class-P names allowed |
+| `strict` | Client, multi-tenant, public OSS | always | on | none |
+
+The companion [`synthesis-git-hooks`](../synthesis-git-hooks/SKILL.md)
+engine implements these classes: `strict_repo_patterns` pins repositories
+strict regardless of remotes (any-match), `public_surface_patterns`
+declares author-published surfaces (all-remotes match), and
+`disclosure_ledger` points at the ledger. The engine fails closed: a
+configured ledger that is missing or unparsable blocks commits on
+public-surface repositories rather than guessing.
+
+## Division of labor
+
+- **Mechanical layer (git hooks):** name and pattern boundaries per
+  surface class, credential scanning everywhere, generic commit messages
+  on published surfaces, fail-closed diagnostics. A grep cannot judge
+  sentiment or aggregation, and does not try.
+- **Semantic layer (agent rules + this skill):** the five tests, register
+  judgment, the Class-X challenge, and the approval-to-ledger loop. This
+  is where identification and aggregation are caught.
+- **Human layer:** the person owns every Class-A approval and every
+  Class-X override. The system's job is to make the decision explicit,
+  informed, and durable — never to make it for them.
+
+## Maintenance protocol
+
+1. New approval → append to the ledger with date and evidence in the same
+   change; the approval is not done until the ledger records it.
+2. Relationship ends or the person retracts a disclosure → the entity
+   stays (precedent is historical) but future drafts treat NEW facts about
+   it as Class A; note the change in the entry.
+3. Run the hook doctor after every ledger or policy edit; a stale
+   allowance or unparsable ledger is a failure, not a warning.
+4. Audit periodically: every ledger citation should still resolve; every
+   public surface should still be listed in `public_surface_patterns`.
+
+## Adopting this for yourself
+
+The mechanism is fully generic; only the data is personal. To adopt:
+
+1. **Collect your precedent.** Inventory the surfaces you personally author
+   and publish — your sites, bios, published articles, public profiles —
+   and list every organization and person you deliberately name there, with
+   the file or URL as evidence. An agent can sweep your site repositories
+   for this in one pass; keep only what YOU published, in biography
+   register, positive or neutral.
+2. **Write your ledger** from
+   [`references/ledger.example.yaml`](references/ledger.example.yaml) into a
+   PRIVATE source-controlled location, and deploy it to a stable local
+   path. The ledger never lives in a public repository.
+3. **Classify your surfaces** in `~/.synthesis/git-hook-config.yaml`:
+   your published-site repos into `public_surface_patterns`, your public
+   OSS repos into `strict_repo_patterns`, your private-notes namespaces
+   into `personal_remote_patterns`, and `disclosure_ledger:` pointing at
+   your deployed ledger.
+4. **Run the doctor**
+   (`python3 ~/.synthesis/git-hooks/_load_config.py --doctor`) and keep it
+   in your rituals — a stale allowance or unreadable ledger is a failure.
+5. **Carry the five tests into your agent rules** so the semantic layer
+   (negativity, identification, aggregation, provenance) governs drafts
+   before the mechanical layer ever sees a commit.
+
+Publishing the mechanism weakens nothing for anyone: the engine is the
+same audited, fail-closed code for every user, and each user's names,
+surfaces, and evidence stay in their own private configuration.
+
+## Relationship to other skills
+
+- [`synthesis-git-hooks`](../synthesis-git-hooks/SKILL.md) — the
+  mechanical enforcement engine for the surface classes and ledger.
+- [`synthesis-content-quality`](../synthesis-content-quality/SKILL.md) —
+  its anonymization checks (outsider, insider, adversary, irony tests)
+  operationalize the identification test for prose review.
+- [`synthesis-message-guard`](../synthesis-message-guard/SKILL.md) —
+  outbound-send gating; drafts that pass the five tests still go through
+  send-time review.
+
+A private companion configuration (the person's actual ledger, surface
+map, and register rules) belongs in their private skill collection — this
+public skill carries the methodology only.

--- a/skills/synthesis-disclosure-policy/agents/openai.yaml
+++ b/skills/synthesis-disclosure-policy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Synthesis Disclosure Policy"
+  short_description: "Govern name disclosure by precedent and approval"
+  default_prompt: "Use $synthesis-disclosure-policy to decide whether this disclosure is published precedent, needs approval, or is protected."

--- a/skills/synthesis-disclosure-policy/references/ledger.example.yaml
+++ b/skills/synthesis-disclosure-policy/references/ledger.example.yaml
@@ -1,0 +1,34 @@
+# Disclosure precedent ledger — template.
+#
+# Copy to a private, source-controlled location of your own (for example a
+# private control-plane or dotfiles repo), deploy it to a stable local path,
+# and point `disclosure_ledger:` in ~/.synthesis/git-hook-config.yaml at the
+# deployed copy. This file is the machine-readable record of facts YOU have
+# personally published; it must never live in a public repository once it
+# contains your real entries.
+#
+# Rules (enforced by the synthesis-git-hooks engine and doctor):
+# - every entity needs at least one `evidence` citation — a file or URL on a
+#   surface you author where you published the fact; entries without
+#   evidence fail closed.
+# - `hook_patterns` values must textually equal entries in your policy's
+#   `tier_1_strict_only` set; each one stops being enforced ONLY in
+#   public-surface repos. The doctor flags stale allowances.
+# - `registers` scope what the precedent covers. `biography` means
+#   relationship, role, era, and public work — never operational detail.
+# - when you approve a new disclosure, append it here with the date in the
+#   same change; approval becomes precedent only when the ledger records it.
+
+ledger_version: 1
+
+entities:
+  example-corp:
+    kind: organization
+    relationship: former employer
+    registers:
+      - biography
+    hook_patterns:
+      - 'example-corp'
+    evidence:
+      - 'personal-site/src/config/site.ts: author bio names example-corp as former employer'
+      - 'https://example.com/about/'

--- a/skills/synthesis-git-hooks/SKILL.md
+++ b/skills/synthesis-git-hooks/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: synthesis-git-hooks
-description: "Deterministic pre-commit policy for the synthesis-engineering workflow. Auto-classifies each repo by its push remotes (personal vs strict), applies a tiered pattern set: Tier 0 credentials always; Tier 1 financial / HR / confidentiality / client names only in strict repos. YAML-driven policy lives in ~/.synthesis/git-hook-config.yaml. Use when asked to: install git hooks, configure pre-commit policy, prevent credential leaks, prevent confidential-name leaks in public repos, set up the synthesis-engineering enforcement layer."
+description: "Deterministic pre-commit policy for the synthesis-engineering workflow. Classifies each repo by publication surface (personal / public-surface / strict) from its push remotes, applies a tiered pattern set: Tier 0 credentials always; Tier 1 financial / HR / confidentiality / client names in strict and public-surface repos — public-surface minus only the disclosure ledger's published-precedent names. YAML-driven policy lives in ~/.synthesis/git-hook-config.yaml. Use when asked to: install git hooks, configure pre-commit policy, prevent credential leaks, prevent confidential-name leaks, allow published bio names on my own sites, disclosure ledger enforcement, set up the synthesis-engineering enforcement layer."
 license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.1.2"
+  version: "2.2.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -46,9 +46,29 @@ Three design guarantees, added after a field incident in which the v1 engine sil
 | Tier | Patterns | When applied |
 |---|---|---|
 | **Tier 0 — credentials** | API keys (AWS, OpenAI, Anthropic, Google, GitHub, GitLab, Slack), private key markers (RSA, OpenSSH, EC, PGP) | Every repo. Credentials don't belong in git regardless of who reads. |
-| **Tier 1 — exposure-sensitive** | Financial, HR/employment, confidentiality markers, confidential client/company names, private skill names, internal URLs | Skip when the repo classifies as `personal` (every push remote matches a configured `personal_remote_patterns` regex). Run otherwise. |
+| **Tier 1 — exposure-sensitive** | Financial, HR/employment, confidentiality markers, confidential client/company names, private skill names, internal URLs | Skip when the repo classifies as `personal`. Run in `strict` and `public-surface` repos — in `public-surface`, minus only the exact name patterns the disclosure ledger records as published precedent. |
 
-The classification is derived from `git remote -v` on every commit — no per-repo flag file, no static declaration, no drift potential. The remote configuration IS the security profile.
+Classification is derived from `git remote -v` on every commit and follows
+the PUBLICATION SURFACE, strict-first:
+
+1. **`strict`** — ANY push remote matches `strict_repo_patterns` (public OSS
+   repos pinned strict even under a personal org), the remote list is empty,
+   or nothing else matches. Full Tier 1, commit-message scan on.
+2. **`public-surface`** — EVERY push remote matches
+   `public_surface_patterns`: sites and other surfaces whose content the
+   user personally authors and publishes, regardless of repository
+   visibility. Full Tier 1 minus ledger allowances; commit-message scan on.
+3. **`personal`** — EVERY push remote matches `personal_remote_patterns`:
+   content only the user reads. Tier 0 only.
+
+Ledger allowances come from `disclosure_ledger` (see the
+[`synthesis-disclosure-policy`](../synthesis-disclosure-policy/SKILL.md)
+skill): each ledger entity carries evidence citations and `hook_patterns`
+strings that must textually equal `tier_1_strict_only` entries. A
+configured ledger that is missing or unparsable fails closed — commits on
+public-surface repos block until it is fixed. No per-repo flag file, no
+static declaration, no drift potential: the remote configuration plus the
+ledger IS the security profile.
 
 ## When to apply
 

--- a/skills/synthesis-git-hooks/scripts/_load_config.py
+++ b/skills/synthesis-git-hooks/scripts/_load_config.py
@@ -50,7 +50,8 @@ import sys
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
-SIDECAR_VERSION = "2.1.0"
+SIDECAR_VERSION = "2.2.0"
+REQUIRED_CONFIG_VERSION = 2
 
 DEFAULT_CONFIG = Path.home() / ".synthesis" / "git-hook-config.yaml"
 DEFAULT_SOURCE_DIR = (
@@ -98,7 +99,10 @@ def _parse_scalar(raw: str, lineno: int) -> Any:
     if len(s) >= 2 and s[0] == "'" and s[-1] == "'":
         return s[1:-1].replace("''", "'")
     if len(s) >= 2 and s[0] == '"' and s[-1] == '"':
-        return s[1:-1].encode().decode("unicode_escape")
+        # Literal text only. `unicode_escape` would silently turn a regex
+        # `\b` into a backspace character: the pattern still compiles, the
+        # doctor still passes, and the protection is dead.
+        return s[1:-1].replace('\\"', '"').replace("\\\\", "\\")
     if s[0] in ("'", '"'):
         raise ConfigError(f"line {lineno}: unterminated quoted string")
     low = s.lower()
@@ -268,14 +272,19 @@ def classify_repo(config: dict, push_urls: List[str]) -> str:
     if not push_urls:
         return "strict"
     strict_patterns = flatten_patterns(config.get("strict_repo_patterns") or [])
-    if strict_patterns and any(_match_any(strict_patterns, u) for u in push_urls):
-        return "strict"
     surface_patterns = flatten_patterns(config.get("public_surface_patterns") or [])
-    if surface_patterns and all(_match_any(surface_patterns, u) for u in push_urls):
-        return "public-surface"
     personal_patterns = flatten_patterns(
         config.get("personal_remote_patterns") or []
     )
+    if strict_patterns and any(_match_any(strict_patterns, u) for u in push_urls):
+        return "strict"
+    if surface_patterns and all(_match_any(surface_patterns, u) for u in push_urls):
+        return "public-surface"
+    # Escalation, never demotion: a repo that partially matches a published
+    # or strict surface must not fall THROUGH to the least-protected class
+    # because a broad personal namespace pattern also matches it.
+    if surface_patterns and any(_match_any(surface_patterns, u) for u in push_urls):
+        return "strict"
     if personal_patterns and all(_match_any(personal_patterns, u) for u in push_urls):
         return "personal"
     return "strict"
@@ -329,6 +338,19 @@ def load_ledger_allowances(config: dict) -> List[str]:
         raise ConfigError(
             f"disclosure ledger has no entities mapping: {path}"
         )
+    # An allowance may only ever subtract an IDENTITY pattern (who), never a
+    # topic pattern (what). Without this, a ledger entry could quietly
+    # disable NDA, compensation, or internal-URL detection.
+    allowed_groups = flatten_patterns(
+        config.get("ledger_allowance_groups") or ["confidential_names"]
+    )
+    tier1 = config.get("tier_1_strict_only") or {}
+    eligible = set()
+    for group in allowed_groups:
+        eligible.update(flatten_patterns(tier1.get(group) or []))
+    registers_vocabulary = set(
+        flatten_patterns(config.get("ledger_registers") or ["biography"])
+    )
     allowances: List[str] = []
     for name, entry in entities.items():
         if not isinstance(entry, dict):
@@ -341,7 +363,28 @@ def load_ledger_allowances(config: dict) -> List[str]:
                 f"citations — precedent without evidence is not precedent: "
                 f"{path}"
             )
-        allowances.extend(flatten_patterns(entry.get("hook_patterns") or []))
+        registers = flatten_patterns(entry.get("registers") or [])
+        if not registers:
+            raise ConfigError(
+                f"disclosure ledger entity {name!r} declares no registers: "
+                f"{path}"
+            )
+        for register in registers:
+            if register not in registers_vocabulary:
+                raise ConfigError(
+                    f"disclosure ledger entity {name!r} declares register "
+                    f"{register!r}, which is not in the approved vocabulary "
+                    f"({', '.join(sorted(registers_vocabulary))}): {path}"
+                )
+        for pattern in flatten_patterns(entry.get("hook_patterns") or []):
+            if pattern not in eligible:
+                raise ConfigError(
+                    f"disclosure ledger entity {name!r} claims hook pattern "
+                    f"{pattern!r}, which is not in an allowance-eligible "
+                    f"group ({', '.join(allowed_groups)}) — allowances may "
+                    f"only subtract identity patterns: {path}"
+                )
+            allowances.append(pattern)
     return allowances
 
 
@@ -356,8 +399,19 @@ def build_active_regex(config: dict, repo_class: str) -> str:
     elif repo_class == "public-surface":
         tier1 = config.get("tier_1_strict_only") or {}
         allowed = set(load_ledger_allowances(config))
+        # Published surfaces enforce the IDENTITY boundary (who is named or
+        # identifiable), not private-notes topic vocabulary. Words like
+        # "salary" or "proprietary" occur legitimately across a long
+        # published archive; an unapproved NAME is the actual exposure.
+        # Absent explicit configuration every group applies (fail closed).
+        groups = flatten_patterns(config.get("public_surface_groups") or [])
+        selected = (
+            {g: tier1.get(g) for g in groups if tier1.get(g) is not None}
+            if groups
+            else tier1
+        )
         parts.extend(
-            p for p in flatten_patterns(tier1) if p not in allowed
+            p for p in flatten_patterns(selected) if p not in allowed
         )
     seen: set = set()
     deduped: List[str] = []
@@ -380,17 +434,23 @@ def build_allowlist_regex(config: dict) -> str:
 DEFAULT_DIFF_EXCLUDE_PATHS = (
     r'(^|/)\.githooks/pre-commit$',
     r'(^|/)\.githooks/extra-patterns\.ya?ml$',
-    r'(^|/)git-hook-config\.ya?ml$',
+    r'^\.synthesis/git-hook-config\.ya?ml$',
     r'(^|/)git-hook-config\.example\.ya?ml$',
     r'(^|/)anti-shortcut-catalog\.ya?ml$',
     # The disclosure-policy methodology and the hook engine's own docs and
     # tests discuss the pattern system by example — pattern-catalog class.
-    r'(^|/)synthesis-disclosure-policy/',
-    r'(^|/)synthesis-git-hooks/SKILL\.md$',
-    r'(^|/)synthesis-git-hooks/scripts/test_pre_commit\.py$',
-    # A disclosure ledger's contents are by definition the guarded names.
-    r'(^|/)disclosure/ledger\.ya?ml$',
+    # ANCHORED to their real locations: a bare basename anywhere would be a
+    # free pass any repo could claim by naming a file conveniently.
+    r'^skills/synthesis-disclosure-policy/',
+    r'^skills/synthesis-git-hooks/',
+    r'^agent-control/git-hook-config\.ya?ml$',
+    r'^agent-control/disclosure/ledger\.ya?ml$',
 )
+
+# Tier 0 is never excluded: credentials in any path, in any repo class,
+# always block. Path exclusions exist for pattern-catalog files, whose
+# risk is false positives on Tier 1 vocabulary — never for secrets.
+
 
 
 def build_diff_exclude_regex(config: dict) -> str:
@@ -398,6 +458,55 @@ def build_diff_exclude_regex(config: dict) -> str:
     user_paths = flatten_patterns(config.get("diff_exclude_paths") or [])
     all_paths = list(DEFAULT_DIFF_EXCLUDE_PATHS) + user_paths
     return "|".join(all_paths)
+
+
+ALL_PATTERN_KEYS = (
+    "personal_remote_patterns",
+    "strict_repo_patterns",
+    "public_surface_patterns",
+    "allowlist_lines",
+    "diff_exclude_paths",
+)
+
+
+def validate_all_patterns(config: dict) -> List[str]:
+    """Return problems for every configured regex in the policy.
+
+    v2.1 validated only the tier patterns. An invalid exclusion or
+    allowlist regex made grep fail, `|| true` swallowed it, and the engine
+    ran with scanning silently disabled while the doctor reported healthy.
+    """
+    problems: List[str] = []
+    groups = {
+        "tier_0_always": flatten_patterns(config.get("tier_0_always") or {}),
+        "tier_1_strict_only": flatten_patterns(
+            config.get("tier_1_strict_only") or {}
+        ),
+    }
+    for key in ALL_PATTERN_KEYS:
+        groups[key] = flatten_patterns(config.get(key) or [])
+    for key, patterns in groups.items():
+        for pattern in patterns:
+            if not pattern:
+                problems.append(
+                    f"{key}: empty pattern — an empty alternation branch "
+                    "matches everything or nothing depending on position"
+                )
+                continue
+            if any(ord(ch) < 32 for ch in pattern):
+                problems.append(
+                    f"{key}: pattern contains a control character "
+                    f"({pattern!r}) — a regex escape was interpreted as a "
+                    "literal (check double-quoted YAML scalars)"
+                )
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                problems.append(f"{key}: rejected by python re: {pattern!r} ({exc})")
+            err = _grep_validates(pattern)
+            if err:
+                problems.append(f"{key}: rejected by grep -E: {pattern!r} ({err})")
+    return problems
 
 
 def load_config(path: Path) -> dict:
@@ -431,14 +540,48 @@ def load_config(path: Path) -> dict:
             file=sys.stderr,
         )
         sys.exit(2)
+    version = config.get("config_version")
+    if not isinstance(version, int) or version < REQUIRED_CONFIG_VERSION:
+        print(
+            f"synthesis-git-hooks: config at {path} declares config_version "
+            f"{version!r}; this engine (v{SIDECAR_VERSION}) requires "
+            f"{REQUIRED_CONFIG_VERSION}. A v1 config paired with this engine "
+            "would silently skip the surface classes and ledger. Update the "
+            "config, or reinstall the matching engine.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    problems = validate_all_patterns(config)
+    if problems:
+        print(
+            "synthesis-git-hooks: invalid pattern(s) in "
+            f"{path} (fail closed):\n  " + "\n  ".join(problems),
+            file=sys.stderr,
+        )
+        sys.exit(2)
     return config
 
 
 def emit_shell_vars(config: dict) -> None:
     push_urls = get_push_remotes()
-    repo_class = classify_repo(config, push_urls)
+    try:
+        repo_class = classify_repo(config, push_urls)
+    except re.error as exc:
+        print(
+            f"synthesis-git-hooks: classification pattern invalid: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     try:
         active = build_active_regex(config, repo_class)
+    except ConfigError as exc:
+        print(f"synthesis-git-hooks: {exc}", file=sys.stderr)
+        sys.exit(2)
+    # Commit messages never get ledger allowances: a message names the
+    # nature of an edit, which no precedent covers, and site commit logs
+    # stay generic.
+    try:
+        message_regex = build_active_regex(config, "strict")
     except ConfigError as exc:
         print(f"synthesis-git-hooks: {exc}", file=sys.stderr)
         sys.exit(2)
@@ -455,6 +598,11 @@ def emit_shell_vars(config: dict) -> None:
     # shlex.quote handles regex escapes safely under bash `eval`.
     print(f"REPO_CLASS={shlex.quote(repo_class)}")
     print(f"ACTIVE_REGEX={shlex.quote(active)}")
+    print(f"MESSAGE_REGEX={shlex.quote(message_regex)}")
+    # Credentials are scanned across EVERY staged path, exclusions included:
+    # a pattern-catalog file is a plausible place for a false positive on
+    # Tier-1 vocabulary, never a legitimate place for a secret.
+    print(f"TIER0_REGEX={shlex.quote(build_active_regex(config, 'personal'))}")
     print(f"ALLOWLIST_REGEX={shlex.quote(allowlist)}")
     print(f"DIFF_EXCLUDE_REGEX={shlex.quote(diff_excludes)}")
     print(f"CHECK_COMMIT_MSG={check_msg}")
@@ -504,19 +652,23 @@ def run_doctor(config_path: Path) -> int:
             )
             if not t0:
                 problems.append("tier_0_always is empty — no credential tier")
-            # 2. Every pattern valid under BOTH python re and grep -E.
-            for p in t0 + t1:
-                try:
-                    re.compile(p)
-                except re.error as exc:
-                    problems.append(
-                        f"pattern rejected by python re: {p!r} ({exc})"
-                    )
-                err = _grep_validates(p)
-                if err:
-                    problems.append(
-                        f"pattern rejected by grep -E: {p!r} ({err})"
-                    )
+            version = config.get("config_version")
+            if not isinstance(version, int) or version < REQUIRED_CONFIG_VERSION:
+                problems.append(
+                    f"config_version is {version!r}; engine v{SIDECAR_VERSION} "
+                    f"requires {REQUIRED_CONFIG_VERSION}"
+                )
+            # 2. EVERY configured regex valid under both python re and grep -E
+            # (tiers, remote patterns, allowlist, exclusions).
+            problems.extend(validate_all_patterns(config))
+            if config.get("public_surface_patterns") and not config.get(
+                "disclosure_ledger"
+            ):
+                problems.append(
+                    "public_surface_patterns configured without a "
+                    "disclosure_ledger — public-surface repos get zero "
+                    "allowances, which blocks published-precedent content"
+                )
         except ConfigError as exc:
             problems.append(f"config unparsable: {exc}")
 
@@ -654,7 +806,7 @@ def main(argv: List[str]) -> int:
     mode.add_argument(
         "--classify",
         action="store_true",
-        help="Print just the repo class (personal|strict) and exit.",
+        help="Print just the repo class (personal|public-surface|strict) and exit.",
     )
     mode.add_argument(
         "--print-active-regex",

--- a/skills/synthesis-git-hooks/scripts/_load_config.py
+++ b/skills/synthesis-git-hooks/scripts/_load_config.py
@@ -380,7 +380,7 @@ def build_allowlist_regex(config: dict) -> str:
 DEFAULT_DIFF_EXCLUDE_PATHS = (
     r'(^|/)\.githooks/pre-commit$',
     r'(^|/)\.githooks/extra-patterns\.ya?ml$',
-    r'(^|/)\.synthesis/git-hook-config\.ya?ml$',
+    r'(^|/)git-hook-config\.ya?ml$',
     r'(^|/)git-hook-config\.example\.ya?ml$',
     r'(^|/)anti-shortcut-catalog\.ya?ml$',
     # The disclosure-policy methodology and the hook engine's own docs and

--- a/skills/synthesis-git-hooks/scripts/_load_config.py
+++ b/skills/synthesis-git-hooks/scripts/_load_config.py
@@ -388,6 +388,8 @@ DEFAULT_DIFF_EXCLUDE_PATHS = (
     r'(^|/)synthesis-disclosure-policy/',
     r'(^|/)synthesis-git-hooks/SKILL\.md$',
     r'(^|/)synthesis-git-hooks/scripts/test_pre_commit\.py$',
+    # A disclosure ledger's contents are by definition the guarded names.
+    r'(^|/)disclosure/ledger\.ya?ml$',
 )
 
 

--- a/skills/synthesis-git-hooks/scripts/_load_config.py
+++ b/skills/synthesis-git-hooks/scripts/_load_config.py
@@ -239,22 +239,46 @@ def get_push_remotes() -> List[str]:
     return urls
 
 
-def classify_repo(personal_patterns: List[str], push_urls: List[str]) -> str:
-    """Return ``"personal"`` if every push remote matches at least one
-    personal-remote pattern (case-insensitive). Otherwise ``"strict"``.
+def _match_any(patterns: List[str], url: str) -> bool:
+    return any(re.search(p, url, re.IGNORECASE) for p in patterns)
 
-    Empty remote list classifies as ``"strict"`` — the safe default for a
-    fresh ``git init`` or any repo without a defined upstream.
+
+def classify_repo(config: dict, push_urls: List[str]) -> str:
+    """Classify the repo by PUBLICATION SURFACE, not repo visibility.
+
+    Returns one of three classes, decided in strict-first precedence:
+
+    - ``"strict"`` when ANY push remote matches ``strict_repo_patterns``
+      (public OSS and multi-tenant repos pinned strict even when their
+      remotes would otherwise read as personal), when the remote list is
+      empty, or when no other class matches. Full Tier 1, no allowances.
+    - ``"public-surface"`` when EVERY push remote matches
+      ``public_surface_patterns``: repositories whose content the user
+      personally authors and publishes (their sites). Full Tier 1, minus
+      only the names the disclosure ledger records as published-precedent.
+    - ``"personal"`` when EVERY push remote matches
+      ``personal_remote_patterns``: content only the user reads. Tier 0
+      only, unchanged semantics.
+
+    The old model classified by remote ownership alone, which failed in
+    both directions: it blocked the user's own published biography on
+    their sites, and it left published surfaces with personal remotes
+    completely unguarded.
     """
     if not push_urls:
         return "strict"
-    if not personal_patterns:
+    strict_patterns = flatten_patterns(config.get("strict_repo_patterns") or [])
+    if strict_patterns and any(_match_any(strict_patterns, u) for u in push_urls):
         return "strict"
-    compiled = [re.compile(p, re.IGNORECASE) for p in personal_patterns]
-    for url in push_urls:
-        if not any(c.search(url) for c in compiled):
-            return "strict"
-    return "personal"
+    surface_patterns = flatten_patterns(config.get("public_surface_patterns") or [])
+    if surface_patterns and all(_match_any(surface_patterns, u) for u in push_urls):
+        return "public-surface"
+    personal_patterns = flatten_patterns(
+        config.get("personal_remote_patterns") or []
+    )
+    if personal_patterns and all(_match_any(personal_patterns, u) for u in push_urls):
+        return "personal"
+    return "strict"
 
 
 def flatten_patterns(node: Any) -> List[str]:
@@ -271,6 +295,56 @@ def flatten_patterns(node: Any) -> List[str]:
     return out
 
 
+def load_ledger_allowances(config: dict) -> List[str]:
+    """Read the disclosure ledger and return its allowed hook patterns.
+
+    The ledger is the machine-readable record of published-precedent
+    disclosures: names the user has personally published in biography
+    register on their own public surfaces, each entry carrying evidence
+    citations. Entries opt specific Tier-1 patterns out of enforcement in
+    ``public-surface`` repos ONLY, via ``hook_patterns`` values that must
+    TEXTUALLY EQUAL entries in ``tier_1_strict_only`` — exact string
+    equality, so every allowance is auditable and no regex-subsumption
+    reasoning is involved.
+
+    Fail closed: a configured ledger path that is missing or unparsable is
+    a ConfigError (the sidecar exits 2 and the engine blocks the commit).
+    No configured ledger simply means no allowances.
+    """
+    path_value = config.get("disclosure_ledger")
+    if not path_value:
+        return []
+    path = Path(os.path.expanduser(str(path_value)))
+    if not path.exists():
+        raise ConfigError(
+            f"disclosure_ledger configured but missing: {path} — "
+            "public-surface allowances refuse to run without their ledger"
+        )
+    try:
+        ledger = parse_simple_yaml(path.read_text())
+    except ConfigError as exc:
+        raise ConfigError(f"disclosure ledger unparsable ({path}): {exc}")
+    entities = ledger.get("entities")
+    if not isinstance(entities, dict) or not entities:
+        raise ConfigError(
+            f"disclosure ledger has no entities mapping: {path}"
+        )
+    allowances: List[str] = []
+    for name, entry in entities.items():
+        if not isinstance(entry, dict):
+            raise ConfigError(
+                f"disclosure ledger entity {name!r} is not a mapping: {path}"
+            )
+        if not flatten_patterns(entry.get("evidence") or []):
+            raise ConfigError(
+                f"disclosure ledger entity {name!r} has no evidence "
+                f"citations — precedent without evidence is not precedent: "
+                f"{path}"
+            )
+        allowances.extend(flatten_patterns(entry.get("hook_patterns") or []))
+    return allowances
+
+
 def build_active_regex(config: dict, repo_class: str) -> str:
     """Concatenate the active patterns into a single alternation regex."""
     parts: List[str] = []
@@ -279,6 +353,12 @@ def build_active_regex(config: dict, repo_class: str) -> str:
     if repo_class == "strict":
         tier1 = config.get("tier_1_strict_only") or {}
         parts.extend(flatten_patterns(tier1))
+    elif repo_class == "public-surface":
+        tier1 = config.get("tier_1_strict_only") or {}
+        allowed = set(load_ledger_allowances(config))
+        parts.extend(
+            p for p in flatten_patterns(tier1) if p not in allowed
+        )
     seen: set = set()
     deduped: List[str] = []
     for p in parts:
@@ -303,6 +383,11 @@ DEFAULT_DIFF_EXCLUDE_PATHS = (
     r'(^|/)\.synthesis/git-hook-config\.ya?ml$',
     r'(^|/)git-hook-config\.example\.ya?ml$',
     r'(^|/)anti-shortcut-catalog\.ya?ml$',
+    # The disclosure-policy methodology and the hook engine's own docs and
+    # tests discuss the pattern system by example — pattern-catalog class.
+    r'(^|/)synthesis-disclosure-policy/',
+    r'(^|/)synthesis-git-hooks/SKILL\.md$',
+    r'(^|/)synthesis-git-hooks/scripts/test_pre_commit\.py$',
 )
 
 
@@ -348,14 +433,23 @@ def load_config(path: Path) -> dict:
 
 
 def emit_shell_vars(config: dict) -> None:
-    personal_patterns = config.get("personal_remote_patterns") or []
     push_urls = get_push_remotes()
-    repo_class = classify_repo(personal_patterns, push_urls)
-    active = build_active_regex(config, repo_class)
+    repo_class = classify_repo(config, push_urls)
+    try:
+        active = build_active_regex(config, repo_class)
+    except ConfigError as exc:
+        print(f"synthesis-git-hooks: {exc}", file=sys.stderr)
+        sys.exit(2)
     allowlist = build_allowlist_regex(config)
     diff_excludes = build_diff_exclude_regex(config)
     check_msg_enabled = bool(config.get("check_commit_message", True))
-    check_msg = "1" if (repo_class == "strict" and check_msg_enabled) else "0"
+    # Commit messages stay generic on every published surface, so the
+    # message scan runs for public-surface exactly as it does for strict.
+    check_msg = (
+        "1"
+        if (repo_class in ("strict", "public-surface") and check_msg_enabled)
+        else "0"
+    )
     # shlex.quote handles regex escapes safely under bash `eval`.
     print(f"REPO_CLASS={shlex.quote(repo_class)}")
     print(f"ACTIVE_REGEX={shlex.quote(active)}")
@@ -472,13 +566,33 @@ def run_doctor(config_path: Path) -> int:
             f"skill source not present at {src_dir} (drift check skipped)"
         )
 
-    # 5. Current repo context (best-effort).
+    # 5. Disclosure ledger (when configured): must exist, parse, carry
+    # evidence, and every allowance must correspond to a real Tier-1
+    # pattern — a stale allowance protects nothing and hides intent.
+    if config is not None and config.get("disclosure_ledger"):
+        try:
+            allowances = load_ledger_allowances(config)
+            tier1 = set(
+                flatten_patterns(config.get("tier_1_strict_only") or {})
+            )
+            stale = [a for a in allowances if a not in tier1]
+            infos.append(
+                f"disclosure ledger OK: {len(allowances)} allowance(s) "
+                "for public-surface repos"
+            )
+            for pattern in stale:
+                problems.append(
+                    "ledger allowance matches no tier_1_strict_only "
+                    f"pattern (stale or typo): {pattern!r}"
+                )
+        except ConfigError as exc:
+            problems.append(str(exc))
+
+    # 6. Current repo context (best-effort).
     if config is not None:
         push_urls = get_push_remotes()
         if push_urls:
-            cls = classify_repo(
-                config.get("personal_remote_patterns") or [], push_urls
-            )
+            cls = classify_repo(config, push_urls)
             infos.append(
                 f"cwd repo class: {cls} ({len(push_urls)} push remotes)"
             )
@@ -560,20 +674,16 @@ def main(argv: List[str]) -> int:
     config = load_config(config_path)
 
     if args.classify:
-        push_urls = get_push_remotes()
-        print(classify_repo(
-            config.get("personal_remote_patterns") or [],
-            push_urls,
-        ))
+        print(classify_repo(config, get_push_remotes()))
         return 0
 
     if args.print_active_regex:
-        push_urls = get_push_remotes()
-        repo_class = classify_repo(
-            config.get("personal_remote_patterns") or [],
-            push_urls,
-        )
-        print(build_active_regex(config, repo_class))
+        repo_class = classify_repo(config, get_push_remotes())
+        try:
+            print(build_active_regex(config, repo_class))
+        except ConfigError as exc:
+            print(f"synthesis-git-hooks: {exc}", file=sys.stderr)
+            return 2
         return 0
 
     # Default: emit shell vars.

--- a/skills/synthesis-git-hooks/scripts/commit-msg
+++ b/skills/synthesis-git-hooks/scripts/commit-msg
@@ -55,8 +55,21 @@ eval "$SIDECAR_OUT"
 # Personal-class repos (CHECK_COMMIT_MSG=0): message scanning off by design.
 if [ "${CHECK_COMMIT_MSG:-0}" = "1" ]; then
     [ -n "${ACTIVE_REGEX:-}" ] || fail_closed "Active pattern set is empty."
+
+    # Messages scan with MESSAGE_REGEX — the strict-class set, never
+    # ledger-reduced. A commit message names the NATURE of an edit, which no
+    # published-precedent entry covers, so commit logs stay generic even
+    # where the diff may restate published biography.
+    SCAN_REGEX="${MESSAGE_REGEX:-$ACTIVE_REGEX}"
+    REGEX_CHECK_ERR=$(echo "" | grep -i -E "$SCAN_REGEX" 2>&1 >/dev/null || true)
+    if echo "$REGEX_CHECK_ERR" | grep -qi -E 'grep:|invalid|unrecognized|error'; then
+        fail_closed "The commit-message regex cannot be parsed by grep -E:
+
+  $REGEX_CHECK_ERR"
+    fi
+
     # Ignore comment lines (stripped by git anyway).
-    MSG_MATCHES=$(grep -v '^#' "$MSG_FILE" | grep -i -E "$ACTIVE_REGEX" || true)
+    MSG_MATCHES=$(grep -v '^#' "$MSG_FILE" | grep -i -E "$SCAN_REGEX" || true)
     if [ -n "$MSG_MATCHES" ] && [ -n "${ALLOWLIST_REGEX:-}" ]; then
         MSG_MATCHES=$(echo "$MSG_MATCHES" | grep -ivE "$ALLOWLIST_REGEX" || true)
     fi

--- a/skills/synthesis-git-hooks/scripts/git-hook-config.example.yaml
+++ b/skills/synthesis-git-hooks/scripts/git-hook-config.example.yaml
@@ -19,6 +19,26 @@ config_version: 1
 personal_remote_patterns:
   - '[:/]YOUR-PERSONAL-ORG/'
 
+# Repos pinned `strict` no matter what their remotes look like (ANY push
+# remote matching flips the repo strict). Use for public OSS repos that live
+# under your personal org — a public repository is never a place for Tier-1
+# content even though its remote reads as personal.
+# strict_repo_patterns:
+#   - '[:/]YOUR-PERSONAL-ORG/your-public-oss-repo(\.git)?$'
+
+# Repos whose content YOU personally author and publish (your sites). They
+# classify `public-surface` when EVERY push remote matches: full Tier 1
+# protection applies, minus only the names your disclosure ledger records as
+# published precedent. See the synthesis-disclosure-policy skill.
+# public_surface_patterns:
+#   - '[:/]YOUR-PERSONAL-ORG/your-personal-site(\.git)?$'
+
+# The disclosure precedent ledger (see synthesis-disclosure-policy). Only
+# read for public-surface repos; entries subtract their exact hook_patterns
+# strings from tier_1_strict_only enforcement there. Missing or unparsable
+# ledger fails closed.
+# disclosure_ledger: '~/.synthesis/agent-control/disclosure/ledger.yaml'
+
 # ─── Tier 0 — credentials. ALWAYS run regardless of repo class. ───────────
 # A private repo can flip to public in one click; credentials shouldn't be in
 # git at all. Defense in depth.

--- a/skills/synthesis-git-hooks/scripts/pre-commit
+++ b/skills/synthesis-git-hooks/scripts/pre-commit
@@ -92,14 +92,62 @@ eval "$SIDECAR_OUT"
 # hundreds of unchanged historical lines as newly introduced content. Copy
 # targets receive status C and are excluded by AM; genuinely new or modified
 # lines remain in scope.
-CHANGED_FILES=$(git diff --cached -C --find-copies-harder --name-only --diff-filter=AM 2>/dev/null || true)
-if [ -n "${DIFF_EXCLUDE_REGEX:-}" ] && [ -n "$CHANGED_FILES" ]; then
-    CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v -E "$DIFF_EXCLUDE_REGEX" || true)
+# One unrestricted diff, filtered per file in-process. The previous design
+# round-tripped filenames through `echo | xargs`, so a filename containing a
+# quote aborted xargs and — via `|| true` — silently emptied the diff,
+# passing the ENTIRE commit unscanned. Filenames never touch the shell now.
+#
+# --diff-filter=AMCR: renames and copies ARE scanned. Under -U0 an exact
+# copy or rename contributes zero added lines (the canonical-file migration
+# stays exempt), while an edited copy/rename contributes exactly its new
+# lines — which is precisely the laundering path that must not pass.
+set +e
+RAW_DIFF=$(git diff --cached -C --find-copies-harder --diff-filter=AMCR -U0 2>/dev/null)
+DIFF_STATUS=$?
+set -e
+[ "$DIFF_STATUS" -eq 0 ] || fail_closed "git diff exited $DIFF_STATUS while collecting staged changes."
+
+if [ -n "${DIFF_EXCLUDE_REGEX:-}" ]; then
+    EXCLUDE_CHECK_ERR=$(echo "" | grep -E "$DIFF_EXCLUDE_REGEX" 2>&1 >/dev/null || true)
+    if echo "$EXCLUDE_CHECK_ERR" | grep -qi -E 'grep:|invalid|unrecognized|error'; then
+        fail_closed "diff_exclude_paths assembled an unparsable regex:
+
+  $EXCLUDE_CHECK_ERR
+
+An invalid exclusion regex would drop every file from the scan."
+    fi
 fi
 
+# Drop hunks belonging to excluded paths; keep everything else.
+DIFF=$(
+    DIFF_EXCLUDE_REGEX="${DIFF_EXCLUDE_REGEX:-}" awk '
+        /^\+\+\+ b\// {
+            path = substr($0, 7)
+            skip = 0
+            if (ENVIRON["DIFF_EXCLUDE_REGEX"] != "") {
+                cmd = "printf %s " sprintf("%c%s%c", 39, path, 39) \
+                      " | grep -qE " sprintf("%c%s%c", 39, ENVIRON["DIFF_EXCLUDE_REGEX"], 39)
+                skip = (system(cmd) == 0)
+            }
+            next
+        }
+        skip { next }
+        { print }
+    ' <<< "$RAW_DIFF"
+)
+
 MATCHES=""
-if [ -n "$CHANGED_FILES" ]; then
-    DIFF=$(echo "$CHANGED_FILES" | xargs git diff --cached -C --find-copies-harder --diff-filter=AM -U0 -- 2>/dev/null || true)
+
+# Tier 0 first, against the UNFILTERED diff: path exclusions never apply to
+# credentials.
+if [ -n "$RAW_DIFF" ] && [ -n "${TIER0_REGEX:-}" ]; then
+    TIER0_HITS=$(echo "$RAW_DIFF" | grep '^+' | grep -v '^+++' | grep -i -E "$TIER0_REGEX" || true)
+    if [ -n "$TIER0_HITS" ]; then
+        MATCHES=$(echo "$TIER0_HITS" | head -20)
+    fi
+fi
+
+if [ -z "$MATCHES" ] && [ -n "$RAW_DIFF" ]; then
     if [ -n "$DIFF" ]; then
         # Stage 1: collect added lines that hit the active regex. Validate the
         # regex against an empty string first — if grep rejects the pattern
@@ -121,6 +169,14 @@ pattern in ERE-compatible form."
         STAGE1=$(echo "$DIFF" | grep '^+' | grep -v '^+++' | grep -i -E "$ACTIVE_REGEX" || true)
         # Stage 2: filter out allowlisted lines (e.g., SPDX license declarations).
         if [ -n "$STAGE1" ] && [ -n "${ALLOWLIST_REGEX:-}" ]; then
+            ALLOWLIST_CHECK_ERR=$(echo "" | grep -iE "$ALLOWLIST_REGEX" 2>&1 >/dev/null || true)
+            if echo "$ALLOWLIST_CHECK_ERR" | grep -qi -E 'grep:|invalid|unrecognized|error'; then
+                fail_closed "allowlist_lines assembled an unparsable regex:
+
+  $ALLOWLIST_CHECK_ERR
+
+An invalid allowlist regex would suppress every detection."
+            fi
             STAGE1=$(echo "$STAGE1" | grep -ivE "$ALLOWLIST_REGEX" || true)
         fi
         MATCHES=$(echo "$STAGE1" | head -20)

--- a/skills/synthesis-git-hooks/scripts/test_pre_commit.py
+++ b/skills/synthesis-git-hooks/scripts/test_pre_commit.py
@@ -23,7 +23,7 @@ def run(repository: Path, *command: str, env: dict[str, str] | None = None):
 def policy(path: Path) -> None:
     path.write_text(
         """\
-config_version: 1
+config_version: 2
 personal_remote_patterns:
   - '[:/]never-matches/'
 tier_0_always:
@@ -116,7 +116,7 @@ def surface_policy(path: Path, ledger: Path | None) -> None:
     ledger_line = f"disclosure_ledger: '{ledger}'\n" if ledger else ""
     path.write_text(
         f"""\
-config_version: 1
+config_version: 2
 personal_remote_patterns:
   - '[:/]example-person/'
 strict_repo_patterns:
@@ -341,7 +341,9 @@ def test_hook_fails_closed_when_surface_ledger_missing(tmp_path: Path) -> None:
     assert "policy engine unavailable" in completed.stderr
 
 
-def test_doctor_flags_stale_ledger_allowance(tmp_path: Path) -> None:
+def test_ledger_allowance_must_be_an_eligible_identity_pattern(
+    tmp_path: Path,
+) -> None:
     config_path = tmp_path / "policy.yaml"
     ledger = tmp_path / "ledger.yaml"
     ledger.write_text(
@@ -349,6 +351,8 @@ def test_doctor_flags_stale_ledger_allowance(tmp_path: Path) -> None:
 ledger_version: 1
 entities:
   example-client:
+    registers:
+      - biography
     hook_patterns:
       - 'name-not-in-tier-one'
     evidence:
@@ -357,12 +361,230 @@ entities:
         encoding="utf-8",
     )
     surface_policy(config_path, ledger)
+    config = load(config_path)
+
+    try:
+        SIDECAR.build_active_regex(config, "public-surface")
+        raise AssertionError("ineligible allowance must fail closed")
+    except SIDECAR.ConfigError as exc:
+        assert "allowance-eligible" in str(exc)
+
+
+def test_ledger_cannot_subtract_a_topic_pattern(tmp_path: Path) -> None:
+    """An allowance may never disable NDA/compensation-class detection."""
+    config_path = tmp_path / "policy.yaml"
+    ledger = tmp_path / "ledger.yaml"
+    ledger.write_text(
+        """\
+ledger_version: 1
+entities:
+  example-client:
+    registers:
+      - biography
+    hook_patterns:
+      - 'confidential'
+    evidence:
+      - 'site.ts: bio'
+""",
+        encoding="utf-8",
+    )
+    surface_policy(config_path, ledger)
+    config = load(config_path)
+
+    try:
+        SIDECAR.build_active_regex(config, "public-surface")
+        raise AssertionError("topic-pattern allowance must fail closed")
+    except SIDECAR.ConfigError as exc:
+        assert "allowance-eligible" in str(exc)
+
+
+def test_ledger_registers_are_validated(tmp_path: Path) -> None:
+    config_path = tmp_path / "policy.yaml"
+    ledger = tmp_path / "ledger.yaml"
+    ledger.write_text(
+        """\
+ledger_version: 1
+entities:
+  example-client:
+    registers:
+      - operational
+    hook_patterns:
+      - 'example-client'
+    evidence:
+      - 'site.ts: bio'
+""",
+        encoding="utf-8",
+    )
+    surface_policy(config_path, ledger)
+    config = load(config_path)
+
+    try:
+        SIDECAR.build_active_regex(config, "public-surface")
+        raise AssertionError("forbidden register must fail closed")
+    except SIDECAR.ConfigError as exc:
+        assert "approved vocabulary" in str(exc)
+
+
+def test_v1_config_is_refused_by_v2_engine(tmp_path: Path) -> None:
+    config_path = tmp_path / "policy.yaml"
+    surface_policy(config_path, None)
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8").replace(
+            "config_version: 2", "config_version: 1"
+        ),
+        encoding="utf-8",
+    )
 
     completed = subprocess.run(
-        [sys.executable, str(SIDECAR_PATH), "--config", str(config_path), "--doctor"],
+        [
+            sys.executable,
+            str(SIDECAR_PATH),
+            "--config",
+            str(config_path),
+            "--emit-shell-vars",
+        ],
         capture_output=True,
         text=True,
         check=False,
     )
-    assert "stale or typo" in completed.stdout
+    assert completed.returncode == 2
+    assert "config_version" in completed.stderr
+
+
+def test_invalid_exclusion_regex_fails_closed(tmp_path: Path) -> None:
+    config_path = tmp_path / "policy.yaml"
+    surface_policy(config_path, None)
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8")
+        + "diff_exclude_paths:\n  - '(^|/)docs/*.md['\n",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SIDECAR_PATH),
+            "--config",
+            str(config_path),
+            "--emit-shell-vars",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 2
+    assert "diff_exclude_paths" in completed.stderr
+
+
+def test_renamed_file_with_new_sensitive_line_blocks(tmp_path: Path) -> None:
+    """Laundering path: git mv out of an excluded path plus new content."""
+    root, environment = repository(tmp_path)
+    (root / "NOTES.md").write_text("Harmless baseline.\n", encoding="utf-8")
+    assert run(root, "git", "add", "NOTES.md").returncode == 0
+    assert (
+        run(
+            root, "git", "-c", "core.hooksPath=/dev/null", "commit", "-m", "Add"
+        ).returncode
+        == 0
+    )
+
+    assert run(root, "git", "mv", "NOTES.md", "PUBLIC.md").returncode == 0
+    (root / "PUBLIC.md").write_text(
+        "Harmless baseline.\nNewly added confidential material.\n",
+        encoding="utf-8",
+    )
+    assert run(root, "git", "add", "PUBLIC.md").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "SENSITIVE PATTERN DETECTED" in completed.stdout
+
+
+def test_copied_file_with_new_sensitive_line_blocks(tmp_path: Path) -> None:
+    root, environment = repository(tmp_path)
+    (root / "SOURCE.md").write_text("Baseline content here.\n", encoding="utf-8")
+    assert run(root, "git", "add", "SOURCE.md").returncode == 0
+    assert (
+        run(
+            root, "git", "-c", "core.hooksPath=/dev/null", "commit", "-m", "Add"
+        ).returncode
+        == 0
+    )
+
+    (root / "COPY.md").write_text(
+        "Baseline content here.\nAdded confidential detail.\n", encoding="utf-8"
+    )
+    assert run(root, "git", "add", "COPY.md").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
     assert completed.returncode == 1
+    assert "SENSITIVE PATTERN DETECTED" in completed.stdout
+
+
+def test_quoted_filename_does_not_disable_the_scan(tmp_path: Path) -> None:
+    """A filename with an apostrophe must not empty the whole diff."""
+    root, environment = repository(tmp_path)
+    (root / "rajiv's notes.md").write_text("Harmless.\n", encoding="utf-8")
+    (root / "plain.md").write_text(
+        "AKIAABCDEFGHIJKLMNOP\n", encoding="utf-8"
+    )
+    assert run(root, "git", "add", "-A").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "SENSITIVE PATTERN DETECTED" in completed.stdout
+
+
+def test_spaced_filename_content_is_scanned(tmp_path: Path) -> None:
+    root, environment = repository(tmp_path)
+    (root / "my notes.md").write_text(
+        "AKIAABCDEFGHIJKLMNOP\n", encoding="utf-8"
+    )
+    assert run(root, "git", "add", "-A").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1
+    assert "SENSITIVE PATTERN DETECTED" in completed.stdout
+
+
+def test_tier0_is_never_excluded_by_path(tmp_path: Path) -> None:
+    """Credentials block even in a pattern-catalog path."""
+    root, environment = repository(tmp_path)
+    catalog = root / "skills" / "synthesis-git-hooks" / "scripts"
+    catalog.mkdir(parents=True)
+    (catalog / "notes.md").write_text(
+        "AKIAABCDEFGHIJKLMNOP\n", encoding="utf-8"
+    )
+    assert run(root, "git", "add", "-A").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "SENSITIVE PATTERN DETECTED" in completed.stdout
+
+
+def test_unanchored_config_basename_is_not_a_free_pass(tmp_path: Path) -> None:
+    """A file merely NAMED git-hook-config.yaml must still be scanned."""
+    root, environment = repository(tmp_path)
+    decoy = root / "src"
+    decoy.mkdir()
+    (decoy / "git-hook-config.yaml").write_text(
+        "note: confidential material\n", encoding="utf-8"
+    )
+    assert run(root, "git", "add", "-A").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1
+    assert "SENSITIVE PATTERN DETECTED" in completed.stdout
+
+
+def test_double_quoted_pattern_keeps_its_escapes(tmp_path: Path) -> None:
+    """`\\b` in a double-quoted scalar must stay a word boundary."""
+    parsed = SIDECAR.parse_simple_yaml('key: "\\\\bsalary\\\\b"\n')
+    assert parsed["key"] == "\\bsalary\\b"
+    assert not any(ord(ch) < 32 for ch in parsed["key"])

--- a/skills/synthesis-git-hooks/scripts/test_pre_commit.py
+++ b/skills/synthesis-git-hooks/scripts/test_pre_commit.py
@@ -99,3 +99,270 @@ def test_genuinely_new_sensitive_line_still_blocks(tmp_path: Path) -> None:
 
     assert completed.returncode == 1
     assert "SENSITIVE PATTERN DETECTED" in completed.stdout
+
+
+import importlib.util
+import sys
+
+SIDECAR_PATH = SCRIPT_DIR / "_load_config.py"
+SPEC = importlib.util.spec_from_file_location("load_config", SIDECAR_PATH)
+assert SPEC and SPEC.loader
+SIDECAR = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = SIDECAR
+SPEC.loader.exec_module(SIDECAR)
+
+
+def surface_policy(path: Path, ledger: Path | None) -> None:
+    ledger_line = f"disclosure_ledger: '{ledger}'\n" if ledger else ""
+    path.write_text(
+        f"""\
+config_version: 1
+personal_remote_patterns:
+  - '[:/]example-person/'
+strict_repo_patterns:
+  - '[:/]example-person/public-oss(\\.git)?$'
+public_surface_patterns:
+  - '[:/]example-person/personal-site(\\.git)?$'
+  - '[:/]example-sites/'
+{ledger_line}tier_0_always:
+  credentials:
+    - 'AKIA[0-9A-Z]{{16}}'
+tier_1_strict_only:
+  confidentiality:
+    - 'confidential'
+  confidential_names:
+    - 'example-client'
+    - 'example-vendor'
+check_commit_message: false
+""",
+        encoding="utf-8",
+    )
+
+
+def write_ledger(path: Path) -> None:
+    path.write_text(
+        """\
+ledger_version: 1
+entities:
+  example-client:
+    kind: organization
+    relationship: former employer
+    registers:
+      - biography
+    hook_patterns:
+      - 'example-client'
+    evidence:
+      - 'personal-site/src/config/site.ts: bio names example-client'
+""",
+        encoding="utf-8",
+    )
+
+
+def load(config_path: Path) -> dict:
+    return SIDECAR.parse_simple_yaml(config_path.read_text())
+
+
+def test_classification_precedence(tmp_path: Path) -> None:
+    config_path = tmp_path / "policy.yaml"
+    ledger = tmp_path / "ledger.yaml"
+    write_ledger(ledger)
+    surface_policy(config_path, ledger)
+    config = load(config_path)
+
+    classify = SIDECAR.classify_repo
+    oss = ["https://github.com/example-person/public-oss.git"]
+    site = ["https://github.com/example-person/personal-site.git"]
+    org_site = ["https://github.com/example-sites/blog.git"]
+    private = ["https://github.com/example-person/notes.git"]
+    mixed = site + ["https://github.com/elsewhere/mirror.git"]
+
+    assert classify(config, oss) == "strict"
+    assert classify(config, site) == "public-surface"
+    assert classify(config, org_site) == "public-surface"
+    assert classify(config, private) == "personal"
+    assert classify(config, mixed) == "strict"
+    assert classify(config, []) == "strict"
+
+
+def test_public_surface_regex_subtracts_only_ledgered_names(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "policy.yaml"
+    ledger = tmp_path / "ledger.yaml"
+    write_ledger(ledger)
+    surface_policy(config_path, ledger)
+    config = load(config_path)
+
+    surface = SIDECAR.build_active_regex(config, "public-surface")
+    assert "example-client" not in surface
+    assert "example-vendor" in surface
+    assert "confidential" in surface
+    assert "AKIA" in surface
+
+    strict = SIDECAR.build_active_regex(config, "strict")
+    assert "example-client" in strict
+
+    personal = SIDECAR.build_active_regex(config, "personal")
+    assert "example-client" not in personal
+    assert "confidential" not in personal
+    assert "AKIA" in personal
+
+
+def test_ledger_failures_are_config_errors(tmp_path: Path) -> None:
+    config_path = tmp_path / "policy.yaml"
+    missing = tmp_path / "missing-ledger.yaml"
+    surface_policy(config_path, missing)
+    config = load(config_path)
+
+    try:
+        SIDECAR.build_active_regex(config, "public-surface")
+        raise AssertionError("missing ledger must fail closed")
+    except SIDECAR.ConfigError:
+        pass
+
+    no_evidence = tmp_path / "no-evidence.yaml"
+    no_evidence.write_text(
+        """\
+ledger_version: 1
+entities:
+  example-client:
+    hook_patterns:
+      - 'example-client'
+""",
+        encoding="utf-8",
+    )
+    surface_policy(config_path, no_evidence)
+    config = load(config_path)
+    try:
+        SIDECAR.build_active_regex(config, "public-surface")
+        raise AssertionError("evidence-free entity must fail closed")
+    except SIDECAR.ConfigError:
+        pass
+
+    # Strict and personal classes never read the ledger, so a broken ledger
+    # must not break them.
+    assert "example-client" in SIDECAR.build_active_regex(config, "strict")
+    assert "AKIA" in SIDECAR.build_active_regex(config, "personal")
+
+
+def surface_repository(
+    tmp_path: Path, remote: str
+) -> tuple[Path, dict[str, str]]:
+    root = tmp_path / "surface-repo"
+    root.mkdir()
+    assert run(root, "git", "init").returncode == 0
+    assert run(root, "git", "config", "user.name", "Test").returncode == 0
+    assert (
+        run(root, "git", "config", "user.email", "test@example.com").returncode
+        == 0
+    )
+    assert run(root, "git", "remote", "add", "origin", remote).returncode == 0
+    (root / "README.md").write_text("# Site\n", encoding="utf-8")
+    assert run(root, "git", "add", "README.md").returncode == 0
+    assert (
+        run(
+            root,
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "commit",
+            "-m",
+            "Initial",
+        ).returncode
+        == 0
+    )
+    config_path = tmp_path / "surface-policy.yaml"
+    ledger = tmp_path / "surface-ledger.yaml"
+    write_ledger(ledger)
+    surface_policy(config_path, ledger)
+    environment = dict(os.environ)
+    environment["SYNTHESIS_GIT_HOOK_CONFIG"] = str(config_path)
+    return root, environment
+
+
+def test_hook_allows_ledgered_name_on_public_surface(tmp_path: Path) -> None:
+    root, environment = surface_repository(
+        tmp_path, "https://github.com/example-person/personal-site.git"
+    )
+    (root / "bio.md").write_text(
+        "I led technology at example-client for five years.\n",
+        encoding="utf-8",
+    )
+    assert run(root, "git", "add", "bio.md").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_hook_blocks_unledgered_name_on_public_surface(tmp_path: Path) -> None:
+    root, environment = surface_repository(
+        tmp_path, "https://github.com/example-person/personal-site.git"
+    )
+    (root / "bio.md").write_text(
+        "We also worked with example-vendor on the rollout.\n",
+        encoding="utf-8",
+    )
+    assert run(root, "git", "add", "bio.md").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1
+    assert "SENSITIVE PATTERN DETECTED" in completed.stdout
+
+
+def test_hook_blocks_ledgered_name_in_forced_strict_repo(tmp_path: Path) -> None:
+    root, environment = surface_repository(
+        tmp_path, "https://github.com/example-person/public-oss.git"
+    )
+    (root / "docs.md").write_text(
+        "Built while at example-client.\n", encoding="utf-8"
+    )
+    assert run(root, "git", "add", "docs.md").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1
+    assert "SENSITIVE PATTERN DETECTED" in completed.stdout
+
+
+def test_hook_fails_closed_when_surface_ledger_missing(tmp_path: Path) -> None:
+    root, environment = surface_repository(
+        tmp_path, "https://github.com/example-person/personal-site.git"
+    )
+    config_path = Path(environment["SYNTHESIS_GIT_HOOK_CONFIG"])
+    surface_policy(config_path, tmp_path / "vanished-ledger.yaml")
+    (root / "bio.md").write_text("Harmless line.\n", encoding="utf-8")
+    assert run(root, "git", "add", "bio.md").returncode == 0
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1
+    assert "policy engine unavailable" in completed.stderr
+
+
+def test_doctor_flags_stale_ledger_allowance(tmp_path: Path) -> None:
+    config_path = tmp_path / "policy.yaml"
+    ledger = tmp_path / "ledger.yaml"
+    ledger.write_text(
+        """\
+ledger_version: 1
+entities:
+  example-client:
+    hook_patterns:
+      - 'name-not-in-tier-one'
+    evidence:
+      - 'site.ts: bio'
+""",
+        encoding="utf-8",
+    )
+    surface_policy(config_path, ledger)
+
+    completed = subprocess.run(
+        [sys.executable, str(SIDECAR_PATH), "--config", str(config_path), "--doctor"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert "stale or typo" in completed.stdout
+    assert completed.returncode == 1


### PR DESCRIPTION
## Summary

Replaces name-blacklist confidentiality with disclosure governance on the approval-and-provenance axis, and fixes five pre-existing fail-open holes an adversarial review proved exploitable.

**New skill — `synthesis-disclosure-policy`.** Three classes (published precedent / approval-required / protected), five decision tests (precedent, provenance, negativity, identification, aggregation), the evidence-cited ledger schema, surface classes, division of labor between the mechanical and semantic layers, an adoption quickstart, and a ledger template. Fully generic: the mechanism ships open, each adopter's names/surfaces/evidence stay in their own private config.

**`synthesis-git-hooks` v2.2.0 — publication-surface classification.** `strict_repo_patterns` (any-remote match) pins public repos strict; `public_surface_patterns` (all-remote match) classifies author-published sites; escalation is one-directional so a partial match can never demote a repo to `personal`. `public_surface_groups` selects which Tier-1 groups apply on published surfaces (identity patterns — names, URLs, private skill names — not private-notes topic vocabulary that fires across a long published archive). `disclosure_ledger` subtracts only exact identity patterns, only on public-surface, only from `ledger_allowance_groups`, only for entities with evidence and an approved register.

### Fail-open holes fixed (all verified exploitable before the fix)

- **Filenames could disable the entire scan.** The `echo | xargs` round-trip let an apostrophe in any staged filename abort xargs; `|| true` swallowed it and the whole commit passed unscanned. Filenames no longer touch the shell — one unrestricted diff, filtered per file in-process.
- **Renames and copies were never scanned** (`--diff-filter=AM`), so content could be laundered out of an excluded path into a published one. Now `AMCR`; under `-U0` an exact copy still contributes zero lines, so the canonical-file migration exemption survives while edited copies are scanned.
- **Path exclusions applied to Tier 0**, so credentials in a pattern-catalog path passed. Tier 0 now scans the unfiltered diff, always.
- **Exclusion and allowlist regexes were never validated** and failed open — one malformed entry silently disabled all scanning while the doctor reported healthy. Every configured regex (tiers, three remote lists, allowlist, exclusions) is now validated under both `re` and `grep -E` at load and in the doctor; the hooks pre-flight and fail closed.
- **Unanchored basename exclusions** were a free pass any repo could claim by naming a file conveniently; exclusions are now anchored to real locations.

Also: double-quoted YAML scalars no longer run through `unicode_escape` (which silently turned `\b` into a backspace, killing patterns while the doctor passed); commit messages scan with an allowance-free regex so logs stay generic; `config_version: 2` handshake prevents a new config from silently degrading against an old engine; doctor gains ledger, register-vocabulary, and surface-without-ledger checks.

## Test plan

- [x] 21 hook tests, including regressions for every proven exploit: quoted and spaced filenames, rename-with-edits, copy-with-edits, Tier-0-in-excluded-path, unanchored-basename decoy, v1-config refusal, invalid-exclusion fail-closed, topic-pattern and ineligible allowance refusal, register-vocabulary validation, double-quoted escape preservation
- [x] Full validation matrix: 113 source checks, 101 tests, installer suite, compileall
- [x] Live-shape verification across 16 real repos — every one classifies into its intended class

Do not merge without fresh authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)