### PR TITLE
Release 4.10.0: portable drift-source resolution for the git-hooks doctor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.10.0] - 2026-08-03
+
+### Changed
+
+- `synthesis-git-hooks` v2.3.0: the doctor's drift check no longer assumes
+  a personal checkout path for the skill source — a hardcoded default that
+  degraded the check on every other machine and violated this repository's
+  own no-personal-paths rule. Resolution now mirrors the conformance
+  suite's client-binary pattern: `$SYNTHESIS_GIT_HOOKS_SOURCE` when set
+  (authoritative; an empty value skips the check deliberately, and an
+  invalid value is reported as a doctor problem instead of silently
+  comparing against nothing), else the running script's own directory when
+  it is not itself an installed engine copy (repo checkouts, worktrees,
+  client plugin caches), else the documented locations the ecosystem's own
+  installers create. A source directory must carry all three engine files
+  to qualify, so a partial copy can no longer report "no drift" for the
+  files it lacks, and the doctor names the resolved source in its output.
+
+### Added
+
+- `synthesis-agent-conformance`: a `source.no-personal-workspace-paths`
+  scan enforcing the no-personal-paths repository rule mechanically —
+  workspace path segments in this public repository must be placeholders
+  or documented generic sample names, never a real username, and
+  home-anchored personal checkout paths are rejected wherever they appear.
+
 ## [4.9.0] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Proven AI agent skills for code review, content creation, project management, an
 
 ## What's new
 
+**Portable drift detection, mechanically enforced (August 2026).**
+The `synthesis-git-hooks` **v2.3.0** doctor no longer assumes where the
+skill source lives: its drift baseline resolves through an explicit
+override, the running copy itself, or documented install locations, so the
+same health check works from a fresh machine, a worktree, or a plugin
+cache — and a misconfigured override fails closed instead of silently
+skipping. `synthesis-agent-conformance` now scans the repository for
+personal workspace paths so this class of defect cannot return. See the
+[4.10.0 release notes](CHANGELOG.md).
+
 **Disclosure governance by precedent, not blacklist (July 2026).**
 `synthesis-disclosure-policy` distinguishes the names you deliberately
 publish in your own biography from disclosures nobody approved, backed by

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -215,23 +215,39 @@ def source_checks(source_root: Path) -> list[Check]:
     root_skills = sorted(path.parent.name for path in source_root.glob("*/SKILL.md"))
     add(checks, "source.no-root-skills", not root_skills, ", ".join(root_skills) or "none")
 
