### PR TITLE
Release 4.17.1: meeting-transcripts v0.5.3 — audit summary counts the corpus, not the listing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,9 @@ jobs:
       - run: python -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-onboarding/scripts/test_onboard.py -q
+      # Standalone runner, not pytest: the file must stay executable from inside a
+      # deployed skill directory, where pytest is not guaranteed to be installed.
+      - run: python skills/synthesis-meeting-transcripts/test_verify_transcripts.py
       - run: sh -n install.sh onboard.sh tests/test_installer.sh
       - run: ./tests/test_installer.sh
       - run: python -m compileall -q skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ python3 -m pytest skills/synthesis-project-management/scripts/test_coordination.
 python3 -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
 python3 -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py -q
 python3 -m pytest skills/synthesis-onboarding/scripts/test_onboard.py -q
+python3 skills/synthesis-meeting-transcripts/test_verify_transcripts.py
 sh -n install.sh onboard.sh tests/test_installer.sh
 ./tests/test_installer.sh
 python3 -m compileall -q skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.17.1] - 2026-08-11
+
+### Fixed
+
+- `synthesis-meeting-transcripts` v0.5.3: **a clean transcript audit no longer
+  looks like a broken one.** `verify_transcripts.py --only-incomplete` filtered
+  the results list *before* computing the summary counters, so every counter
+  described the filtered listing instead of the audited corpus. A clean corpus
+  printed `Total: 0 files — 0 incomplete, 0 skipped, 0 no-source-transcript` —
+  a clean bill of health rendered byte-identical to "the path was wrong / no
+  `.md` files found." Observed 2026-08-11 against a 282-file corpus that was
+  actually 0-incomplete, 2 skipped, 19 no-source-transcript; only reading the
+  source told the two apart. `--json` carried the same defect through
+  `total_files`. This is the flag `synthesis-daily-rituals` uses, so the
+  success path was the one that read as a failure — the way a fail-closed
+  control gets routed around, and the mirror image of the v0.5.1
+  false-positive fix. Counters and the file total now always describe the
+  corpus; the filter narrows only the listed rows, and the summary discloses
+  that with `(listing filtered to incomplete only)`. An empty listing prints
+  `(none — no audited file matches the active listing filter)` rather than a
+  bare table. `--json` keeps `total_files` as the corpus count and adds
+  `listed_count` plus `only_incomplete` for the listing. Exit codes unchanged.
+
+### Added
+
+- `test_verify_transcripts.py` gains 14 end-to-end reporting checks that invoke
+  the CLI against a synthetic clean corpus (complete + skipped +
+  no-source-transcript, zero incomplete) and fail if the summary ever reports
+  `Total: 0 files` again, plus the inverse case proving filtering still filters
+  and a real incomplete file still exits 1. CI and `AGENTS.md` now run this test
+  file, which no check previously invoked.
+
 ## [4.17.0] - 2026-08-09
 
 ### Changed

--- a/skills/synthesis-meeting-transcripts/SKILL.md
+++ b/skills/synthesis-meeting-transcripts/SKILL.md
@@ -5,10 +5,50 @@ license: "Apache-2.0"
 metadata:
   depends_on: "synthesis-daily-rituals (optional integration)"
   author: "Rajiv Pant"
