### PR TITLE
Add local and remote project continuity states

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.24.2",
+  "version": "4.25.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.24.2",
+  "version": "4.25.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.25.0] - 2026-08-14
+
+### Added
+
+- **Two-state project continuity** — local-ready and local-recoverable evidence
+  support same-machine Claude Code and Codex switching without per-turn Git or
+  network activity; remote-ready provides the explicit cross-machine gate.
+- **Continuity conformance** — local and remote readiness checks verify edit
+  attribution, Stop receipts, repository state, and upstream equality.
+
+### Changed
+
+- **Project lifecycle** — SessionStart resolves named projects from the tracked
+  registry when no leased pointer exists; Stop records local content receipts;
+  explicit remote handoff and day-end publish the attributed batch.
+- **Context doctor** — local mode keeps structural defects fail-closed while
+  reporting recoverable Git state as warnings; remote mode remains strict.
+
+### Fixed
+
+- **Interrupted-task recovery** — a PostToolUse manifest remains sufficient
+  evidence to reconstruct unfinished work when a task never reaches Stop.
+
 ## [4.24.2] - 2026-08-14
 
 ### Fixed

--- a/docs/runtime-integration.md
+++ b/docs/runtime-integration.md
@@ -14,7 +14,7 @@ a pass.
 | Source | Is the canonical implementation internally valid? | manifests, schemas, unit tests, license and metadata checks |
 | Installed | Did the intended version reach this client? | native plugin listing, immutable cache version, source-to-install hashes |
 | Live | Did the client execute the behavior in a real session? | fresh client-specific hook receipt, actual skill registry response |
-| Continuity | Can another session recover the work safely? | durable project files, active pointer, lease ownership, pushed commits |
+| Continuity | Can another session recover the work safely? | local edit manifests and receipts, durable project files, active pointer, lease ownership, remote publication receipts |
 | Capability | Can the runtime perform the authenticated operation? | read-only connector handshake with timestamp and explicit status |
 
 Statuses are `PASS`, `FAIL`, `UNKNOWN`, or `UNSUPPORTED`. `UNKNOWN` means the
@@ -62,7 +62,7 @@ Reference contracts:
 
 ## Durable project continuity
 
-A runtime integration reads and writes the same committed project structure:
+A runtime integration reads and writes the same filesystem-backed project structure:
 
 ```text
 projects/<slug>/
@@ -80,6 +80,16 @@ Two sessions may work at once when they use different worktrees and
 non-overlapping source claims. The coordination board is an advisory interface
 backed by an atomic remote lease, not an invitation to edit the Markdown file
 directly.
+
+Continuity has two independently reported states. `LOCAL_READY` means the
+project record and attributed working-tree edits are recoverable by another
+client on the same filesystem; Stop must not commit or use the network.
+`LOCAL_RECOVERABLE` means a successful edit manifest survived an interrupted
+task even though no Stop receipt exists. `REMOTE_READY` additionally requires
+source repositories and exact-path project-context commits to be clean and
+equal to fetched upstreams, with no pending manifests. Day-end and explicit
+remote-handoff sync create that state; a local pass may never be presented as a
+cross-machine pass.
 
 ## Capability probes
 

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.0.2"
+  version: "1.2.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -26,8 +26,9 @@ Verify five planes:
    trust state. Never infer or write trust state.
 3. **Live:** client-specific receipts created by genuine lifecycle events. A
    static script probe is not live evidence.
-4. **Continuity:** coordination leases, active pointers, pushed project state,
-   and bidirectional handoff exercises.
+4. **Continuity:** coordination leases, active pointers, attributed local
+   working state, explicit remote publication, and bidirectional handoff
+   exercises.
 5. **Capability:** authenticated read-only outcomes and explicitly supported,
    unsupported, or unverifiable product surfaces.
 
@@ -97,12 +98,19 @@ Run:
 ```bash
 python3 scripts/conformance.py handoff --project <project-directory>
 python3 scripts/conformance.py pointer --project <project-directory>
