### PR TITLE
Fix transcript-verifier false positive on Plaud spaced timestamp ranges (4.14.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.14.1] - 2026-08-04
+
+### Fixed
+
+- `synthesis-meeting-transcripts` v0.5.1: `verify_transcripts.py` flagged
+  genuine Plaud transcripts as INCOMPLETE. v0.5.0 added Plaud's
+  timestamp-before-name format but matched only the unspaced range
+  `[00:00-00:08]`; Plaud emits `**[00:00 - 00:08] Name:**` with spaces. Two
+  live transcripts carrying 98 and 163 timestamps of real diarized dialogue
+  were reported incomplete. Whitespace around the separator is now optional
+  and en/em dashes are accepted. A false positive on a fail-closed gate is
+  as damaging as a false negative — it teaches bypass. New
+  `test_verify_transcripts.py` pins every real-world line shape plus
+  negative controls proving a summary still cannot pass.
+
 ## [4.14.0] - 2026-08-04
 
 ### Added

--- a/skills/synthesis-meeting-transcripts/SKILL.md
+++ b/skills/synthesis-meeting-transcripts/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 metadata:
   depends_on: "synthesis-daily-rituals (optional integration)"
   author: "Rajiv Pant"
-  version: "0.5.0"
+  version: "0.5.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -45,6 +45,21 @@ The gate is deliberately cheap (a timestamp-marker floor, not a full parse) so i
 **2. Fetch-time rule, as a non-negotiable.** Saving a summary when the source has a transcript is a failure, not a shortcut. If the source provides a transcript, it MUST be fetched and saved in full — never abridged, never "omitted for brevity," never replaced by a paraphrase or a smoothed reconstruction. A summary-only save is legitimate ONLY when the source has no transcript, and it MUST carry the `<!-- VERIFIER: no-source-transcript -->` marker with a one-line reason.
 
 **3. Verifier detector hardened.** `verify_transcripts.py` now recognizes the recorder timestamp-led speaker line (`**[00:00] Name:**` and the range form `[00:00-00:32] Name:`), and treats a dense run of standalone-timestamp lines as a complete undiarized transcript. This removes the false positives — full transcripts flagged incomplete because only one speaker was diarized; unattributed running transcripts — that previously trained agents to distrust the verifier. Total-timestamp count alone cannot separate a transcript from a summary whose "Details" bullets carry inline timestamps (a summary can even wear a "Verbatim transcript" heading); **standalone-timestamp-line and speaker-line structure can.** A verbatim record that was saved with escaped `\r\n` sequences instead of real newlines reads as summary-only to every tool and to humans — always save real line breaks.
+
+## v0.5.1 — Plaud spaced timestamp ranges (completeness-gate false positive)
+
+v0.5.1 (2026-08-04) fixes a false POSITIVE in `verify_transcripts.py`. v0.5.0 taught the speaker-line
+detector about Plaud's timestamp-before-name format but matched only the UNSPACED range
+`[00:00-00:08]`; Plaud actually emits `**[00:00 - 00:08] Name:**` with spaces around the separator.
+Both live Plaud transcripts in a production corpus were flagged INCOMPLETE despite carrying 98 and
+163 timestamps of real diarized dialogue. Whitespace around the separator is now optional and en/em
+dashes are accepted alongside `-`.
+
+Why a false positive matters as much as a false negative: this gate is fail-closed, and a control
+that cries wolf on genuine work is a control agents learn to route around. `test_verify_transcripts.py`
+ships alongside the script and pins every real-world line shape — Plaud spaced/unspaced/en-dash/em-dash,
+hour-length ranges, undiarized `Speaker N`, Gemini bare names — plus negative controls proving a
+summary body still cannot clear the thresholds.
 
 ## v0.4.0 — Transcript-primary sourcing (summaries demoted, never trusted for attribution)
 