-  version: "0.5.2"
+  version: "0.5.3"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
+
+## v0.5.3 — A clean audit no longer looks like a broken one
+
+v0.5.3 (2026-08-11) fixes a reporting defect in `verify_transcripts.py`. It is not a
+detector change — no file's status moves — but it changes what an operator concludes
+from a run, which is the same thing in practice.
+
+`--only-incomplete` filtered the results list **before** the summary counters were
+computed, so every counter described the filtered listing rather than the corpus. On a
+clean corpus the script printed:
+
+```
+Total: 0 files — 0 incomplete, 0 skipped, 0 no-source-transcript.
+```
+
+That is a clean bill of health rendered byte-identical to *"the path was wrong / no `.md`
+files were found."* Observed on 2026-08-11 against a 282-file corpus that was actually
+0-incomplete, 2 skipped, 19 no-source-transcript; the only way to tell the two apart was
+to read the source. `--json` carried the same defect through `total_files`.
+
+This matters because **the daily ritual invokes the script with `--only-incomplete`**, so
+the success path was the one that looked broken. That is how a fail-closed control gets
+routed around — the same erosion the v0.5.1 false-positive fix existed to prevent,
+arriving from the opposite direction. A control has two ways to lose an operator's trust:
+crying wolf, and being unable to say "all clear" out loud.
+
+**The fix:** counters and the file total always describe the audited corpus; the filter
+narrows only which rows are listed. A run with filtering active now says so:
+
+```
+Total: 282 files — 0 incomplete, 2 skipped, 19 no-source-transcript. (listing filtered to incomplete only)
+```
+
+An empty listing prints `(none — no audited file matches the active listing filter)`
+rather than a bare table. In `--json`, `total_files` stays the corpus count, and new
+`listed_count` and `only_incomplete` keys describe the listing, so machine consumers see
+the same split. Exit codes are unchanged (`0` clean, `1` incomplete found, `2` bad path).
+`test_verify_transcripts.py` gains end-to-end coverage that runs the CLI against a
+synthetic clean corpus and fails if the summary ever reports `Total: 0 files` again —
+and CI now runs that test file, which it previously did not.
 
 ## v0.5.2 — Inferred-speaker annotation format + version-stamped output
 