+python3 scripts/conformance.py continuity \
+  --project <project-directory> --readiness local
+python3 scripts/conformance.py continuity \
+  --project <project-directory> --readiness remote
 ```
 
-The check verifies the project structure, current context fields, plan link,
-git repository, and active-project pointer. Then open the project in the other
-client and confirm its SessionStart or PostCompact context names the same phase,
-status, plan, and next action.
+`pointer` verifies a live owner's leased cache. Local continuity verifies that
+Claude and Codex reconstruct identical project state with no pointer, accepts a
+current Stop receipt as `LOCAL_READY`, and accepts an attributed manifest as
+`LOCAL_RECOVERABLE` after interruption. Remote continuity additionally requires
+no pending manifest and a clean upstream-current project record. Then open the
+project in the other client and confirm its SessionStart or first named-project
+turn recovers the same state.
 
 ### 5. Close the loop
 
@@ -126,6 +134,11 @@ behavior-producing implementation. The script:
 
 - verifies the local clock;
 - reads the active-project pointer;
+- discovers a stopped project directly when the task directory is inside its
+  durable project tree;
+- when neither route identifies a project, instructs the receiving agent to
+  resolve the user's named project through the git-tracked registry and run
+  the Session Start Protocol automatically;
 - verifies that the project still exists;
 - extracts the current phase, status, plan, and next actions from durable files;
 - emits a compact context anchor;
@@ -140,6 +153,12 @@ Codex hook trust is a separate human-controlled check within installed state:
 `hook-trust` queries
 Codex app-server's read-only `hooks/list` API for the current normalized hash,
 source owner, and trust reason, and never edits `hooks.state`.
+
+The active pointer is deliberately not synchronized as one global current
+project. Parallel root sessions may work on different projects. Same-machine
+cross-client continuity consumes project files plus attributed working-tree
+state. Cross-computer continuity requires the explicit `REMOTE_READY`
+transition and a fast-forwarded destination checkout.
 
 ## Skill catalog contract
 

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -89,6 +89,9 @@ DEFAULT_CAPABILITY_EVIDENCE = (
     / "agent-conformance"
     / "capabilities.json"
 )
+DEFAULT_REPO_GUARD_STATE = Path(
+    os.environ.get("SYNTHESIS_HOME", str(Path.home() / ".synthesis"))
+) / "repo-guard"
 COORDINATION_HELPER = (
     SCRIPT_PATH.parents[2]
     / "synthesis-project-management"
@@ -150,6 +153,7 @@ PLANE_BY_PREFIX = {
     "coordination": "continuity",
     "pointer": "continuity",
     "handoff": "continuity",
+    "continuity": "continuity",
     "hook-live": "live",
     "capability": "capability",
     "surface": "capability",
@@ -1510,6 +1514,12 @@ def handoff_checks(
     coordination_board: Path = DEFAULT_COORDINATION_BOARD,
 ) -> list[Check]:
     summary, checks = project_summary(project)
+    stopped_parity, stopped_detail = stopped_payload_parity(
+        project,
+        summary,
+        coordination_board,
+    )
+    add(checks, "handoff.stopped-task-payload", stopped_parity, stopped_detail)
     try:
         active = json.loads(pointer.read_text(encoding="utf-8"))
         matches = Path(active["project"]).resolve() == project.resolve()
@@ -1523,8 +1533,351 @@ def handoff_checks(
             )
         parity, detail = payload_parity(pointer, coordination_board)
         add(checks, "handoff.payload-parity", parity, detail)
+    except FileNotFoundError:
+        add(
+            checks,
+            "handoff.pointer-cache",
+            True,
+            "absent by design; stopped-task recovery uses the durable project record",
+            required=False,
+        )
     except Exception as exc:
         add(checks, "handoff.pointer", False, f"{pointer}: {exc}")
+    return checks
+
+
+def stopped_payload_parity(
+    project: Path,
+    summary: dict[str, object],
+    coordination_board: Path = DEFAULT_COORDINATION_BOARD,
+) -> tuple[bool, str]:
+    """Prove both adapters reconstruct a stopped project without a pointer."""
+    script = SCRIPTS_DIR / "session_context.py"
+    missing_pointer = project / ".synthesis-stopped-pointer-must-not-exist.json"
+    if missing_pointer.exists():
+        return False, f"reserved stopped-task probe path exists: {missing_pointer}"
+    contexts: dict[str, str] = {}
+    input_text = json.dumps({"cwd": str(project)})
+    for client_format in ("claude", "codex"):
+        result = run(
+            [
+                sys.executable,
+                str(script),
+                "--format",
+                client_format,
+                "--active-project-file",
+                str(missing_pointer),
+                "--coordination-board",
+                str(coordination_board),
+            ],
+            input_text=input_text,
+        )
+        if result.returncode != 0:
+            return False, (
+                f"{client_format} stopped-task payload failed: "
+                + (result.stderr.strip() or f"exit {result.returncode}")
+            )
+        try:
+            contexts[client_format] = json.loads(result.stdout)["hookSpecificOutput"][
+                "additionalContext"
+            ]
+        except Exception as exc:
+            return False, f"{client_format} stopped-task envelope is invalid: {exc}"
+
+    normalized = {
+        client: TIMESTAMP_LINE.sub("Verified local time: <normalized>", context)
+        for client, context in contexts.items()
+    }
+    if normalized["claude"] != normalized["codex"]:
+        return False, "Claude and Codex stopped-task payloads diverge"
+    message = contexts["codex"]
+    expected = [
+        str(project.resolve()),
+        f"Current phase: {summary.get('phase', 'unknown')}.",
+        f"Current status: {summary.get('status', 'unknown')}.",
+        f"Controlling plan: {summary.get('plan', 'unknown')}.",
+    ]
+    missing = [value for value in expected if value not in message]
+    if missing:
+        return False, "stopped-task payload is missing: " + ", ".join(missing)
+    return True, "Claude and Codex reconstruct the same durable record without a pointer"
+
+
+def _manifest_records_project(data: dict[str, object], project: Path) -> bool:
+    project_root = project.resolve()
+    values = data.get("remote_paths", data.get("paths", []))
+    if not isinstance(values, list):
+        return False
+    for value in values:
+        try:
+            Path(str(value)).expanduser().resolve(strict=False).relative_to(project_root)
+            return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
+def project_pending_manifests(project: Path, state_root: Path) -> list[tuple[Path, dict]]:
+    pending = state_root / "pending"
+    found: list[tuple[Path, dict]] = []
+    if not pending.is_dir():
+        return found
+    for path in sorted(pending.glob("*.json")):
+        if path.is_symlink():
+            raise ValueError(f"pending handoff manifest is a symlink: {path}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        session_id = data.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError(f"pending handoff manifest has no session id: {path}")
+        if not isinstance(data.get("paths"), list):
+            raise ValueError(f"pending handoff manifest paths are invalid: {path}")
+        if "remote_paths" in data and not isinstance(data.get("remote_paths"), list):
+            raise ValueError(f"pending handoff manifest remote_paths are invalid: {path}")
+        expected = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+        if path.name != expected:
+            raise ValueError(f"pending handoff manifest name mismatch: {path}")
+        if _manifest_records_project(data, project):
+            found.append((path, data))
+    return found
+
+
+def _file_receipt_matches(item: dict[str, object]) -> bool:
+    path = Path(str(item.get("path") or "")).expanduser()
+    state = item.get("state")
+    if state == "deleted-or-missing":
+        return not path.exists()
+    if state != "present" or not path.is_file() or path.is_symlink():
+        return False
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest() == item.get("sha256")
+
+
+def valid_local_receipt(session_id: str, state_root: Path) -> bool:
+    name = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+    receipt = state_root / "local-handoff" / name
+    if not receipt.is_file() or receipt.is_symlink():
+        return False
+    try:
+        data = json.loads(receipt.read_text(encoding="utf-8"))
+        if data.get("session_id") != session_id or data.get("readiness") != "LOCAL_READY":
+            return False
+        results = [
+            result for result in data.get("results", []) if isinstance(result, dict)
+        ]
+        evidence = [
+            item
+            for result in results
+            for item in result.get("file_evidence", [])
+            if isinstance(item, dict)
+        ]
+        if not evidence or not all(_file_receipt_matches(item) for item in evidence):
+            return False
+        for result in results:
+            if result.get("action") != "local-ready" or result.get("alert"):
+                return False
+            repo = Path(str(result.get("repo") or "")).expanduser()
+            branch = run(["git", "-C", str(repo), "branch", "--show-current"])
+            head = run(["git", "-C", str(repo), "rev-parse", "HEAD"])
+            if (
+                branch.returncode != 0
+                or head.returncode != 0
+                or branch.stdout.strip() != result.get("branch")
+                or head.stdout.strip() != result.get("head")
+            ):
+                return False
+        return True
+    except (OSError, ValueError, TypeError):
+        return False
+
+
+def porcelain_paths(output: str, repo_root: Path) -> set[Path]:
+    paths: set[Path] = set()
+    for line in output.splitlines():
+        if len(line) < 4:
+            continue
+        value = line[3:]
+        if " -> " in value:
+            value = value.split(" -> ", 1)[1]
+        value = value.strip().strip('"')
+        if value:
+            paths.add((repo_root / value).resolve(strict=False))
+    return paths
+
+
+def continuity_readiness_checks(
+    project: Path,
+    readiness: str,
+    state_root: Path = DEFAULT_REPO_GUARD_STATE,
+) -> list[Check]:
+    checks: list[Check] = []
+    try:
+        manifests = project_pending_manifests(project, state_root)
+    except (OSError, ValueError, TypeError) as exc:
+        add(checks, "continuity.local-manifest", False, str(exc))
+        return checks
+
+    root_result = run(["git", "-C", str(project), "rev-parse", "--show-toplevel"])
+    if root_result.returncode != 0 or not root_result.stdout.strip():
+        add(checks, "continuity.local-state", False, "git repository root is unavailable")
+        return checks
+    repo_root = Path(root_result.stdout.strip()).resolve()
+    status = run(
+        [
+            "git",
+            "-C",
+            str(project),
+            "-c",
+            "core.quotePath=false",
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--",
+            ".",
+        ]
+    )
+    if status.returncode != 0:
+        add(
+            checks,
+            "continuity.local-state",
+            False,
+            status.stderr.strip() or "git status failed",
+        )
+        return checks
+    dirty_files = porcelain_paths(status.stdout, repo_root)
+    dirty = bool(dirty_files)
+    attributed = {
+        Path(str(value)).expanduser().resolve(strict=False)
+        for _, data in manifests
+        for value in data.get("paths", [])
+    }
+    unattributed = sorted(dirty_files - attributed)
+    if dirty and (not manifests or unattributed):
+        add(
+            checks,
+            "continuity.local-state",
+            False,
+            (
+                "project has unattributed local edits: "
+                + ", ".join(str(path) for path in unattributed[:5])
+            )
+            if unattributed
+            else "project has unattributed local edits; no client-session manifest can reconstruct the interruption",
+        )
+    elif manifests:
+        receipt_count = sum(
+            valid_local_receipt(str(data["session_id"]), state_root)
+            for _, data in manifests
+        )
+        state = "LOCAL_READY" if receipt_count == len(manifests) else "LOCAL_RECOVERABLE"
+        add(
+            checks,
+            "continuity.local-state",
+            True,
+            f"{state}: {len(manifests)} attributed session manifest(s), {receipt_count} current Stop receipt(s)",
+        )
+    else:
+        add(
+            checks,
+            "continuity.local-state",
+            True,
+            "LOCAL_READY: project record is clean and readable on this machine",
+        )
+
+    if readiness == "local":
+        return checks
+
+    add(
+        checks,
+        "continuity.remote-pending",
+        not manifests,
+        "no pending local handoff manifests"
+        if not manifests
+        else f"{len(manifests)} local handoff manifest(s) still require publication",
+    )
+    upstream = run(
+        [
+            "git",
+            "-C",
+            str(project),
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ]
+    )
+    if upstream.returncode != 0 or not upstream.stdout.strip():
+        add(
+            checks,
+            "continuity.remote-upstream",
+            False,
+            "current branch has no upstream",
+        )
+        return checks
+    branch = run(["git", "-C", str(project), "branch", "--show-current"])
+    remote = run(
+        [
+            "git",
+            "-C",
+            str(project),
+            "config",
+            "--get",
+            f"branch.{branch.stdout.strip()}.remote",
+        ]
+    )
+    if (
+        branch.returncode != 0
+        or not branch.stdout.strip()
+        or remote.returncode != 0
+        or not remote.stdout.strip()
+        or remote.stdout.strip() == "."
+    ):
+        add(
+            checks,
+            "continuity.remote-upstream",
+            False,
+            "current branch has no fetchable remote",
+        )
+        return checks
+    fetched = run(
+        ["git", "-C", str(project), "fetch", remote.stdout.strip()]
+    )
+    if fetched.returncode != 0:
+        add(
+            checks,
+            "continuity.remote-upstream",
+            False,
+            fetched.stderr.strip() or "remote fetch failed",
+        )
+        return checks
+    counts = run(
+        [
+            "git",
+            "-C",
+            str(project),
+            "rev-list",
+            "--left-right",
+            "--count",
+            f"{upstream.stdout.strip()}...HEAD",
+            "--",
+            str(project),
+        ]
+    )
+    parts = counts.stdout.split()
+    comparable = counts.returncode == 0 and len(parts) == 2
+    behind, ahead = (int(value) for value in parts) if comparable else (-1, -1)
+    add(
+        checks,
+        "continuity.remote-upstream",
+        comparable and behind == 0 and ahead == 0 and not dirty,
+        (
+            f"REMOTE_READY against fetched {upstream.stdout.strip()}"
+            if comparable and behind == 0 and ahead == 0 and not dirty
+            else f"remote readiness failed: dirty={dirty}, ahead={ahead}, behind={behind}"
+        ),
+    )
     return checks
 
 
@@ -1781,6 +2134,7 @@ def parser() -> argparse.ArgumentParser:
             "capabilities",
             "surfaces",
             "coordination",
+            "continuity",
             "activate",
             "handoff",
             "all",
@@ -1789,6 +2143,12 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--source-root", type=Path, default=DEFAULT_SOURCE_ROOT)
     result.add_argument("--repo-root", type=Path)
     result.add_argument("--project", type=Path)
+    result.add_argument(
+        "--readiness",
+        choices=("local", "remote"),
+        default="local",
+        help="Continuity gate: same-machine recovery or published cross-machine state",
+    )
     result.add_argument("--active-project-file", type=Path, default=DEFAULT_ACTIVE_PROJECT)
     result.add_argument(
         "--session-id",
@@ -1908,6 +2268,22 @@ def main() -> int:
                 args.project.resolve(),
                 args.active_project_file.expanduser(),
                 args.coordination_board.expanduser(),
+            )
+        )
+    if args.command == "continuity":
+        if not args.project:
+            raise SystemExit("--project is required")
+        summary, project_checks = project_summary(args.project.resolve())
+        checks.extend(project_checks)
+        parity, detail = stopped_payload_parity(
+            args.project.resolve(),
+            summary,
+            args.coordination_board.expanduser(),
+        )
+        add(checks, "continuity.stopped-task-payload", parity, detail)
+        checks.extend(
+            continuity_readiness_checks(
+                args.project.resolve(), args.readiness
             )
         )
     return render(checks, args.json, args.report_file)

--- a/skills/synthesis-agent-conformance/scripts/session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/session_context.py
@@ -33,6 +33,9 @@ DEFAULT_LIVE_RECEIPT = (
     / "live"
     / "public-sessionstart.json"
 )
+DEFAULT_PENDING_HANDOFFS = Path(
+    os.environ.get("SYNTHESIS_HOME", str(Path.home() / ".synthesis"))
+) / "repo-guard" / "pending"
 
 
 def atomic_json_write(destination: Path, payload: dict[str, object]) -> None:
@@ -178,41 +181,65 @@ def active_session_ids(board: Path) -> list[str]:
     return active
 
 
-def build(pointer: Path, coordination_board: Path = DEFAULT_COORDINATION_BOARD) -> str:
-    now = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S %Z (%A)")
-    lines = [f"Verified local time: {now}."]
-    sessions = active_session_ids(coordination_board)
-    if sessions:
-        lines.append(
-            "Cross-agent coordination is active for session(s): "
-            + ", ".join(sessions)
-            + ". Read the coordination board and verify claims before writes."
-        )
-    if not pointer.is_file():
-        lines.append("No active synthesis project pointer is set.")
-        return "\n".join(lines)
+def pending_handoff_count(directory: Path) -> int:
+    if not directory.is_dir():
+        return 0
+    count = 0
+    for path in directory.glob("*.json"):
+        if path.is_symlink():
+            raise ValueError(f"pending handoff manifest is a symlink: {path}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data.get("session_id"), str) or not isinstance(
+            data.get("paths"), list
+        ):
+            raise ValueError(f"pending handoff manifest is invalid: {path}")
+        count += 1
+    return count
 
-    data, pointer_issues = load_and_validate(pointer, coordination_board)
-    if pointer_issues:
-        raise ValueError("; ".join(pointer_issues))
-    project = Path(data["project"]).expanduser().resolve()
+
+def project_from_cwd(cwd: Path | None) -> Path | None:
+    """Discover a durable project when a task opens inside its directory."""
+    if cwd is None:
+        return None
+    try:
+        candidate = cwd.expanduser().resolve(strict=True)
+    except OSError:
+        return None
+    if candidate.is_file():
+        candidate = candidate.parent
+    for directory in (candidate, *candidate.parents):
+        if (
+            (directory / "CONTEXT.md").is_file()
+            and (directory / "REFERENCE.md").is_file()
+            and (directory / "sessions").is_dir()
+        ):
+            return directory
+    return None
+
+
+def linked_plan(project: Path, context: str) -> Path | None:
+    match = re.search(
+        r"\((resources/artifacts/[^)\n]*plan[^)\n]*\.md)\)",
+        context,
+        re.IGNORECASE,
+    )
+    return project / match.group(1) if match else None
+
+
+def append_project_context(lines: list[str], project: Path, *, label: str) -> None:
     context_path = project / "CONTEXT.md"
-    if not context_path.is_file():
-        raise FileNotFoundError(f"active project CONTEXT.md is missing: {context_path}")
-
     context = context_path.read_text(encoding="utf-8")
     phase = extract(context, "Phase")
     status = extract(context, "Status")
-    plan = data.get("plan", "unknown")
-    if plan != "unknown" and not Path(plan).is_file():
+    plan = linked_plan(project, context)
+    if plan is not None and not plan.is_file():
         raise FileNotFoundError(f"active plan is missing: {plan}")
-
     lines.extend(
         [
-            f"Active synthesis project: {project}.",
+            f"{label}: {project}.",
             f"Current phase: {phase}.",
             f"Current status: {status}.",
-            f"Controlling plan: {plan}.",
+            f"Controlling plan: {plan or 'unknown'}.",
         ]
     )
     fresh, freshness_detail = record_freshness(project)
@@ -223,6 +250,61 @@ def build(pointer: Path, coordination_board: Path = DEFAULT_COORDINATION_BOARD) 
         lines.append("Recorded next actions:")
         lines.extend(f"- {action}" for action in actions)
     lines.append("Re-read CONTEXT.md and the controlling plan before substantive work.")
+
+
+def build(
+    pointer: Path,
+    coordination_board: Path = DEFAULT_COORDINATION_BOARD,
+    cwd: Path | None = None,
+    pending_handoffs: Path = DEFAULT_PENDING_HANDOFFS,
+) -> str:
+    now = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S %Z (%A)")
+    lines = [f"Verified local time: {now}."]
+    sessions = active_session_ids(coordination_board)
+    if sessions:
+        lines.append(
+            "Cross-agent coordination is active for session(s): "
+            + ", ".join(sessions)
+            + ". Read the coordination board and verify claims before writes."
+        )
+    pending = pending_handoff_count(pending_handoffs)
+    if pending:
+        lines.append(
+            f"Local continuity: {pending} attributed edit manifest(s) await "
+            "remote publication. Inspect working-tree truth before relying on "
+            "cached project context; an interrupted task remains recoverable on "
+            "this machine."
+        )
+    if not pointer.is_file():
+        lines.append("No active synthesis project pointer is set.")
+        discovered = project_from_cwd(cwd)
+        if discovered is not None:
+            append_project_context(
+                lines,
+                discovered,
+                label="Stopped synthesis project discovered from the task directory",
+            )
+        else:
+            lines.append(
+                "Stopped-task recovery remains available: when the user names a "
+                "synthesis project, resolve it from the git-tracked projects/index.yaml "
+                "and run the Session Start Protocol automatically; never ask the user "
+                "to run a context-lifecycle command or save state manually."
+            )
+        return "\n".join(lines)
+
+    data, pointer_issues = load_and_validate(pointer, coordination_board)
+    if pointer_issues:
+        raise ValueError("; ".join(pointer_issues))
+    project = Path(data["project"]).expanduser().resolve()
+    context_path = project / "CONTEXT.md"
+    if not context_path.is_file():
+        raise FileNotFoundError(f"active project CONTEXT.md is missing: {context_path}")
+
+    plan = data.get("plan", "unknown")
+    if plan != "unknown" and not Path(plan).is_file():
+        raise FileNotFoundError(f"active plan is missing: {plan}")
+    append_project_context(lines, project, label="Active synthesis project")
     return "\n".join(lines)
 
 
@@ -259,6 +341,7 @@ def main() -> int:
         message = build(
             args.active_project_file.expanduser(),
             args.coordination_board.expanduser(),
+            Path(str(payload["cwd"])) if payload.get("cwd") else None,
         )
     except Exception as exc:
         print(f"synthesis project context failed closed: {exc}", file=sys.stderr)

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -527,6 +527,125 @@ def test_payload_parity_reports_broken_pointer(tmp_path: Path) -> None:
     assert "payload failed" in detail
 
 
+def test_stopped_handoff_passes_without_active_pointer(tmp_path: Path) -> None:
+    subprocess = __import__("subprocess")
+    repo = tmp_path / "repo"
+    project = repo / "projects" / "demo"
+    plan = project / "resources" / "artifacts" / "demo-plan.md"
+    plan.parent.mkdir(parents=True)
+    (project / "sessions").mkdir()
+    (project / "CONTEXT.md").write_text(
+        "**Phase:** Ready\n"
+        "**Status:** Paused\n\n"
+        "[plan](resources/artifacts/demo-plan.md)\n\n"
+        "## What's Next\n\n"
+        "1. [ ] Resume on either client.\n",
+        encoding="utf-8",
+    )
+    (project / "REFERENCE.md").write_text("# Reference\n", encoding="utf-8")
+    plan.write_text("# Plan\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "init", "--quiet", "--initial-branch", "main", str(repo)],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "seed"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "update-ref", "refs/remotes/origin/main", "HEAD"],
+        check=True,
+    )
+
+    checks = MODULE.handoff_checks(
+        project,
+        tmp_path / "missing-pointer.json",
+        tmp_path / "missing-board.md",
+    )
+
+    assert all(check.ok for check in checks if check.required)
+    named = {check.name: check for check in checks}
+    assert named["handoff.stopped-task-payload"].ok
+    assert named["handoff.pointer-cache"].ok
+
+
+def test_local_continuity_recovers_interrupted_attributed_edits(tmp_path: Path) -> None:
+    project, _stale = clone_pair_with_project(tmp_path)
+    context = project / "CONTEXT.md"
+    context.write_text("**Phase:** interrupted\n", encoding="utf-8")
+    state = tmp_path / "repo-guard"
+    pending = state / "pending"
+    pending.mkdir(parents=True)
+    session_id = "interrupted-session"
+    manifest = pending / (
+        MODULE.hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+    )
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": session_id,
+                "paths": [str(context)],
+                "remote_paths": [str(context)],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    checks = MODULE.continuity_readiness_checks(project, "local", state)
+
+    assert all(check.ok for check in checks if check.required)
+    assert "LOCAL_RECOVERABLE" in checks[0].detail
+
+
+def test_local_continuity_rejects_dirty_project_paths_missing_from_manifest(
+    tmp_path: Path,
+) -> None:
+    project, _stale = clone_pair_with_project(tmp_path)
+    context = project / "CONTEXT.md"
+    reference = project / "REFERENCE.md"
+    context.write_text("**Phase:** attributed\n", encoding="utf-8")
+    reference.write_text("# Unattributed\n", encoding="utf-8")
+    state = tmp_path / "repo-guard"
+    pending = state / "pending"
+    pending.mkdir(parents=True)
+    session_id = "partial-session"
+    manifest = pending / (
+        MODULE.hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+    )
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": session_id,
+                "paths": [str(context)],
+                "remote_paths": [str(context)],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    checks = MODULE.continuity_readiness_checks(project, "local", state)
+
+    local = next(check for check in checks if check.name == "continuity.local-state")
+    assert not local.ok
+    assert "REFERENCE.md" in local.detail
+
+
+def test_remote_continuity_requires_clean_published_project(tmp_path: Path) -> None:
+    project, _stale = clone_pair_with_project(tmp_path)
+
+    checks = MODULE.continuity_readiness_checks(
+        project, "remote", tmp_path / "empty-state"
+    )
+
+    assert all(check.ok for check in checks if check.required)
+    assert any("REMOTE_READY" in check.detail for check in checks)
+
+
 def test_runtime_checks_fail_structurally_when_binaries_absent(monkeypatch) -> None:
     monkeypatch.setattr(MODULE, "resolve_client_binary", lambda name: None)
 

--- a/skills/synthesis-agent-conformance/scripts/test_session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/test_session_context.py
@@ -64,6 +64,66 @@ def test_build_includes_active_coordination(tmp_path: Path) -> None:
     assert "verify claims before writes" in message
 
 
+def test_build_without_pointer_explains_automatic_named_project_recovery(
+    tmp_path: Path,
+) -> None:
+    message = MODULE.build(tmp_path / "missing-pointer.json", tmp_path / "no-board.md")
+
+    assert "No active synthesis project pointer is set." in message
+    assert "resolve it from the git-tracked projects/index.yaml" in message
+    assert "never ask the user to run a context-lifecycle command" in message
+
+
+def test_build_surfaces_interrupted_local_handoff_without_names(tmp_path: Path) -> None:
+    pending = tmp_path / "repo-guard" / "pending"
+    pending.mkdir(parents=True)
+    (pending / "one.json").write_text(
+        json.dumps({"session_id": "session-a", "paths": ["/private/path"]}),
+        encoding="utf-8",
+    )
+
+    message = MODULE.build(
+        tmp_path / "missing-pointer.json",
+        tmp_path / "no-board.md",
+        pending_handoffs=pending,
+    )
+
+    assert "Local continuity: 1 attributed edit manifest" in message
+    assert "/private/path" not in message
+    assert "interrupted task remains recoverable" in message
+
+
+def test_build_discovers_stopped_project_from_cwd(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "projects" / "alpha"
+    plan = project / "resources" / "artifacts" / "alpha-plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Plan\n", encoding="utf-8")
+    (project / "sessions").mkdir()
+    (project / "REFERENCE.md").write_text("# Reference\n", encoding="utf-8")
+    (project / "CONTEXT.md").write_text(
+        "# Alpha\n\n"
+        "**Phase:** Validation\n"
+        "**Status:** Active\n\n"
+        "[plan](resources/artifacts/alpha-plan.md)\n\n"
+        "## What's Next\n\n"
+        "- [ ] Resume from durable state.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(MODULE, "record_freshness", lambda path: (True, "current"))
+
+    message = MODULE.build(
+        tmp_path / "missing-pointer.json",
+        tmp_path / "no-board.md",
+        project / "resources",
+    )
+
+    assert f"Stopped synthesis project discovered from the task directory: {project}." in message
+    assert "Current phase: Validation." in message
+    assert "Current status: Active." in message
+    assert f"Controlling plan: {plan}." in message
+    assert "Resume from durable state" in message
+
+
 def test_build_rejects_incomplete_or_unleased_pointer(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/skills/synthesis-catchup-ledger/SKILL.md
+++ b/skills/synthesis-catchup-ledger/SKILL.md
@@ -5,14 +5,14 @@ license: "CC0-1.0"
 depends_on: ["synthesis-daily-rituals", "synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "0.2.1"
+  version: "0.3.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
 
 # Synthesis Catch-up Ledger
 
-**Version 0.2.1** (2026-07-09)
+**Version 0.3.0** (2026-08-14)
 
 > **Consumer note (v0.2.0):** synthesis-console v0.14+ renders ledgers live at
 > `/ledger` — it classifies H2 sections by the heading keywords used in this
@@ -127,9 +127,9 @@ Location: `{action_plan_repo}/catchup-ledgers/YYYY-MM-DD.md` (sibling convention
 - EXPIRED lessons that generalize beyond the period get promoted to the lessons directory; period-specific ones stay in the ledger.
 - Update the ratchet marker so the next sweep is incremental.
 
-### Step 6 — Commit
+### Step 6 — Record readiness
 
-Commit and push the ledger (and any annotated sources) in the same invocation, per the standard commit protocol: stage only files this invocation touched, never `git add -A`.
+Leave the ledger and annotated sources session-attributed and locally receipted. Publish their exact paths during explicit remote handoff or day-end under the repository policy; never use broad staging.
 
 ## Tone requirements for the ledger
 

--- a/skills/synthesis-checkpoint/SKILL.md
+++ b/skills/synthesis-checkpoint/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.2.0"
+  version: "1.3.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -129,7 +129,7 @@ Show this verification step in the response. It is the L4 visible-verification m
 
 ### Step 6 — Update CONTEXT.md if it was stale
 
-If Step 3 revealed CONTEXT.md was out of date (later commits exist that aren't reflected in its "Last session" or "Recent Sessions" sections), update CONTEXT.md in place to reflect verified facts. Commit and push that update separately from any other work. This prevents the next session from inheriting the stale cache.
+If Step 3 revealed CONTEXT.md was out of date (later commits exist that aren't reflected in its "Last session" or "Recent Sessions" sections), update CONTEXT.md in place to reflect verified facts. Leave the correction session-attributed and locally receipted; publish it in the next explicit remote handoff or day-end batch. This prevents the next local client from inheriting the stale cache without creating a network round trip at every checkpoint.
 
 ## Output Format
 

--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.5.0"
+  version: "1.7.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -314,6 +314,35 @@ python3 <skill-root>/scripts/conformance.py activate \
 The pointer accelerates SessionStart and PostCompact recovery. It is a cache;
 the project files and git history remain authoritative.
 
+### Seamless client and computer switching
+
+Rajiv never has to run this protocol or save state manually. The working agent
+owns the checkpoint before it yields. A normal stopped-task transition is:
+
+1. the agent updates `CONTEXT.md`, stable `REFERENCE.md` facts, the current
+   session log, and the controlling plan as the work changes;
+2. the client adapter records the exact context paths changed by that session;
+3. Stop hashes the attributed files into a local receipt without committing or
+   using the network; an interruption before Stop leaves the manifest plus Git
+   working-tree state as `LOCAL_RECOVERABLE` evidence;
+4. an explicit remote handoff or day-end publishes source work under repository
+   policy and batches exact private-context paths before the destination
+   computer fast-forwards; and
+5. when Rajiv names the project, the receiving client resolves it through the
+   git-tracked `projects/index.yaml` and runs this Session Start Protocol
+   automatically.
+
+A valid live pointer accelerates the same-client case. Its absence after claim
+release is normal and must not block recovery from the durable record. A single
+global durable "current project" marker is prohibited because independent
+Claude Code and Codex tasks may own different projects simultaneously.
+
+The guarantee has explicit boundaries: do not switch while a task is still
+running; an offline origin can preserve a local checkpoint but cannot make it
+available on another computer; divergence, a behind checkout, missing
+authentication, and overlapping claims must surface visibly instead of being
+called seamless.
+
 **Why this order matters.** Steps 1 and 2 establish ground truth from external sources (OS clock, git). Step 3 reads the cache. Step 4 reads the most recent narrative. The order means by the time you act, you have verified facts AND the project's own framing — and you have noticed any discrepancy between them.
 
 **Visible to the user.** Show the verification step in your first response of the session. Example:
@@ -349,7 +378,7 @@ Long conversations cause context drift. The mid-session refresh protocol re-sync
 3. Re-read CONTEXT.md from disk
 4. Re-read the latest sessions/YYYY-MM.md entry
 5. Reconcile: where does in-context memory disagree with disk/git? Report the discrepancy in the next response.
-6. If CONTEXT.md is stale, update it. Commit and push the correction separately.
+6. If CONTEXT.md is stale, update it and preserve session-attributed local evidence. Publish it during explicit remote handoff or day-end.
 
 **Compaction detection signals.** Context-window compaction (the harness summarizing older turns) is opaque — you cannot reliably detect when it happened. Treat these as red flags suggesting compaction may have occurred:
 
@@ -396,11 +425,11 @@ Archive when ANY of these conditions are true:
    - CONTEXT.md ≤150 lines
    - No information lost (everything archived before removal)
    - Cross-references updated (CONTEXT.md points to REFERENCE.md and sessions/)
-8. **Commit AND push** with message: "Maintain context: archive sessions, extract reference facts". Stage only the files this invocation modified — do not `git add -A`. See the Commit Protocol section below for the full rule.
+8. **Record local readiness.** The client edit hook attributes the changed files automatically. Commit and push during an explicit remote handoff or day-end, scoped to the exact files and repository policy.
 
 **CRITICAL: Archive FIRST, then delete. NEVER delete content from CONTEXT.md before confirming it exists in sessions/ or REFERENCE.md. Two-phase commit: write to destination, verify, then remove from source.**
 
-**ALSO CRITICAL: Commit-and-push is part of this protocol, not an afterthought.** Every non-trivial context modification (archival or otherwise) must be committed and pushed in the same invocation. See the Commit Protocol section for scoping rules.
+**ALSO CRITICAL: local continuity and remote readiness are different states.** Do not create a network commit after every context edit. Keep the local tiers current, and publish them through explicit remote handoff or day-end.
 
 ### Decision Tree: Where Does This Content Belong?
 
@@ -514,7 +543,8 @@ python3 <skill>/scripts/context_doctor.py            # all sources from console.
 python3 <skill>/scripts/context_doctor.py --source ~/kb   # explicit source roots
 python3 <skill>/scripts/context_doctor.py --project ~/kb/projects/alpha
 python3 <skill>/scripts/context_doctor.py --json     # for consoles and rituals
-python3 <skill>/scripts/context_doctor.py --quiet    # exit code + one line
+python3 <skill>/scripts/context_doctor.py --quiet --readiness local
+python3 <skill>/scripts/context_doctor.py --project ~/kb/projects/alpha --readiness remote
 ```
 
 What it checks:
