### PR TITLE
Correct installed catalog conformance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.24.0",
+  "version": "4.24.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.24.0",
+  "version": "4.24.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.24.1] - 2026-08-14
+
+### Fixed
+
+- **Installed catalog parity** — source-checkout Python and pytest caches no
+  longer create false drift against clean plugin packages; substantive skill
+  content remains digest-bound.
+- **Codex plugin skill discovery** — authoritative `skills/list` namespaced
+  names are matched to their canonical public skill names, so a healthy
+  enabled plugin no longer reports every public skill as missing.
+
 ## [4.24.0] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **Codex catalog pressure is now engineered, not tolerated (August 2026).**
-Release **4.24.0** adds an implicit-core/explicit-specialist catalog with a
+Release **4.24.1** adds an implicit-core/explicit-specialist catalog with a
 public routing skill, app-server-backed hook and skill audits, live capability
 evidence, leased active-project validation, session-safe plugin refresh semantics,
 and an explicit supported-surface matrix. Claude Code keeps its complete
 native trigger behavior; Codex keeps every specialist explicitly available
-with measurable prompt reserve. See the [4.24.0 release notes](CHANGELOG.md).
+with measurable prompt reserve. See the [4.24.1 release notes](CHANGELOG.md).
 
 **Release surfaces can no longer drift apart (August 2026).** Conformance
 gains `source.changelog-version-parity` **(4.23.0)**: both plugin manifests

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.0.0"
+  version: "1.0.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-agent-conformance/scripts/codex_skill_catalog.py
+++ b/skills/synthesis-agent-conformance/scripts/codex_skill_catalog.py
@@ -24,6 +24,7 @@ DEFAULT_CHAR_BUDGET = 8_000
 CONTEXT_PERCENT = 2
 MAX_DESCRIPTION_CHARS = 1_024
 ALIAS_INSTRUCTION_RESERVE_TOKENS = 256
+PUBLIC_PLUGIN_NAMESPACE = "synthesis-skills:"
 
 
 def _codex_home(home: Path | None = None) -> Path:
@@ -169,11 +170,14 @@ def normalized_audit(
         for skill in rows[0].get("skills", [])
         if isinstance(skill, dict) and bool(skill.get("enabled", True))
     ]