@@ -254,6 +294,8 @@ python3 <synthesis-meeting-transcripts-root>/verify_transcripts.py \
 ```
 
 The script counts timestamp markers (`00:01:31`-style) in each meeting file. A real Gemini transcript has ~5–50 timestamps; a summary-only save has 0–2. If the just-saved file shows `INCOMPLETE`, re-fetch the Drive doc and re-save — your earlier extraction missed the Transcript tab.
+
+**Reading the summary line.** `--only-incomplete` narrows the listed rows, never the counts: the `Total:` line always describes the whole audited corpus and appends `(listing filtered to incomplete only)`. So a clean run reports the real corpus size with `0 incomplete` — an empty listing under a real total is the all-clear, not a failed invocation. A wrong path is a distinct outcome: `ERROR: not a directory` (or `no .md files found`) on stderr, exit code 2. In `--json`, `total_files` is the corpus and `listed_count` is the rows.
 
 **Failure modes this catches:**
 - Saved the Gemini email body instead of the Drive doc

--- a/skills/synthesis-meeting-transcripts/test_verify_transcripts.py
+++ b/skills/synthesis-meeting-transcripts/test_verify_transcripts.py
@@ -31,12 +31,28 @@ headers sharing the "Word (parenthetical):" shape (e.g. "**Attendees (Invited):*
 do NOT start matching — the fix is scoped to the timestamp-led branch only,
 specifically to avoid eroding precision on summary-only files.
 
+v0.5.3 (2026-08-11) adds a THIRD failure direction, in the reporting layer rather
+than the detector: `--only-incomplete` filtered the results list before the summary
+counters were computed, so a clean corpus printed "Total: 0 files — 0 incomplete,
+0 skipped, 0 no-source-transcript" — a clean bill of health rendered byte-identical
+to "wrong path / no .md files found." Observed against a 282-file corpus that was
+actually 0-incomplete, 2 skipped, 19 no-source-transcript; only reading the source
+told the two apart. The daily ritual invokes the script with exactly that flag, so
+the success case was the one that looked broken — the same way a control gets
+distrusted, arriving from the opposite side of the false positives above. The
+end-to-end checks below pin the split: counters and total describe the CORPUS, the
+listing alone is filtered.
+
 Run: python3 test_verify_transcripts.py
 """
 
+import contextlib
 import importlib.util
+import io
+import json
 import pathlib
 import sys
+import tempfile
 
 _spec = importlib.util.spec_from_file_location(
     "verify_transcripts", pathlib.Path(__file__).parent / "verify_transcripts.py"
@@ -87,6 +103,125 @@ STANDALONE_TS_CASES = [
     ("inline ts in prose", "discussed X (00:05:12) and moved on", False),
 ]
 
+# What a healthy corpus looks like on the summary line. SKIPPED and
+# no-source-transcript are the two statuses that are legitimately not INCOMPLETE, and
+# they are what the buggy summary erased: a corpus that reports non-zero counts for
+# them is visibly a corpus, while one reporting all-zeros is indistinguishable from an
+# empty directory. Both are therefore present in the fixture, deliberately.
+CLEAN_CORPUS_SUMMARY = "Total: 6 files — 0 incomplete, 2 skipped, 1 no-source-transcript."
+
+
+def write_clean_corpus(root: pathlib.Path) -> None:
+    """3 complete diarized transcripts, 1 explicitly no-source-transcript, 2 skipped
+    by filename prefix, 0 incomplete."""
+    for n in (1, 2, 3):
+        dialogue = "\n".join(
+            f"**[{m:02d}:00 - {m:02d}:30] {'Taylor Nguyen' if m % 2 else 'Speaker 2'}:** line {m}"
+            for m in range(1, 16)
+        )
+        (root / f"complete-{n}.md").write_text(
+            f"# Meeting {n}\n\n## 📖 Verbatim transcript\n\n{dialogue}\n", encoding="utf-8"
+        )
+    (root / "no-source-1.md").write_text(
+        f"# Casual 1:1\n\n{v.NO_SOURCE_TRANSCRIPT_MARKER}\n"
+        "Recorded without transcription enabled — notes are the only source record.\n",
+        encoding="utf-8",
+    )
+    (root / "_BACKFILL_TODO.md").write_text("# Backfill TODO\n", encoding="utf-8")
+    (root / "gdoc-strategy.md").write_text("# Imported Google Doc\n", encoding="utf-8")
+
+
+def write_summary_only(path: pathlib.Path) -> None:
+    """A Details-summary wearing a transcript heading: inline timestamps, no dialogue.
+    The one file shape the verifier must flag INCOMPLETE."""
+    bullets = "\n".join(
+        f"* Topic {m} was discussed at length by the group (00:{m:02d}:12)." for m in range(1, 16)
+    )
+    path.write_text(f"# Standup\n\n## Verbatim transcript\n\n{bullets}\n", encoding="utf-8")
+
+
+def run_cli(argv: list[str]) -> tuple[int, str]:
+    """Invoke main() end-to-end with the given arguments, capturing stdout.
+    The reporting bug lived entirely in main(), below every unit-testable helper —
+    only a real invocation can catch it."""
+    buffer = io.StringIO()
+    saved_argv = sys.argv
+    sys.argv = ["verify_transcripts.py", *argv]
+    try:
+        with contextlib.redirect_stdout(buffer):
+            code = v.main()
+    finally:
+        sys.argv = saved_argv
+    return code, buffer.getvalue()
+
+
+def reporting_cases(corpus: pathlib.Path) -> list[tuple[str, bool, str]]:
+    """(label, passed, detail) for the listing-vs-corpus contract. Every check runs
+    against the SAME clean corpus the ritual would see on a good day."""
+    cases: list[tuple[str, bool, str]] = []
+
+    code, out = run_cli([str(corpus)])
+    cases.append(("clean corpus exits 0", code == 0, f"expected exit 0, got {code}"))
+    cases.append((
+        "unfiltered summary counts the corpus",
+        CLEAN_CORPUS_SUMMARY in out,
+        f"expected {CLEAN_CORPUS_SUMMARY!r} in:\n{out}",
+    ))
+
+    code, out = run_cli([str(corpus), "--only-incomplete"])
+    cases.append(("clean corpus exits 0 under --only-incomplete", code == 0, f"got exit {code}"))
+    cases.append((
+        "--only-incomplete never prints 'Total: 0 files' on a non-empty corpus",
+        "Total: 0 files" not in out,
+        "a clean 6-file corpus reported 'Total: 0 files' — indistinguishable from a "
+        f"wrong path or an empty directory:\n{out}",
+    ))
+    cases.append((
+        "--only-incomplete keeps the corpus counters",
+        CLEAN_CORPUS_SUMMARY in out,
+        f"expected {CLEAN_CORPUS_SUMMARY!r} in:\n{out}",
+    ))
+    cases.append((
+        "--only-incomplete says the listing is filtered",
+        "(listing filtered to incomplete only)" in out,
+        f"summary did not disclose the active filter:\n{out}",
+    ))
+
+    code, out = run_cli([str(corpus), "--only-incomplete", "--json"])
+    payload = json.loads(out)
+    # .get(), not [] — a stale copy predating a key must report a failed check, not
+    # crash the runner. Diagnosing a stale install is the exact case these tests serve.
+    for label, key, want in (
+        ("total_files is the corpus", "total_files", 6),
+        ("listed_count is the filtered rows", "listed_count", 0),
+        ("rows match listed_count", "results", []),
+        ("incomplete_count", "incomplete_count", 0),
+        ("skipped_count survives filtering", "skipped_count", 2),
+        ("no_source_count survives filtering", "no_source_count", 1),
+    ):
+        cases.append((
+            f"--json {label}",
+            payload.get(key, "<missing>") == want,
+            f"{key}={payload.get(key, '<missing>')!r}, want {want!r} — full payload: {payload}",
+        ))
+
+    # The other direction: filtering must still filter, and a real failure must still fail.
+    write_summary_only(corpus / "summary-only.md")
+    code, out = run_cli([str(corpus), "--only-incomplete"])
+    cases.append(("an incomplete file exits 1", code == 1, f"expected exit 1, got {code}"))
+    cases.append((
+        "the listing still shows only incomplete rows",
+        "summary-only.md" in out and "complete-1.md" not in out,
+        f"listing was not filtered to incomplete:\n{out}",
+    ))
+    cases.append((
+        "totals grow with the corpus, not with the listing",
+        "Total: 7 files — 1 incomplete, 2 skipped, 1 no-source-transcript." in out,
+        f"summary did not describe the 7-file corpus:\n{out}",
+    ))
+
+    return cases
+
 
 def main() -> int:
     failures = []
@@ -120,13 +255,26 @@ def main() -> int:
             f"summary body counted {v.count_speaker_lines(summary_body)} speaker lines, must stay <10"
         )
 
-    total = len(SPEAKER_CASES) + len(STANDALONE_TS_CASES) + 2
+    # Reporting layer: --only-incomplete filters the listing, never the counters.
+    with tempfile.TemporaryDirectory() as tmp:
+        corpus = pathlib.Path(tmp)
+        write_clean_corpus(corpus)
+        reporting = reporting_cases(corpus)
+
+    for label, passed, detail in reporting:
+        if not passed:
+            failures.append(f"REPORTING {label!r}: {detail}")
+
+    total = len(SPEAKER_CASES) + len(STANDALONE_TS_CASES) + 2 + len(reporting)
     if failures:
         print(f"FAILED — {len(failures)} of {total} checks:")
         for f in failures:
             print("  -", f)
         return 1
-    print(f"OK — {total} checks passed (Plaud spaced/unspaced/en-dash, Gemini, negative controls)")
+    print(
+        f"OK — {total} checks passed (Plaud spaced/unspaced/en-dash, Gemini, "
+        "negative controls, listing-vs-corpus reporting)"
+    )
     return 0
 
 

--- a/skills/synthesis-meeting-transcripts/verify_transcripts.py
+++ b/skills/synthesis-meeting-transcripts/verify_transcripts.py
@@ -32,6 +32,13 @@ Usage:
   python3 verify_transcripts.py <dir> --only-incomplete
   python3 verify_transcripts.py <dir> --no-skip       # audit ALL files (debug)
 
+Reporting contract:
+  `--only-incomplete` narrows which ROWS are listed. It never narrows the
+  summary counters — those always describe the whole audited corpus, so a
+  clean run reports "Total: 282 files — 0 incomplete, ..." rather than
+  "Total: 0 files", which would be byte-identical to a wrong path. The same
+  split holds in --json: `total_files` is the corpus, `listed_count` the rows.
+
 Exit code:
   0 — all audited files have full transcripts
   1 — at least one audited file is incomplete (failures listed)
@@ -49,16 +56,18 @@ import re
 import sys
 from pathlib import Path
 
-# Bump with every detector-affecting change (regex, thresholds, marker names) and add a
-# matching entry to SKILL.md's changelog. Printed in every run's output specifically so a
-# stale copy is self-diagnosing: on 2026-08-06 an orphaned plugin-cache directory (v4.9.0,
-# predating the v0.5.0 Plaud-format + undiarized-override fixes) was run in place of the
-# actually-installed v4.14.1, producing 26 false-positive INCOMPLETE flags on a corpus the
+# Bump with every detector-affecting change (regex, thresholds, marker names) OR any change
+# to what the run REPORTS, and add a matching entry to SKILL.md's changelog. Output changes
+# count because the banner exists to tell a reader which behavior produced the numbers they
+# are looking at — and a summary line is behavior. Printed in every run's output specifically
+# so a stale copy is self-diagnosing: on 2026-08-06 an orphaned plugin-cache directory
+# (v4.9.0, predating the v0.5.0 Plaud-format + undiarized-override fixes) was run in place of
+# the actually-installed v4.14.1, producing 26 false-positive INCOMPLETE flags on a corpus the
 # fixed detector reads as 0 incomplete. The script had no version banner, so nothing in its
 # own output could reveal that the copy being run was stale. This constant plus the banner
 # line below close that gap — if the printed version doesn't match SKILL.md's frontmatter
 # version, the copy being run is not the one you think it is.
-SCRIPT_VERSION = "0.5.2"
+SCRIPT_VERSION = "0.5.3"
 
 # Any HH:MM:SS or MM:SS anywhere — Gemini uses bare, bold, heading, and markdown-link forms
 TIMESTAMP_RE = re.compile(r"\b\d{1,2}:\d{2}(?::\d{2})?\b")
@@ -246,12 +255,18 @@ def main() -> int:
         print(f"ERROR: no .md files found in {meetings_dir}", file=sys.stderr)
         return 2
 
-    if args.only_incomplete:
-        results = [r for r in results if r["status"] == "INCOMPLETE"]
-
+    # Counters describe the CORPUS; --only-incomplete narrows only the LISTING. Computing
+    # them from the filtered list (the v0.5.2 behavior) made a clean corpus print
+    # "Total: 0 files — 0 incomplete, 0 skipped, 0 no-source-transcript" — a clean bill of
+    # health rendered byte-identical to "wrong path / nothing audited", and the daily ritual
+    # invokes this script with exactly that flag. A control whose success output reads as a
+    # broken invocation is one operators learn to distrust, which is the same failure mode
+    # the v0.5.1 false-positive fix existed to prevent, arriving from the other direction.
     incomplete_count = sum(1 for r in results if r["status"] == "INCOMPLETE")
     skipped_count = sum(1 for r in results if r["status"] == "SKIPPED")
     no_source_count = sum(1 for r in results if r["status"] == "OK (no-source-transcript)")
+
+    listed = [r for r in results if r["status"] == "INCOMPLETE"] if args.only_incomplete else results
 
     if args.json:
         print(json.dumps({
@@ -259,11 +274,13 @@ def main() -> int:
             "dir": str(meetings_dir),
             "min_markers": args.min_markers,
             "min_speakers": args.min_speakers,
-            "total_files": len(results),
+            "total_files": len(results),      # the corpus that was audited
+            "listed_count": len(listed),      # rows present in "results" below
+            "only_incomplete": args.only_incomplete,
             "incomplete_count": incomplete_count,
             "skipped_count": skipped_count,
             "no_source_count": no_source_count,
-            "results": results,
+            "results": listed,
         }, indent=2))
     else:
         print(f"=== Transcript completeness audit: {meetings_dir} ===")
@@ -273,11 +290,14 @@ def main() -> int:
         print()
         print(f"{'STATUS':<25} {'TSTAMPS':<8} {'SPKRS':<6} {'HEAD':<5} {'SIZE_KB':<9} FILE")
         print("-" * 110)
-        for r in results:
+        for r in listed:
             heading = "yes" if r["has_transcript_heading"] else "no"
             print(f"{r['status']:<25} {r['timestamps']:<8} {r['speakers']:<6} {heading:<5} {r['size_kb']:<9} {r['file']}")
+        if not listed:
+            print("(none — no audited file matches the active listing filter)")
         print()
-        print(f"Total: {len(results)} files — {incomplete_count} incomplete, {skipped_count} skipped, {no_source_count} no-source-transcript.")
+        filter_note = " (listing filtered to incomplete only)" if args.only_incomplete else ""
+        print(f"Total: {len(results)} files — {incomplete_count} incomplete, {skipped_count} skipped, {no_source_count} no-source-transcript.{filter_note}")
         if incomplete_count:
             print()
             print("Incomplete files need backfill: re-fetch the source Google Doc")


### PR DESCRIPTION
## The defect

`verify_transcripts.py --only-incomplete` filtered the results list **before** computing the summary counters, so every counter described the filtered listing rather than the audited corpus. On a clean corpus the script printed:

```
Total: 0 files — 0 incomplete, 0 skipped, 0 no-source-transcript.
```

That clean bill of health is byte-identical to *"the path was wrong / no `.md` files were found."* Observed 2026-08-11 against a 282-file corpus that was actually 0-incomplete, 2 skipped, 19 no-source-transcript; only reading the source told the two apart. `--json` carried the same defect through `total_files`.

`synthesis-daily-rituals` invokes the script with exactly this flag, so **the success path was the one that read as a broken invocation** — which is how a fail-closed control gets routed around. It is the mirror image of the v0.5.1 false-positive fix: a control has two ways to lose an operator's trust, crying wolf and being unable to say "all clear" out loud.

## The fix

Counters and the file total always describe the corpus; the filter narrows only which rows are listed.

```
Total: 282 files — 0 incomplete, 2 skipped, 19 no-source-transcript. (listing filtered to incomplete only)
```

- An empty listing prints `(none — no audited file matches the active listing filter)` instead of a bare table.
- `--json` keeps `total_files` as the corpus count and adds `listed_count` and `only_incomplete` for the listing, so machine consumers see the same split.
- Exit codes unchanged: `0` clean, `1` incomplete found, `2` bad path. A wrong path remains a distinct outcome (`ERROR: not a directory` on stderr, exit 2).
- No detector change — no file's status moves. `SCRIPT_VERSION` bumped to 0.5.3 anyway, because the banner exists to tell a reader which behavior produced the numbers in front of them, and a summary line is behavior.

## Coverage

`test_verify_transcripts.py` gains 14 end-to-end checks that invoke the CLI against a synthetic clean corpus (complete + skipped + no-source-transcript, zero incomplete) and fail if the summary ever reports `Total: 0 files` again — plus the inverse case proving filtering still filters and a real incomplete file still exits 1. Verified to fail 8/42 against the pre-fix script and pass 42/42 after.

CI and `AGENTS.md` now run this test file, which **no check previously invoked** — the regression test would otherwise have sat uncalled.

## Verification

Full `AGENTS.md` check list run locally, all green: conformance source (120 checks) + instructions, all five pytest suites (128 passed), the new standalone runner (42 checks), `compileall`, shell syntax, installer tests, and the three inbox-cleanup runners. Confirmed live against the real 282-file corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)