@@ -525,7 +555,7 @@ What it checks:
 | Budgets | CONTEXT.md ≤150 active / ≤80 completed; REFERENCE.md ≤300 (warning) |
 | Cross-tier agreement | index.yaml status agrees with the CONTEXT.md header; completed projects carry `completed_date`; indexed projects have directories and vice versa |
 | Freshness | index.yaml `last_session` and the CONTEXT.md header agree with real git history |
-| Durability | no uncommitted project files; tier files actually **tracked** by git, not merely clean; a remote and upstream exist and the branch is pushed |
+| Durability | tier files are tracked by git; local mode reports recoverable uncommitted or ahead state as warnings; remote mode requires a clean upstream-current branch |
 | Disclosure | anything unverifiable is reported rather than skipped — unreadable status headers and freshness that cannot be established both surface as findings |
 
 Exit codes follow the guard contract: `0` healthy, `1` defects found, `2` the doctor could not establish ground truth. The third is the important one — an unreadable source or a source outside git exits 2 rather than reporting health, because a check that cannot run must never look like a check that passed.
@@ -536,9 +566,9 @@ Exit codes follow the guard contract: `0` healthy, `1` defects found, `2` the do
 
 **The report cache.** Every full-corpus run writes its JSON report to `$SYNTHESIS_HOME/context-doctor/last-report.json` (v1.2.0+), so fast surfaces — SessionStart hooks, console pages — can show the latest corpus state without paying for a fresh audit. Single-project runs never touch the cache: a one-project result must not masquerade as corpus state. Suppress with `--no-report-cache`.
 
-**Enforcement posture (decided 2026-08-03).** Fail-closed for the actor, report-only for the bystander. At day-end (and any session close-out), `context_doctor.py --project <path>` must be CLEAN for every project the session worked — defects block the close and get fixed on the spot, because the session that made the record defective can repair it in minutes. Corpus-wide findings stay report-only at day-start and SessionStart: gating one session on another project's legacy debt manufactures false alarms, and false alarms train bypass. An unfixed active-project defect is not silently droppable — it re-surfaces at every subsequent SessionStart until repaired.
+**Enforcement posture.** Day-start and ordinary same-machine handoffs use `--readiness local`: structural defects still fail, while attributed uncommitted or ahead state is visible as a warning. Explicit cross-machine handoff and day-end use `--readiness remote` for every project worked and fail closed until its context is committed, pushed, and upstream-current. Corpus-wide findings remain report-only.
 
-**Where it runs.** A doctor nobody runs is the same as no doctor. It is wired into: day-start Step 1 (full corpus, report-only, refreshes the cache), day-end Step 7 (per-worked-project, fail-closed), SessionStart surfacing (active project live + corpus from cache), and the synthesis console's Context Integrity page. The `--json` output is stable for those consumers.
+**Where it runs.** Day-start refreshes the corpus cache in local mode. Day-end and explicit remote handoff run per-project remote mode. SessionStart and Synthesis Console surface the cached result. The JSON output includes its readiness mode so a local pass cannot masquerade as remote readiness.
 
 ---
 
@@ -565,31 +595,56 @@ Stage 3 is the 80/20 solution that makes long-running AI-assisted projects susta
 
 ---
 
-## Commit Protocol — Not Optional
+## Local Continuity and Remote Readiness Protocol
 
-Context files are only useful if they reach the remote repository. Every invocation that creates or modifies context files (CONTEXT.md, REFERENCE.md, session archives, daily plans, transcripts) must commit and push those changes before the invocation ends.
+Context is maintained continuously, but it is not published after every
+prompt or response. The system exposes two honest states:
 
-This is not deferred to "end of day" or "end of session." Treat it as part of the same action: if you wrote to a context file, you also commit and push it. Interactive sessions span multiple turns and may not have a clean "end" — so the commit must happen at the point of modification, not at some later checkpoint that may never arrive.
+- **LOCAL_READY:** project tiers and working-tree edits are available on the
+  shared local filesystem. PostToolUse records every repository edit in a
+  client-session manifest; Stop adds an atomic content receipt. Claude Code
+  and Codex can switch on the same machine without a commit or network call.
+- **LOCAL_RECOVERABLE:** an interrupted task left its edit manifest but never
+  reached Stop. The receiving client reads project files, Git status and diff,
+  the controlling plan, and the manifest before continuing.
+- **REMOTE_READY:** source repositories are clean and upstream-current;
+  private project context has been committed and pushed in exact-path batches;
+  pending manifests are retired; remote-mode context doctor and conformance
+  pass.
 
-### Scope Rule: Only Commit Repos Touched in This Invocation
+### Automatic same-machine handoff
 
-Never run workspace-wide commit or push operations. Only commit repos where this specific invocation created or modified files. If the user has other uncommitted work in unrelated repos (personal projects, other workspaces, unrelated branches), leave those alone — they belong to other sessions.
+Before a natural pause, the agent updates CONTEXT.md, REFERENCE.md, the
+current session log, plan artifacts, and index.yaml as the work requires. It
+releases or narrows coordination claims. The hooks record local evidence.
+Rajiv does not run a lifecycle command, save state manually, or wait for a
+network commit before opening the project in the other client.
 