--- a/skills/synthesis-meeting-transcripts/test_verify_transcripts.py
+++ b/skills/synthesis-meeting-transcripts/test_verify_transcripts.py
@@ -1,0 +1,105 @@
+"""Regression tests for verify_transcripts.py speaker/timestamp detection.
+
+The completeness gate exists to make it impossible to save a meeting SUMMARY in
+place of the verbatim transcript. That gate is only as good as its detectors, and
+both directions of failure are costly:
+
+  - False NEGATIVE (a summary passes) — the primary record is silently lost.
+  - False POSITIVE (a real transcript fails) — the gate cries wolf, and an agent
+    under time pressure learns to route around it. This is how fail-closed
+    controls get disabled in practice.
+
+Both live Plaud transcripts on 2026-08-04 were flagged INCOMPLETE despite carrying
+98 and 163 timestamps of real diarized dialogue: v0.5.0 added Plaud support but
+matched only the UNSPACED range form `[00:00-00:08]`, while Plaud actually emits
+`**[00:00 - 00:08] Name:**` with spaces. These tests pin every real-world shape.
+
+Run: python3 test_verify_transcripts.py
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+_spec = importlib.util.spec_from_file_location(
+    "verify_transcripts", pathlib.Path(__file__).parent / "verify_transcripts.py"
+)
+v = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(v)
+
+
+# (label, line, should_match)
+SPEAKER_CASES = [
+    # --- Plaud: timestamp BEFORE the name, bold-wrapped ---
+    ("plaud spaced hyphen range", "**[00:00 - 00:08] Rajiv Pant:** Oh okay great", True),
+    ("plaud unspaced range", "**[00:00-00:08] Rajiv Pant:** Oh okay", True),
+    ("plaud en-dash range", "**[00:00 – 00:08] Rajiv Pant:** Oh okay", True),
+    ("plaud em-dash range", "**[00:00 — 00:08] Rajiv Pant:** Oh okay", True),
+    ("plaud single timestamp", "**[00:00] Rajiv Pant:** Oh okay", True),
+    ("plaud undiarized Speaker N", "**[00:16 - 00:26] Speaker 2:** Yeah.", True),
+    ("plaud hour-length range", "**[1:02:03 - 1:02:44] Ana Laura Volkman:** Hi", True),
+    ("plaud inner padding", "**[ 00:00 - 00:08 ] Rajiv Pant:** Hi", True),
+    ("plaud without bold", "[00:00 - 00:08] Rajiv Pant: Hi", True),
+    # --- Gemini: bare name, no timestamp prefix ---
+    ("gemini plain name", "Rajiv Pant: So AI knowledge", True),
+    ("gemini bold name", "**Kathryn Sheplavy:** thanks Efren", True),
+    ("gemini three-part name", "Ana Laura Volkman: Good morning", True),
+    # --- Negative controls: a SUMMARY must never look like dialogue ---
+    ("summary bullet w/ inline ts", "The team discussed the roadmap (00:05:12).", False),
+    ("summary sentence", "* Rajiv Pant discussed integrating the tool (00:01:02).", False),
+    ("bare url", "https://example.com/doc: see here", False),
+]
+
+STANDALONE_TS_CASES = [
+    ("bare ts line", "00:01:31", True),
+    ("bracketed ts line", "[00:01:31]", True),
+    ("bold ts line", "**00:01:31**", True),
+    ("indented ts line", "   00:01:31   ", True),
+    ("inline ts in prose", "discussed X (00:05:12) and moved on", False),
+]
+
+
+def main() -> int:
+    failures = []
+
+    for label, line, want in SPEAKER_CASES:
+        got = bool(v.SPEAKER_RE.search(line))
+        if got != want:
+            failures.append(f"SPEAKER_RE {label!r}: expected {want}, got {got} — {line!r}")
+
+    for label, line, want in STANDALONE_TS_CASES:
+        got = bool(v.STANDALONE_TS_RE.search(line))
+        if got != want:
+            failures.append(f"STANDALONE_TS_RE {label!r}: expected {want}, got {got} — {line!r}")
+
+    # End-to-end: a realistic Plaud transcript body must clear the default thresholds.
+    plaud_body = "\n".join(
+        f"**[{m:02d}:00 - {m:02d}:30] {'Rajiv Pant' if m % 2 else 'Speaker 2'}:** line {m}"
+        for m in range(1, 16)
+    )
+    if v.count_speaker_lines(plaud_body) < 10:
+        failures.append(
+            f"realistic Plaud body counted {v.count_speaker_lines(plaud_body)} speaker lines, need >=10"
+        )
+
+    # End-to-end: a summary-shaped body must NOT clear them.
+    summary_body = "\n".join(
+        f"* Topic {m} was discussed at length by the group (00:{m:02d}:12)." for m in range(1, 16)
+    )
+    if v.count_speaker_lines(summary_body) >= 10:
+        failures.append(
+            f"summary body counted {v.count_speaker_lines(summary_body)} speaker lines, must stay <10"
+        )
+
+    total = len(SPEAKER_CASES) + len(STANDALONE_TS_CASES) + 2
+    if failures:
+        print(f"FAILED — {len(failures)} of {total} checks:")
+        for f in failures:
+            print("  -", f)
+        return 1
+    print(f"OK — {total} checks passed (Plaud spaced/unspaced/en-dash, Gemini, negative controls)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/synthesis-meeting-transcripts/verify_transcripts.py
+++ b/skills/synthesis-meeting-transcripts/verify_transcripts.py
@@ -59,13 +59,17 @@ TIMESTAMP_RE = re.compile(r"\b\d{1,2}:\d{2}(?::\d{2})?\b")
 #   - Plaud (timestamp-led): **[00:00] Name Surname:** text...  or  **[0:20] Speaker 2:** text...
 #     Plaud puts a bracketed [MM:SS]/[H:MM:SS] BEFORE the name, so the older name-anchored
 #     regex missed every Plaud dialogue line and flagged full Plaud transcripts as incomplete.
+#     v0.5.1: Plaud emits SPACED ranges — `**[00:00 - 00:08] Name:**` — and the v0.5.0 pattern
+#     only accepted the unspaced `[00:00-00:08]` form, so real Plaud transcripts still failed.
+#     Whitespace around the separator is now optional, and en/em dashes are accepted alongside `-`.
 # A real verbatim transcript has dozens of these per file; a summary-only save has none.
 # We accept an optional leading [timestamp], then 1-4 capitalized words (or "Speaker N") ending
 # in a colon. The high min-speakers threshold (default 10) ensures cumulative false positives from
 # non-dialogue patterns can't push a summary-only file over.
 SPEAKER_RE = re.compile(
     r"^(?:\*\*)?"                                                     # optional bold
-    r"(?:\[\d{1,2}:\d{2}(?::\d{2})?(?:-\d{1,2}:\d{2}(?::\d{2})?)?\]\s*)?"  # optional leading [t] or [t-t] (Plaud)
+    r"(?:\[\s*\d{1,2}:\d{2}(?::\d{2})?"                               # optional leading [t ...
+    r"(?:\s*[-–—]\s*\d{1,2}:\d{2}(?::\d{2})?)?\s*\]\s*)?"              # ... or [t - t] (Plaud; spaces/en-dash OK)
     r"[A-Z][a-zA-Z]{2,}(?:\s+(?:[A-Z][a-zA-Z]+|\d{1,3})){0,3}"        # Name, Name Surname, or "Speaker 2"
     r":(?:\*\*)?\s",                                                  # colon, optional closing bold, space
     re.MULTILINE,


### PR DESCRIPTION
`verify_transcripts.py` reported genuine Plaud transcripts as INCOMPLETE.

**Root cause.** v0.5.0 taught the speaker-line detector about Plaud's timestamp-before-name format, but the pattern only accepted the *unspaced* range `[00:00-00:08]`. Plaud actually emits `**[00:00 - 00:08] Name:**` — spaces around the separator — so every Plaud dialogue line still missed. Two live transcripts carrying 98 and 163 timestamps of real diarized dialogue were reported incomplete.

**Fix.** Whitespace around the separator is optional; en/em dashes accepted alongside `-`; inner bracket padding tolerated.

**Why this is worth a patch release.** The completeness gate is fail-closed — it exists so a meeting *summary* can never be saved in place of the verbatim transcript. A gate that cries wolf on genuine work is one operators learn to route around, so a false positive degrades the control as surely as a false negative.

**Tests.** New `test_verify_transcripts.py` (22 checks) pins every real-world line shape — Plaud spaced/unspaced/en-dash/em-dash, hour-length ranges, undiarized `Speaker N`, unbolded, Gemini bare names — plus negative controls proving a summary-shaped body still cannot clear the thresholds, and an end-to-end count check in both directions.

Verified against a 252-file production corpus: 0 incomplete after the fix (2 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)