### PR TITLE
Release 4.13.3: onboarding fallback probe requires copies present

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.13.2",
+  "version": "4.13.3",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.13.2",
+  "version": "4.13.3",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.13.3] - 2026-08-03
+
+### Fixed
+
+- `synthesis-onboarding` v1.0.1: on a fresh machine with a client present
+  but the plugin CLI unavailable, the file-copy fallback was skipped —
+  `install.sh status` exits 0 when the target skill directories do not
+  exist yet, and the engine's probe read that as "already current." The
+  probe now also requires copies to actually be present. Found by the
+  post-merge QA run of a live org quickstart; regression test added.
+
 ## [4.13.2] - 2026-08-03
 
 ### Fixed

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.0.0"
+  version: "1.0.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -32,7 +32,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-ENGINE_VERSION = "1.0.0"
+ENGINE_VERSION = "1.0.1"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"
@@ -545,8 +545,14 @@ def phase_ecosystem(report, clients, dry_run, no_plugin_cli):
         if dry_run:
             report.add("ecosystem", CHANGED, "would run fallback: sh %s install" % installer)
             return
+        # A clean `status` alone is not proof of an install: on a machine
+        # where the target directories do not exist yet, status has nothing
+        # to check and exits 0. Require actual copies before skipping.
         rc, _, _ = run(["sh", str(installer), "status"], timeout=300)
-        if rc == 0:
+        copies_present = any(
+            target.is_dir() and any(target.glob("synthesis-*"))
+            for target in (HOME / ".claude" / "skills", HOME / ".agents" / "skills"))
+        if rc == 0 and copies_present:
             report.add("ecosystem", OK, "fallback skill copies already current")
             return
         rc, out, err = run(["sh", str(installer), "install"], timeout=600)

--- a/skills/synthesis-onboarding/scripts/test_onboard.py
+++ b/skills/synthesis-onboarding/scripts/test_onboard.py
@@ -312,6 +312,32 @@ class EngineTests(unittest.TestCase):
         log2 = sh(["git", "-C", str(repo), "log", "--oneline"], env=self.box.git_env)
         self.assertEqual(len(log2.strip().splitlines()), 1)
 
+    def test_fallback_installs_on_fresh_machine_with_client(self):
+        """Regression (2026-08-03 post-merge QA): with a client present and
+        the plugin CLI unavailable, a fresh machine must get fallback copies.
+        `install.sh status` exits 0 when the target dirs don't exist yet, so
+        the probe must also require copies to be present before skipping."""
+        env = dict(os.environ)
+        env.update(self.box.env_overrides())
+        env["SYNTHESIS_CLAUDE_BIN"] = "/usr/bin/true"
+        env["SYNTHESIS_ONBOARD_NO_PLUGIN_CLI"] = "1"
+        env["SYNTHESIS_SKILLS_SOURCE_DIR"] = str(REPO_ROOT)
+
+        def run_engine(*args):
+            return subprocess.run(
+                [sys.executable, str(ENGINE)] + list(args) + ["--json"],
+                env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+        proc = run_engine("install")
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        copies = list((self.box.home / ".claude" / "skills").glob("synthesis-*"))
+        self.assertTrue(copies, "fallback copies missing after fresh install")
+        proc2 = run_engine("install")
+        data2 = json.loads(proc2.stdout)
+        self.assertNotIn("changed", [s["status"] for s in data2["steps"]])
+        proc3 = run_engine("doctor")
+        self.assertEqual(proc3.returncode, 0, proc3.stdout + proc3.stderr)
+
     def test_uninstall_archives_generated_files_only(self):
         manifest = self.box.manifest()
         self.box.run_json("install", "--manifest", str(manifest), expect=0)


### PR DESCRIPTION
## Summary

Post-merge QA of a live org quickstart (fresh sandbox HOME, real remotes) caught a fresh-machine bug in the synthesis-onboarding fallback path: `install.sh status` exits 0 when the target skill directories do not exist yet, so the engine's status probe read a bare machine as "already current" and skipped the copy install entirely (its own doctor then correctly flagged the machine unhealthy). The probe now also requires copies to actually be present before skipping. Engine v1.0.1, plugin 4.13.2 → 4.13.3.

## Test plan

- [x] New regression test: fresh sandbox + client present + plugin CLI unavailable → copies must exist after install, second run reports no changes, doctor exits 0. Suite now 17 tests, green.
- [x] conformance `source` 116/116; compileall clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)