-The pattern:
-1. Track which files THIS invocation modified (the agent's own action history is the source of truth).
-2. Group those files by containing repo.
-3. For each containing repo: `git add` ONLY those specific files (never `git add -A` or `git add .`), commit, push.
-4. Never touch repos where you did not create or modify files in this invocation.
+A new client resolves the named project from projects/index.yaml, reads the
+durable tiers and linked plan, then treats Git status and diff as newer truth
+than cached prose. If a task was interrupted, it reconstructs the incomplete
+work from the attributed manifest and working tree rather than discarding it.
 
-### Why Point-of-Modification, Not Session-End
+### Explicit cross-machine handoff
 
-Context that exists only on one machine is invisible to the next session on a different machine. The entire point of structured context is cross-session continuity — uncommitted context breaks that guarantee.
+Before changing computers, invoke synthesis-mac-sync in remote-handoff mode.
+That workflow checks coordination, refreshes project tiers, publishes source
+repositories under their own branch and review policies, flushes exact private
+context paths, runs the doctor and conformance in remote mode, and verifies
+upstream equality. Day-end performs the same transition automatically.
 
-Deferring commits to session-end has three failure modes:
-1. **Session never ends cleanly.** Long-running conversations resume across days; a "session-end" hook may never fire.
-2. **Modified ritual modes skip the day-end checklist.** Mid-day syncs, vacation/observer catch-ups, and partial rituals update context without running the full day-end sequence. If commit is only in day-end, these updates never ship.
-3. **Multiple invocations compound uncommitted work.** By the time someone notices, there's a week of context changes stranded on one machine.
+On the destination computer, synchronize repositories first, verify no
+divergence or overlapping lease, then resume through the normal Session Start
+Protocol. Offline, behind, diverged, or policy-blocked state is not
+REMOTE_READY and must be reported explicitly.
 
-### Verification
+### Scope and index safety
 
-Use `synthesis-repo-guard` as a detector across the workspace (reports dirty repos) but NEVER as a committer. The commit step must be explicit and per-repo-scoped to this invocation's actual changes. See `synthesis-repo-guard` for session-end hook integration — that hook should alert and surface dirty repos, not blanket-commit them.
+Never run a workspace-wide commit over dirty files. Remote publication uses
+only session-attributed context paths. Source repos follow their own branch,
+review, and deployment policies. Before every commit, inspect status and the
+staged index; do not include another session's paths. Never bypass hooks.
+
+Use synthesis-repo-guard for local receipts and pending publication;
+synthesis-agent-conformance `continuity --readiness local|remote` for the two
+gates; and context_doctor with the matching readiness mode.

--- a/skills/synthesis-context-lifecycle/scripts/context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_doctor.py
@@ -28,10 +28,9 @@ Checks (see CHECKS for the registry):
                    completed projects carry completed_date
   freshness        index.yaml last_session and the CONTEXT.md "Last session"
                    header agree with the project's real git history
-  durability       no uncommitted context files; tier files are TRACKED by git,
-                   not merely clean; a remote and upstream exist and the branch
-                   is pushed, because context that exists on one machine is not
-                   durable context
+  durability       tier files are TRACKED by git; remote mode requires a clean,
+                   upstream-current branch; local mode reports recoverable
+                   uncommitted or ahead state as warnings
   disclosure       anything the doctor could not verify is reported, never
                    silently skipped: unreadable records and freshness that
                    cannot be established both surface as findings
@@ -40,6 +39,8 @@ Usage:
     context_doctor.py                    # audit every source in console.yaml
     context_doctor.py --source PATH ...  # audit explicit source roots
     context_doctor.py --project PATH     # audit one project directory
+    context_doctor.py --readiness local  # same-machine continuity posture
+    context_doctor.py --readiness remote # cross-machine publication posture
     context_doctor.py --json             # machine-readable report
     context_doctor.py --quiet            # exit code + one summary line
 
@@ -58,7 +59,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
 
-DOCTOR_VERSION = "1.2.2"
+DOCTOR_VERSION = "1.3.0"
 
 # Budgets from the tiered context architecture.
 CONTEXT_BUDGET_ACTIVE = 150
@@ -696,6 +697,7 @@ def audit_project(
     index_entry: dict | None,
     repo_root: Path,
     projects_root: Path,
+    readiness: str = "remote",
 ) -> ProjectAudit:
     audit = ProjectAudit(source=source.name, project_id=project_id, path=project_path)
 
@@ -856,10 +858,10 @@ def audit_project(
     if dirty:
         audit.add(
             "uncommitted-context",
-            "defect",
-            f"{len(dirty)} uncommitted file(s) under the project — context that "
-            "exists on one machine is not durable context",
-            "commit and push the project files",
+            "defect" if readiness == "remote" else "warning",
+            f"{len(dirty)} uncommitted file(s) under the project — same-machine "
+            "continuity is available, but this project is not REMOTE_READY",
+            "run the explicit remote-handoff sync before changing computers",
         )
 
     # A clean `git status` says nothing about a file git was never told to
@@ -893,7 +895,10 @@ def audit_project(
 
 
 def durability_findings(
-    source_name: str, repo_root: Path, projects_root: Path
+    source_name: str,
+    repo_root: Path,
+    projects_root: Path,
+    readiness: str = "remote",
 ) -> list[Finding]:
     """Repo-level durability, shared by whole-source and single-project runs.
 
@@ -910,7 +915,7 @@ def durability_findings(
                 project="(repository)",
                 source=source_name,
                 check="unpushed-context",
-                severity="defect",
+                severity="defect" if readiness == "remote" else "warning",
                 message=f"{count} commit(s) touching project context are not "
                 "pushed — another machine or agent cannot see this context yet",
                 remedy="push the branch",
@@ -923,7 +928,7 @@ def durability_findings(
                 project="(repository)",
                 source=source_name,
                 check="unpushed-context",
-                severity="defect",
+                severity="defect" if readiness == "remote" else "warning",
                 message=message,
                 remedy=remedy,
             )
@@ -938,7 +943,7 @@ def durability_findings(
                 project="(source)",
                 source=source_name,
                 check="uncommitted-context",
-                severity="defect",
+                severity="defect" if readiness == "remote" else "warning",
                 message="projects/index.yaml has uncommitted changes",
                 remedy="commit and push index.yaml",
             )
@@ -947,7 +952,9 @@ def durability_findings(
     return findings
 
 
-def audit_source(source: Source) -> tuple[list[ProjectAudit], list[Finding]]:
+def audit_source(
+    source: Source, readiness: str = "remote"
+) -> tuple[list[ProjectAudit], list[Finding]]:
     source_findings: list[Finding] = []
     projects_root = source.projects_root
 
@@ -1017,6 +1024,7 @@ def audit_source(source: Source) -> tuple[list[ProjectAudit], list[Finding]]:
                 index_by_id.get(child.name),
                 repo_root,
                 projects_root,
+                readiness,
             )
         )
 
@@ -1037,7 +1045,9 @@ def audit_source(source: Source) -> tuple[list[ProjectAudit], list[Finding]]:
             )
         )
 
-    source_findings.extend(durability_findings(source.name, repo_root, projects_root))
+    source_findings.extend(
+        durability_findings(source.name, repo_root, projects_root, readiness)
+    )
 
     return audits, source_findings
 
@@ -1118,6 +1128,15 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="exit non-zero on warnings too",
     )
+    parser.add_argument(
+        "--readiness",
+        choices=("local", "remote"),
+        default="remote",
+        help=(
+            "local accepts recoverable same-machine Git state as warnings; "
+            "remote requires committed and pushed context"
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -1153,17 +1172,20 @@ def main(argv: list[str] | None = None) -> int:
                     entry,
                     repo_root,
                     projects_root,
+                    args.readiness,
                 )
             )
             findings.extend(
-                durability_findings(source.name, repo_root, projects_root)
+                durability_findings(
+                    source.name, repo_root, projects_root, args.readiness
+                )
             )
             source_count = 1
         else:
             sources = discover_sources(args.source)
             source_count = len(sources)
             for source in sources:
-                src_audits, src_findings = audit_source(source)
+                src_audits, src_findings = audit_source(source, args.readiness)
                 audits.extend(src_audits)
                 findings.extend(src_findings)
 
@@ -1195,6 +1217,7 @@ def main(argv: list[str] | None = None) -> int:
     payload = {
         "ok": not failed,
         "doctor_version": DOCTOR_VERSION,
+        "readiness": args.readiness,
         "generated_at": datetime.now().astimezone().isoformat(timespec="seconds"),
         "sources": source_count,
         "projects_audited": len(audits),

--- a/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
@@ -345,6 +345,24 @@ class ContextDoctorTests(unittest.TestCase):
         )
         self.assertIn("uncommitted-context", checks_in(self.fx.audit()))
 
+    def test_local_readiness_reports_uncommitted_context_as_warning(self):
+        self.fx.project("alpha")
+        self.fx.index([{"id": "alpha", "status": "active"}])
+        self.fx.commit()
+        (self.fx.projects / "alpha" / "CONTEXT.md").write_text(
+            "# P\n\n**Status:** Active\n\nlocal handoff\n", encoding="utf-8"
+        )
+
+        result = self.fx.audit("--readiness", "local")
+
+        finding = next(
+            item
+            for item in result["data"]["findings"]
+            if item["check"] == "uncommitted-context"
+        )
+        self.assertEqual(finding["severity"], "warning")
+        self.assertEqual(result["code"], 0)
+
     # --- durability: the critical hole the refute panel found --------------
 
     def test_never_pushed_branch_is_a_defect(self):
@@ -374,6 +392,25 @@ class ContextDoctorTests(unittest.TestCase):
         )
         self.fx.commit(push=False)
         self.assertIn("unpushed-context", checks_in(self.fx.audit()))
+
+    def test_local_readiness_reports_ahead_context_as_warning(self):
+        self.fx.project("alpha")
+        self.fx.index([{"id": "alpha", "status": "active"}])
+        self.fx.commit()
+        (self.fx.projects / "alpha" / "CONTEXT.md").write_text(
+            "# P\n\n**Status:** Active\n\ncommitted locally\n", encoding="utf-8"
+        )
+        self.fx.commit(push=False)
+
+        result = self.fx.audit("--readiness", "local")
+
+        finding = next(
+            item
+            for item in result["data"]["findings"]
+            if item["check"] == "unpushed-context"
+        )
+        self.assertEqual(finding["severity"], "warning")
+        self.assertEqual(result["code"], 0)
 
     def test_gitignored_context_file_is_a_defect(self):
         self.fx.project("alpha")

--- a/skills/synthesis-daily-rituals/SKILL.md
+++ b/skills/synthesis-daily-rituals/SKILL.md
@@ -10,7 +10,7 @@ depends_on:
   - synthesis-checkpoint
 metadata:
   author: "Rajiv Pant"
-  version: "2.21.0"
+  version: "2.22.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -18,6 +18,17 @@ metadata:
 # Daily Rituals — Global Checklists
 
 Standard day-start and day-end rituals for synthesis engineering projects. These are the global (per-person) checklists. Each project may have a project-specific supplement that extends these with channel-specific sync, repo-specific checks, and stakeholder-specific communications.
+
+## v2.22.0 — Local continuity during the day; remote readiness at day-end
+
+Routine turns, day-start, and mid-day sync keep the filesystem-backed project
+record current and rely on session-attributed local receipts. They do not
+create Git commits or network pushes merely to switch Claude Code and Codex on
+one machine. Day-end is the batched cross-machine publication boundary: it
+publishes owned source work under repository policy, flushes exact private
+project-context paths, runs remote-mode doctor and conformance, and verifies
+remote heads. An interrupted task remains locally recoverable from its edit
+manifest even when Stop never ran.
 
 ## v2.21.0 — Inbox hygiene joins the morning sync, scoped to the seat
 
@@ -326,7 +337,7 @@ The LLM has no clock and its sense of "today" can drift across conversation gaps
 - [ ] Invoke the `synthesis-checkpoint` skill on any project whose cached state may be stale — it is the codified protocol for this verification.
 - [ ] **Protection-health check (v2.15.0):** run `python3 ~/.synthesis/git-hooks/_load_config.py --doctor`. It verifies the commit-boundary policy engine end to end: config parses, every pattern is valid for both `re` and `grep -E`, `core.hooksPath` is wired, the installed engine matches the skill source (drift detection), and the cwd repo's classification. **A protective control that nobody monitors is one that is quietly broken** — this check exists because a dependency failure once disabled scanning silently while commits kept passing. If the doctor reports UNHEALTHY, surface it in the brief as urgent and fix before any commit-bearing work; the v2 engine fails closed, so an unhealthy engine means commits will be blocked, not unprotected.
 - [ ] **Message-guard health check (v2.15.1):** run `python3 <synthesis-message-guard-root>/scripts/message_guard.py --doctor`. It verifies the pre-send correspondence gate end to end: patterns config parses, positive/negative scan controls pass, the PreToolUse wiring covers the send/draft tool family, and the state dir is writable. Same rationale as the git-hooks check above: a protective control that nobody monitors is quietly broken. The guard fails closed, so UNHEALTHY means sends will be blocked, not unprotected — fix before any correspondence work.
-- [ ] **Context-integrity check (v2.16.0):** run `python3 <synthesis-context-lifecycle-root>/scripts/context_doctor.py --quiet`. It audits every project in every configured source for the defects that break a cold resumption: missing tiers, budget overruns, an index.yaml status that disagrees with the project's own CONTEXT.md, `last_session` fields that git history contradicts, and uncommitted or unpushed context. Same rationale as the two guards above, applied to the layer they all rest on — the durable record is what lets another agent or another machine pick the work up, and until today it was the only protective layer whose health nobody could check. Exit 2 means the doctor could not establish ground truth; treat that exactly like an UNHEALTHY guard. Defects are not urgent in the way an unhealthy commit gate is, so surface the count in the brief and fix the active project's defects before working it.
+- [ ] **Context-integrity check (v2.16.0):** run `python3 <synthesis-context-lifecycle-root>/scripts/context_doctor.py --quiet --readiness local`. It audits every project in every configured source for the defects that break a cold resumption: missing tiers, budget overruns, an index.yaml status that disagrees with the project's own CONTEXT.md, `last_session` fields that git history contradicts, while surfacing uncommitted or unpushed context as local-only warnings. Same rationale as the two guards above, applied to the layer they all rest on — the durable record is what lets another agent or another machine pick the work up, and until today it was the only protective layer whose health nobody could check. Exit 2 means the doctor could not establish ground truth; treat that exactly like an UNHEALTHY guard. Defects are not urgent in the way an unhealthy commit gate is, so surface the count in the brief and fix the active project's defects before working it.
 - [ ] **Dual-client parity check (v2.18.0):** run `python3 <synthesis-agent-conformance-root>/scripts/conformance.py parity` (from the SOURCE checkout, or pass `--source-root <synthesis-skills repo>`). Filesystem-only and fast: it verifies the two source manifests agree, both clients have the plugin installed, both clients carry the SAME newest version, and that version matches source main. This is the daily layer of the dual-runtime guarantee — CI enforces source parity and the release protocol documents the dual refresh, but only this check notices the day a release reaches one client and not the other. Any FAIL is a drift that gets fixed in this step (refresh the stale marketplace/plugin), not noted for later.
 - [ ] **Day-end state read (v2.14.0):** read `~/.synthesis/day-end/state.json` and report the last day-end (date + mode) in the day plan's header or brief. If the most recent workday's day-end is missing, say so explicitly — visible skips are recoverable skips. Update `last_day_start` in the same file as part of this ritual.
 - [ ] **Weekly-review-owed check (v2.14.0):** if today is on/after the most recent Friday AND `last_weekly_review` predates that Friday, the Weekly Loose-Ends Review is owed — run the Day-End Step 10 scan in THIS session (either ritual direction, any mode) and update `last_weekly_review`. If a `synthesis-catchup-ledger` sweep already ran on/after that Friday, record its date instead of re-scanning — the ledger supersedes the review for its window.
@@ -765,7 +776,7 @@ The day-start checklist does a full sync. The user will ask for syncs repeatedly
 
 The key discipline encoded in that skill: **every sync must re-read ALL threads with replies from today**, not just fetch new channel-level messages. Thread replies don't appear as channel messages — skipping thread re-reads causes stale action plans and duplicate message sends.
 
-**Commit after every sync.** Any sync that creates or updates transcript files, daily plans, or context files must commit and push those changes in the same invocation. See the "Commit Protocol" section below. Do not defer to day-end — the day-end checklist may not run on a given day, and the value of the transcript is lost if it never reaches the remote.
+**Record after every sync.** Any sync that creates or updates transcripts, daily plans, or context files must leave session-attributed local state. Day-start and mid-day sync do not push merely to make same-machine client switching work; day-end and explicit remote handoff publish the batch.
 
 ---
 
@@ -773,7 +784,7 @@ The key discipline encoded in that skill: **every sync must re-read ALL threads 
 
 Use this variant when the user signals they are not actively working ("I'm on vacation", "observer mode", "just keeping up", "don't want to send messages"). Common phrasings: "do the modified ritual", "do what you did the last few days", "stay in observer mode".
 
-Observer mode is NOT a reduced-effort version of the day-start checklist. It is a specific pattern that combines sync + context + commit WITHOUT the active-work steps.
+Observer mode is a specific sync and context pattern. Its changes become LOCAL_READY immediately and REMOTE_READY at day-end or explicit remote handoff.
 
 ### Steps
 
@@ -787,7 +798,7 @@ Observer mode is NOT a reduced-effort version of the day-start checklist. It is 
    - DO include: "Things to Know for Return" section with 5-10 items
    - DO include: any decisions, incidents, product signals, or concerns that would be hard to catch up on later
 5. **Update CONTEXT.md** and session archive with the day's events. Follow the context lifecycle skill's archival protocol if needed.
-6. **Commit and push** all files touched in this invocation. See Commit Protocol below. Scope strictly to the repos where files were actually modified.
+6. **Record local handoff state** for files touched in this invocation. Publish them only in day-end or explicit remote-handoff mode.
 
 ### What Observer Mode Skips (Deliberately)
 
@@ -805,11 +816,12 @@ From the normal Day-End:
 - Transcript capture
 - Daily plan creation (in observer format)
 - CONTEXT.md + session archive updates
-- **Commit and push in the same invocation** — this is the most commonly missed step in modified rituals. Observer mode does not commit less than active mode; it commits exactly the same.
+- **Attributed local persistence** — observer mode records every changed file;
+  its batch reaches the remote at day-end or explicit remote handoff.
 
 ### Why This Is Codified
 
-When observer mode is reinvented per conversation ("do the thing you did yesterday"), the agent makes judgment calls about which steps matter. The commit step is the most often dropped because it feels like a day-end concern. This skill now states explicitly: commit-and-push is part of every observer-mode invocation, not a deferred step.
+When observer mode is reinvented per conversation, the agent often drops durable state. The rule is now explicit: every observer run leaves attributed local state, while day-end or remote-handoff mode owns publication.
 
 ---
 
@@ -839,6 +851,12 @@ The Weekly Loose-Ends Review (Step 10) attaches to whichever ritual runs first o
 ### 2. Source-Code Sync
 
 End-of-day code sync ensures local main/develop reflects everything that landed during the day and that tomorrow's day-start begins from a clean, current state. Run the same source-code sync as Day-Start Step 3a — same workspace repo list, same fetch + fast-forward semantics, same surfacing of divergence.
+
+- [ ] Read the pending repo-guard manifests first. For every recorded source
+  path owned by this ritual session, run its required tests, inspect the staged
+  index, commit only attributed paths, and push under the repository's branch,
+  review, and deployment policy. Do not mutate another active claim. Any path
+  that cannot be published keeps the affected project below `REMOTE_READY`.
 
 - [ ] For every repo the workspace manifest marks for sync (`<workspace>/.agents/repos.yaml` `ritual_sync: yes`; fallback: the `AGENTS.md` table's Yes rows — the complete set, no activity judgment; v2.12.1/v2.13.0): `git fetch --all`, then `git pull --ff-only` on each long-running branch (typically `main` and `develop`).
 - [ ] Surface any branches that are diverged or have local-only commits not yet pushed. These are decisions to make NOW, not at next day-start, so the agent can act on them while context is fresh.
@@ -905,10 +923,7 @@ may be wrong by hours or days. Re-anchor before writing.
 - [ ] Update CONTEXT.md with day's progress and new state. Refresh the "Last session" field with today's verified date. Update "Recent Sessions" with a one-line summary.
 - [ ] Update MEMORY.md if current state info is stale (version numbers, environment status, team assignments).
 - [ ] Update `last_session` date in `index.yaml` for each active project worked on today — use today's verified date.
-- [ ] **Active-project context gate (v2.18.0, fail-closed):** run `python3 <synthesis-context-lifecycle-root>/scripts/context_doctor.py --project <active-project-path>` for EACH project worked today. Defects BLOCK this step: the session that made the record defective is the session that can fix it in minutes, so fix and re-run to clean before continuing. Do not close the day with a defective active-project record — an unfixed defect re-surfaces at every subsequent SessionStart until repaired, so skipping the gate saves nothing. (Corpus-wide findings from the day-start run stay report-only; this gate is scoped to the projects this session actually touched.)
-- [ ] Commit context changes per the Commit Protocol below — separate commit per logical group (project context updates, lessons learned, etc.). Use `git add <specific-files>`, NOT `git add -A`.
-- [ ] **Push and verify.** Run `git push` for each modified repo, then run `git log origin/main..HEAD` to confirm the local HEAD reached origin. If the output is non-empty, the push did not land — investigate (network failure, branch protection rule, merge conflict) and re-push. Do NOT assume "git push said success" means the commits are durable on the remote.
-- [ ] Push updates to any shared ai-knowledge repos if modified. Same push-verify step applies.
+- [ ] **Local context gate:** run context_doctor.py --project <active-project-path> --readiness local for every project worked today. Structural defects block; expected local-only Git state remains visible.
 - [ ] **Write the day-end state (v2.14.0):** update `~/.synthesis/day-end/state.json` (atomic temp+rename) and append one line to `~/.synthesis/day-end/history.jsonl` — date, ritual direction, mode, outcome, and the send-or-release counts. Every mode writes state, observer included; day-start rituals update their own fields the same way.
 
 ### 8. Skills Maintenance
@@ -961,55 +976,42 @@ This step exists because work falls through the cracks during a week. A missed c
 - [ ] Add a `## Weekly Loose-Ends Review` section to today's (Friday's) daily plan. Structure: scan summary at top (count of items by classification + per-source breakdown), then the explicit STILL RELEVANT list (these are what Monday picks up), then OBSOLETE-with-reason list (audit trail), then AMBIGUOUS list (decision queue for the user).
 - [ ] If items in STILL RELEVANT need to be tracked across the weekend, populate today's daily plan `## Carried Items` section. (Monday's plan, when created, will pull from there as part of normal day-start.)
 - [ ] Annotate OBSOLETE items in their ORIGINAL source files (not in this review section) so they get marked once and stay marked.
-- [ ] Commit + push the daily plan and any annotated source files per the Commit Protocol below.
+- [ ] Leave every changed plan and annotation session-attributed; Step 11 publishes the final day-end batch.
 
 **Failure mode to avoid:** writing a `## Weekly Loose-Ends Review` section header without actually scanning the sources. The value is in the scan. If sources have not been read in this invocation, do not write the section — note "Weekly Loose-Ends Review skipped — scan not performed this invocation" in the plan and surface the gap to the user.
 
 **Idempotency:** if a Friday review was missed and the agent runs this step on a later weekday, the scan still works because it's date-bounded (past 14 calendar days from today), not weekday-bounded. The Friday-default is about WHEN it normally fires; the scan output is meaningful on any day.
 
-### 11. Repo Guard — Final Verification
+### 11. Remote Readiness and Final Verification
 
-**This step is mandatory and must be the last step before ending any session.**
+**This step is mandatory and is the final mutating day-end step.**
 
-- [ ] Run `repo_sync_check.py` (from `synthesis-repo-guard` skill) across the full workspace.
-- [ ] If ANY repos are dirty or unpushed, resolve them before ending: commit and push, or explicitly decide to discard.
-- [ ] Zero untracked files, zero uncommitted changes, zero unpushed commits. No exceptions.
+- [ ] Re-read the lease-backed coordination board. Do not mutate paths held by another active session; report them as active local work rather than defects in this ritual.
+- [ ] Publish every pending source path owned by this ritual under its repository policy. Inspect status and the staged index before each exact-path commit; run required tests and normal hooks.
+- [ ] Run `checkpoint_sync.py --flush-pending`. Any retained relevant manifest blocks day-end remote readiness.
+- [ ] For every project worked today, run `context_doctor.py --project <path> --readiness remote` and `conformance.py continuity --project <path> --readiness remote`. Require PASS.
+- [ ] Run `repo_sync_check.py` across the full workspace. Every path owned by this ritual must be clean and upstream-current. Dirty state protected by another active coordination claim is reported and left untouched.
+- [ ] Verify intended remote heads independently. Record `REMOTE_READY` in day-end state only when the project gates pass; otherwise record `blocked` with the local recovery state intact.
 
-This is not the same as steps 7-9. Those steps commit specific known changes. This step is the **verification gate** that catches anything those steps missed — files from earlier in the session, changes in repos you forgot about, installed skill copies that were changed without source updates. The gate must pass before the session ends.
+This gate distinguishes incomplete publication from legitimate parallel work. It never sweeps another session, discards local changes, bypasses hooks, or turns a local-only pass into a cross-machine claim.
 
 ---
 
-## Commit Protocol — Apply to Every Ritual Invocation
+## Ritual Persistence Protocol
 
-Every ritual invocation — day-start, mid-day sync, day-end, or observer mode — must commit and push any context, transcript, plan, or reference files it modifies. This is not deferred; it happens at the point of modification.
+Day-start, mid-day sync, and observer mode leave their writes session-attributed and locally recoverable. They do not commit or push merely to preserve same-machine continuity. Day-end and explicit remote-handoff mode publish the batch.
 
-### Scope Rule: Only Commit Repos Touched in This Invocation
+### Local mode
 
-This is a hard rule to prevent unintended commits of unrelated work:
+Track every file this invocation changes. Update project tiers before a natural pause and release or narrow coordination claims. PostToolUse manifests and Stop receipts provide automatic local continuity; an interrupted run remains recoverable from its manifest plus Git status and diff.
 
-1. **Track** which files this invocation created or modified. The agent's own action history is the source of truth — do not infer scope from `git status`, which may include unrelated work in progress.
-2. **Group** those files by their containing repo.
-3. **For each repo touched:** `git add <specific files>` (never `git add -A`, never `git add .`), then commit, then push.
-4. **Never touch** repos where this invocation did not create or modify files, even if they are dirty. That work belongs to another session.
+### Remote mode
 
-**Example:** A daily ritual for Project A updates `projects/project-a/CONTEXT.md` and creates `daily-plans/YYYY-MM-DD.md`. If the user also has uncommitted work in `projects/project-b/` from a different session, the ritual does NOT commit that. Only the files this invocation touched.
+Publish source paths first under each repository branch, review, test, and deployment policy. Then flush exact private-context paths through synthesis-repo-guard. Before each source commit, inspect the full staged index and include only attributed paths. Never use broad staging, never touch another active claim, and never bypass hooks.
 
-### Pre-Commit Hook Failures
+Commit messages follow the global hygiene rule: generic in public and private repositories, with no sensitive names, titles, rationale, or prior values. Git history is not a session transcript.
 
-If a pre-commit hook flags sensitive content:
-- If the destination repo is PRIVATE and the content is intentional (shared reference docs, meeting transcripts, strategic planning copies), use `git commit --no-verify` only after confirming with the user.
-- If the destination repo is PUBLIC, stop. Sanitize the content or exclude the file. Never bypass hooks to push sensitive content to a public repo.
-- If the content is unexpectedly sensitive (credentials, tokens, personal data leaked into a config), investigate before deciding. Do not commit.
-
-### Commit Message Standards
-
-- Reflect the actual changes ("Project week N: context, daily plans, transcripts") not generic filler ("Update files").
-- For private repos, be specific. For public repos, use generic messages that don't reveal restricted names, article titles, or client-specific details.
-- Include `Co-Authored-By` trailer when appropriate.
-
-### Verification Is Separate from Commit
-
-`synthesis-repo-guard` is a **detector** across the workspace — it reports dirty repos. It is NOT a committer. Use it as a final verification gate at session end to catch anything missed, not as the primary commit mechanism.
+Remote publication is complete only when remote-mode context doctor and continuity conformance pass, intended remote heads are verified, and no relevant pending manifest remains.
 
 ---
 

--- a/skills/synthesis-mac-sync/SKILL.md
+++ b/skills/synthesis-mac-sync/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.0.0"
+  version: "2.1.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -150,14 +150,25 @@ For `owner-only` repos:
 - If any non-owner remote exists, abort with an error and alert the user
 - These repos exist per ADR-013 (workspace-private repos); the `-private` suffix is also a discovery protocol filter (ADR-014)
 
-### Session-End Check
+### Local session end and remote handoff
 
-Every AI coding session should end with all repos committed and pushed. Use `synthesis-repo-guard` to verify — and, since its v2.0.0, to self-heal: `checkpoint_sync.py` auto-commits+pushes the configured private context-repo class at workflow events (agent turn end, console writes), so mac-sync's day-boundary sweep normally finds those repos already clean.
+Ordinary Claude Code and Codex turn boundaries target LOCAL_READY, not a remote push. Synthesis-repo-guard records session-attributed edit manifests and Stop receipts without changing Git. Same-machine switching therefore needs no commit or network call.
 
-- If repo-guard reports clean: session can end safely.
-- If repo-guard reports dirty: the detail is in `~/.synthesis/repo-guard/last-report.txt` and the synthesis-console `/sync` page (audible/banner alerts are deliberately generic — counts only, never repo or client names). Commit and push per the report, or run a full mac-sync.
+- If repo-guard reports local state: another client on this machine can recover it.
+- If repo-guard reports unattributed or unsafe state: inspect the detailed report and repair the local handoff before switching clients.
 
-Configure repo-guard hooks per the `synthesis-repo-guard` skill (Claude Code, Codex, Cursor, synthesis-console). Mac-sync remains the full multi-machine operation and the sweep for out-of-class repos (source code, public repos) that checkpoint automation deliberately never touches.
+Configure repo-guard hooks per the synthesis-repo-guard skill. Mac-sync owns cross-machine publication and source-repository policy; repo-guard owns attribution, local receipts, and exact private-context publication.
+
+#### Remote-handoff mode
+
+Invoke this mode before changing computers. It refreshes the coordination lease, updates project tiers from working-tree truth, reads pending manifests, publishes owned source paths under each repository policy, flushes exact private-context paths, and verifies remote readiness. Source paths that are dirty, ahead, behind, detached, or lack an upstream keep the handoff blocked. A pr-required repository remains gated by its review policy.
+
+Run remote-mode context doctor and continuity conformance for every project being transferred, then run the full repo detector and verify intended remote heads. Report REMOTE_READY only when no relevant pending manifest remains. Day-end performs this same transition automatically. The destination computer runs the pull side first, verifies fast-forward state and lease ownership, then uses the normal Session Start Protocol.
+
+The source-machine gate runs the checkpoint flush, context doctor with
+readiness `remote`, and continuity conformance with readiness `remote`, in that
+order after source repositories are published. The destination repeats remote
+continuity after fetching and fast-forwarding.
 
 ---
 
@@ -292,8 +303,12 @@ Only proceed with the pull operation when the placeholder list is empty. If the 
 
 When drafting a one-time action that involves running mac-sync on a different Mac (e.g., "the second Mac should now pull what the first Mac just pushed"):
 
-1. **On the source Mac, BEFORE drafting the handoff prompt:** run `brctl monitor --wait-uploaded -t 300 "$ICLOUD_BASE"` and confirm upload complete. Only then is it safe to send the prompt.
-2. **In the handoff prompt itself:** include the download trigger + placeholder poll above as the FIRST step on the destination Mac, before any pull operation.
+1. **On the source Mac:** complete remote-handoff mode and obtain
+   `REMOTE_READY` for the project and its repositories.
+2. **Before drafting the handoff prompt:** run `brctl monitor --wait-uploaded -t 300 "$ICLOUD_BASE"` and confirm upload complete.
+3. **In the handoff prompt itself:** include the download trigger and
+   placeholder poll as the first destination step, then fetch, fast-forward,
+   and run remote continuity before project work resumes.
 
 These two together close the two-stage gap.
 
@@ -422,7 +437,7 @@ Maintain a **manifest file** (`git-repos.yaml`) that caches discovered repos, th
 
 1. **ALWAYS fetch first** — run `git fetch origin` before checking any status
 2. **NEVER force push** — always use regular `git push`
-3. **NEVER silently auto-commit** — always show uncommitted files and ask before committing. Uncommitted changes are unsynced state; ignoring them defeats the purpose of the sync. Group files into separate commits by topic — never bundle unrelated files
+3. **Never sweep uncommitted work** — ordinary sync reports dirty files. In explicit remote-handoff or day-end mode, commit only session-attributed paths authorized by the repository workflow. Exact private-context batching uses synthesis-repo-guard. Unattributed, overlapping, or policy-gated paths block REMOTE_READY.
 4. **NEVER bypass hooks without explicit permission** — if a pre-commit hook blocks a commit, STOP and ask the user. Never use `--no-verify` on your own. If the user approves bypassing for a specific commit, that approval does not extend to other commits
 5. **Sanitize ALL commit messages** — never include people's names, company names, project codenames, article titles, or meeting topics in commit messages. Use generic descriptions like "Add meeting transcript", "Update context", "Add new blog post". Git history is persistent and can leak confidential information
 6. **Push automatically if ahead** — if working tree is clean and repo is ahead, push without asking

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.9.0"
+  version: "2.1.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -248,7 +248,7 @@ Rules: record `model`/`effort` only when the current session or the user explici
 ### During Work
 
 ```
-Complete task → Update CONTEXT.md → Commit → Next task
+Complete task → Update CONTEXT.md → local receipt → Next task
 ```
 
 **NOT:**
@@ -274,7 +274,9 @@ Complete task → Complete task → Complete task → (context compaction) → L
 2. **Archive if needed** — Move old sessions to sessions/, stable facts to REFERENCE.md
 3. **Attribute if warranted** — If multiple agents/models contributed materially, end the session-log entry with Attribution line(s) (see Agent Attribution)
 4. **Update index.yaml** — Set `last_session` date
-5. **Commit all changes** — Do not leave uncommitted work
+5. **Verify local continuity** — Confirm session-attributed state is readable;
+   do not create a commit or network push solely because the user is switching
+   clients on this machine
 6. **Release coordination claims** — Mark the session released or narrow its
    claims before pausing or ending
 
@@ -386,14 +388,17 @@ bootstrap/retirement, and worktree-retirement details.
 
 ### Cross-Agent Handoff
 
-Before pausing work that may continue in another tool:
+Before pausing work that may continue in another tool, the outgoing agent runs
+this protocol automatically. Rajiv does not invoke lifecycle commands or save
+state by hand:
 
 1. Update `CONTEXT.md` with current state, decisions, and next actions
 2. Move stable facts into `REFERENCE.md`
 3. Append chronological detail to `sessions/YYYY-MM.md`
 4. End the session-log entry with an Attribution line for the departing agent (see Agent Attribution) — the receiving agent should know who did what, with what verification
 5. Save substantial plans, audits, or checklists under `resources/artifacts/`
-6. Commit and push the project-management changes
+6. Verify `LOCAL_READY` or `LOCAL_RECOVERABLE`; a same-machine client switch
+   does not require a commit, push, or manual lifecycle command
 7. If `synthesis-agent-conformance` is installed, activate and verify the
    project:
 
@@ -401,17 +406,36 @@ Before pausing work that may continue in another tool:
    python3 <skill-root>/scripts/conformance.py activate \
      --project <project> --session-id <coordination-session-id>
    python3 <skill-root>/scripts/conformance.py pointer --project <project>
-   python3 <skill-root>/scripts/conformance.py handoff --project <project>
+   python3 <skill-root>/scripts/conformance.py continuity \
+     --project <project> --readiness local
    ```
-8. Release or transfer this session's coordination claims. A normal release
+8. When changing computers, run `synthesis-mac-sync` remote-handoff mode, then
+   verify `continuity --readiness remote`. Day-end performs the same transition.
+9. Release or transfer this session's coordination claims. A normal release
    recoverably moves an active-project pointer owned by that session into
    `~/.synthesis/active-project-history/`; a pointer owned by another session is
    untouched.
 
-When resuming work from another agent, re-run `handoff`, read CONTEXT.md and
-the linked plan, and verify git history before acting. Trust the project files
-over tool-specific memory. The continuity source of truth is the synthesis
-project context, not the previous assistant's chat transcript.
+When resuming work from another agent, resolve the named project through the
+git-tracked `projects/index.yaml`, run local continuity for a stopped project,
+read CONTEXT.md and the linked plan, and inspect Git status and diff before
+acting. Working-tree truth supersedes cached project prose after an interrupted
+task. This is automatic agent work, not a prerequisite Rajiv performs. The
+continuity source of truth is the filesystem-backed synthesis record, not the
+previous assistant's chat transcript.
+
+The pointer is a leased acceleration cache for a live context owner. Claim
+release archives it recoverably, so its absence after a clean stop is expected.
+Never replace it with one git-tracked global "current project" value: parallel
+Claude Code and Codex sessions can legitimately work different projects. A
+stopped task resumes by named-project registry resolution; a task opened inside
+the project directory can also be discovered from its durable file structure.
+
+Cross-computer recovery adds two preconditions: the source machine must reach
+`REMOTE_READY` through synthesis-mac-sync or day-end, and the destination must
+fetch and fast-forward before Session Start. Offline, divergent, behind,
+unpublished, or overlapping-claim states are reported explicitly and are not
+remote-continuity passes.
 
 ### Parallel Sub-Agent Dispatch
 

--- a/skills/synthesis-project-management/references/parallel-agent-protocol.md
+++ b/skills/synthesis-project-management/references/parallel-agent-protocol.md
@@ -23,9 +23,10 @@ machine:
    directory creates a worktree of the wrong repository).
 4. **Work.** Heartbeat at checkpoints; keep the plan file current at phase
    boundaries — it is the artifact that survives a crash (see "Digests").
-5. **Close.** Commit and push durable state, message affected sessions,
-   release the claim, and retire merged worktrees with
-   `retire_worktree.py`, never by hand.
+5. **Close.** Update durable project tiers, create the local handoff receipt,
+   message affected sessions, release the claim, and retire merged worktrees
+   with `retire_worktree.py`, never by hand. Publish the attributed batch
+   only for explicit remote handoff or day-end.
 
 ## Digests — what survives a crash
 
@@ -49,7 +50,7 @@ Different projects may run at the same time. Each session:
 3. uses an isolated worktree when another live session touches the same
    repository;
 4. heartbeats at checkpoints; and
-5. commits project state and releases its claims before pausing.
+5. updates project state, leaves attributed local evidence, and releases its claims before pausing; remote publication belongs to explicit handoff or day-end.
 
 Claims remain resource-based. Two different synthesis projects can still
 conflict when they edit the same repository or home configuration, so project

--- a/skills/synthesis-repo-guard/SKILL.md
+++ b/skills/synthesis-repo-guard/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: synthesis-repo-guard
-description: "Workspace git-sync guard: detects uncommitted/unpushed repos, reports through confidentiality-safe channels (generic audio/banner + detailed report files + synthesis-console tile), and auto-heals private context repos at workflow events via checkpoint_sync.py. Works with any AI coding tool (Claude Code, Codex, Cursor, etc.) or standalone. Use when asked to: repo guard, check repos, session end check, sync check, repo status, workspace status, checkpoint sync, auto-commit context repos."
+description: "Workspace git-sync guard: detects unsynced repos, records session-attributed local handoff receipts, and batches private project-context commits for explicit remote handoff or day-end. Reports through confidentiality-safe channels."
 license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.0.0"
+  version: "2.1.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -14,7 +14,7 @@ metadata:
 
 ## The Problem
 
-AI coding assistants and project-management tooling create and modify files continuously. When a session ends — completion, timeout, closed window — uncommitted or unpushed changes are stranded on that machine, breaking the multi-machine sync chain. Tools that write files *outside* agent sessions (a project console writing status markers, manual edits) never commit at all.
+AI coding assistants and project-management tooling create and modify files continuously. A stopped task needs lightweight same-machine recovery immediately, while another computer needs a deliberate publication boundary. Treating both cases as an automatic commit creates noisy history and network latency; treating neither creates invisible local-only state. Tools that write files *outside* agent sessions (a project console writing status markers, manual edits) need the same attribution contract.
 
 v1 of this skill detected stranded state and alerted with a count ("N repositories have unsynced changes"). Two failures emerged in practice:
 
@@ -27,9 +27,11 @@ v1 of this skill detected stranded state and alerted with a count ("N repositori
 |-------|-----------|-----|
 | Detector | `repo_sync_check.py` (scan) | Find dirty / ahead / behind / detached repos under a workspace root |
 | Messenger | `repo_sync_check.py` (output) | Generic audio/banner ping + detailed report files + console tile data |
-| Remediator | `checkpoint_sync.py` | Auto-commit + push the configured private context-repo class at workflow events |
+| Checkpointer | `checkpoint_sync.py` | Record local handoffs; batch exact context paths at explicit remote-sync events |
 
-End state: routine changes are checkpointed silently, an always-on synthesis-console tile shows ambient status, and audible/banner alerts fire only for states automation cannot heal (blocked pre-commit hook, divergence, out-of-class dirt, stale lock) — rare, and always actionable.
+End state: same-computer client switching is filesystem-local and fast.
+Cross-computer publication is batched and explicit. The synthesis-console shows
+ambient status, and alerts remain rare and actionable.
 
 ## Confidentiality rule for alert surfaces (ABSOLUTE)
 
@@ -45,36 +47,53 @@ End state: routine changes are checkpointed silently, an always-on synthesis-con
 
 `repo_sync_check.py` **detects and never modifies** — correct scope: every repo in the workspace.
 
-Commits happen in exactly two sanctioned ways:
+There are two separate readiness transitions:
 
-1. **Per-invocation agent commits** (unchanged rule): an agent commits only the files IT modified in the current invocation — never workspace-wide, never other sessions' work. See `synthesis-daily-rituals` "Commit Protocol".
-2. **`checkpoint_sync.py`** — the deliberate, narrowly-scoped exception: it auto-commits repos in the configured **auto-sync class only** (private, single-writer context repos whose history is an operational log), protected by a runtime guard (below). Source-code repos and shared/public repos are structurally out of reach.
+1. **Local handoff:** PostToolUse records structured edits by one client session; paired shell snapshots add net-new formatter, generator, and bulk-rewrite output without claiming unchanged pre-existing dirty paths. Stop writes an atomic receipt with branch, HEAD, file state, and content hashes. It performs no Git commit and no network call. If the client is interrupted before Stop, the pending manifest makes the work LOCAL_RECOVERABLE on the same filesystem.
+2. **Remote handoff:** the flush-pending command batches only private project-context paths into exact-path commits. Source paths remain owned by their repository workflow and must already be clean and equal to their upstream before manifests retire.
 
-## The remediator: event-driven, never scheduled
+## The checkpointer: local by default, remote by explicit event
 
-`checkpoint_sync.py` runs ONLY at workflow events — moments when the user is demonstrably present and the machine awake:
+`checkpoint_sync.py` runs at workflow events:
 
-- **AI-tool turn/session end** (throttled via stamp file, default 10 min): catches agent sessions — and manual edits too, since sessions are usually live.
-- **After a console cockpit write:** the console calls `checkpoint_sync.py --repo <written-file> --now`, so producers own their commits through the one shared mechanism.
-- **Rituals / mac-sync:** the existing day-boundary sweeps.
+- **AI-tool Stop:** writes a local receipt for that client session. A Stop
+  with no attributed repository changes is a cheap no-op.
+- **After a console cockpit write:** `--repo <written-file> --now` records
+  a local producer manifest and receipt.
+- **Day-end / mac-sync:** `--flush-pending` publishes exact private-context
+  paths after the owning workflows publish any source paths.
 
-**Deliberately NOT a launchd/cron job.** Wall-clock daemons run detached from presence: they race the same repos across machines and create close-the-lid anxiety. Event-driven runs execute on the origin machine seconds after the change — which also shrinks multi-machine divergence windows, because work is pushed before you switch machines. (Read-only polling — the console tile refreshing — is exempt: interrupting a read is harmless.)
+**Deliberately not a launchd or cron job.** Wall-clock mutation can race
+repositories across machines. Local receipts follow edit events; remote
+mutation occurs only when the user invokes cross-machine sync or as part of
+day-end. Read-only console polling remains safe.
 
 ### The auto-sync class + runtime guard
 
-Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`) lists the class by explicit path and glob. Membership criteria: private, single-writer knowledge/context repos (personal ai-knowledge repos, `*-<person>-private` workspace repos, daily plans). Never source-code repos, never shared/public repos.
+Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`) lists the class by explicit path and glob. Membership criteria: private knowledge/context repos (personal ai-knowledge repos, `*-<person>-private` workspace repos, daily plans). A configured checkout's isolated git worktrees inherit membership through their shared git-common-dir identity. Never source-code repos, never shared/public repos.
 
 **The runtime remote guard is independent of config:** a repo is touched only if EVERY push remote starts with an allowed prefix (your private GitHub namespace). A glob that accidentally matches a repo with a client/org remote is excluded at run time, every time — config declares intent; the guard verifies reality. Empty `allowed_remote_prefixes` fails closed.
 
 ### Safety properties
 
-- Ordering: `add -A` → `commit` → `fetch` → push **only if fast-forward**.
-- Distinct commit author (e.g. "Synthesis Checkpoint") — automated checkpoints are always distinguishable from curated commits.
-- Divergence → the commit stays local (durable, resolvable) + alert. Never rebase, never force-push.
-- Pre-commit hooks run normally; a rejection aborts that repo with an alert. **Never `--no-verify`.**
-- Quiescence: skip repos with files modified in the last N minutes (default 15) — no mid-thought commits. `--now` bypasses this for producer writes that are known-complete.
-- Stale `index.lock` (>10 min): reported, never deleted.
-- Interruption-safe by construction: runs at interactive moments; an interrupted git op doesn't corrupt a repo (killed pushes are retryable; sleep suspends rather than kills).
+- Stop never commits, pushes, fetches, stages, or changes branches.
+- Shell attribution compares pre/post Git state and fails closed when its
+  pre-tool snapshot is absent, unsafe, or belongs to another session.
+- Remote publication orders exact-path context commit, fetch, then
+  fast-forward push. Existing staged or dirty files outside the manifest
+  remain untouched.
+- A distinct commit author identifies batched remote-context commits.
+- Divergence leaves the exact commit and manifest local and reports the
+  block. Never rebase or force-push.
+- Pre-commit hooks run normally. Never bypass them.
+- Source paths and remotely publishable context paths are distinct fields
+  in each client-session manifest.
+- A first commit on a feature branch publishes that exact branch with an
+  upstream.
+- Active and stale Git index locks are reported and never deleted.
+- A successful edit leaves a manifest even if Stop never runs. Remote
+  publication retains manifests until source and context paths are verified
+  upstream-current.
 
 ---
 
@@ -90,21 +109,24 @@ Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`)
 # Generic attention ping if dirty (mute-aware)
 ./repo_sync_check.py --speak --notify --dirty-only
 
-# What would the checkpoint do right now?
+# Preview pending remote publication
 ./checkpoint_sync.py --dry-run
 
-# Throttled sweep (what the turn-end hook runs)
+# Record a same-machine Stop receipt
 ./checkpoint_sync.py --hook --quiet --notify
 
-# Producer mode: checkpoint the repo containing a just-written file
+# Record a just-written producer file locally
 ./checkpoint_sync.py --repo ~/workspaces/example/daily-plans/today.md --now
+
+# Publish pending project context after source repos are upstream-current
+./checkpoint_sync.py --flush-pending
 ```
 
 ### Exit codes (both scripts)
 
 | Code | repo_sync_check.py | checkpoint_sync.py |
 |------|--------------------|--------------------|
-| 0 | all clean & synced | nothing needed / all healed |
+| 0 | all clean & synced | requested readiness reached |
 | 1 | repos need attention | alerts raised (detail in state file) |
 | 2 | error | error |
 
@@ -124,7 +146,8 @@ Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`)
 
 ### Claude Code (`~/.claude/settings.json`)
 
-Turn-end remediation (throttled — cheap no-op most turns) plus optional session-end verification:
+Turn-end remediation of the current session's attributed context paths plus
+optional session-end verification:
 
 ```json
 {
@@ -151,7 +174,9 @@ Turn-end remediation (throttled — cheap no-op most turns) plus optional sessio
   "timeout": 120 } ] } ] } }
 ```
 
-The throttle stamp is shared across tools — multiple agents coexist without duplicate runs.
+Each client session has its own hashed pending manifest under
+`~/.synthesis/repo-guard/pending/`. Multiple agents can therefore coexist
+without one hook committing, publishing, or overwriting another session's files.
 
 ### Cursor (`.cursor/settings.json`)
 
@@ -163,8 +188,8 @@ The throttle stamp is shared across tools — multiple agents coexist without du
 
 - **Always-on sync tile:** polls `repo_sync_check.py --json --quiet` (read-only; lid-safe) and renders `checkpoint-state.json` outcomes.
 - **Quiet-audio toggle button:** creates/removes `~/.synthesis/quiet-audio`.
-- **"Sync now" button:** `checkpoint_sync.py --no-throttle` (throttle bypassed; quiescence still honored).
-- **Producer commits:** after writing a plan marker, the console fires `checkpoint_sync.py --repo <file> --now`.
+- **"Sync now" button:** `checkpoint_sync.py --no-throttle`, an explicit remote-context handoff alias.
+- **Producer receipts:** after writing a plan marker, the console records local state with `--repo <file> --now`.
 
 ### Scheduled execution — read-only only
 
@@ -174,8 +199,8 @@ If a tool supports no hooks at all, a scheduled **detector** run (`repo_sync_che
 
 ## Relationship to Other Skills
 
-- **synthesis-mac-sync** — the full multi-machine sync operation (config files, credentials, all repos, with user approval). Repo-guard keeps context repos continuously clean so mac-sync's day-boundary sweep mostly finds nothing; run mac-sync when the report shows out-of-class problems or when switching machines.
-- **synthesis-context-lifecycle / synthesis-daily-rituals** — those skills commit their own changes at the point of modification (the primary mechanism). checkpoint_sync is the safety net beneath them; `repo_sync_check.py` is the final verification gate at day-end.
+- **synthesis-mac-sync** — the full multi-machine sync operation (config files, credentials, all repos, with user approval). Repo-guard keeps same-machine work recoverable; mac-sync owns the explicit cross-machine publication transition.
+- **synthesis-context-lifecycle / synthesis-daily-rituals** — those skills keep local project state current during work and publish it through remote handoff or day-end. `repo_sync_check.py` is the final day-end verification gate.
 
 ---
 
@@ -187,13 +212,16 @@ repo_sync_check.py [--workspace W] [--max-depth N] [--quiet] [--json]
                    [--report-dir D] [--no-report]
 
 checkpoint_sync.py [--config C] [--repo PATH] [--hook] [--now]
-                   [--no-throttle] [--dry-run] [--quiet] [--json]
+                   [--flush-pending] [--no-throttle] [--dry-run]
+                   [--quiet] [--json]
                    [--speak] [--notify]
 ```
 
 - `--speak/--notify/--alert` are generic + mute-aware on both scripts.
-- `checkpoint_sync --repo` accepts any path inside a repo (resolved via `git rev-parse --show-toplevel`).
-- `--hook` honors the shared throttle; `--now` bypasses throttle + quiescence (producer mode); `--no-throttle` bypasses throttle only (manual button).
+- `checkpoint_sync --repo` records one configured producer path locally; it does not commit or use the network.
+- `--hook` consumes the calling session's JSON hook payload and never falls
+  back to a workspace-wide mutation. `--flush-pending` is the explicit
+  remote-context transition; `--no-throttle` is its console compatibility alias.
 
 ---
 
@@ -201,13 +229,14 @@ checkpoint_sync.py [--config C] [--repo PATH] [--hook] [--now]
 
 1. **Zero AI and zero external dependencies** — Python stdlib + git CLI (PyYAML used if present, minimal built-in parser otherwise)
 2. **LLM-agnostic** — same scripts for Claude Code, Codex, Cursor, console, or manual use
-3. **Detector never modifies; remediator modifies only the guarded auto-sync class**
+3. **Detector never modifies; Stop is local-only; remote publication modifies only exact guarded context paths**
 4. **Identifying names (repo, workspace, client) never on audio/banner surfaces** — counts and pointers only
-5. **Mutation is event-driven; only reads may poll**
+5. **Remote mutation is explicit or day-end; only reads may poll**
 6. **Fail closed, never force** — empty guard config disables; divergence/hook-failures stop and alert
 7. **Composable** — exit codes, JSON output, shared state files
 
 ## Changelog
 
+- **2.1.0 (2026-08-14):** separates LOCAL_READY and REMOTE_READY. Stop records atomic client-session receipts without Git or network mutation; interruption leaves a recoverable manifest; explicit remote handoff batches exact private-context paths only after source paths are upstream-current. Adds worktree identity, first-branch publication, generic commit messages, staged-index isolation, and integration fixtures.
 - **2.0.0 (2026-07-08):** three-layer redesign. Generic-only audio/banner (confidentiality rule), `~/.synthesis/quiet-audio` mute flag, report files + history, remediation hints, new `checkpoint_sync.py` (event-driven auto-commit/push: runtime remote guard, quiescence, shared throttle, ff-only push, distinct author, stale-lock detection), synthesis-console integration contract, scheduled-mutation explicitly disallowed. Origin: 2026-07-08 design review (lesson: alert-channel confidentiality + event-driven checkpoints).
 - **1.1.0:** detector + count-only audio alerts.

--- a/skills/synthesis-repo-guard/checkpoint-sync.example.yaml
+++ b/skills/synthesis-repo-guard/checkpoint-sync.example.yaml
@@ -1,9 +1,10 @@
 # checkpoint-sync.example.yaml — copy to ~/.synthesis/checkpoint-sync.yaml and edit.
 #
-# Defines the AUTO-SYNC CLASS: private context repos that checkpoint_sync.py may
-# auto-commit and push at workflow events (agent turn end, console cockpit writes,
-# rituals, mac-sync). Keep this to single-writer knowledge/context repos whose git
-# history is an operational log. NEVER list source-code repos or shared/public repos.
+# Defines the REMOTE-PUBLICATION CLASS: private context repos whose exact
+# session-attributed context paths checkpoint_sync.py may commit and push only
+# during an explicit remote handoff or day-end. Stop and console writes record
+# local receipts without Git or network mutation. Never list source-code repos
+# or shared/public repos.
 #
 # SAFETY: the runtime remote guard is independent of this file — a repo is only
 # touched if EVERY push remote starts with one of allowed_remote_prefixes. If a
@@ -23,13 +24,7 @@ allowed_remote_prefixes:
   - https://github.com/example-person/
   - git@github.com:example-person/
 
-# Skip a repo if any dirty file changed within this window (never commit mid-thought).
-quiescence_minutes: 15
-
-# Hook-mode runs (agent turn end) no-op if a run happened this recently.
-throttle_minutes: 10
-
 # Distinct author so automated checkpoints are always distinguishable from
-# curated commits in history.
+# curated commits in history. This author appears only at a remote-sync event.
 commit_author_name: Synthesis Checkpoint
 commit_author_email: checkpoint@example.com

--- a/skills/synthesis-repo-guard/checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/checkpoint_sync.py
@@ -1,54 +1,54 @@
 #!/usr/bin/env python3
 """
-checkpoint_sync.py — Event-driven auto-commit + push for private context repos.
+checkpoint_sync.py — Local handoff receipts and explicit remote publication.
 
 The REMEDIATOR layer of synthesis-repo-guard (see SKILL.md for the full
 three-layer design). Invoked at WORKFLOW EVENTS, never on a wall-clock timer:
 
-  - AI-tool turn/session end (e.g., Claude Code Stop hook), throttled
-  - synthesis-console after a cockpit write (`--repo <path> --now`)
-  - daily rituals / mac-sync sweeps
+  - AI-tool Stop records a LOCAL_READY receipt for one client session
+  - synthesis-console records a producer path without committing or networking
+  - day-end and synthesis-mac-sync publish pending context with
+    ``--flush-pending``
 
 Design rules (agreed 2026-07-08; companion lesson
 2026-07-08-alert-channel-confidentiality-and-event-driven-checkpoints):
 
-  1. NO background timers. Runs only at interactive workflow moments, on the
-     machine where the change originated. Read-only status polling elsewhere
-     is fine; mutation is event-driven only.
-  2. RUNTIME REMOTE GUARD: regardless of config, a repo is touched only if
-     EVERY push remote matches an allowed prefix (the owner's private
-     GitHub namespace). Config declares intent; the guard verifies reality.
-  3. Safe ordering: commit local first (snapshot), then fetch, push only if
-     fast-forward. On divergence: leave the commit local and alert. Never
-     rebase, never force-push, never --no-verify. Pre-commit hook failures
-     abort that repo's checkpoint and alert.
-  4. Quiescence: skip a repo if any dirty file changed in the last N minutes
-     (never commit mid-thought). `--now` bypasses (console just finished its
-     own write). Deleted paths are inherently quiescent.
-  5. Stale index.lock (> 10 min): report, never delete.
+  1. NO background mutation. Stop and producer events write atomic local
+     receipts only. Network publication is an explicit remote-handoff or
+     day-end event.
+  2. RUNTIME REMOTE GUARD: regardless of config, a context repo is published
+     only if every push remote matches an allowed private namespace.
+  3. Source-code paths are evidence, never auto-commit targets. Their owning
+     workflow must commit and publish them before pending context manifests
+     are retired.
+  4. Safe publication: exact context paths only, then fetch, then a normal
+     fast-forward push. Never rebase, force-push, or bypass hooks.
+  5. Existing staged and dirty paths outside the manifest remain untouched.
   6. Alerts are GENERIC on audio/banner surfaces (no repo/client names —
      same rule as repo_sync_check.py); detail goes to the state file that
      synthesis-console renders.
 
 Config: ~/.synthesis/checkpoint-sync.yaml (see checkpoint-sync.example.yaml).
-State:  ~/.synthesis/repo-guard/checkpoint-state.json (+ throttle stamp).
+State:  ~/.synthesis/repo-guard/checkpoint-state.json plus per-session pending manifests.
 
-Exit codes: 0 = nothing needed / all healed; 1 = alerts raised; 2 = error.
+Exit codes: 0 = requested readiness reached; 1 = attention required; 2 = error.
 
 Examples:
-  ./checkpoint_sync.py --hook --quiet        # throttled sweep (Stop hook)
-  ./checkpoint_sync.py --repo ~/x/plan.md --now   # single-repo, post-write
-  ./checkpoint_sync.py --dry-run             # show what would happen
-  ./checkpoint_sync.py --no-throttle         # manual "Sync now" button
+  ./checkpoint_sync.py --hook --quiet        # same-machine Stop receipt
+  ./checkpoint_sync.py --repo ~/x/plan.md --now   # local producer receipt
+  ./checkpoint_sync.py --flush-pending       # explicit remote handoff
+  ./checkpoint_sync.py --dry-run             # preview remote handoff
 """
 
 import argparse
-import fnmatch
+import fcntl
+import hashlib
 import json
 import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -57,15 +57,15 @@ SYNTHESIS_HOME = Path(os.environ.get("SYNTHESIS_HOME", str(Path.home() / ".synth
 CONFIG_PATH = SYNTHESIS_HOME / "checkpoint-sync.yaml"
 STATE_DIR = SYNTHESIS_HOME / "repo-guard"
 STATE_FILE = STATE_DIR / "checkpoint-state.json"
-THROTTLE_STAMP = STATE_DIR / "last-checkpoint-run"
 QUIET_AUDIO_FLAG = SYNTHESIS_HOME / "quiet-audio"
+PENDING_DIR = STATE_DIR / "pending"
+LOCAL_HANDOFF_DIR = STATE_DIR / "local-handoff"
+REMOTE_HANDOFF_STATE = STATE_DIR / "remote-handoff-last.json"
 
 DEFAULTS = {
     "repos": [],
     "repo_globs": [],
     "allowed_remote_prefixes": [],
-    "quiescence_minutes": 15,
-    "throttle_minutes": 10,
     "commit_author_name": "Synthesis Checkpoint",
     "commit_author_email": "checkpoint@synthesisengineering.org",
 }
@@ -116,8 +116,6 @@ def load_config(path: Path) -> dict:
 def resolve_config(path: Path) -> dict:
     cfg = dict(DEFAULTS)
     cfg.update({k: v for k, v in load_config(path).items() if v is not None})
-    cfg["quiescence_minutes"] = int(cfg["quiescence_minutes"])
-    cfg["throttle_minutes"] = int(cfg["throttle_minutes"])
     return cfg
 
 
@@ -144,6 +142,33 @@ def configured_repos(cfg: dict) -> list[Path]:
         except Exception:
             continue
     return found
+
+
+def pending_manifest_path(session_id: str) -> Path:
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    return PENDING_DIR / f"{digest}.json"
+
+
+def atomic_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise ValueError(f"refusing to replace symlinked state path: {path}")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    except Exception:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -194,7 +219,9 @@ def dirty_paths(repo: Path) -> list[str]:
     # (" M path"). A global strip() eats that space on the FIRST line and the
     # fixed-width `line[3:]` slice then chops the path's first character.
     # (Found live 2026-07-08: producer mode saw "rojects/…" and matched nothing.)
-    rc, out, _ = git(repo, "status", "--porcelain", strip=False)
+    rc, out, _ = git(
+        repo, "status", "--porcelain", "--untracked-files=all", strip=False
+    )
     if rc != 0 or not out.strip():
         return []
     paths = []
@@ -212,25 +239,135 @@ def dirty_paths(repo: Path) -> list[str]:
     return paths
 
 
-def newest_mtime(repo: Path, rel_paths: list[str]) -> float:
-    newest = 0.0
-    for rel in rel_paths:
-        fp = repo / rel
-        try:
-            newest = max(newest, fp.stat().st_mtime)
-        except OSError:
-            continue  # deleted paths are inherently quiescent
-    return newest
-
-
 def ahead_behind(repo: Path, branch: str) -> tuple[int, int]:
     rc, out, _ = git(repo, "rev-list", "--left-right", "--count", f"origin/{branch}...{branch}")
     if rc != 0:
-        return (0, 0)
+        return (-1, -1)
     parts = out.split()
     if len(parts) == 2:
         return int(parts[0]), int(parts[1])  # (behind, ahead)
-    return (0, 0)
+    return (-1, -1)
+
+
+def git_common_dir(repo: Path) -> Path | None:
+    rc, output, _ = git(repo, "rev-parse", "--git-common-dir")
+    if rc != 0 or not output:
+        return None
+    candidate = Path(output)
+    if not candidate.is_absolute():
+        candidate = repo / candidate
+    return candidate.resolve()
+
+
+def git_path(repo: Path, name: str) -> Path | None:
+    rc, output, _ = git(repo, "rev-parse", "--git-path", name)
+    if rc != 0 or not output:
+        return None
+    candidate = Path(output)
+    if not candidate.is_absolute():
+        candidate = repo / candidate
+    return candidate.resolve(strict=False)
+
+
+def configured_repo_identity(repo: Path, cfg: dict) -> tuple[bool, str]:
+    """Accept configured checkouts and their isolated git worktrees.
+
+    A feature worktree is a separate filesystem path but shares the configured
+    checkout's git common directory. Comparing that identity keeps the
+    auto-sync class narrow without excluding the worktrees synthesis uses for
+    concurrent projects.
+    """
+    identity = git_common_dir(repo)
+    if identity is None:
+        return False, "git common directory is unavailable"
+    configured = configured_repos(cfg)
+    configured_identities = {
+        candidate_identity
+        for candidate in configured
+        if (candidate_identity := git_common_dir(candidate)) is not None
+    }
+    if identity not in configured_identities:
+        return False, "repository is outside the configured auto-sync class"
+    return True, "ok"
+
+
+def remote_branch_exists(repo: Path, branch: str) -> bool:
+    rc, _, _ = git(repo, "show-ref", "--verify", "--quiet", f"refs/remotes/origin/{branch}")
+    return rc == 0
+
+
+def finish_sync(
+    repo: Path,
+    branch: str,
+    rec: dict,
+    *,
+    committed: bool,
+    dry_run: bool,
+) -> dict:
+    """Fetch and fast-forward-push one branch, including its first push."""
+    rc, _, err = git(repo, "fetch", "origin", timeout=120)
+    if rc != 0:
+        rec.update(
+            action="committed-no-push" if committed else "fetch-failed",
+            alert=f"fetch failed (offline?): {err[:200]}",
+        )
+        return rec
+
+    if not remote_branch_exists(repo, branch):
+        if not committed:
+            rec.update(action="unpublished-branch", alert=f"origin/{branch} does not exist")
+            return rec
+        if dry_run:
+            rec.update(action="would-publish-branch")
+            return rec
+        rc, out, err = git(repo, "push", "--set-upstream", "origin", branch, timeout=180)
+        if rc != 0:
+            rec.update(action="committed-push-failed", alert=f"push failed: {(err or out)[:200]}")
+            return rec
+        rec.update(action="committed-pushed", ahead=1)
+        return rec
+
+    behind, ahead = ahead_behind(repo, branch)
+    if behind < 0 or ahead < 0:
+        rec.update(
+            action="committed-unverifiable" if committed else "unverifiable",
+            alert=f"could not compare the local branch with origin/{branch}",
+        )
+        return rec
+    if ahead > 0:
+        if behind > 0:
+            rec.update(
+                action="committed-diverged" if committed else "diverged",
+                alert=(
+                    f"diverged from origin/{branch} (ahead {ahead}, behind {behind}) "
+                    "— resolve manually; commit is safe locally"
+                ),
+            )
+            return rec
+        if dry_run:
+            rec.update(action="would-push", ahead=ahead)
+            return rec
+        rc, out, err = git(repo, "push", "origin", branch, timeout=180)
+        if rc != 0:
+            rec.update(
+                action="committed-push-failed" if committed else "push-failed",
+                alert=f"push failed: {(err or out)[:200]}",
+            )
+            return rec
+        rec.update(action="committed-pushed" if committed else "pushed-stranded", ahead=ahead)
+    elif behind > 0:
+        rec.update(
+            action="committed-diverged" if committed else "behind",
+            alert=(
+                f"local branch is behind origin/{branch} by {behind} commit(s); "
+                "fast-forward before declaring remote readiness"
+            ),
+        )
+    elif committed:
+        rec.update(action="committed-pushed")
+    else:
+        rec.update(action="clean")
+    return rec
 
 
 # ---------------------------------------------------------------------------
@@ -243,28 +380,26 @@ def summarize_paths(paths: list[str], limit: int = 3) -> str:
     return shown + (f" +{extra} more" if extra > 0 else "")
 
 
-def checkpoint_repo(repo: Path, cfg: dict, *, skip_quiescence: bool, dry_run: bool,
-                    only_file: Path | None = None) -> dict:
-    """Attempt to checkpoint one repo. Returns an outcome record.
+def repo_root_for_path(path: Path) -> Path | None:
+    probe = path if path.is_dir() else path.parent
+    rc, output, _ = git(probe, "rev-parse", "--show-toplevel")
+    return Path(output).resolve() if rc == 0 and output else None
 
-    only_file (producer mode): stage and commit JUST that file — other dirty
-    files in the repo may belong to an in-flight session and are left for the
-    next quiescence-respecting sweep."""
+
+def checkpoint_explicit_paths(repo: Path, paths: list[Path], cfg: dict, *, dry_run: bool) -> dict:
+    """Checkpoint only files attributed to one client session."""
     rec: dict = {"repo": str(repo), "name": repo.name, "action": "none", "alert": None}
-
+    configured, reason = configured_repo_identity(repo, cfg)
+    if not configured:
+        rec.update(action="guard-rejected", alert=reason)
+        return rec
     ok, reason = remote_guard(repo, cfg["allowed_remote_prefixes"])
     if not ok:
         rec.update(action="guard-rejected", alert=f"remote guard: {reason}")
         return rec
-
-    # Stale lock check — report, never delete
-    lock = repo / ".git" / "index.lock"
-    if lock.exists():
-        age_min = (time.time() - lock.stat().st_mtime) / 60
-        if age_min > 10:
-            rec.update(action="skipped", alert=f"stale index.lock ({age_min:.0f} min old) — investigate manually")
-        else:
-            rec.update(action="skipped-lock-active")
+    lock = git_path(repo, "index.lock")
+    if lock is not None and lock.exists():
+        rec.update(action="skipped-lock-active", alert="git index.lock is present")
         return rec
 
     rc, branch, _ = git(repo, "branch", "--show-current")
@@ -272,73 +407,387 @@ def checkpoint_repo(repo: Path, cfg: dict, *, skip_quiescence: bool, dry_run: bo
         rec.update(action="skipped", alert="detached HEAD or no branch")
         return rec
 
-    paths = dirty_paths(repo)
-    if only_file is not None:
+    relative: list[str] = []
+    for path in paths:
         try:
-            rel = str(only_file.resolve().relative_to(repo.resolve()))
+            rel = str(path.resolve(strict=False).relative_to(repo.resolve()))
         except ValueError:
-            rel = None
-        paths = [p for p in paths if rel is not None and p == rel]
-
-    if paths and not skip_quiescence:
-        quiet_s = cfg["quiescence_minutes"] * 60
-        if time.time() - newest_mtime(repo, paths) < quiet_s:
-            rec.update(action="skipped-quiescence", detail=f"{len(paths)} file(s) changed recently")
+            rec.update(action="guard-rejected", alert=f"pending path is outside repository: {path}")
             return rec
+        relative.append(rel)
+    relative = sorted(set(relative))
 
+    dirty = set(dirty_paths(repo))
+    changed = [path for path in relative if path in dirty]
     committed = False
-    if paths:
+    if changed:
         if dry_run:
-            rec.update(action="would-commit", files=len(paths), detail=summarize_paths(paths))
+            rec.update(action="would-commit", files=len(changed), detail=summarize_paths(changed))
             return rec
-        if only_file is not None:
-            rc, _, err = git(repo, "add", "--", *paths)
-        else:
-            rc, _, err = git(repo, "add", "-A")
-        if rc != 0:
-            rec.update(action="failed", alert=f"git add failed: {err}")
-            return rec
-        msg = f"checkpoint auto-sync: {summarize_paths(paths)}"
+        intent_paths: list[str] = []
+        for path in changed:
+            tracked_rc, _, _ = git(repo, "ls-files", "--error-unmatch", "--", path)
+            if tracked_rc == 0:
+                continue
+            add_rc, _, add_error = git(repo, "add", "--intent-to-add", "--", path)
+            if add_rc != 0:
+                rec.update(
+                    action="failed",
+                    alert=f"could not prepare untracked context path: {add_error}",
+                )
+                return rec
+            intent_paths.append(path)
         author_env = {
             "GIT_AUTHOR_NAME": cfg["commit_author_name"],
             "GIT_AUTHOR_EMAIL": cfg["commit_author_email"],
             "GIT_COMMITTER_NAME": cfg["commit_author_name"],
             "GIT_COMMITTER_EMAIL": cfg["commit_author_email"],
         }
-        rc, out, err = git(repo, "commit", "-m", msg, env=author_env, timeout=120)
+        rc, out, err = git(
+            repo,
+            "commit",
+            "-m",
+            "Update project context",
+            "--only",
+            "--",
+            *changed,
+            env=author_env,
+            timeout=120,
+        )
         if rc != 0:
-            # Most likely a pre-commit hook rejection — never bypass it.
-            rec.update(action="hook-blocked", alert=f"commit blocked (pre-commit hook?): {(err or out)[:300]}")
+            if intent_paths:
+                git(repo, "reset", "--", *intent_paths)
+            rec.update(action="hook-blocked", alert=f"commit blocked: {(err or out)[:300]}")
             return rec
         committed = True
-        rec.update(files=len(paths), detail=summarize_paths(paths))
+        rec.update(files=len(changed), detail=summarize_paths(changed))
 
-    # Push anything unpushed (this run's commit or an earlier stranded one)
-    rc, _, err = git(repo, "fetch", "origin", timeout=120)
-    if rc != 0:
-        rec.update(action="committed-no-push" if committed else "fetch-failed",
-                   alert=f"fetch failed (offline?): {err[:200]}")
-        return rec
-    behind, ahead = ahead_behind(repo, branch)
-    if ahead > 0:
-        if behind > 0:
-            rec.update(action="committed-diverged" if committed else "diverged",
-                       alert=f"diverged from origin/{branch} (ahead {ahead}, behind {behind}) — resolve manually; commit is safe locally")
-            return rec
-        if dry_run:
-            rec.update(action="would-push", ahead=ahead)
-            return rec
-        rc, out, err = git(repo, "push", "origin", branch, timeout=180)
-        if rc != 0:
-            rec.update(action="committed-push-failed" if committed else "push-failed",
-                       alert=f"push failed: {(err or out)[:200]}")
-            return rec
-        rec.update(action="committed-pushed" if committed else "pushed-stranded", ahead=ahead)
-    elif committed:
-        rec.update(action="committed-pushed")  # shouldn't happen (ahead>=1), defensive
-    elif not paths:
-        rec.update(action="clean")
-    return rec
+    return finish_sync(repo, branch, rec, committed=committed, dry_run=dry_run)
+
+
+def load_pending_manifest(session_id: str) -> tuple[Path, list[Path]]:
+    manifest = pending_manifest_path(session_id)
+    if manifest.is_symlink():
+        raise ValueError(f"pending manifest is a symlink: {manifest}")
+    if not manifest.is_file():
+        return manifest, []
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+    if data.get("session_id") != session_id or not isinstance(data.get("paths"), list):
+        raise ValueError("session or paths mismatch")
+    return manifest, [Path(str(value)).expanduser() for value in data["paths"]]
+
+
+def file_evidence(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {"path": str(path), "state": "deleted-or-missing"}
+    if path.is_symlink() or not path.is_file():
+        return {"path": str(path), "state": "unsafe-non-file"}
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return {
+        "path": str(path),
+        "state": "present",
+        "size": path.stat().st_size,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def local_handoff_checkpoint(payload: dict, cfg: dict) -> tuple[list[dict], Path | None]:
+    """Record LOCAL_READY evidence without committing or using the network."""
+    session_id = payload.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return [], None
+    try:
+        manifest, paths = load_pending_manifest(session_id)
+    except (OSError, ValueError, TypeError) as exc:
+        return [{"repo": "unknown", "name": "pending-session", "action": "failed", "alert": f"invalid pending manifest: {exc}"}], None
+    if not paths:
+        return [], manifest
+
+    grouped: dict[Path, list[Path]] = {}
+    for path in paths:
+        root = repo_root_for_path(path)
+        if root is None:
+            return [{"repo": str(path), "name": "pending-session", "action": "failed", "alert": "pending path is not inside an available git worktree"}], manifest
+        grouped.setdefault(root, []).append(path)
+
+    results: list[dict] = []
+    for repo, repo_paths in sorted(grouped.items(), key=lambda item: str(item[0])):
+        branch_rc, branch, _ = git(repo, "branch", "--show-current")
+        head_rc, head, _ = git(repo, "rev-parse", "HEAD")
+        if branch_rc != 0 or not branch or head_rc != 0:
+            results.append({"repo": str(repo), "name": repo.name, "action": "failed", "alert": "checkout identity is unavailable"})
+            continue
+        evidence = [file_evidence(path) for path in sorted(set(repo_paths))]
+        unsafe = [item for item in evidence if item["state"] == "unsafe-non-file"]
+        if unsafe:
+            results.append({"repo": str(repo), "name": repo.name, "action": "guard-rejected", "alert": "pending path is a symlink or non-file"})
+            continue
+        results.append(
+            {
+                "repo": str(repo),
+                "name": repo.name,
+                "action": "local-ready",
+                "branch": branch,
+                "head": head,
+                "files": len(evidence),
+                "file_evidence": evidence,
+                "alert": None,
+            }
+        )
+
+    receipt = LOCAL_HANDOFF_DIR / f"{hashlib.sha256(session_id.encode('utf-8')).hexdigest()}.json"
+    atomic_json(
+        receipt,
+        {
+            "schema_version": 1,
+            "readiness": "LOCAL_READY" if results and not any(item.get("alert") for item in results) else "BLOCKED",
+            "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "session_id": session_id,
+            "cwd": payload.get("cwd"),
+            "results": results,
+            "pending_manifest": str(manifest),
+        },
+    )
+    return results, manifest
+
+
+def flush_all_pending(cfg: dict, *, dry_run: bool) -> tuple[list[dict], list[Path]]:
+    """Batch every pending session into one exact-path commit per repository."""
+    manifests = sorted(PENDING_DIR.glob("*.json")) if PENDING_DIR.is_dir() else []
+    all_paths: list[Path] = []
+    source_paths: list[Path] = []
+    valid_manifests: list[Path] = []
+    errors: list[dict] = []
+    locks = []
+    try:
+        for manifest in manifests:
+            lock_path = manifest.with_suffix(".lock")
+            if lock_path.is_symlink():
+                errors.append({"repo": str(lock_path), "name": "pending-session", "action": "failed", "alert": "pending manifest lock is a symlink"})
+                continue
+            lock = lock_path.open("a+", encoding="utf-8")
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            locks.append(lock)
+            if manifest.is_symlink():
+                errors.append({"repo": str(manifest), "name": "pending-session", "action": "failed", "alert": "pending manifest is a symlink"})
+                continue
+            if not manifest.exists():
+                continue
+            try:
+                data = json.loads(manifest.read_text(encoding="utf-8"))
+                session_id = data.get("session_id")
+                if not isinstance(session_id, str) or pending_manifest_path(session_id) != manifest:
+                    raise ValueError("manifest filename or session mismatch")
+                remote_paths = data.get("remote_paths", data.get("paths"))
+                if not isinstance(remote_paths, list):
+                    raise ValueError("remote_paths must be a list")
+                all_values = data.get("paths")
+                if not isinstance(all_values, list):
+                    raise ValueError("paths must be a list")
+                remote_set = {
+                    Path(str(value)).expanduser().resolve(strict=False)
+                    for value in remote_paths
+                }
+                all_set = {
+                    Path(str(value)).expanduser().resolve(strict=False)
+                    for value in all_values
+                }
+                all_paths.extend(remote_set)
+                source_paths.extend(all_set - remote_set)
+                valid_manifests.append(manifest)
+            except (OSError, ValueError, TypeError) as exc:
+                errors.append({"repo": str(manifest), "name": "pending-session", "action": "failed", "alert": f"invalid pending manifest: {exc}"})
+
+        grouped: dict[Path, list[Path]] = {}
+        for path in sorted(set(all_paths)):
+            root = repo_root_for_path(path)
+            if root is None:
+                errors.append({"repo": str(path), "name": "pending-session", "action": "failed", "alert": "pending path is not inside an available git worktree"})
+                continue
+            grouped.setdefault(root, []).append(path)
+        results = errors + source_paths_remote_ready(source_paths) + [
+            checkpoint_explicit_paths(repo, paths, cfg, dry_run=dry_run)
+            for repo, paths in sorted(grouped.items(), key=lambda item: str(item[0]))
+        ]
+        if not dry_run and valid_manifests and not any(result.get("alert") for result in results):
+            for manifest in valid_manifests:
+                manifest.unlink(missing_ok=True)
+        return results, valid_manifests
+    finally:
+        for lock in reversed(locks):
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+            lock.close()
+
+
+def source_paths_remote_ready(paths: list[Path]) -> list[dict]:
+    """Verify source edits were published by their policy-owning workflow."""
+    grouped: dict[Path, list[Path]] = {}
+    results: list[dict] = []
+    for path in sorted(set(paths)):
+        root = repo_root_for_path(path)
+        if root is None:
+            results.append(
+                {
+                    "repo": str(path),
+                    "name": "source-path",
+                    "action": "source-unavailable",
+                    "alert": "edited source path is not inside an available git worktree",
+                }
+            )
+            continue
+        grouped.setdefault(root, []).append(path)
+
+    for repo, repo_paths in sorted(grouped.items(), key=lambda item: str(item[0])):
+        relative = [str(path.resolve(strict=False).relative_to(repo.resolve())) for path in repo_paths]
+        status_rc, status, status_error = git(
+            repo, "status", "--porcelain", "--", *relative, strip=False
+        )
+        if status_rc != 0:
+            results.append(
+                {
+                    "repo": str(repo),
+                    "name": repo.name,
+                    "action": "source-unverifiable",
+                    "alert": f"source status failed: {status_error}",
+                }
+            )
+            continue
+        if status.strip():
+            results.append(
+                {
+                    "repo": str(repo),
+                    "name": repo.name,
+                    "action": "source-local-only",
+                    "alert": "edited source paths remain uncommitted",
+                }
+            )
+            continue
+        upstream_rc, upstream, _ = git(
+            repo, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"
+        )
+        if upstream_rc != 0 or not upstream:
+            results.append(
+                {
+                    "repo": str(repo),
+                    "name": repo.name,
+                    "action": "source-local-only",
+                    "alert": "source branch has no upstream",
+                }
+            )
+            continue
+        branch_rc, branch, _ = git(repo, "branch", "--show-current")
+        remote_rc, remote, _ = git(
+            repo, "config", "--get", f"branch.{branch}.remote"
+        )
+        if branch_rc != 0 or not branch or remote_rc != 0 or not remote or remote == ".":
+            results.append(
+                {
+                    "repo": str(repo),
+                    "name": repo.name,
+                    "action": "source-local-only",
+                    "alert": "source branch has no fetchable remote",
+                }
+            )
+            continue
+        fetch_rc, _, fetch_error = git(repo, "fetch", remote, timeout=120)
+        if fetch_rc != 0:
+            results.append(
+                {
+                    "repo": str(repo),
+                    "name": repo.name,
+                    "action": "source-unverifiable",
+                    "alert": f"source fetch failed: {fetch_error}",
+                }
+            )
+            continue
+        counts_rc, counts, counts_error = git(
+            repo, "rev-list", "--left-right", "--count", f"{upstream}...HEAD"
+        )
+        if counts_rc != 0 or len(counts.split()) != 2:
+            results.append(
+                {
+                    "repo": str(repo),
+                    "name": repo.name,
+                    "action": "source-unverifiable",
+                    "alert": f"source upstream comparison failed: {counts_error}",
+                }
+            )
+            continue
+        behind, ahead = (int(value) for value in counts.split())
+        if behind or ahead:
+            results.append(
+                {
+                    "repo": str(repo),
+                    "name": repo.name,
+                    "action": "source-not-remote-ready",
+                    "alert": f"source branch is ahead {ahead}, behind {behind}",
+                }
+            )
+            continue
+        results.append(
+            {
+                "repo": str(repo),
+                "name": repo.name,
+                "action": "source-remote-ready",
+                "files": len(relative),
+                "alert": None,
+            }
+        )
+    return results
+
+
+def record_producer_path(path: Path, cfg: dict) -> tuple[list[dict], Path | None]:
+    """Record a console or other non-agent producer write as local state."""
+    target = path.expanduser().resolve(strict=False)
+    root = repo_root_for_path(target)
+    if root is None:
+        return [
+            {
+                "repo": str(target),
+                "name": "producer",
+                "action": "failed",
+                "alert": "producer path is not inside an available git worktree",
+            }
+        ], None
+    configured, reason = configured_repo_identity(root, cfg)
+    if not configured:
+        return [
+            {
+                "repo": str(root),
+                "name": root.name,
+                "action": "guard-rejected",
+                "alert": reason,
+            }
+        ], None
+    ok, reason = remote_guard(root, cfg["allowed_remote_prefixes"])
+    if not ok:
+        return [
+            {
+                "repo": str(root),
+                "name": root.name,
+                "action": "guard-rejected",
+                "alert": f"remote guard: {reason}",
+            }
+        ], None
+    session_id = f"producer:{os.getpid()}:{time.time_ns()}"
+    manifest = pending_manifest_path(session_id)
+    atomic_json(
+        manifest,
+        {
+            "schema_version": 2,
+            "session_id": session_id,
+            "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "paths": [str(target)],
+            "remote_paths": [str(target)],
+            "producer": True,
+        },
+    )
+    return local_handoff_checkpoint(
+        {"session_id": session_id, "cwd": str(root)}, cfg
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -364,7 +813,7 @@ def generic_alert_ping(alert_count: int, speak: bool, notify: bool) -> None:
 
 
 # ---------------------------------------------------------------------------
-# State + throttle
+# State
 # ---------------------------------------------------------------------------
 
 def write_state(mode: str, results: list[dict], running: bool) -> None:
@@ -382,18 +831,6 @@ def write_state(mode: str, results: list[dict], running: bool) -> None:
     tmp.replace(STATE_FILE)
 
 
-def throttled(minutes: int) -> bool:
-    try:
-        return (time.time() - THROTTLE_STAMP.stat().st_mtime) < minutes * 60
-    except OSError:
-        return False
-
-
-def stamp_throttle() -> None:
-    STATE_DIR.mkdir(parents=True, exist_ok=True)
-    THROTTLE_STAMP.touch()
-
-
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -401,12 +838,35 @@ def stamp_throttle() -> None:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--config", type=Path, default=CONFIG_PATH, help=f"Config path (default {CONFIG_PATH})")
-    ap.add_argument("--repo", type=Path, default=None,
-                    help="Single-repo mode: any path inside the repo (resolved via git rev-parse)")
-    ap.add_argument("--hook", action="store_true", help="Hook mode: honor throttle, quiet by default")
-    ap.add_argument("--now", action="store_true", help="Bypass throttle AND quiescence (post-write producer mode)")
-    ap.add_argument("--no-throttle", action="store_true", help="Bypass throttle only (manual Sync-now button)")
-    ap.add_argument("--dry-run", action="store_true", help="Report what would happen; change nothing")
+    ap.add_argument(
+        "--repo",
+        type=Path,
+        default=None,
+        help="Record one non-agent producer path as local handoff state",
+    )
+    ap.add_argument(
+        "--hook",
+        action="store_true",
+        help="Record same-machine handoff evidence from a client Stop payload",
+    )
+    ap.add_argument(
+        "--flush-pending",
+        action="store_true",
+        help="Commit and push all session-attributed context paths for remote handoff",
+    )
+    ap.add_argument(
+        "--now",
+        action="store_true",
+        help="Compatibility flag for local post-write producer mode",
+    )
+    ap.add_argument(
+        "--no-throttle",
+        action="store_true",
+        help="Compatibility alias for an explicit remote handoff",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="Preview remote publication"
+    )
     ap.add_argument("--quiet", "-q", action="store_true", help="No stdout (state file still written)")
     ap.add_argument("--json", "-j", action="store_true", help="Print outcomes as JSON")
     ap.add_argument("--speak", action="store_true", help="Generic spoken ping if alerts (mute-aware)")
@@ -415,65 +875,88 @@ def main() -> int:
 
     cfg = resolve_config(args.config.expanduser())
 
-    skip_quiescence = bool(args.now)
-    skip_throttle = bool(args.now or args.no_throttle or args.repo or args.dry_run)
-
-    if args.hook and not skip_throttle and throttled(cfg["throttle_minutes"]):
-        if not args.quiet:
-            print("checkpoint_sync: throttled (recent run) — nothing done")
-        return 0
-
-    # Target set
-    if args.repo:
-        rc = subprocess.run(
-            ["git", "-C", str(args.repo.expanduser() if args.repo.is_dir() else args.repo.expanduser().parent),
-             "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True,
-        )
-        if rc.returncode != 0:
-            print(f"Error: {args.repo} is not inside a git repo", file=sys.stderr)
-            return 2
-        targets = [Path(rc.stdout.strip())]
-        only_file = args.repo.expanduser() if args.repo.expanduser().is_file() else None
-    else:
-        only_file = None
-        targets = configured_repos(cfg)
-        if not targets:
+    if args.hook:
+        try:
+            raw_payload = sys.stdin.read()
+            hook_payload = json.loads(raw_payload) if raw_payload.strip() else {}
+        except (OSError, json.JSONDecodeError) as exc:
             if not args.quiet:
-                print(f"checkpoint_sync: no configured repos found (config: {args.config})")
-            return 0
+                print(f"checkpoint_sync: invalid hook payload: {exc}", file=sys.stderr)
+            return 2
+        results, manifest = local_handoff_checkpoint(hook_payload, cfg)
+        if not args.dry_run:
+            write_state("hook", results, running=False)
+        alerts = [result for result in results if result.get("alert")]
+        if alerts:
+            generic_alert_ping(len(alerts), speak=args.speak, notify=args.notify)
+        if not args.quiet:
+            if args.json:
+                print(json.dumps(results, indent=2))
+            elif not results:
+                state = f" ({manifest})" if manifest is not None else ""
+                print(f"checkpoint_sync: no session-attributed context changes{state}")
+            else:
+                for result in results:
+                    line = f"{result['name']}: {result['action']}"
+                    if result.get("detail"):
+                        line += f" ({result['detail']})"
+                    if result.get("alert"):
+                        line += f"  ⚠ {result['alert']}"
+                    print(line)
+        return 1 if alerts else 0
 
-    if not args.dry_run:
-        write_state("single" if args.repo else ("hook" if args.hook else "manual"), [], running=True)
+    if args.repo:
+        results, manifest = record_producer_path(args.repo, cfg)
+        if not args.dry_run:
+            write_state("producer-local", results, running=False)
+        alerts = [result for result in results if result.get("alert")]
+        if alerts:
+            generic_alert_ping(len(alerts), speak=args.speak, notify=args.notify)
+        if not args.quiet:
+            if args.json:
+                print(json.dumps(results, indent=2))
+            else:
+                for result in results:
+                    line = f"{result['name']}: {result['action']}"
+                    if result.get("alert"):
+                        line += f"  ⚠ {result['alert']}"
+                    print(line)
+        return 1 if alerts else 0
 
-    results = [
-        checkpoint_repo(t, cfg, skip_quiescence=skip_quiescence, dry_run=args.dry_run,
-                        only_file=only_file)
-        for t in targets
-    ]
+    if args.flush_pending or args.no_throttle or not args.hook:
+        results, manifests = flush_all_pending(cfg, dry_run=args.dry_run)
+        alerts = [result for result in results if result.get("alert")]
+        readiness = (
+            "BLOCKED"
+            if alerts
+            else ("REMOTE_READY" if manifests else "CLEAN")
+        )
+        if not args.dry_run:
+            atomic_json(
+                REMOTE_HANDOFF_STATE,
+                {
+                    "schema_version": 1,
+                    "readiness": readiness,
+                    "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                    "manifests": [str(path) for path in manifests],
+                    "results": results,
+                },
+            )
+        if alerts:
+            generic_alert_ping(len(alerts), speak=args.speak, notify=args.notify)
+        if not args.quiet:
+            if args.json:
+                print(json.dumps({"readiness": readiness, "results": results}, indent=2))
+            else:
+                print(f"remote handoff: {readiness}")
+                for result in results:
+                    line = f"{result['name']}: {result['action']}"
+                    if result.get("alert"):
+                        line += f"  ⚠ {result['alert']}"
+                    print(line)
+        return 1 if alerts else 0
 
-    if not args.dry_run:
-        write_state("single" if args.repo else ("hook" if args.hook else "manual"), results, running=False)
-        if args.hook:
-            stamp_throttle()
-
-    alerts = [r for r in results if r.get("alert")]
-    if alerts:
-        generic_alert_ping(len(alerts), speak=args.speak, notify=args.notify)
-
-    if not args.quiet:
-        if args.json:
-            print(json.dumps(results, indent=2))
-        else:
-            for r in results:
-                line = f"{r['name']}: {r['action']}"
-                if r.get("detail"):
-                    line += f" ({r['detail']})"
-                if r.get("alert"):
-                    line += f"  ⚠ {r['alert']}"
-                print(line)
-
-    return 1 if alerts else 0
+    return 2
 
 
 if __name__ == "__main__":

--- a/skills/synthesis-repo-guard/repo_sync_check.py
+++ b/skills/synthesis-repo-guard/repo_sync_check.py
@@ -24,8 +24,9 @@ v2 (three-layer redesign: detector / messenger / remediator):
     detail belongs only in pull channels (report files, synthesis-console).
   - MUTE FLAG: --speak/--alert/--notify honor ~/.synthesis/quiet-audio
     (created/removed by the synthesis-console toggle; or `touch` it manually).
-  - REMEDIATOR: companion script checkpoint_sync.py auto-commits+pushes the
-    configured private context-repo class at workflow events. See SKILL.md.
+  - CHECKPOINTER: companion script checkpoint_sync.py records local handoff
+    receipts at Stop and publishes exact private-context paths only during an
+    explicit remote handoff or day-end. See SKILL.md.
 
 Exit codes:
   0 — All repos clean and synced

--- a/skills/synthesis-repo-guard/test_checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/test_checkpoint_sync.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("checkpoint_sync.py")
+SPEC = importlib.util.spec_from_file_location("checkpoint_sync", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def command(*args: str, cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        list(args), cwd=cwd, capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def repository(tmp_path: Path) -> tuple[Path, Path, dict]:
+    remote = tmp_path / "remote.git"
+    repo = tmp_path / "repo"
+    command("git", "init", "--bare", "-q", str(remote))
+    command("git", "clone", "-q", str(remote), str(repo))
+    command("git", "config", "user.name", "Test", cwd=repo)
+    command("git", "config", "user.email", "test@example.com", cwd=repo)
+    context = repo / "projects" / "alpha" / "CONTEXT.md"
+    context.parent.mkdir(parents=True)
+    context.write_text("one\n", encoding="utf-8")
+    unrelated = repo / "unrelated.md"
+    unrelated.write_text("one\n", encoding="utf-8")
+    command("git", "add", "projects/alpha/CONTEXT.md", "unrelated.md", cwd=repo)
+    command("git", "commit", "-qm", "seed", cwd=repo)
+    branch = command("git", "branch", "--show-current", cwd=repo)
+    command("git", "push", "-qu", "origin", branch, cwd=repo)
+    cfg = {
+        **MODULE.DEFAULTS,
+        "repos": [str(repo)],
+        "allowed_remote_prefixes": [str(tmp_path)],
+    }
+    return repo, remote, cfg
+
+
+def test_resolve_config_accepts_current_schema_without_legacy_timers(
+    tmp_path: Path,
+) -> None:
+    config = tmp_path / "checkpoint-sync.yaml"
+    config.write_text("repos: []\nrepo_globs: []\n", encoding="utf-8")
+
+    resolved = MODULE.resolve_config(config)
+
+    assert resolved["repos"] == []
+    assert "quiescence_minutes" not in resolved
+    assert "throttle_minutes" not in resolved
+
+
+def test_explicit_checkpoint_commits_only_session_paths(tmp_path: Path) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    context = repo / "projects" / "alpha" / "CONTEXT.md"
+    unrelated = repo / "unrelated.md"
+    context.write_text("two\n", encoding="utf-8")
+    unrelated.write_text("two\n", encoding="utf-8")
+
+    result = MODULE.checkpoint_explicit_paths(repo, [context], cfg, dry_run=False)
+
+    assert result["action"] == "committed-pushed"
+    assert command("git", "show", "HEAD:projects/alpha/CONTEXT.md", cwd=repo) == "two"
+    assert command("git", "show", "HEAD:unrelated.md", cwd=repo) == "one"
+    status = command("git", "status", "--porcelain", cwd=repo)
+    assert "unrelated.md" in status
+
+
+def test_configured_identity_accepts_feature_worktree(tmp_path: Path) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    worktree = tmp_path / "worktree"
+    command("git", "worktree", "add", "-qb", "feature/test", str(worktree), cwd=repo)
+
+    ok, detail = MODULE.configured_repo_identity(worktree, cfg)
+
+    assert ok, detail
+
+
+def test_new_branch_is_published_and_manifest_is_removed(tmp_path: Path, monkeypatch) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    command("git", "switch", "-qc", "feature/new", cwd=repo)
+    context = repo / "projects" / "alpha" / "CONTEXT.md"
+    context.write_text("branch\n", encoding="utf-8")
+    pending = tmp_path / "state" / "pending"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    pending.mkdir(parents=True)
+    manifest = MODULE.pending_manifest_path("session-a")
+    manifest.write_text(
+        json.dumps({"schema_version": 1, "session_id": "session-a", "paths": [str(context)]}),
+        encoding="utf-8",
+    )
+
+    results, observed = MODULE.flush_all_pending(cfg, dry_run=False)
+
+    assert observed == [manifest]
+    assert results[0]["action"] == "committed-pushed"
+    assert not manifest.exists()
+    assert command("git", "show-ref", "--verify", "refs/remotes/origin/feature/new", cwd=repo)
+
+
+def test_local_handoff_records_evidence_without_committing_or_pushing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    context = repo / "projects" / "alpha" / "CONTEXT.md"
+    context.write_text("local only\n", encoding="utf-8")
+    pending = tmp_path / "state" / "pending"
+    receipts = tmp_path / "state" / "local-handoff"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    monkeypatch.setattr(MODULE, "LOCAL_HANDOFF_DIR", receipts)
+    pending.mkdir(parents=True)
+    manifest = MODULE.pending_manifest_path("session-local")
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "session_id": "session-local",
+                "paths": [str(context)],
+            }
+        ),
+        encoding="utf-8",
+    )
+    before = command("git", "rev-parse", "HEAD", cwd=repo)
+
+    results, observed = MODULE.local_handoff_checkpoint(
+        {"session_id": "session-local", "cwd": str(repo)}, cfg
+    )
+
+    assert observed == manifest
+    assert results[0]["action"] == "local-ready"
+    assert command("git", "rev-parse", "HEAD", cwd=repo) == before
+    assert "CONTEXT.md" in command("git", "status", "--porcelain", cwd=repo)
+    assert manifest.exists()
+    receipt = next(receipts.glob("*.json"))
+    payload = json.loads(receipt.read_text(encoding="utf-8"))
+    assert payload["readiness"] == "LOCAL_READY"
+    assert payload["results"][0]["file_evidence"][0]["sha256"]
+
+
+def test_local_handoff_rejects_dangling_manifest_symlink(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _repo, _remote, cfg = repository(tmp_path)
+    pending = tmp_path / "state" / "pending"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    pending.mkdir(parents=True)
+    MODULE.pending_manifest_path("session-symlink").symlink_to(tmp_path / "missing")
+
+    results, _manifest = MODULE.local_handoff_checkpoint(
+        {"session_id": "session-symlink", "cwd": str(tmp_path)}, cfg
+    )
+
+    assert results[0]["action"] == "failed"
+    assert "symlink" in results[0]["alert"]
+
+
+def test_offline_push_preserves_local_commit_and_manifest(tmp_path: Path, monkeypatch) -> None:
+    repo, remote, cfg = repository(tmp_path)
+    context = repo / "projects" / "alpha" / "CONTEXT.md"
+    context.write_text("offline\n", encoding="utf-8")
+    command("git", "remote", "set-url", "origin", str(remote) + "-missing", cwd=repo)
+    pending = tmp_path / "state" / "pending"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    pending.mkdir(parents=True)
+    manifest = MODULE.pending_manifest_path("session-b")
+    manifest.write_text(
+        json.dumps({"schema_version": 1, "session_id": "session-b", "paths": [str(context)]}),
+        encoding="utf-8",
+    )
+
+    results, _ = MODULE.flush_all_pending(cfg, dry_run=False)
+
+    assert results[0]["action"] == "committed-no-push"
+    assert results[0]["alert"]
+    assert manifest.exists()
+    assert command("git", "status", "--porcelain", cwd=repo) == ""
+
+
+def test_remote_flush_commits_new_context_file_without_staged_collisions(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    created = repo / "projects" / "alpha" / "resources" / "artifacts" / "plan.md"
+    created.parent.mkdir(parents=True)
+    created.write_text("plan\n", encoding="utf-8")
+    unrelated = repo / "unrelated.md"
+    unrelated.write_text("staged elsewhere\n", encoding="utf-8")
+    command("git", "add", "unrelated.md", cwd=repo)
+    pending = tmp_path / "state" / "pending"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    pending.mkdir(parents=True)
+    manifest = MODULE.pending_manifest_path("session-new")
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": "session-new",
+                "paths": [str(created)],
+                "remote_paths": [str(created)],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    results, _ = MODULE.flush_all_pending(cfg, dry_run=False)
+
+    assert results[0]["action"] == "committed-pushed"
+    assert command(
+        "git", "show", "HEAD:projects/alpha/resources/artifacts/plan.md", cwd=repo
+    ) == "plan"
+    assert command("git", "diff", "--cached", "--name-only", cwd=repo) == "unrelated.md"
+
+
+def test_remote_flush_waits_until_source_paths_are_published(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    context = repo / "projects" / "alpha" / "CONTEXT.md"
+    source = repo / "src" / "feature.py"
+    source.parent.mkdir()
+    source.write_text("one\n", encoding="utf-8")
+    command("git", "add", "src/feature.py", cwd=repo)
+    command("git", "commit", "-qm", "source seed", cwd=repo)
+    branch = command("git", "branch", "--show-current", cwd=repo)
+    command("git", "push", "-q", "origin", branch, cwd=repo)
+    context.write_text("context two\n", encoding="utf-8")
+    source.write_text("source two\n", encoding="utf-8")
+    pending = tmp_path / "state" / "pending"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    pending.mkdir(parents=True)
+    manifest = MODULE.pending_manifest_path("session-source")
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": "session-source",
+                "paths": [str(context), str(source)],
+                "remote_paths": [str(context)],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    results, _ = MODULE.flush_all_pending(cfg, dry_run=False)
+
+    assert any(result["action"] == "source-local-only" for result in results)
+    assert manifest.exists()
+    assert command("git", "show", "HEAD:projects/alpha/CONTEXT.md", cwd=repo) == "context two"
+
+
+def test_existing_remote_branch_that_is_behind_blocks_readiness(
+    tmp_path: Path,
+) -> None:
+    repo, remote, _cfg = repository(tmp_path)
+    branch = command("git", "branch", "--show-current", cwd=repo)
+    other = tmp_path / "other"
+    command("git", "clone", "-q", "--no-checkout", str(remote), str(other))
+    command("git", "switch", "-q", branch, cwd=other)
+    command("git", "config", "user.name", "Other", cwd=other)
+    command("git", "config", "user.email", "other@example.com", cwd=other)
+    new_file = other / "new.md"
+    new_file.write_text("remote\n", encoding="utf-8")
+    command("git", "add", "new.md", cwd=other)
+    command("git", "commit", "-qm", "remote", cwd=other)
+    command("git", "push", "-q", "origin", branch, cwd=other)
+
+    result = MODULE.finish_sync(
+        repo, branch, {"repo": str(repo), "name": repo.name}, committed=False, dry_run=False
+    )
+
+    assert result["action"] == "behind"
+    assert result["alert"]
+
+
+def test_flush_rejects_symlinked_manifest_lock(tmp_path: Path, monkeypatch) -> None:
+    _repo, _remote, cfg = repository(tmp_path)
+    pending = tmp_path / "state" / "pending"
+    pending.mkdir(parents=True)
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    session_id = "session-lock"
+    manifest = MODULE.pending_manifest_path(session_id)
+    manifest.write_text(
+        json.dumps({"session_id": session_id, "paths": []}), encoding="utf-8"
+    )
+    manifest.with_suffix(".lock").symlink_to(tmp_path / "elsewhere")
+
+    results, observed = MODULE.flush_all_pending(cfg, dry_run=False)
+
+    assert observed == []
+    assert results[0]["action"] == "failed"
+    assert manifest.exists()


### PR DESCRIPTION
## What changed

- Separates same-machine local continuity from explicit cross-machine remote readiness.
- Records interruption-safe edit manifests and Stop receipts without per-turn Git or network activity.
- Adds named-project recovery without an active pointer, local and remote conformance modes, and context-doctor readiness modes.
- Makes explicit remote handoff and day-end responsible for policy-aware publication.

## Verification

- 300 public tests passed.
- 186 source conformance checks passed.
- Local interruption, shell attribution, offline, behind-remote, symlink, staged-index, first-branch, and cross-client parity fixtures passed.