-    discovered_names = {
-        str(skill.get("name") or "").rsplit(":", 1)[-1]
-        for skill in discovered
-        if skill.get("name")
-    }
+    discovered_names = set()
+    for skill in discovered:
+        name = str(skill.get("name") or "")
+        if not name:
+            continue
+        if name.startswith(PUBLIC_PLUGIN_NAMESPACE):
+            name = name.removeprefix(PUBLIC_PLUGIN_NAMESPACE)
+        discovered_names.add(name)
     missing_skills = sorted((expected_skill_names or set()) - discovered_names)
     skills = [
         skill

--- a/skills/synthesis-agent-conformance/scripts/codex_skill_catalog.py
+++ b/skills/synthesis-agent-conformance/scripts/codex_skill_catalog.py
@@ -170,7 +170,9 @@ def normalized_audit(
         if isinstance(skill, dict) and bool(skill.get("enabled", True))
     ]
     discovered_names = {
-        str(skill.get("name") or "") for skill in discovered if skill.get("name")
+        str(skill.get("name") or "").rsplit(":", 1)[-1]
+        for skill in discovered
+        if skill.get("name")
     }
     missing_skills = sorted((expected_skill_names or set()) - discovered_names)
     skills = [

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -241,7 +241,10 @@ def directory_digest(path: Path) -> str:
     files = sorted(
         item
         for item in path.rglob("*")
-        if item.is_file() and item.name not in {".source.json", ".DS_Store"}
+        if item.is_file()
+        and item.name not in {".source.json", ".DS_Store"}
+        and not any(part in {"__pycache__", ".pytest_cache"} for part in item.parts)
+        and item.suffix not in {".pyc", ".pyo"}
     )
     for item in files:
         digest.update(str(item.relative_to(path)).encode())

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -243,7 +243,10 @@ def directory_digest(path: Path) -> str:
         for item in path.rglob("*")
         if item.is_file()
         and item.name not in {".source.json", ".DS_Store"}
-        and not any(part in {"__pycache__", ".pytest_cache"} for part in item.parts)
+        and not any(
+            part in {"__pycache__", ".pytest_cache"}
+            for part in item.relative_to(path).parts
+        )
         and item.suffix not in {".pyc", ".pyo"}
     )
     for item in files:

--- a/skills/synthesis-agent-conformance/scripts/test_codex_skill_catalog.py
+++ b/skills/synthesis-agent-conformance/scripts/test_codex_skill_catalog.py
@@ -90,6 +90,20 @@ def test_resolved_catalog_fails_when_expected_skill_is_missing(tmp_path: Path) -
     assert audit["missing_skill_names"] == ["missing-skill"]
 
 
+def test_expected_skill_matches_plugin_namespaced_runtime_name(tmp_path: Path) -> None:
+    root = tmp_path / "skills"
+    skill = _skill(root, "synthesis-skills:synthesis-autopilot")
+
+    audit = normalized_audit(
+        {"data": [{"skills": [skill], "errors": []}]},
+        home=_home(tmp_path),
+        expected_skill_names={"synthesis-autopilot"},
+    )
+
+    assert audit["status"] == "PASS"
+    assert audit["missing_skill_names"] == []
+
+
 def test_catalog_budget_honors_codex_home(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/skills/synthesis-agent-conformance/scripts/test_codex_skill_catalog.py
+++ b/skills/synthesis-agent-conformance/scripts/test_codex_skill_catalog.py
@@ -104,6 +104,22 @@ def test_expected_skill_matches_plugin_namespaced_runtime_name(tmp_path: Path) -
     assert audit["missing_skill_names"] == []
 
 
+def test_other_plugin_namespace_cannot_substitute_for_expected_skill(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "skills"
+    skill = _skill(root, "other-plugin:synthesis-autopilot")
+
+    audit = normalized_audit(
+        {"data": [{"skills": [skill], "errors": []}]},
+        home=_home(tmp_path),
+        expected_skill_names={"synthesis-autopilot"},
+    )
+
+    assert audit["status"] == "FAIL"
+    assert audit["missing_skill_names"] == ["synthesis-autopilot"]
+
+
 def test_catalog_budget_honors_codex_home(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -1047,6 +1047,10 @@ def test_catalog_checks_enforce_installed_content_parity(
     )
     source_bytecode.parent.mkdir(parents=True)
     source_bytecode.write_bytes(b"transient source bytecode")
+    for suffix in ("pyc", "pyo"):
+        (source_bytecode.parents[1] / f"direct-bytecode.{suffix}").write_bytes(
+            b"transient direct bytecode"
+        )
     installed_pytest_cache = (
         home
         / ".claude"
@@ -1094,12 +1098,16 @@ def test_directory_digest_ignores_cache_children_not_cache_named_ancestors(
     regular_checkout = tmp_path / "regular"
     cache_named_checkout.mkdir(parents=True)
     regular_checkout.mkdir()
-    (cache_named_checkout / "SKILL.md").write_text("first\n", encoding="utf-8")
-    (regular_checkout / "SKILL.md").write_text("second\n", encoding="utf-8")
+    cache_named_skill = cache_named_checkout / "SKILL.md"
+    cache_named_skill.write_text("same\n", encoding="utf-8")
+    (regular_checkout / "SKILL.md").write_text("same\n", encoding="utf-8")
 
-    assert MODULE.directory_digest(cache_named_checkout) != MODULE.directory_digest(
+    original = MODULE.directory_digest(cache_named_checkout)
+    assert original == MODULE.directory_digest(
         regular_checkout
     )
+    cache_named_skill.write_text("changed\n", encoding="utf-8")
+    assert MODULE.directory_digest(cache_named_checkout) != original
 
 
 def test_enabled_codex_root_binds_to_inventory_marketplace(

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -1037,6 +1037,35 @@ def test_catalog_checks_enforce_installed_content_parity(
 
     assert all(check.ok for check in checks)
 
+    source_bytecode = (
+        source
+        / "skills"
+        / "synthesis-one"
+        / "scripts"
+        / "__pycache__"
+        / "probe.cpython-312.pyc"
+    )
+    source_bytecode.parent.mkdir(parents=True)
+    source_bytecode.write_bytes(b"transient source bytecode")
+    installed_pytest_cache = (
+        home
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "marketplace"
+        / "synthesis-skills"
+        / "1.0.0"
+        / "skills"
+        / ".pytest_cache"
+        / "README.md"
+    )
+    installed_pytest_cache.parent.mkdir(parents=True)
+    installed_pytest_cache.write_text("transient test cache\n", encoding="utf-8")
+
+    checks = MODULE.catalog_checks(source, home)
+
+    assert all(check.ok for check in checks)
+
     drifted = (
         home
         / ".codex"

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -1087,6 +1087,21 @@ def test_catalog_checks_enforce_installed_content_parity(
     assert "source_digest=" in codex_cache.detail
 
 
+def test_directory_digest_ignores_cache_children_not_cache_named_ancestors(
+    tmp_path: Path,
+) -> None:
+    cache_named_checkout = tmp_path / "__pycache__" / "source"
+    regular_checkout = tmp_path / "regular"
+    cache_named_checkout.mkdir(parents=True)
+    regular_checkout.mkdir()
+    (cache_named_checkout / "SKILL.md").write_text("first\n", encoding="utf-8")
+    (regular_checkout / "SKILL.md").write_text("second\n", encoding="utf-8")
+
+    assert MODULE.directory_digest(cache_named_checkout) != MODULE.directory_digest(
+        regular_checkout
+    )
+
+
 def test_enabled_codex_root_binds_to_inventory_marketplace(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Exclude transient Python and pytest caches from package-content parity.
- Recognize Codex plugin-namespaced skill identifiers during authoritative catalog checks.
- Publish the corrections as v4.24.1.

## Verification

- 277 tests passed.
- Source conformance passed.
- Live v4.24.0 cache parity and resolved catalog budget passed through the repaired checks.