-    stale_patterns = {
+    forbidden_patterns = {
         "source.no-client-copy-paths": re.compile(
             r"(?:~|\$HOME)/\.(?:codex|claude|agents)/skills/synthesis-"
         ),
         "source.no-old-source-layout": re.compile(r"synthesis-skills/synthesis-"),
+        # Repository rule 8: no personal paths in this public repository. A
+        # workspace path segment must be a placeholder (<you>, *, $VAR,
+        # example-…) or a documented generic sample name (demo, personal,
+        # work, user) — never a real username. The second alternation
+        # catches home-anchored personal checkout paths in prose.
+        "source.no-personal-workspace-paths": re.compile(
+            r"workspaces/(?!<|\*|\$|example|demo/|personal/|work/|user/)[\w.-]+/"
+            r"|/(?:Users|home)/(?!user/|<)[\w.-]+/workspaces/"
+        ),
     }
-    text_files = [
-        path
-        for path in source_root.rglob("*")
-        if path.is_file()
-        and ".git" not in path.parts
-        and ".claude" not in path.parts
-        and path.resolve() != SCRIPT_PATH
-        and path.resolve() != SCRIPT_PATH.with_name("test_conformance.py")
-        and path.suffix in {".md", ".py", ".sh", ".yaml", ".yml", ".json"}
-    ]
-    for name, pattern in stale_patterns.items():
+    def scannable(path: Path) -> bool:
+        if not path.is_file():
+            return False
+        # Exclusions apply RELATIVE to the source root: a checkout may
+        # itself sit under a .claude/worktrees/ directory, and matching
+        # ancestor components would empty the scan into a silent pass.
+        rel_parts = path.relative_to(source_root).parts
+        if ".git" in rel_parts or ".claude" in rel_parts:
+            return False
+        if path.resolve() in (
+            SCRIPT_PATH,
+            SCRIPT_PATH.with_name("test_conformance.py"),
+        ):
+            return False
+        return path.suffix in {".md", ".py", ".sh", ".yaml", ".yml", ".json"}
+
+    text_files = [path for path in source_root.rglob("*") if scannable(path)]
+    for name, pattern in forbidden_patterns.items():
         matches = []
         for path in text_files:
             try:

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -120,6 +120,67 @@ def test_source_checks_reject_client_bound_runtime_path(tmp_path: Path) -> None:
     assert not stale.ok
 
 
+def test_source_checks_reject_personal_workspace_paths(tmp_path: Path) -> None:
+    write_manifests(tmp_path)
+    write_skill(tmp_path, "synthesis-test")
+    (tmp_path / "skills" / "synthesis-test" / "drift.py").write_text(
+        'SOURCE = "~/workspaces/someone/synthesis-skills/skills"\n',
+        encoding="utf-8",
+    )
+
+    checks = MODULE.source_checks(tmp_path)
+
+    personal = next(
+        check
+        for check in checks
+        if check.name == "source.no-personal-workspace-paths"
+    )
+    assert not personal.ok
+
+
+def test_source_scans_survive_claude_worktree_ancestors(tmp_path: Path) -> None:
+    """A checkout under .claude/worktrees/ must still be scanned — ancestor
+    path components must not empty the forbidden-pattern scans."""
+    nested = tmp_path / ".claude" / "worktrees" / "wt"
+    nested.mkdir(parents=True)
+    write_manifests(nested)
+    write_skill(nested, "synthesis-test")
+    (nested / "skills" / "synthesis-test" / "drift.py").write_text(
+        'SOURCE = "~/workspaces/someone/synthesis-skills/skills"\n',
+        encoding="utf-8",
+    )
+
+    checks = MODULE.source_checks(nested)
+
+    personal = next(
+        check
+        for check in checks
+        if check.name == "source.no-personal-workspace-paths"
+    )
+    assert not personal.ok
+
+
+def test_placeholder_workspace_paths_are_allowed(tmp_path: Path) -> None:
+    write_manifests(tmp_path)
+    write_skill(tmp_path, "synthesis-test")
+    (tmp_path / "skills" / "synthesis-test" / "notes.md").write_text(
+        "Run ~/workspaces/<you>/synthesis-skills/install.sh, or glob\n"
+        "~/workspaces/*/ai-knowledge-*; sample layouts use\n"
+        "~/workspaces/example-person/ai-knowledge-example-person/ and\n"
+        "/home/user/workspaces/demo/ai-knowledge-demo/.\n",
+        encoding="utf-8",
+    )
+
+    checks = MODULE.source_checks(tmp_path)
+
+    personal = next(
+        check
+        for check in checks
+        if check.name == "source.no-personal-workspace-paths"
+    )
+    assert personal.ok
+
+
 def test_instruction_adapter(tmp_path: Path) -> None:
     (tmp_path / "AGENTS.md").write_text("# Rules\n", encoding="utf-8")
     (tmp_path / "CLAUDE.md").write_text("@AGENTS.md\n", encoding="utf-8")

--- a/skills/synthesis-fact-checking/references/bibliography.md
+++ b/skills/synthesis-fact-checking/references/bibliography.md
@@ -184,7 +184,8 @@ All entries in this section anchor to `production-incident-archive.md` by defaul
 
 ## 5. Synthesis project internal cross-references
 
-Paths below are relative to `/Users/rajiv/workspaces/rajiv/`.
+Paths below are relative to the author's workspace root — the directory
+that holds these project checkouts.
 
 Bucket paths share the prefix `ai-knowledge-rajiv/projects/synthesis-quality-skills-upgrade/resources/artifacts/`. Abbreviated as `<bucket>/` below.
 

--- a/skills/synthesis-git-hooks/SKILL.md
+++ b/skills/synthesis-git-hooks/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.2.1"
+  version: "2.3.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -15,6 +15,18 @@ metadata:
 A YAML-driven pre-commit policy engine. Part of the synthesis-engineering operational layer — deterministic enforcement that catches credential leaks and exposure-sensitive content at the commit boundary, before the diff persists.
 
 The engine is small (one bash script + one Python sidecar). The policy is data — a YAML file at `~/.synthesis/git-hook-config.yaml` that anyone adopting synthesis engineering fills in with their own personal-remote patterns, client names, and internal URLs.
+
+## v2.3.0 — Portable drift-source resolution
+
+v2.3.0 (2026-08-03) removes the doctor's hardcoded personal checkout path.
+The drift check's source now resolves portably: `$SYNTHESIS_GIT_HOOKS_SOURCE`
+when set (authoritative — an empty value skips the check deliberately; an
+invalid value is a doctor problem, fail closed), else the running script's
+own directory when it is not itself an installed engine copy (repo
+checkouts, worktrees, client plugin caches), else the documented locations
+the ecosystem's own installers create (direct-copy skill installs, the
+shared installer's cached clone). A source must carry all three engine
+files to qualify, and the doctor names the resolved source in its output.
 
 ## v2.1.2 — Exact-copy migration calibration
 

--- a/skills/synthesis-git-hooks/scripts/_load_config.py
+++ b/skills/synthesis-git-hooks/scripts/_load_config.py
@@ -25,7 +25,11 @@ v2 design changes (fail-closed hardening):
 * **`--doctor`.** Self-check for rituals/bootstrap: config parses, every
   pattern compiles under both Python `re` and `grep -E`, core.hooksPath is
   wired, installed engine matches the skill source (drift detection), and
-  the cwd repo's classification + chained hook are reported.
+  the cwd repo's classification + chained hook are reported. The drift
+  source resolves portably — `$SYNTHESIS_GIT_HOOKS_SOURCE` (authoritative;
+  invalid values fail closed), else this script's own directory when it is
+  not itself an installed copy, else documented install locations — never
+  a hardcoded personal checkout path.
 
 Supported config subset (see README / SKILL.md):
   - comments (# ...), full-line or trailing outside quotes
@@ -51,14 +55,17 @@ import warnings
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
-SIDECAR_VERSION = "2.2.1"
+SIDECAR_VERSION = "2.3.0"
 REQUIRED_CONFIG_VERSION = 2
 
 DEFAULT_CONFIG = Path.home() / ".synthesis" / "git-hook-config.yaml"
-DEFAULT_SOURCE_DIR = (
-    Path.home()
-    / "workspaces/rajiv/synthesis-skills/skills/synthesis-git-hooks/scripts"
-)
+
+# The three files that constitute the engine. A directory qualifies as a
+# drift-comparison source only when it carries all of them — a partial copy
+# would let missing files pass the byte-compare loop as "no drift".
+ENGINE_FILES = ("pre-commit", "commit-msg", "_load_config.py")
+
+SOURCE_ENV = "SYNTHESIS_GIT_HOOKS_SOURCE"
 
 
 class ConfigError(Exception):
@@ -636,6 +643,88 @@ def _grep_validates(pattern: str) -> Optional[str]:
     return None
 
 
+def _is_engine_source(path: Path) -> bool:
+    """True when ``path`` carries every engine file (a usable drift source)."""
+    return all((path / name).is_file() for name in ENGINE_FILES)
+
+
+def _installed_engine_dirs(hooks_path: Optional[Path]) -> set:
+    """Directories holding INSTALLED engine copies — never a drift source.
+
+    Comparing an installed copy against itself would report "no drift"
+    unconditionally, which is exactly the false health the check exists to
+    prevent.
+    """
+    dirs = {(Path.home() / ".synthesis" / "git-hooks").resolve()}
+    if hooks_path is not None:
+        dirs.add(hooks_path.resolve())
+    return dirs
+
+
+def _documented_source_dirs() -> List[Path]:
+    """Stable locations this ecosystem's own installers create.
+
+    Direct-copy skill installs plus the shared installer's cached clone.
+    Client plugin caches are deliberately absent: they are version-numbered,
+    client-owned layouts where several stale versions coexist, and when the
+    doctor runs from a plugin cache the running script's own directory
+    already covers it — the same reasoning as the conformance suite's
+    client-binary resolution (client_binaries.py).
+    """
+    home = Path.home()
+    rel = Path("synthesis-git-hooks") / "scripts"
+    cache_home = Path(os.environ.get("XDG_CACHE_HOME") or (home / ".cache"))
+    return [
+        home / ".claude" / "skills" / rel,
+        home / ".agents" / "skills" / rel,
+        home / ".codex" / "skills" / rel,
+        cache_home / "synthesis-skills" / "skills" / rel,
+    ]
+
+
+def resolve_source_dir(
+    hooks_path: Optional[Path],
+) -> Tuple[Optional[Path], Optional[str]]:
+    """Resolve the skill-source directory the drift check compares against.
+
+    Order (mirrors the conformance suite's client-binary resolution):
+
+    1. ``$SYNTHESIS_GIT_HOOKS_SOURCE``. A set override is authoritative:
+       empty means "no source on this machine — skip drift deliberately",
+       and a value that is not an engine source directory is a doctor
+       problem rather than a fallthrough, so a misconfigured override
+       fails closed instead of silently comparing against nothing.
+    2. This script's own directory, unless it is itself an installed engine
+       copy — running the doctor from a repo checkout, a worktree, or a
+       client plugin cache compares the installation against that copy.
+    3. Documented locations the ecosystem's own installers create, first
+       complete candidate wins.
+
+    Returns ``(source_dir, problem)``. Both ``None`` means no source is
+    available and the drift check is skipped.
+    """
+    if SOURCE_ENV in os.environ:
+        override = os.environ[SOURCE_ENV]
+        if not override:
+            return None, None
+        path = Path(override).expanduser()
+        if _is_engine_source(path):
+            return path, None
+        return None, (
+            f"{SOURCE_ENV} is set to {override!r}, which is not an engine "
+            f"source directory (needs {', '.join(ENGINE_FILES)}) — fix or "
+            "unset it (fail closed)"
+        )
+    installed = _installed_engine_dirs(hooks_path)
+    own_dir = Path(__file__).resolve().parent
+    if own_dir not in installed and _is_engine_source(own_dir):
+        return own_dir, None
+    for candidate in _documented_source_dirs():
+        if candidate.resolve() not in installed and _is_engine_source(candidate):
+            return candidate, None
+    return None, None
+
+
 def run_doctor(config_path: Path) -> int:
     """Self-check the whole protection chain. Exit 0 = healthy."""
     problems: List[str] = []
@@ -691,11 +780,12 @@ def run_doctor(config_path: Path) -> int:
         hooks_path = proc.stdout.strip()
     except FileNotFoundError:
         problems.append("git not found on PATH")
+    hp_dir: Optional[Path] = None
     if hooks_path:
-        hp = Path(os.path.expanduser(hooks_path))
-        infos.append(f"core.hooksPath: {hp}")
-        for name in ("pre-commit", "commit-msg", "_load_config.py"):
-            f = hp / name
+        hp_dir = Path(os.path.expanduser(hooks_path))
+        infos.append(f"core.hooksPath: {hp_dir}")
+        for name in ENGINE_FILES:
+            f = hp_dir / name
             if not f.exists():
                 problems.append(f"hooksPath missing {name}: {f}")
             elif name in ("pre-commit", "commit-msg") and not os.access(f, os.X_OK):
@@ -705,28 +795,31 @@ def run_doctor(config_path: Path) -> int:
             "core.hooksPath is not set globally — the engine is not wired in"
         )
 
-    # 4. Drift: installed engine vs skill source (when the source is present).
-    src_dir = Path(
-        os.environ.get("SYNTHESIS_GIT_HOOKS_SOURCE", str(DEFAULT_SOURCE_DIR))
-    )
-    if hooks_path and src_dir.is_dir():
-        hp = Path(os.path.expanduser(hooks_path))
-        drift_found = False
-        for name in ("pre-commit", "commit-msg", "_load_config.py"):
-            src, inst = src_dir / name, hp / name
-            if src.exists() and inst.exists():
-                if src.read_bytes() != inst.read_bytes():
-                    drift_found = True
-                    problems.append(
-                        f"DRIFT: installed {name} differs from skill source "
-                        f"({inst} vs {src}) — reinstall or sync back"
-                    )
-        if not drift_found:
-            infos.append("installed engine matches skill source (no drift)")
-    elif not src_dir.is_dir():
+    # 4. Drift: installed engine vs skill source. See resolve_source_dir for
+    # the portable resolution order (env override, own directory, documented
+    # install locations) — never a hardcoded checkout path.
+    src_dir, src_problem = resolve_source_dir(hp_dir)
+    if src_problem:
+        problems.append(src_problem)
+    elif src_dir is None:
         infos.append(
-            f"skill source not present at {src_dir} (drift check skipped)"
+            "skill source not found (drift check skipped) — set "
+            f"{SOURCE_ENV} to the skill's scripts/ directory to enable it"
         )
+    elif hp_dir is not None:
+        drift_found = False
+        for name in ENGINE_FILES:
+            src, inst = src_dir / name, hp_dir / name
+            if inst.exists() and src.read_bytes() != inst.read_bytes():
+                drift_found = True
+                problems.append(
+                    f"DRIFT: installed {name} differs from skill source "
+                    f"({inst} vs {src}) — reinstall or sync back"
+                )
+        if not drift_found:
+            infos.append(
+                f"installed engine matches skill source (no drift): {src_dir}"
+            )
 
     # 5. Disclosure ledger (when configured): must exist, parse, carry
     # evidence, and every allowance must correspond to a real Tier-1

--- a/skills/synthesis-git-hooks/scripts/test_pre_commit.py
+++ b/skills/synthesis-git-hooks/scripts/test_pre_commit.py
@@ -588,3 +588,134 @@ def test_double_quoted_pattern_keeps_its_escapes(tmp_path: Path) -> None:
     parsed = SIDECAR.parse_simple_yaml('key: "\\\\bsalary\\\\b"\n')
     assert parsed["key"] == "\\bsalary\\b"
     assert not any(ord(ch) < 32 for ch in parsed["key"])
+
+
+# ─── drift-source resolution (doctor) ────────────────────────────────────
+
+
+def engine_copy(target: Path) -> None:
+    """Copy the three engine files into `target`, executable bits included."""
+    target.mkdir(parents=True, exist_ok=True)
+    for name in SIDECAR.ENGINE_FILES:
+        destination = target / name
+        destination.write_bytes((SCRIPT_DIR / name).read_bytes())
+        destination.chmod(0o755)
+
+
+def test_source_env_override_is_authoritative(tmp_path, monkeypatch) -> None:
+    source = tmp_path / "anywhere" / "scripts"
+    engine_copy(source)
+    monkeypatch.setenv("SYNTHESIS_GIT_HOOKS_SOURCE", str(source))
+
+    resolved, problem = SIDECAR.resolve_source_dir(None)
+
+    assert problem is None
+    assert resolved == source
+
+
+def test_misconfigured_source_override_fails_closed(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("SYNTHESIS_GIT_HOOKS_SOURCE", str(tmp_path / "missing"))
+
+    resolved, problem = SIDECAR.resolve_source_dir(None)
+
+    assert resolved is None
+    assert problem is not None and "fail closed" in problem
+
+
+def test_incomplete_source_override_fails_closed(tmp_path, monkeypatch) -> None:
+    """A lone sidecar copy is not a source; byte-comparing against a partial
+    directory would report "no drift" for the files it lacks."""
+    partial = tmp_path / "partial"
+    partial.mkdir()
+    (partial / "_load_config.py").write_text("# lone file\n", encoding="utf-8")
+    monkeypatch.setenv("SYNTHESIS_GIT_HOOKS_SOURCE", str(partial))
+
+    resolved, problem = SIDECAR.resolve_source_dir(None)
+
+    assert resolved is None
+    assert problem is not None
+
+
+def test_empty_source_override_skips_deliberately(monkeypatch) -> None:
+    monkeypatch.setenv("SYNTHESIS_GIT_HOOKS_SOURCE", "")
+
+    assert SIDECAR.resolve_source_dir(None) == (None, None)
+
+
+def test_own_directory_is_the_default_source(tmp_path, monkeypatch) -> None:
+    """Run from a checkout, worktree, or plugin cache, the running copy is
+    the drift baseline — no hardcoded checkout path involved."""
+    monkeypatch.delenv("SYNTHESIS_GIT_HOOKS_SOURCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    installed = tmp_path / ".synthesis" / "git-hooks"
+    engine_copy(installed)
+
+    resolved, problem = SIDECAR.resolve_source_dir(installed)
+
+    assert problem is None
+    assert resolved == SCRIPT_DIR
+
+
+def test_installed_copy_never_compares_against_itself(tmp_path, monkeypatch) -> None:
+    """When the doctor runs from the installed engine, the drift source must
+    come from documented locations — comparing the installation against
+    itself would report "no drift" unconditionally."""
+    monkeypatch.delenv("SYNTHESIS_GIT_HOOKS_SOURCE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+
+    resolved, problem = SIDECAR.resolve_source_dir(SCRIPT_DIR)
+    assert (resolved, problem) == (None, None)
+
+    direct_copy = (
+        tmp_path / ".claude" / "skills" / "synthesis-git-hooks" / "scripts"
+    )
+    engine_copy(direct_copy)
+
+    resolved, problem = SIDECAR.resolve_source_dir(SCRIPT_DIR)
+    assert problem is None
+    assert resolved == direct_copy
+
+
+def test_doctor_detects_drift_end_to_end(tmp_path: Path) -> None:
+    """Installed engine + discovered source, healthy then drifted."""
+    home = tmp_path / "home"
+    installed = home / ".synthesis" / "git-hooks"
+    engine_copy(installed)
+    source = home / ".claude" / "skills" / "synthesis-git-hooks" / "scripts"
+    engine_copy(source)
+    config = tmp_path / "policy.yaml"
+    policy(config)
+    (home / ".gitconfig").write_text(
+        f"[core]\n\thooksPath = {installed}\n", encoding="utf-8"
+    )
+    environment = dict(os.environ)
+    environment["HOME"] = str(home)
+    environment["SYNTHESIS_GIT_HOOK_CONFIG"] = str(config)
+    for variable in (
+        "SYNTHESIS_GIT_HOOKS_SOURCE",
+        "XDG_CACHE_HOME",
+        "XDG_CONFIG_HOME",
+        "GIT_CONFIG_GLOBAL",
+    ):
+        environment.pop(variable, None)
+
+    def doctor():
+        return subprocess.run(
+            [sys.executable, str(installed / "_load_config.py"), "--doctor"],
+            cwd=tmp_path,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    healthy = doctor()
+    assert healthy.returncode == 0, healthy.stdout + healthy.stderr
+    assert "no drift" in healthy.stdout
+
+    (source / "pre-commit").write_bytes(b"#!/bin/bash\n# hotfixed\n")
+    drifted = doctor()
+    assert drifted.returncode == 1, drifted.stdout + drifted.stderr
+    assert "DRIFT: installed pre-commit" in drifted.stdout


### PR DESCRIPTION
## Summary

- **synthesis-git-hooks v2.3.0** — removes the doctor's hardcoded personal checkout path (a portability defect and a violation of this repo's own no-personal-paths rule). The drift baseline now resolves like the conformance suite's client-binary pattern: `$SYNTHESIS_GIT_HOOKS_SOURCE` when set (authoritative; empty skips deliberately, invalid fails closed as a doctor problem), else the running script's own directory when it is not itself an installed engine copy (checkouts, worktrees, plugin caches), else the documented locations the ecosystem's own installers create. A qualifying source must carry all three engine files, closing a latent hole where a partial directory byte-compared as "no drift" for files it lacked. The doctor now names the resolved source in its output.
- **synthesis-agent-conformance** — new `source.no-personal-workspace-paths` scan enforces the no-personal-paths rule mechanically (placeholder or documented generic segments only; home-anchored personal checkout paths rejected). Scan exclusions now apply **relative to the source root**, fixing a fail-open where a checkout under a `.claude/worktrees/` directory scanned zero files and passed vacuously.
- Second personal-path instance found by the new scan fixed in `synthesis-fact-checking/references/bibliography.md`.
- Release records: both plugin manifests at 4.10.0 in parity, CHANGELOG entry, README note, SKILL.md v2.3.0.

## Verification

Full AGENTS.md battery run clean in the worktree: `conformance.py source` (115 PASS, scans now exercising 217 files) and `instructions`; pytest suites for agent-conformance (31, incl. 3 new), git-hooks (28, incl. 7 new — resolution order, both fail-closed paths, self-comparison guard, hermetic end-to-end drift detection), coordination (27), kb-edit+okf (8), daily-rituals+message-guard+git-hooks (38); `sh -n` + installer tests; `compileall`; inbox-cleanup poisoned/resolver/runtime-installer suites. Live doctor run from the worktree correctly resolved itself as drift source and flagged the (expectedly stale) installed engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)