### PR TITLE
Reconcile handoff state during verified worktree retirement

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.25.1",
+  "version": "4.25.2",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.25.1",
+  "version": "4.25.2",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.25.2] - 2026-08-14
+
+### Fixed
+
+- **Worktree-retirement continuity** — the fail-closed retirement helper now
+  reconciles session manifests only after proving that the clean worktree head
+  is contained in the fetched remote base. A standalone, equally verified
+  reconciliation path repairs a removal that completed before its manifest
+  update. Unexplained missing paths continue to block Stop.
+
 ## [4.25.1] - 2026-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   receipts, remote flushes, and retirement now share one lifecycle lock. The
   helper pins a freshly fetched remote-tracking commit, stages a known-capable
   reconciler outside the target, and fsyncs a resumable intent before removal.
-  Completion is idempotent after interruption; unexplained missing or
-  unpublished paths continue to block Stop.
+  Interrupted completion selects and verifies that exact content-addressed
+  reconciler even after an upgrade. Optional remote branch deletion is bound
+  to the recorded remote and head with Git's compare-and-delete lease.
+  Completion is idempotent; unexplained missing or unpublished paths continue
+  to block Stop.
 
 ## [4.25.1] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
 
 ### Fixed
 
-- **Worktree-retirement continuity** — the fail-closed retirement helper now
-  reconciles session manifests only after proving that the clean worktree head
-  is contained in the fetched remote base. A standalone, equally verified
-  reconciliation path repairs a removal that completed before its manifest
-  update. Unexplained missing paths continue to block Stop.
+- **Transactional worktree-retirement continuity** — manifest writers, Stop
+  receipts, remote flushes, and retirement now share one lifecycle lock. The
+  helper pins a freshly fetched remote-tracking commit, stages a known-capable
+  reconciler outside the target, and fsyncs a resumable intent before removal.
+  Completion is idempotent after interruption; unexplained missing or
+  unpublished paths continue to block Stop.
 
 ## [4.25.1] - 2026-08-14
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **Verified cleanup is part of continuity (August 2026).** Release **4.25.2**
-connects fail-closed worktree retirement to session-attributed handoff state.
-Once a clean worktree head is proven contained in the fetched remote base, its
-retired paths are removed from pending manifests and any stale local receipt is
-invalidated. Missing paths without that proof still block Stop. See the
-[4.25.2 release notes](CHANGELOG.md).
+makes worktree retirement a resumable handoff transaction. One lifecycle lock
+spans durable intent, removal, manifest reconciliation, and receipt
+invalidation. The ancestry authority is a freshly fetched remote-tracking
+commit, and the reconciler is staged outside the target before removal.
+Missing paths without that proof still block Stop. See the [4.25.2 release
+notes](CHANGELOG.md).
 
 **Codex catalog pressure is now engineered, not tolerated (August 2026).**
 Release **4.24.1** adds an implicit-core/explicit-specialist catalog with a

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Verified cleanup is part of continuity (August 2026).** Release **4.25.2**
+connects fail-closed worktree retirement to session-attributed handoff state.
+Once a clean worktree head is proven contained in the fetched remote base, its
+retired paths are removed from pending manifests and any stale local receipt is
+invalidated. Missing paths without that proof still block Stop. See the
+[4.25.2 release notes](CHANGELOG.md).
+
 **Codex catalog pressure is now engineered, not tolerated (August 2026).**
 Release **4.24.1** adds an implicit-core/explicit-specialist catalog with a
 public routing skill, app-server-backed hook and skill audits, live capability

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 makes worktree retirement a resumable handoff transaction. One lifecycle lock
 spans durable intent, removal, manifest reconciliation, and receipt
 invalidation. The ancestry authority is a freshly fetched remote-tracking
-commit, and the reconciler is staged outside the target before removal.
-Missing paths without that proof still block Stop. See the [4.25.2 release
-notes](CHANGELOG.md).
+commit, the reconciler is content-addressed outside the target before removal,
+and interrupted recovery executes that exact pinned copy. Optional remote
+branch deletion uses a lease bound to the verified remote head. Missing paths
+without that proof still block Stop. See the [4.25.2 release notes](CHANGELOG.md).
 
 **Codex catalog pressure is now engineered, not tolerated (August 2026).**
 Release **4.24.1** adds an implicit-core/explicit-specialist catalog with a

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -381,12 +381,14 @@ Retire merged feature worktrees with `scripts/retire_worktree.py`
 (explicit repository argument, freshly fetched remote-tracking ancestry,
 fail-closed on dirty or unpublished state) instead of hand-run git sequences.
 The helper holds the shared handoff lifecycle lock across preparation, removal,
-and reconciliation; pins the remote commit; stages its reconciler outside the
-target; and fsyncs a resumable intent before removal. Unexplained missing paths
-remain blocking Stop failures. There is no offline or local-ref escape hatch.
-If interruption lands after removal, rerun the same helper command: it finds
-the matching prepared intent, completes reconciliation idempotently, and then
-finishes safe branch cleanup.
+and reconciliation; pins the remote commit; content-addresses its reconciler
+outside the target; and fsyncs a resumable intent before removal. Unexplained
+missing paths remain blocking Stop failures. There is no offline or local-ref
+escape hatch. If interruption lands after removal, rerun the same helper
+command: it finds the matching prepared intent, executes that exact pinned
+reconciler, completes reconciliation idempotently, and then finishes branch
+cleanup. Optional remote deletion uses a compare-and-delete lease and refuses
+an advanced or differently sourced branch.
 See
 [`references/active-sessions-template.md`](references/active-sessions-template.md)
 for the canonical file shape and

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.1.0"
+  version: "2.1.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -379,7 +379,10 @@ file-sync conflict resolution is not a distributed lock.
 
 Retire merged feature worktrees with `scripts/retire_worktree.py`
 (explicit repository argument, fetch-then-verify remote ancestry, fail-closed
-on dirty or unmerged state) instead of hand-run git sequences. See
+on dirty or unmerged state) instead of hand-run git sequences. The helper also
+reconciles session-attributed paths beneath the retired worktree after removal,
+but only after the same remote-ancestry proof; unexplained missing paths remain
+blocking Stop failures. See
 [`references/active-sessions-template.md`](references/active-sessions-template.md)
 for the canonical file shape and
 [`references/parallel-agent-protocol.md`](references/parallel-agent-protocol.md)

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.1.1"
+  version: "2.2.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -378,11 +378,16 @@ simultaneous cross-machine writes to the same resources remain prohibited —
 file-sync conflict resolution is not a distributed lock.
 
 Retire merged feature worktrees with `scripts/retire_worktree.py`
-(explicit repository argument, fetch-then-verify remote ancestry, fail-closed
-on dirty or unmerged state) instead of hand-run git sequences. The helper also
-reconciles session-attributed paths beneath the retired worktree after removal,
-but only after the same remote-ancestry proof; unexplained missing paths remain
-blocking Stop failures. See
+(explicit repository argument, freshly fetched remote-tracking ancestry,
+fail-closed on dirty or unpublished state) instead of hand-run git sequences.
+The helper holds the shared handoff lifecycle lock across preparation, removal,
+and reconciliation; pins the remote commit; stages its reconciler outside the
+target; and fsyncs a resumable intent before removal. Unexplained missing paths
+remain blocking Stop failures. There is no offline or local-ref escape hatch.
+If interruption lands after removal, rerun the same helper command: it finds
+the matching prepared intent, completes reconciliation idempotently, and then
+finishes safe branch cleanup.
+See
 [`references/active-sessions-template.md`](references/active-sessions-template.md)
 for the canonical file shape and
 [`references/parallel-agent-protocol.md`](references/parallel-agent-protocol.md)

--- a/skills/synthesis-project-management/scripts/retire_worktree.py
+++ b/skills/synthesis-project-management/scripts/retire_worktree.py
@@ -34,6 +34,17 @@ import sys
 from pathlib import Path
 
 
+SYNTHESIS_HOME = Path(
+    os.environ.get("SYNTHESIS_HOME", str(Path.home() / ".synthesis"))
+)
+PENDING_DIR = SYNTHESIS_HOME / "repo-guard" / "pending"
+CHECKPOINT_SYNC = (
+    Path(__file__).resolve().parents[2]
+    / "synthesis-repo-guard"
+    / "checkpoint_sync.py"
+)
+
+
 def run(
     repository: Path, *arguments: str, timeout: int = 60
 ) -> subprocess.CompletedProcess[str]:
@@ -68,6 +79,62 @@ def worktree_entries(repository: Path) -> list[dict[str, str]]:
     if current:
         entries.append(current)
     return entries
+
+
+def path_is_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=False))
+        return True
+    except ValueError:
+        return False
+
+
+def checkpoint_sync_path(repository: Path, worktree: Path) -> Path | None:
+    """Return a reconciler that will survive removal of the target worktree."""
+
+    candidates = [
+        repository / "skills" / "synthesis-repo-guard" / "checkpoint_sync.py",
+        CHECKPOINT_SYNC,
+    ]
+    for candidate in candidates:
+        if candidate.is_symlink() or not candidate.is_file():
+            continue
+        resolved = candidate.resolve()
+        if not path_is_within(resolved, worktree):
+            return resolved
+    return None
+
+
+def reconcile_pending_handoffs(
+    checkpoint_sync: Path,
+    repository: Path,
+    worktree: Path,
+    head: str,
+    base: str,
+    *,
+    dry_run: bool,
+) -> subprocess.CompletedProcess[str]:
+    arguments = [
+        sys.executable,
+        str(checkpoint_sync),
+        "--reconcile-retired-worktree",
+        str(worktree),
+        "--retirement-repository",
+        str(repository),
+        "--retirement-head",
+        head,
+        "--retirement-base",
+        base,
+    ]
+    if dry_run:
+        arguments.append("--dry-run")
+    return subprocess.run(
+        arguments,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
 
 
 def main() -> int:
@@ -193,10 +260,45 @@ def main() -> int:
             "have not been verified on the remote"
         )
 
+    head_result = run(worktree, "rev-parse", "HEAD")
+    if head_result.returncode != 0 or not head_result.stdout.strip():
+        return fail(head_result.stderr.strip() or "worktree HEAD is unavailable")
+    head = head_result.stdout.strip()
+
+    if PENDING_DIR.is_symlink():
+        return fail(f"pending handoff directory is a symlink: {PENDING_DIR}")
+    pending_exists = PENDING_DIR.is_dir() and any(PENDING_DIR.glob("*.json"))
+    checkpoint_sync = checkpoint_sync_path(repository, worktree)
+    if pending_exists:
+        if checkpoint_sync is None:
+            return fail(
+                "pending handoff manifests exist but their source-managed "
+                "reconciler is unavailable outside the target worktree"
+            )
+        preflight = reconcile_pending_handoffs(
+            checkpoint_sync, repository, worktree, head, base, dry_run=True
+        )
+        if preflight.returncode != 0:
+            detail = (preflight.stderr or preflight.stdout).strip()
+            return fail(f"pending handoff reconciliation preflight failed: {detail}")
+
     removed = run(repository, "worktree", "remove", str(worktree))
     if removed.returncode != 0:
         return fail(removed.stderr.strip() or "git worktree remove failed")
     print(f"Removed worktree {worktree}")
+
+    if checkpoint_sync is not None:
+        reconciled = reconcile_pending_handoffs(
+            checkpoint_sync, repository, worktree, head, base, dry_run=False
+        )
+        if reconciled.returncode != 0:
+            detail = (reconciled.stderr or reconciled.stdout).strip()
+            return fail(
+                "worktree was removed after remote verification, but pending "
+                f"handoff reconciliation failed: {detail}"
+            )
+        if reconciled.stdout.strip():
+            print(reconciled.stdout.strip())
 
     deleted = run(repository, "branch", "-d", branch)
     if deleted.returncode != 0:

--- a/skills/synthesis-project-management/scripts/retire_worktree.py
+++ b/skills/synthesis-project-management/scripts/retire_worktree.py
@@ -184,6 +184,33 @@ def verify_reconciler_interface(checkpoint_sync: Path) -> None:
         raise ValueError("staged retirement reconciler lacks the required interface")
 
 
+def reconciler_digest(data: dict) -> str:
+    digest = data.get("reconciler_sha256")
+    if (
+        not isinstance(digest, str)
+        or len(digest) != 64
+        or any(character not in "0123456789abcdef" for character in digest)
+    ):
+        raise ValueError("retirement intent has no valid reconciler digest")
+    return digest
+
+
+def pinned_reconciler(data: dict) -> Path:
+    digest = reconciler_digest(data)
+    checkpoint_sync = RETIREMENT_RUNTIME_DIR / f"checkpoint-sync-{digest}.py"
+    validate_state_paths(RETIREMENT_RUNTIME_DIR, checkpoint_sync)
+    if checkpoint_sync.is_symlink() or not checkpoint_sync.is_file():
+        raise ValueError(
+            f"retirement intent's pinned reconciler is unavailable: {checkpoint_sync}"
+        )
+    if hashlib.sha256(checkpoint_sync.read_bytes()).hexdigest() != digest:
+        raise ValueError(
+            f"retirement intent's pinned reconciler hash does not match: {checkpoint_sync}"
+        )
+    verify_reconciler_interface(checkpoint_sync)
+    return checkpoint_sync
+
+
 def run_reconciler(
     checkpoint_sync: Path,
     arguments: list[str],
@@ -255,29 +282,60 @@ def matching_retirement_intent(
 
 
 def cleanup_branch(
-    repository: Path, branch: str, remote: str, *, delete_remote: bool
+    repository: Path,
+    branch: str,
+    remote: str,
+    expected_head: str,
+    *,
+    delete_remote: bool,
 ) -> int:
-    deleted = run(repository, "branch", "-d", branch)
-    if deleted.returncode != 0:
-        print(
-            f"retire-worktree: local branch kept: "
-            + (deleted.stderr.strip() or f"could not delete {branch}"),
-            file=sys.stderr,
-        )
-    else:
+    branch_check = run(repository, "check-ref-format", "--branch", branch)
+    if branch_check.returncode != 0:
+        return fail(f"retirement intent branch is invalid: {branch}")
+    head_check = run(repository, "rev-parse", "--verify", f"{expected_head}^{{commit}}")
+    if head_check.returncode != 0 or head_check.stdout.strip() != expected_head:
+        return fail("retirement intent head is not a canonical commit")
+
+    local_ref = f"refs/heads/{branch}"
+    local_exists = run(repository, "show-ref", "--verify", "--quiet", local_ref)
+    if local_exists.returncode == 0:
+        deleted = run(repository, "branch", "-d", branch)
+        if deleted.returncode != 0:
+            return fail(
+                "local branch cleanup failed; remote branch was not touched: "
+                + (deleted.stderr.strip() or f"could not delete {branch}")
+            )
         print(f"Deleted local branch {branch}")
+    elif local_exists.returncode == 1:
+        print(f"Local branch {branch} already absent")
+    else:
+        return fail(local_exists.stderr.strip() or "could not inspect local branch")
 
     if delete_remote:
-        listed = run(repository, "ls-remote", "--heads", remote, branch)
+        remote_ref = f"refs/heads/{branch}"
+        listed = run(repository, "ls-remote", "--heads", remote, remote_ref)
         if listed.returncode != 0:
             return fail(f"could not query {remote}: {listed.stderr.strip()}")
         if not listed.stdout.strip():
             print(f"Remote branch {remote}/{branch} already absent")
         else:
-            pushed = run(repository, "push", remote, "--delete", branch)
+            lines = [line.split() for line in listed.stdout.splitlines() if line.strip()]
+            if lines != [[expected_head, remote_ref]]:
+                return fail(
+                    f"remote branch {remote}/{branch} no longer equals the "
+                    "verified retirement head; it was not deleted"
+                )
+            pushed = run(
+                repository,
+                "push",
+                f"--force-with-lease={remote_ref}:{expected_head}",
+                remote,
+                f":{remote_ref}",
+            )
             if pushed.returncode != 0:
                 return fail(
-                    f"remote branch deletion failed: {pushed.stderr.strip()}"
+                    "remote branch deletion lease failed; the branch may have "
+                    f"advanced and was not deleted: {pushed.stderr.strip()}"
                 )
             print(f"Deleted remote branch {remote}/{branch}")
     return 0
@@ -296,16 +354,25 @@ def resume_retirement(
         return None
     intent, data = match
     recorded_branch = data.get("branch")
+    recorded_remote = data.get("remote")
+    recorded_head = data.get("head")
     if recorded_branch is not None and not isinstance(recorded_branch, str):
         return fail("retirement intent branch is invalid")
+    if not isinstance(recorded_remote, str) or not recorded_remote:
+        return fail("retirement intent remote is invalid")
+    if remote != recorded_remote:
+        return fail(
+            f"retirement intent was verified against {recorded_remote}, not {remote}"
+        )
+    if not isinstance(recorded_head, str) or not recorded_head:
+        return fail("retirement intent head is invalid")
     if expected_branch and recorded_branch and expected_branch != recorded_branch:
         return fail(
             f"retirement intent is for {recorded_branch}, not {expected_branch}"
         )
     try:
         with lifecycle_lock() as lock_fd:
-            checkpoint_sync = stage_reconciler()
-            verify_reconciler_interface(checkpoint_sync)
+            checkpoint_sync = pinned_reconciler(data)
             completed = run_reconciler(
                 checkpoint_sync,
                 ["--complete-worktree-retirement", str(intent)],
@@ -319,7 +386,13 @@ def resume_retirement(
     if not branch:
         print("retire-worktree: no recorded branch; branch cleanup was not attempted")
         return 0
-    return cleanup_branch(repository, branch, remote, delete_remote=delete_remote)
+    return cleanup_branch(
+        repository,
+        branch,
+        recorded_remote,
+        recorded_head,
+        delete_remote=delete_remote,
+    )
 
 
 def main() -> int:
@@ -489,6 +562,8 @@ def main() -> int:
                 lock_fd,
             )
             intent = reconciler_detail(prepared)
+            intent_data = json.loads(intent.read_text(encoding="utf-8"))
+            checkpoint_sync = pinned_reconciler(intent_data)
 
             removed = run(repository, "worktree", "remove", str(worktree))
             if removed.returncode != 0:
@@ -507,7 +582,11 @@ def main() -> int:
         return fail(str(exc))
 
     return cleanup_branch(
-        repository, branch, args.remote, delete_remote=args.delete_remote
+        repository,
+        branch,
+        args.remote,
+        head,
+        delete_remote=args.delete_remote,
     )
 
 

--- a/skills/synthesis-project-management/scripts/retire_worktree.py
+++ b/skills/synthesis-project-management/scripts/retire_worktree.py
@@ -21,8 +21,9 @@ directory, and refuses every unsafe state:
 - the local branch is deleted with git's safe delete only, and the remote
   branch only when --delete-remote is passed.
 
-Nothing here ever uses --force variants, and nothing is removed before its
-verification passes.
+Nothing here uses unconditional force. Optional remote deletion uses only a
+commit-bound --force-with-lease compare-and-delete operation, and nothing is
+removed before its verification passes.
 """
 
 from __future__ import annotations

--- a/skills/synthesis-project-management/scripts/retire_worktree.py
+++ b/skills/synthesis-project-management/scripts/retire_worktree.py
@@ -28,9 +28,15 @@ verification passes.
 from __future__ import annotations
 
 import argparse
+import fcntl
+import hashlib
+import json
 import os
+import stat
 import subprocess
 import sys
+import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 
 
@@ -38,6 +44,11 @@ SYNTHESIS_HOME = Path(
     os.environ.get("SYNTHESIS_HOME", str(Path.home() / ".synthesis"))
 )
 PENDING_DIR = SYNTHESIS_HOME / "repo-guard" / "pending"
+STATE_DIR = PENDING_DIR.parent
+LIFECYCLE_LOCK = STATE_DIR / "lifecycle.lock"
+RETIREMENT_RUNTIME_DIR = STATE_DIR / "retirement-runtime"
+RETIREMENT_DIR = STATE_DIR / "retired-worktrees"
+LIFECYCLE_LOCK_FD_ENV = "SYNTHESIS_LIFECYCLE_LOCK_FD"
 CHECKPOINT_SYNC = (
     Path(__file__).resolve().parents[2]
     / "synthesis-repo-guard"
@@ -81,60 +92,234 @@ def worktree_entries(repository: Path) -> list[dict[str, str]]:
     return entries
 
 
-def path_is_within(path: Path, root: Path) -> bool:
+def lexical_absolute(path: Path) -> Path:
+    return Path(os.path.abspath(os.path.expanduser(str(path))))
+
+
+def validate_state_paths(*paths: Path) -> None:
+    for value in paths:
+        path = lexical_absolute(value)
+        current = Path(path.anchor)
+        for part in path.parts[1:]:
+            current = current / part
+            if os.path.lexists(current) and current.is_symlink():
+                raise ValueError(f"state path contains a symlink component: {current}")
+
+
+@contextmanager
+def lifecycle_lock():
+    validate_state_paths(STATE_DIR, LIFECYCLE_LOCK, RETIREMENT_RUNTIME_DIR)
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    validate_state_paths(STATE_DIR, LIFECYCLE_LOCK, RETIREMENT_RUNTIME_DIR)
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(LIFECYCLE_LOCK, flags, 0o600)
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise ValueError(f"lifecycle lock is not a regular file: {LIFECYCLE_LOCK}")
+    fcntl.flock(descriptor, fcntl.LOCK_EX)
     try:
-        path.resolve(strict=False).relative_to(root.resolve(strict=False))
-        return True
-    except ValueError:
-        return False
+        yield descriptor
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
 
 
-def checkpoint_sync_path(repository: Path, worktree: Path) -> Path | None:
-    """Return a reconciler that will survive removal of the target worktree."""
+def stage_reconciler() -> Path:
+    source = CHECKPOINT_SYNC
+    if source.is_symlink() or not source.is_file():
+        raise ValueError(f"source-managed retirement reconciler is unavailable: {source}")
+    content = source.read_bytes()
+    digest = hashlib.sha256(content).hexdigest()
+    destination = RETIREMENT_RUNTIME_DIR / f"checkpoint-sync-{digest}.py"
+    validate_state_paths(RETIREMENT_RUNTIME_DIR, destination)
+    RETIREMENT_RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+    validate_state_paths(RETIREMENT_RUNTIME_DIR, destination)
+    if destination.is_symlink():
+        raise ValueError(f"staged retirement reconciler is a symlink: {destination}")
+    if destination.is_file():
+        if hashlib.sha256(destination.read_bytes()).hexdigest() != digest:
+            raise ValueError(f"staged retirement reconciler hash mismatch: {destination}")
+        return destination
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.", suffix=".tmp", dir=str(RETIREMENT_RUNTIME_DIR)
+    )
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary_name, 0o700)
+        os.replace(temporary_name, destination)
+        directory_fd = os.open(
+            RETIREMENT_RUNTIME_DIR,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except Exception:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+        raise
+    return destination
 
-    candidates = [
-        repository / "skills" / "synthesis-repo-guard" / "checkpoint_sync.py",
-        CHECKPOINT_SYNC,
-    ]
-    for candidate in candidates:
-        if candidate.is_symlink() or not candidate.is_file():
-            continue
-        resolved = candidate.resolve()
-        if not path_is_within(resolved, worktree):
-            return resolved
-    return None
+
+def verify_reconciler_interface(checkpoint_sync: Path) -> None:
+    completed = subprocess.run(
+        [sys.executable, str(checkpoint_sync), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    required = {
+        "--prepare-worktree-retirement",
+        "--complete-worktree-retirement",
+        "--retirement-remote",
+    }
+    if completed.returncode != 0 or not required.issubset(set(completed.stdout.split())):
+        raise ValueError("staged retirement reconciler lacks the required interface")
 
 
-def reconcile_pending_handoffs(
+def run_reconciler(
     checkpoint_sync: Path,
-    repository: Path,
-    worktree: Path,
-    head: str,
-    base: str,
-    *,
-    dry_run: bool,
+    arguments: list[str],
+    lock_fd: int,
 ) -> subprocess.CompletedProcess[str]:
-    arguments = [
+    environment = dict(os.environ)
+    environment[LIFECYCLE_LOCK_FD_ENV] = str(lock_fd)
+    command = [
         sys.executable,
         str(checkpoint_sync),
-        "--reconcile-retired-worktree",
-        str(worktree),
-        "--retirement-repository",
-        str(repository),
-        "--retirement-head",
-        head,
-        "--retirement-base",
-        base,
+        *arguments,
+        "--json",
     ]
-    if dry_run:
-        arguments.append("--dry-run")
     return subprocess.run(
-        arguments,
+        command,
         capture_output=True,
         text=True,
         timeout=60,
         check=False,
+        env=environment,
+        pass_fds=(lock_fd,),
     )
+
+
+def reconciler_detail(completed: subprocess.CompletedProcess[str]) -> Path:
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        try:
+            payload = json.loads(completed.stdout)
+            detail = str(payload[0].get("alert") or detail)
+        except (IndexError, TypeError, json.JSONDecodeError):
+            pass
+        raise ValueError(f"retirement preparation or completion failed: {detail}")
+    try:
+        payload = json.loads(completed.stdout)
+        detail = payload[0]["detail"]
+    except (KeyError, IndexError, TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("retirement reconciler returned invalid intent evidence") from exc
+    return lexical_absolute(Path(str(detail)))
+
+
+def matching_retirement_intent(
+    repository: Path, worktree: Path
+) -> tuple[Path, dict] | None:
+    validate_state_paths(RETIREMENT_DIR)
+    if not RETIREMENT_DIR.is_dir():
+        return None
+    matches: list[tuple[Path, dict]] = []
+    for intent in sorted(RETIREMENT_DIR.glob("*.json")):
+        validate_state_paths(intent)
+        if intent.is_symlink():
+            raise ValueError(f"retirement intent is a symlink: {intent}")
+        data = json.loads(intent.read_text(encoding="utf-8"))
+        if data.get("schema_version") != 2 or data.get("state") not in {
+            "prepared",
+            "completed",
+        }:
+            raise ValueError(f"retirement intent is invalid: {intent}")
+        if (
+            lexical_absolute(Path(str(data.get("repository") or "")))
+            == lexical_absolute(repository)
+            and lexical_absolute(Path(str(data.get("worktree") or "")))
+            == lexical_absolute(worktree)
+        ):
+            matches.append((intent, data))
+    if len(matches) > 1:
+        raise ValueError("multiple retirement intents match the missing worktree")
+    return matches[0] if matches else None
+
+
+def cleanup_branch(
+    repository: Path, branch: str, remote: str, *, delete_remote: bool
+) -> int:
+    deleted = run(repository, "branch", "-d", branch)
+    if deleted.returncode != 0:
+        print(
+            f"retire-worktree: local branch kept: "
+            + (deleted.stderr.strip() or f"could not delete {branch}"),
+            file=sys.stderr,
+        )
+    else:
+        print(f"Deleted local branch {branch}")
+
+    if delete_remote:
+        listed = run(repository, "ls-remote", "--heads", remote, branch)
+        if listed.returncode != 0:
+            return fail(f"could not query {remote}: {listed.stderr.strip()}")
+        if not listed.stdout.strip():
+            print(f"Remote branch {remote}/{branch} already absent")
+        else:
+            pushed = run(repository, "push", remote, "--delete", branch)
+            if pushed.returncode != 0:
+                return fail(
+                    f"remote branch deletion failed: {pushed.stderr.strip()}"
+                )
+            print(f"Deleted remote branch {remote}/{branch}")
+    return 0
+
+
+def resume_retirement(
+    repository: Path,
+    worktree: Path,
+    expected_branch: str | None,
+    remote: str,
+    *,
+    delete_remote: bool,
+) -> int | None:
+    match = matching_retirement_intent(repository, worktree)
+    if match is None:
+        return None
+    intent, data = match
+    recorded_branch = data.get("branch")
+    if recorded_branch is not None and not isinstance(recorded_branch, str):
+        return fail("retirement intent branch is invalid")
+    if expected_branch and recorded_branch and expected_branch != recorded_branch:
+        return fail(
+            f"retirement intent is for {recorded_branch}, not {expected_branch}"
+        )
+    try:
+        with lifecycle_lock() as lock_fd:
+            checkpoint_sync = stage_reconciler()
+            verify_reconciler_interface(checkpoint_sync)
+            completed = run_reconciler(
+                checkpoint_sync,
+                ["--complete-worktree-retirement", str(intent)],
+                lock_fd,
+            )
+            reconciler_detail(completed)
+            print(f"Resumed retirement from {intent}")
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        return fail(str(exc))
+    branch = expected_branch or recorded_branch
+    if not branch:
+        print("retire-worktree: no recorded branch; branch cleanup was not attempted")
+        return 0
+    return cleanup_branch(repository, branch, remote, delete_remote=delete_remote)
 
 
 def main() -> int:
@@ -158,12 +343,6 @@ def main() -> int:
         "<remote>/main).",
     )
     parser.add_argument("--remote", default="origin")
-    parser.add_argument(
-        "--no-fetch",
-        action="store_true",
-        help="Skip the pre-verification fetch (verification then runs against "
-        "the last-fetched state).",
-    )
     parser.add_argument(
         "--delete-remote",
         action="store_true",
@@ -201,6 +380,18 @@ def main() -> int:
         None,
     )
     if match is None:
+        try:
+            resumed = resume_retirement(
+                repository,
+                worktree,
+                args.branch,
+                args.remote,
+                delete_remote=args.delete_remote,
+            )
+        except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            return fail(str(exc))
+        if resumed is not None:
+            return resumed
         return fail(f"{worktree} is not a worktree of {repository}")
     if Path(match["worktree"]).resolve() == main_worktree:
         return fail("refusing to retire the repository's main worktree")
@@ -228,14 +419,12 @@ def main() -> int:
     if args.branch and args.branch != branch:
         return fail(f"worktree is on {branch}, not the expected {args.branch}")
 
-    if not args.no_fetch:
-        fetched = run(repository, "fetch", "--quiet", "--prune", args.remote)
-        if fetched.returncode != 0:
-            return fail(
-                f"fetch from {args.remote} failed (pass --no-fetch only to "
-                "verify against last-fetched state): "
-                + fetched.stderr.strip()
-            )
+    fetched = run(repository, "fetch", "--quiet", "--prune", args.remote)
+    if fetched.returncode != 0:
+        return fail(
+            f"fetch from {args.remote} failed; remote ancestry cannot be proven: "
+            + fetched.stderr.strip()
+        )
 
     base = args.base
     if base is None:
@@ -249,11 +438,23 @@ def main() -> int:
             f"could not resolve a verification base under {args.remote}; "
             "pass --base explicitly"
         )
-    base_check = run(repository, "rev-parse", "--verify", "--quiet", base)
-    if base_check.returncode != 0:
+    symbolic_base = run(repository, "rev-parse", "--symbolic-full-name", base)
+    remote_prefix = f"refs/remotes/{args.remote}/"
+    if (
+        symbolic_base.returncode != 0
+        or not symbolic_base.stdout.strip().startswith(remote_prefix)
+    ):
+        return fail(
+            f"verification base must be a freshly fetched {args.remote} "
+            "remote-tracking ref"
+        )
+    base = symbolic_base.stdout.strip()
+    base_check = run(repository, "rev-parse", "--verify", f"{base}^{{commit}}")
+    if base_check.returncode != 0 or not base_check.stdout.strip():
         return fail(f"verification base does not resolve: {base}")
+    base_oid = base_check.stdout.strip()
 
-    ancestry = run(repository, "merge-base", "--is-ancestor", branch, base)
+    ancestry = run(repository, "merge-base", "--is-ancestor", branch, base_oid)
     if ancestry.returncode != 0:
         return fail(
             f"branch {branch} is not fully contained in {base}; its commits "
@@ -265,65 +466,49 @@ def main() -> int:
         return fail(head_result.stderr.strip() or "worktree HEAD is unavailable")
     head = head_result.stdout.strip()
 
-    if PENDING_DIR.is_symlink():
-        return fail(f"pending handoff directory is a symlink: {PENDING_DIR}")
-    pending_exists = PENDING_DIR.is_dir() and any(PENDING_DIR.glob("*.json"))
-    checkpoint_sync = checkpoint_sync_path(repository, worktree)
-    if pending_exists:
-        if checkpoint_sync is None:
-            return fail(
-                "pending handoff manifests exist but their source-managed "
-                "reconciler is unavailable outside the target worktree"
+    try:
+        with lifecycle_lock() as lock_fd:
+            checkpoint_sync = stage_reconciler()
+            verify_reconciler_interface(checkpoint_sync)
+            prepared = run_reconciler(
+                checkpoint_sync,
+                [
+                    "--prepare-worktree-retirement",
+                    str(worktree),
+                    "--retirement-repository",
+                    str(repository),
+                    "--retirement-head",
+                    head,
+                    "--retirement-remote",
+                    args.remote,
+                    "--retirement-base",
+                    base,
+                    "--retirement-branch",
+                    branch,
+                ],
+                lock_fd,
             )
-        preflight = reconcile_pending_handoffs(
-            checkpoint_sync, repository, worktree, head, base, dry_run=True
-        )
-        if preflight.returncode != 0:
-            detail = (preflight.stderr or preflight.stdout).strip()
-            return fail(f"pending handoff reconciliation preflight failed: {detail}")
+            intent = reconciler_detail(prepared)
 
-    removed = run(repository, "worktree", "remove", str(worktree))
-    if removed.returncode != 0:
-        return fail(removed.stderr.strip() or "git worktree remove failed")
-    print(f"Removed worktree {worktree}")
+            removed = run(repository, "worktree", "remove", str(worktree))
+            if removed.returncode != 0:
+                return fail(removed.stderr.strip() or "git worktree remove failed")
+            print(f"Removed worktree {worktree}")
 
-    if checkpoint_sync is not None:
-        reconciled = reconcile_pending_handoffs(
-            checkpoint_sync, repository, worktree, head, base, dry_run=False
-        )
-        if reconciled.returncode != 0:
-            detail = (reconciled.stderr or reconciled.stdout).strip()
-            return fail(
-                "worktree was removed after remote verification, but pending "
-                f"handoff reconciliation failed: {detail}"
+            completed = run_reconciler(
+                checkpoint_sync,
+                ["--complete-worktree-retirement", str(intent)],
+                lock_fd,
             )
-        if reconciled.stdout.strip():
-            print(reconciled.stdout.strip())
+            reconciler_detail(completed)
+            if completed.stdout.strip():
+                print(completed.stdout.strip())
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        return fail(str(exc))
 
-    deleted = run(repository, "branch", "-d", branch)
-    if deleted.returncode != 0:
-        print(
-            f"retire-worktree: local branch kept: "
-            + (deleted.stderr.strip() or f"could not delete {branch}"),
-            file=sys.stderr,
-        )
-    else:
-        print(f"Deleted local branch {branch}")
-
-    if args.delete_remote:
-        listed = run(repository, "ls-remote", "--heads", args.remote, branch)
-        if listed.returncode != 0:
-            return fail(f"could not query {args.remote}: {listed.stderr.strip()}")
-        if not listed.stdout.strip():
-            print(f"Remote branch {args.remote}/{branch} already absent")
-        else:
-            pushed = run(repository, "push", args.remote, "--delete", branch)
-            if pushed.returncode != 0:
-                return fail(
-                    f"remote branch deletion failed: {pushed.stderr.strip()}"
-                )
-            print(f"Deleted remote branch {args.remote}/{branch}")
-    return 0
+    return cleanup_branch(
+        repository, branch, args.remote, delete_remote=args.delete_remote
+    )
 
 
 if __name__ == "__main__":

--- a/skills/synthesis-project-management/scripts/test_retire_worktree.py
+++ b/skills/synthesis-project-management/scripts/test_retire_worktree.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import hashlib
+import importlib.util
+import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 
 SCRIPT = Path(__file__).with_name("retire_worktree.py")
+SPEC = importlib.util.spec_from_file_location("retire_worktree", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
 
 
 def git(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
@@ -18,12 +26,17 @@ def git(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
 
 
 def retire(*arguments: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    worktree = Path(arguments[arguments.index("--worktree") + 1])
+    synthesis_home = worktree.parent.parent / "synthesis-home"
+    environment = dict(os.environ)
+    environment["SYNTHESIS_HOME"] = str(synthesis_home)
     return subprocess.run(
         [sys.executable, str(SCRIPT), *arguments],
         capture_output=True,
         text=True,
         check=False,
         cwd=str(cwd) if cwd else None,
+        env=environment,
     )
 
 
@@ -183,3 +196,114 @@ def test_no_fetch_verifies_against_last_fetched_state(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert not worktree.exists()
+
+
+def test_retirement_reconciles_session_manifest_and_invalidates_receipt(
+    tmp_path: Path,
+) -> None:
+    _remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+    synthesis_home = worktree.parent.parent / "synthesis-home"
+    pending = synthesis_home / "repo-guard" / "pending"
+    receipts = synthesis_home / "repo-guard" / "local-handoff"
+    pending.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    session_id = "session-retirement"
+    name = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+    manifest = pending / name
+    survivor = clone / "seed.txt"
+    retired = worktree / "change.txt"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": session_id,
+                "paths": [str(retired), str(survivor)],
+                "remote_paths": [str(survivor)],
+            }
+        ),
+        encoding="utf-8",
+    )
+    receipt = receipts / name
+    receipt.write_text("{}\n", encoding="utf-8")
+
+    result = retire("--repository", str(clone), "--worktree", str(worktree))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert payload["paths"] == [str(survivor)]
+    assert payload["remote_paths"] == [str(survivor)]
+    assert payload["retired_worktrees"][0]["worktree"] == str(worktree.resolve())
+    assert not receipt.exists()
+    records = list((synthesis_home / "repo-guard" / "retired-worktrees").glob("*.json"))
+    assert len(records) == 1
+    assert json.loads(records[0].read_text(encoding="utf-8"))["paths_removed"] == 1
+
+
+def test_invalid_manifest_blocks_retirement_before_worktree_removal(
+    tmp_path: Path,
+) -> None:
+    _remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+    synthesis_home = worktree.parent.parent / "synthesis-home"
+    pending = synthesis_home / "repo-guard" / "pending"
+    pending.mkdir(parents=True)
+    (pending / "invalid.json").write_text("not-json\n", encoding="utf-8")
+
+    result = retire("--repository", str(clone), "--worktree", str(worktree))
+
+    assert result.returncode == 2
+    assert "reconciliation preflight failed" in result.stderr
+    assert worktree.exists()
+
+
+def test_invalid_retirement_history_blocks_removal(tmp_path: Path) -> None:
+    _remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+    synthesis_home = worktree.parent.parent / "synthesis-home"
+    pending = synthesis_home / "repo-guard" / "pending"
+    pending.mkdir(parents=True)
+    session_id = "session-invalid-history"
+    name = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+    (pending / name).write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": session_id,
+                "paths": [str(worktree / "change.txt")],
+                "remote_paths": [],
+                "retired_worktrees": "invalid",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = retire("--repository", str(clone), "--worktree", str(worktree))
+
+    assert result.returncode == 2
+    assert "retired_worktrees history is invalid" in result.stderr
+    assert worktree.exists()
+
+
+def test_reconciler_resolution_survives_target_worktree_removal(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repository = tmp_path / "repository"
+    worktree = tmp_path / "target-worktree"
+    canonical = (
+        repository / "skills" / "synthesis-repo-guard" / "checkpoint_sync.py"
+    )
+    target_local = worktree / "skills" / "synthesis-repo-guard" / "checkpoint_sync.py"
+    canonical.parent.mkdir(parents=True)
+    target_local.parent.mkdir(parents=True)
+    canonical.write_text("# canonical\n", encoding="utf-8")
+    target_local.write_text("# target local\n", encoding="utf-8")
+    monkeypatch.setattr(MODULE, "CHECKPOINT_SYNC", target_local)
+
+    assert MODULE.checkpoint_sync_path(repository, worktree) == canonical.resolve()
+
+    canonical.unlink()
+    assert MODULE.checkpoint_sync_path(repository, worktree) is None

--- a/skills/synthesis-project-management/scripts/test_retire_worktree.py
+++ b/skills/synthesis-project-management/scripts/test_retire_worktree.py
@@ -4,12 +4,16 @@ import hashlib
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 
 SCRIPT = Path(__file__).with_name("retire_worktree.py")
+CHECKPOINT_SCRIPT = (
+    SCRIPT.resolve().parents[2] / "synthesis-repo-guard" / "checkpoint_sync.py"
+)
 SPEC = importlib.util.spec_from_file_location("retire_worktree", SCRIPT)
 assert SPEC and SPEC.loader
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -182,7 +186,7 @@ def test_branch_mismatch_and_detached_head_refuse(tmp_path: Path) -> None:
     assert "not on a local branch" in result.stderr
 
 
-def test_no_fetch_verifies_against_last_fetched_state(tmp_path: Path) -> None:
+def test_no_fetch_escape_hatch_is_rejected(tmp_path: Path) -> None:
     remote, clone = build_repo(tmp_path)
     worktree = add_feature_worktree(tmp_path, clone)
     commit_and_merge(clone, worktree)
@@ -194,8 +198,28 @@ def test_no_fetch_verifies_against_last_fetched_state(tmp_path: Path) -> None:
         str(worktree),
         "--no-fetch",
     )
-    assert result.returncode == 0, result.stderr
-    assert not worktree.exists()
+    assert result.returncode == 2
+    assert "unrecognized arguments: --no-fetch" in result.stderr
+    assert worktree.exists()
+
+
+def test_local_verification_base_is_rejected(tmp_path: Path) -> None:
+    _remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+
+    result = retire(
+        "--repository",
+        str(clone),
+        "--worktree",
+        str(worktree),
+        "--base",
+        "HEAD",
+    )
+
+    assert result.returncode == 2
+    assert "remote-tracking ref" in result.stderr
+    assert worktree.exists()
 
 
 def test_retirement_reconciles_session_manifest_and_invalidates_receipt(
@@ -255,7 +279,7 @@ def test_invalid_manifest_blocks_retirement_before_worktree_removal(
     result = retire("--repository", str(clone), "--worktree", str(worktree))
 
     assert result.returncode == 2
-    assert "reconciliation preflight failed" in result.stderr
+    assert "retirement preparation or completion failed" in result.stderr
     assert worktree.exists()
 
 
@@ -288,22 +312,162 @@ def test_invalid_retirement_history_blocks_removal(tmp_path: Path) -> None:
     assert worktree.exists()
 
 
-def test_reconciler_resolution_survives_target_worktree_removal(
+def test_staged_reconciler_survives_source_removal(
     tmp_path: Path, monkeypatch
 ) -> None:
-    repository = tmp_path / "repository"
     worktree = tmp_path / "target-worktree"
-    canonical = (
-        repository / "skills" / "synthesis-repo-guard" / "checkpoint_sync.py"
-    )
     target_local = worktree / "skills" / "synthesis-repo-guard" / "checkpoint_sync.py"
-    canonical.parent.mkdir(parents=True)
     target_local.parent.mkdir(parents=True)
-    canonical.write_text("# canonical\n", encoding="utf-8")
-    target_local.write_text("# target local\n", encoding="utf-8")
+    shutil.copy2(CHECKPOINT_SCRIPT, target_local)
     monkeypatch.setattr(MODULE, "CHECKPOINT_SYNC", target_local)
+    monkeypatch.setattr(MODULE, "RETIREMENT_RUNTIME_DIR", tmp_path / "runtime")
 
-    assert MODULE.checkpoint_sync_path(repository, worktree) == canonical.resolve()
+    staged = MODULE.stage_reconciler()
+    MODULE.verify_reconciler_interface(staged)
+    expected = hashlib.sha256(target_local.read_bytes()).hexdigest()
 
-    canonical.unlink()
-    assert MODULE.checkpoint_sync_path(repository, worktree) is None
+    shutil.rmtree(worktree)
+    assert staged.is_file()
+    assert hashlib.sha256(staged.read_bytes()).hexdigest() == expected
+
+
+def test_helper_invoked_from_target_completes_after_target_removal(
+    tmp_path: Path,
+) -> None:
+    _remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    target_helper = (
+        worktree
+        / "skills"
+        / "synthesis-project-management"
+        / "scripts"
+        / "retire_worktree.py"
+    )
+    target_reconciler = (
+        worktree / "skills" / "synthesis-repo-guard" / "checkpoint_sync.py"
+    )
+    target_helper.parent.mkdir(parents=True)
+    target_reconciler.parent.mkdir(parents=True)
+    shutil.copy2(SCRIPT, target_helper)
+    shutil.copy2(CHECKPOINT_SCRIPT, target_reconciler)
+    retired = worktree / "change.txt"
+    retired.write_text("change\n", encoding="utf-8")
+    git(worktree, "add", ".")
+    git(worktree, "commit", "--quiet", "-m", "change")
+    git(worktree, "push", "--quiet", "-u", "origin", "feature/demo")
+    git(clone, "merge", "--quiet", "--no-edit", "feature/demo")
+    git(clone, "push", "--quiet", "origin", "main")
+
+    synthesis_home = tmp_path / "synthesis-home"
+    pending = synthesis_home / "repo-guard" / "pending"
+    receipts = synthesis_home / "repo-guard" / "local-handoff"
+    pending.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    session_id = "session-target-helper"
+    name = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+    manifest = pending / name
+    survivor = clone / "seed.txt"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": session_id,
+                "paths": [str(retired), str(survivor)],
+                "remote_paths": [str(survivor)],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipts / name).write_text("{}\n", encoding="utf-8")
+    environment = dict(os.environ)
+    environment["SYNTHESIS_HOME"] = str(synthesis_home)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(target_helper),
+            "--repository",
+            str(clone),
+            "--worktree",
+            str(worktree),
+        ],
+        cwd=clone,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not worktree.exists()
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert payload["paths"] == [str(survivor)]
+    intents = list((synthesis_home / "repo-guard" / "retired-worktrees").glob("*.json"))
+    assert len(intents) == 1
+    assert json.loads(intents[0].read_text(encoding="utf-8"))["state"] == "completed"
+
+
+def test_helper_resumes_from_prepared_intent_after_interruption(
+    tmp_path: Path,
+) -> None:
+    _remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+    head = git(worktree, "rev-parse", "HEAD").stdout.strip()
+    synthesis_home = worktree.parent.parent / "synthesis-home"
+    pending = synthesis_home / "repo-guard" / "pending"
+    pending.mkdir(parents=True)
+    session_id = "session-interrupted-retirement"
+    name = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+    manifest = pending / name
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": session_id,
+                "paths": [str(worktree / "change.txt")],
+                "remote_paths": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    environment = dict(os.environ)
+    environment["SYNTHESIS_HOME"] = str(synthesis_home)
+    prepared = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKPOINT_SCRIPT),
+            "--prepare-worktree-retirement",
+            str(worktree),
+            "--retirement-repository",
+            str(clone),
+            "--retirement-head",
+            head,
+            "--retirement-remote",
+            "origin",
+            "--retirement-base",
+            "origin/main",
+            "--retirement-branch",
+            "feature/demo",
+            "--json",
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert prepared.returncode == 0, prepared.stderr
+    intent = Path(json.loads(prepared.stdout)[0]["detail"])
+    assert json.loads(intent.read_text(encoding="utf-8"))["state"] == "prepared"
+    git(clone, "worktree", "remove", str(worktree))
+
+    resumed = retire("--repository", str(clone), "--worktree", str(worktree))
+
+    assert resumed.returncode == 0, resumed.stderr
+    assert "Resumed retirement" in resumed.stdout
+    assert not manifest.exists()
+    assert json.loads(intent.read_text(encoding="utf-8"))["state"] == "completed"
+    assert not git(clone, "branch", "--list", "feature/demo").stdout.strip()
+
+    repeated = retire("--repository", str(clone), "--worktree", str(worktree))
+    assert repeated.returncode == 0, repeated.stderr

--- a/skills/synthesis-project-management/scripts/test_retire_worktree.py
+++ b/skills/synthesis-project-management/scripts/test_retire_worktree.py
@@ -433,6 +433,10 @@ def test_helper_resumes_from_prepared_intent_after_interruption(
     )
     environment = dict(os.environ)
     environment["SYNTHESIS_HOME"] = str(synthesis_home)
+    digest = hashlib.sha256(CHECKPOINT_SCRIPT.read_bytes()).hexdigest()
+    runtime = synthesis_home / "repo-guard" / "retirement-runtime"
+    runtime.mkdir(parents=True)
+    shutil.copy2(CHECKPOINT_SCRIPT, runtime / f"checkpoint-sync-{digest}.py")
     prepared = subprocess.run(
         [
             sys.executable,
@@ -471,3 +475,247 @@ def test_helper_resumes_from_prepared_intent_after_interruption(
 
     repeated = retire("--repository", str(clone), "--worktree", str(worktree))
     assert repeated.returncode == 0, repeated.stderr
+
+
+def test_resume_uses_intent_pinned_reconciler_after_source_changes(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+    head = git(worktree, "rev-parse", "HEAD").stdout.strip()
+    synthesis_home = worktree.parent.parent / "synthesis-home"
+    state = synthesis_home / "repo-guard"
+    pending = state / "pending"
+    runtime = state / "retirement-runtime"
+    retirements = state / "retired-worktrees"
+    pending.mkdir(parents=True)
+    runtime.mkdir(parents=True)
+    session_id = "session-pinned-reconciler"
+    name = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+    manifest = pending / name
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": session_id,
+                "paths": [str(worktree / "change.txt")],
+                "remote_paths": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    digest = hashlib.sha256(CHECKPOINT_SCRIPT.read_bytes()).hexdigest()
+    pinned = runtime / f"checkpoint-sync-{digest}.py"
+    shutil.copy2(CHECKPOINT_SCRIPT, pinned)
+    environment = dict(os.environ)
+    environment["SYNTHESIS_HOME"] = str(synthesis_home)
+    prepared = subprocess.run(
+        [
+            sys.executable,
+            str(pinned),
+            "--prepare-worktree-retirement",
+            str(worktree),
+            "--retirement-repository",
+            str(clone),
+            "--retirement-head",
+            head,
+            "--retirement-remote",
+            "origin",
+            "--retirement-base",
+            "origin/main",
+            "--retirement-branch",
+            "feature/demo",
+            "--json",
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert prepared.returncode == 0, prepared.stderr
+    intent = Path(json.loads(prepared.stdout)[0]["detail"])
+    git(clone, "worktree", "remove", str(worktree))
+
+    changed_source = tmp_path / "changed-checkpoint-sync.py"
+    changed_source.write_text("raise SystemExit('wrong reconciler')\n", encoding="utf-8")
+    monkeypatch.setattr(MODULE, "CHECKPOINT_SYNC", changed_source)
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    monkeypatch.setattr(MODULE, "STATE_DIR", state)
+    monkeypatch.setattr(MODULE, "LIFECYCLE_LOCK", state / "lifecycle.lock")
+    monkeypatch.setattr(MODULE, "RETIREMENT_RUNTIME_DIR", runtime)
+    monkeypatch.setattr(MODULE, "RETIREMENT_DIR", retirements)
+    monkeypatch.setenv("SYNTHESIS_HOME", str(synthesis_home))
+
+    result = MODULE.resume_retirement(
+        clone, worktree, "feature/demo", "origin", delete_remote=False
+    )
+
+    assert result == 0
+    assert not manifest.exists()
+    assert json.loads(intent.read_text(encoding="utf-8"))["state"] == "completed"
+
+
+def test_resume_refuses_remote_different_from_intent(tmp_path: Path) -> None:
+    _remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+    head = git(worktree, "rev-parse", "HEAD").stdout.strip()
+    synthesis_home = worktree.parent.parent / "synthesis-home"
+    pending = synthesis_home / "repo-guard" / "pending"
+    pending.mkdir(parents=True)
+    session_id = "session-remote-mismatch"
+    name = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+    manifest = pending / name
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": session_id,
+                "paths": [str(worktree / "change.txt")],
+                "remote_paths": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    environment = dict(os.environ)
+    environment["SYNTHESIS_HOME"] = str(synthesis_home)
+    prepared = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKPOINT_SCRIPT),
+            "--prepare-worktree-retirement",
+            str(worktree),
+            "--retirement-repository",
+            str(clone),
+            "--retirement-head",
+            head,
+            "--retirement-remote",
+            "origin",
+            "--retirement-base",
+            "origin/main",
+            "--retirement-branch",
+            "feature/demo",
+            "--json",
+        ],
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert prepared.returncode == 0, prepared.stderr
+    git(clone, "worktree", "remove", str(worktree))
+
+    result = retire(
+        "--repository",
+        str(clone),
+        "--worktree",
+        str(worktree),
+        "--remote",
+        "other",
+    )
+
+    assert result.returncode == 2
+    assert "verified against origin, not other" in result.stderr
+    assert manifest.exists()
+    assert git(clone, "branch", "--list", "feature/demo").stdout.strip()
+
+
+def test_remote_branch_advance_blocks_delete(tmp_path: Path) -> None:
+    remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    commit_and_merge(clone, worktree)
+    expected_head = git(worktree, "rev-parse", "HEAD").stdout.strip()
+    git(clone, "worktree", "remove", str(worktree))
+
+    contender = tmp_path / "contender"
+    subprocess.run(
+        ["git", "clone", "--quiet", str(remote), str(contender)],
+        check=True,
+        capture_output=True,
+    )
+    git(contender, "config", "user.email", "test@example.com")
+    git(contender, "config", "user.name", "Test")
+    git(contender, "checkout", "--quiet", "-b", "feature/demo", "origin/feature/demo")
+    (contender / "advanced.txt").write_text("advanced\n", encoding="utf-8")
+    git(contender, "add", "advanced.txt")
+    git(contender, "commit", "--quiet", "-m", "advanced")
+    git(contender, "push", "--quiet", "origin", "feature/demo")
+    advanced_head = git(contender, "rev-parse", "HEAD").stdout.strip()
+
+    result = MODULE.cleanup_branch(
+        clone,
+        "feature/demo",
+        "origin",
+        expected_head,
+        delete_remote=True,
+    )
+
+    assert result == 2
+    remote_head = git(clone, "ls-remote", "--heads", "origin", "feature/demo").stdout
+    assert remote_head.split()[0] == advanced_head
+
+
+def test_local_branch_delete_failure_never_touches_remote(tmp_path: Path) -> None:
+    _remote, clone = build_repo(tmp_path)
+    worktree = add_feature_worktree(tmp_path, clone)
+    (worktree / "unmerged.txt").write_text("unmerged\n", encoding="utf-8")
+    git(worktree, "add", "unmerged.txt")
+    git(worktree, "commit", "--quiet", "-m", "unmerged")
+    git(worktree, "push", "--quiet", "-u", "origin", "feature/demo")
+    expected_head = git(worktree, "rev-parse", "HEAD").stdout.strip()
+    git(clone, "worktree", "remove", str(worktree))
+    git(clone, "branch", "--unset-upstream", "feature/demo")
+
+    result = MODULE.cleanup_branch(
+        clone,
+        "feature/demo",
+        "origin",
+        expected_head,
+        delete_remote=True,
+    )
+
+    assert result == 2
+    remote_head = git(clone, "ls-remote", "--heads", "origin", "feature/demo").stdout
+    assert remote_head.split()[0] == expected_head
+
+
+def test_remote_delete_uses_compare_and_delete_lease(monkeypatch, tmp_path: Path) -> None:
+    expected_head = "a" * 40
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(_repository: Path, *arguments: str, timeout: int = 60):
+        del timeout
+        calls.append(arguments)
+        if arguments[:2] == ("check-ref-format", "--branch"):
+            return subprocess.CompletedProcess(arguments, 0, "feature/demo\n", "")
+        if arguments[:2] == ("rev-parse", "--verify"):
+            return subprocess.CompletedProcess(arguments, 0, f"{expected_head}\n", "")
+        if arguments[:3] == ("show-ref", "--verify", "--quiet"):
+            return subprocess.CompletedProcess(arguments, 1, "", "")
+        if arguments[:2] == ("ls-remote", "--heads"):
+            return subprocess.CompletedProcess(
+                arguments, 0, f"{expected_head}\trefs/heads/feature/demo\n", ""
+            )
+        if arguments[0] == "push":
+            return subprocess.CompletedProcess(arguments, 0, "", "")
+        raise AssertionError(arguments)
+
+    monkeypatch.setattr(MODULE, "run", fake_run)
+
+    result = MODULE.cleanup_branch(
+        tmp_path,
+        "feature/demo",
+        "origin",
+        expected_head,
+        delete_remote=True,
+    )
+
+    assert result == 0
+    push = next(arguments for arguments in calls if arguments[0] == "push")
+    assert push == (
+        "push",
+        f"--force-with-lease=refs/heads/feature/demo:{expected_head}",
+        "origin",
+        ":refs/heads/feature/demo",
+    )

--- a/skills/synthesis-repo-guard/SKILL.md
+++ b/skills/synthesis-repo-guard/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.1.2"
+  version: "2.2.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -83,10 +83,11 @@ Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`)
 - Remote publication orders exact-path context commit, fetch, then
   fast-forward push. Existing staged or dirty files outside the manifest
   remain untouched.
-- The worktree-retirement helper removes attributed paths only after proving
-  the clean worktree head is contained in the fetched remote base. It
-  invalidates the old local receipt and records an audit artifact; a missing
-  path without this lifecycle proof remains a fail-closed Stop error.
+- Manifest writers, Stop receipts, remote flushes, and worktree retirement use
+  one lifecycle lock. Retirement pins a freshly fetched remote-tracking
+  commit, fsyncs a resumable intent before removal, invalidates old receipts,
+  and completes idempotently after interruption. A missing path without this
+  proof remains a fail-closed Stop error.
 - A distinct commit author identifies batched remote-context commits.
 - Divergence leaves the exact commit and manifest local and reports the
   block. Never rebase or force-push.
@@ -218,9 +219,13 @@ repo_sync_check.py [--workspace W] [--max-depth N] [--quiet] [--json]
 
 checkpoint_sync.py [--config C] [--repo PATH] [--hook] [--now]
                    [--flush-pending] [--no-throttle] [--dry-run]
+                   [--prepare-worktree-retirement PATH
+                    --retirement-repository REPO --retirement-head SHA
+                    --retirement-remote REMOTE --retirement-base REMOTE_REF]
+                   [--complete-worktree-retirement INTENT]
                    [--reconcile-retired-worktree PATH
                     --retirement-repository REPO --retirement-head SHA
-                    --retirement-base REF]
+                    --retirement-remote REMOTE --retirement-base REMOTE_REF]
                    [--quiet] [--json]
                    [--speak] [--notify]
 ```
@@ -245,9 +250,9 @@ checkpoint_sync.py [--config C] [--repo PATH] [--hook] [--now]
 
 ## Changelog
 
-- **2.1.2 (2026-08-14):** reconciles verified retired-worktree paths with
-  pending session manifests, invalidates stale receipts, and keeps unexplained
-  missing paths fail-closed.
+- **2.2.0 (2026-08-14):** makes retirement a lifecycle-locked, remote-pinned,
+  fsynced, resumable transaction across manifests and receipts; keeps
+  unexplained missing and unpublished paths fail-closed.
 - **2.1.1 (2026-08-14):** clarifies that a clean no-edit task needs no empty receipt and that remote readiness compares complete branch heads rather than project-path history.
 - **2.1.0 (2026-08-14):** separates local and remote readiness. Stop records atomic client-session receipts without Git or network mutation; interruption leaves a recoverable manifest; explicit remote handoff batches exact private-context paths only after source paths are upstream-current. Adds worktree identity, first-branch publication, generic commit messages, staged-index isolation, and integration fixtures.
 - **2.0.0 (2026-07-08):** three-layer redesign. Generic-only audio/banner (confidentiality rule), `~/.synthesis/quiet-audio` mute flag, report files + history, remediation hints, new `checkpoint_sync.py` (event-driven auto-commit/push: runtime remote guard, quiescence, shared throttle, ff-only push, distinct author, stale-lock detection), synthesis-console integration contract, scheduled-mutation explicitly disallowed. Origin: 2026-07-08 design review (lesson: alert-channel confidentiality + event-driven checkpoints).

--- a/skills/synthesis-repo-guard/SKILL.md
+++ b/skills/synthesis-repo-guard/SKILL.md
@@ -251,8 +251,10 @@ checkpoint_sync.py [--config C] [--repo PATH] [--hook] [--now]
 ## Changelog
 
 - **2.2.0 (2026-08-14):** makes retirement a lifecycle-locked, remote-pinned,
-  fsynced, resumable transaction across manifests and receipts; keeps
-  unexplained missing and unpublished paths fail-closed.
+  fsynced, resumable transaction across manifests and receipts; resumes with
+  the intent's exact content-addressed reconciler and compare-binds optional
+  remote branch deletion to the verified head; keeps unexplained missing and
+  unpublished paths fail-closed.
 - **2.1.1 (2026-08-14):** clarifies that a clean no-edit task needs no empty receipt and that remote readiness compares complete branch heads rather than project-path history.
 - **2.1.0 (2026-08-14):** separates local and remote readiness. Stop records atomic client-session receipts without Git or network mutation; interruption leaves a recoverable manifest; explicit remote handoff batches exact private-context paths only after source paths are upstream-current. Adds worktree identity, first-branch publication, generic commit messages, staged-index isolation, and integration fixtures.
 - **2.0.0 (2026-07-08):** three-layer redesign. Generic-only audio/banner (confidentiality rule), `~/.synthesis/quiet-audio` mute flag, report files + history, remediation hints, new `checkpoint_sync.py` (event-driven auto-commit/push: runtime remote guard, quiescence, shared throttle, ff-only push, distinct author, stale-lock detection), synthesis-console integration contract, scheduled-mutation explicitly disallowed. Origin: 2026-07-08 design review (lesson: alert-channel confidentiality + event-driven checkpoints).

--- a/skills/synthesis-repo-guard/SKILL.md
+++ b/skills/synthesis-repo-guard/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.1.1"
+  version: "2.1.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -83,6 +83,10 @@ Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`)
 - Remote publication orders exact-path context commit, fetch, then
   fast-forward push. Existing staged or dirty files outside the manifest
   remain untouched.
+- The worktree-retirement helper removes attributed paths only after proving
+  the clean worktree head is contained in the fetched remote base. It
+  invalidates the old local receipt and records an audit artifact; a missing
+  path without this lifecycle proof remains a fail-closed Stop error.
 - A distinct commit author identifies batched remote-context commits.
 - Divergence leaves the exact commit and manifest local and reports the
   block. Never rebase or force-push.
@@ -214,6 +218,9 @@ repo_sync_check.py [--workspace W] [--max-depth N] [--quiet] [--json]
 
 checkpoint_sync.py [--config C] [--repo PATH] [--hook] [--now]
                    [--flush-pending] [--no-throttle] [--dry-run]
+                   [--reconcile-retired-worktree PATH
+                    --retirement-repository REPO --retirement-head SHA
+                    --retirement-base REF]
                    [--quiet] [--json]
                    [--speak] [--notify]
 ```
@@ -238,6 +245,9 @@ checkpoint_sync.py [--config C] [--repo PATH] [--hook] [--now]
 
 ## Changelog
 
+- **2.1.2 (2026-08-14):** reconciles verified retired-worktree paths with
+  pending session manifests, invalidates stale receipts, and keeps unexplained
+  missing paths fail-closed.
 - **2.1.1 (2026-08-14):** clarifies that a clean no-edit task needs no empty receipt and that remote readiness compares complete branch heads rather than project-path history.
 - **2.1.0 (2026-08-14):** separates local and remote readiness. Stop records atomic client-session receipts without Git or network mutation; interruption leaves a recoverable manifest; explicit remote handoff batches exact private-context paths only after source paths are upstream-current. Adds worktree identity, first-branch publication, generic commit messages, staged-index isolation, and integration fixtures.
 - **2.0.0 (2026-07-08):** three-layer redesign. Generic-only audio/banner (confidentiality rule), `~/.synthesis/quiet-audio` mute flag, report files + history, remediation hints, new `checkpoint_sync.py` (event-driven auto-commit/push: runtime remote guard, quiescence, shared throttle, ff-only push, distinct author, stale-lock detection), synthesis-console integration contract, scheduled-mutation explicitly disallowed. Origin: 2026-07-08 design review (lesson: alert-channel confidentiality + event-driven checkpoints).

--- a/skills/synthesis-repo-guard/checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/checkpoint_sync.py
@@ -46,10 +46,13 @@ import hashlib
 import json
 import os
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
+import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 # SYNTHESIS_HOME overrides the state root (tests, sandboxes). Default ~/.synthesis
@@ -62,6 +65,8 @@ PENDING_DIR = STATE_DIR / "pending"
 LOCAL_HANDOFF_DIR = STATE_DIR / "local-handoff"
 REMOTE_HANDOFF_STATE = STATE_DIR / "remote-handoff-last.json"
 RETIREMENT_DIR = STATE_DIR / "retired-worktrees"
+LIFECYCLE_LOCK_FD_ENV = "SYNTHESIS_LIFECYCLE_LOCK_FD"
+_LIFECYCLE_LOCK_STATE = threading.local()
 
 DEFAULTS = {
     "repos": [],
@@ -151,7 +156,9 @@ def pending_manifest_path(session_id: str) -> Path:
 
 
 def atomic_json(path: Path, payload: dict) -> None:
+    validate_state_paths(path.parent, path)
     path.parent.mkdir(parents=True, exist_ok=True)
+    validate_state_paths(path.parent, path)
     if path.is_symlink():
         raise ValueError(f"refusing to replace symlinked state path: {path}")
     descriptor, temporary_name = tempfile.mkstemp(
@@ -164,12 +171,101 @@ def atomic_json(path: Path, payload: dict) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary_name, path)
+        directory_fd = os.open(
+            path.parent,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
     except Exception:
         try:
             os.unlink(temporary_name)
         except FileNotFoundError:
             pass
         raise
+
+
+def lexical_absolute(path: Path) -> Path:
+    return Path(os.path.abspath(os.path.expanduser(str(path))))
+
+
+def validate_state_paths(*paths: Path) -> None:
+    """Reject any existing symlink component in a state mutation path."""
+
+    for value in paths:
+        path = lexical_absolute(value)
+        current = Path(path.anchor)
+        for part in path.parts[1:]:
+            current = current / part
+            if os.path.lexists(current) and current.is_symlink():
+                raise ValueError(f"state path contains a symlink component: {current}")
+
+
+def lifecycle_lock_path() -> Path:
+    return PENDING_DIR.parent / "lifecycle.lock"
+
+
+def open_lock_file(path: Path) -> int:
+    validate_state_paths(path.parent, path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    validate_state_paths(path.parent, path)
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise ValueError(f"state lock is not a regular file: {path}")
+    return descriptor
+
+
+def inherited_lifecycle_lock_fd(path: Path) -> int | None:
+    raw = os.environ.get(LIFECYCLE_LOCK_FD_ENV)
+    if raw is None:
+        return None
+    try:
+        descriptor = int(raw)
+        inherited = os.fstat(descriptor)
+        expected = os.stat(path, follow_symlinks=False)
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"inherited lifecycle lock is invalid: {exc}") from exc
+    if (inherited.st_dev, inherited.st_ino) != (expected.st_dev, expected.st_ino):
+        raise ValueError("inherited lifecycle lock does not match the state lock")
+    if not stat.S_ISREG(inherited.st_mode):
+        raise ValueError("inherited lifecycle lock is not a regular file")
+    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    return descriptor
+
+
+@contextmanager
+def lifecycle_lock():
+    """Serialize every pending-manifest, receipt, and retirement mutation."""
+
+    depth = getattr(_LIFECYCLE_LOCK_STATE, "depth", 0)
+    if depth:
+        _LIFECYCLE_LOCK_STATE.depth = depth + 1
+        try:
+            yield
+        finally:
+            _LIFECYCLE_LOCK_STATE.depth -= 1
+        return
+
+    path = lifecycle_lock_path()
+    validate_state_paths(
+        path.parent, path, PENDING_DIR, LOCAL_HANDOFF_DIR, RETIREMENT_DIR
+    )
+    inherited = inherited_lifecycle_lock_fd(path)
+    descriptor = inherited if inherited is not None else open_lock_file(path)
+    if inherited is None:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+    _LIFECYCLE_LOCK_STATE.depth = 1
+    try:
+        yield
+    finally:
+        _LIFECYCLE_LOCK_STATE.depth = 0
+        if inherited is None:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+            os.close(descriptor)
 
 
 # ---------------------------------------------------------------------------
@@ -407,97 +503,135 @@ def listed_worktree_roots(repository: Path) -> tuple[list[Path], str | None]:
     return roots, None
 
 
-def reconcile_retired_worktree(
-    worktree: Path,
-    repository: Path,
-    verified_head: str,
-    base: str,
-    *,
-    dry_run: bool,
-) -> tuple[list[dict], list[Path]]:
-    """Remove only remotely verified, retired-worktree paths from manifests.
+def fsync_directory(path: Path) -> None:
+    descriptor = os.open(
+        path,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+    )
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
-    A missing pending path remains a hard failure unless the lifecycle helper
-    proves that the exact worktree was clean, removed, and already contained in
-    the stated base. Dry-run mode is the helper's pre-removal validation pass.
-    """
 
-    worktree = worktree.expanduser().resolve(strict=False)
-    repository_input = repository.expanduser()
-    result = {
-        "repo": str(repository_input),
+def retirement_result(repository: Path | str) -> dict:
+    return {
+        "repo": str(repository),
         "name": "retired-worktree",
         "action": "retirement-reconcile-failed",
         "alert": None,
     }
 
+
+def validate_retirement_target(
+    worktree: Path, repository: Path, *, expect_active: bool
+) -> tuple[Path, Path]:
+    repository_input = lexical_absolute(repository)
+    worktree_input = lexical_absolute(worktree)
+    if repository_input.is_symlink():
+        raise ValueError("repository path is a symlink")
+    if worktree_input.is_symlink():
+        raise ValueError("retired worktree path is a symlink")
     try:
-        if repository_input.is_symlink():
-            raise ValueError("repository path is a symlink")
         repository = repository_input.resolve(strict=True)
     except OSError as exc:
-        result["alert"] = f"repository is unavailable: {exc}"
-        return [result], []
+        raise ValueError(f"repository is unavailable: {exc}") from exc
+    worktree = worktree_input.resolve(strict=False)
 
     unsafe_roots = {Path("/").resolve(), Path.home().resolve(), Path.cwd().resolve()}
     if worktree in unsafe_roots:
-        result["alert"] = f"unsafe retired-worktree root: {worktree}"
-        return [result], []
+        raise ValueError(f"unsafe retired-worktree root: {worktree}")
     if (
         worktree == repository
         or worktree in repository.parents
         or repository in worktree.parents
     ):
-        result["alert"] = "retired worktree overlaps the repository root"
-        return [result], []
+        raise ValueError("retired worktree overlaps the repository root")
 
     top_rc, top, top_error = git(repository, "rev-parse", "--show-toplevel")
     if top_rc != 0 or not top or Path(top).resolve() != repository:
-        result["alert"] = top_error or "repository is not its git toplevel"
-        return [result], []
+        raise ValueError(top_error or "repository is not its git toplevel")
 
     worktrees, worktree_error = listed_worktree_roots(repository)
     if worktree_error:
-        result["alert"] = worktree_error
-        return [result], []
+        raise ValueError(worktree_error)
     target_is_active = worktree in worktrees
-    if dry_run:
-        if not target_is_active or not worktree.is_dir() or worktree.is_symlink():
-            result["alert"] = "retirement preflight requires the exact active worktree"
-            return [result], []
+    if expect_active:
+        if not target_is_active or not worktree.is_dir():
+            raise ValueError("retirement preparation requires the exact active worktree")
     elif target_is_active or os.path.lexists(worktree):
-        result["alert"] = "retired worktree still exists or remains registered"
-        return [result], []
+        raise ValueError("retired worktree still exists or remains registered")
+    return worktree, repository
 
+
+def fetched_remote_base(
+    repository: Path, remote: str, base: str
+) -> tuple[str, str]:
+    if not remote or any(character.isspace() for character in remote):
+        raise ValueError("retirement remote name is invalid")
+    fetch_rc, _, fetch_error = git(repository, "fetch", "--quiet", "--prune", remote)
+    if fetch_rc != 0:
+        raise ValueError(f"retirement remote fetch failed: {fetch_error}")
+    full_rc, full_ref, full_error = git(
+        repository, "rev-parse", "--symbolic-full-name", base
+    )
+    prefix = f"refs/remotes/{remote}/"
+    if full_rc != 0 or not full_ref.startswith(prefix):
+        raise ValueError(
+            full_error
+            or f"retirement base must be a fetched {remote} remote-tracking ref"
+        )
+    base_rc, base_oid, base_error = git(
+        repository, "rev-parse", "--verify", f"{full_ref}^{{commit}}"
+    )
+    if base_rc != 0 or not base_oid:
+        raise ValueError(base_error or "retirement base does not resolve")
+    return full_ref, base_oid
+
+
+def canonical_retirement_commits(
+    repository: Path, verified_head: str, base_oid: str
+) -> tuple[str, str]:
     head_rc, canonical_head, head_error = git(
         repository, "rev-parse", "--verify", f"{verified_head}^{{commit}}"
     )
-    base_rc, _canonical_base, base_error = git(
-        repository, "rev-parse", "--verify", f"{base}^{{commit}}"
+    base_rc, canonical_base, base_error = git(
+        repository, "rev-parse", "--verify", f"{base_oid}^{{commit}}"
     )
     if head_rc != 0 or not canonical_head:
-        result["alert"] = head_error or "verified retirement head does not resolve"
-        return [result], []
-    if base_rc != 0:
-        result["alert"] = base_error or "retirement base does not resolve"
-        return [result], []
+        raise ValueError(head_error or "verified retirement head does not resolve")
+    if base_rc != 0 or not canonical_base:
+        raise ValueError(base_error or "pinned retirement base does not resolve")
     ancestry_rc, _, ancestry_error = git(
-        repository, "merge-base", "--is-ancestor", canonical_head, base
+        repository, "merge-base", "--is-ancestor", canonical_head, canonical_base
     )
     if ancestry_rc != 0:
-        result["alert"] = ancestry_error or "retired head is not contained in the verification base"
-        return [result], []
+        raise ValueError(
+            ancestry_error or "retired head is not contained in the pinned remote base"
+        )
+    return canonical_head, canonical_base
 
+
+def retirement_intent_path(worktree: Path, head: str, base_oid: str) -> Path:
+    identity = hashlib.sha256(
+        f"{worktree}\0{head}\0{base_oid}".encode("utf-8")
+    ).hexdigest()
+    return RETIREMENT_DIR / f"{identity}.json"
+
+
+def manifest_reconciliation_plans(
+    worktree: Path,
+) -> tuple[list[tuple[Path, dict, list[str], list[str], list[str]]], list[object]]:
+    validate_state_paths(PENDING_DIR, LOCAL_HANDOFF_DIR, RETIREMENT_DIR)
     manifests = sorted(PENDING_DIR.glob("*.json")) if PENDING_DIR.is_dir() else []
     plans: list[tuple[Path, dict, list[str], list[str], list[str]]] = []
-    locks = []
+    locks: list[object] = []
     try:
         for manifest in manifests:
             lock_path = manifest.with_suffix(".lock")
-            if lock_path.is_symlink():
-                raise ValueError(f"pending manifest lock is a symlink: {lock_path}")
-            lock = lock_path.open("a+", encoding="utf-8")
-            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            descriptor = open_lock_file(lock_path)
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            lock = os.fdopen(descriptor, "a+", encoding="utf-8")
             locks.append(lock)
             if manifest.is_symlink():
                 raise ValueError(f"pending manifest is a symlink: {manifest}")
@@ -521,104 +655,236 @@ def reconcile_retired_worktree(
                 raise ValueError(
                     f"pending manifest paths must be absolute strings: {manifest}"
                 )
-
-            removed = [
-                str(value)
-                for value in paths
-                if path_is_within(Path(str(value)).expanduser(), worktree)
-            ]
-            if not removed:
-                continue
-            remaining = [
-                str(value)
-                for value in paths
-                if not path_is_within(Path(str(value)).expanduser(), worktree)
-            ]
-            remaining_remote = [
-                str(value)
-                for value in remote_paths
-                if not path_is_within(Path(str(value)).expanduser(), worktree)
-            ]
-            receipt = LOCAL_HANDOFF_DIR / manifest.name
-            if receipt.is_symlink():
-                raise ValueError(f"local handoff receipt is a symlink: {receipt}")
+            if not set(remote_paths).issubset(set(paths)):
+                raise ValueError(f"pending remote_paths are not a subset of paths: {manifest}")
             history = data.get("retired_worktrees", [])
             if not isinstance(history, list):
                 raise ValueError(f"retired_worktrees history is invalid: {manifest}")
+
+            removed = [
+                value
+                for value in paths
+                if path_is_within(Path(value).expanduser(), worktree)
+            ]
+            if not removed:
+                continue
+            remaining = [value for value in paths if value not in set(removed)]
+            remaining_remote = [
+                value for value in remote_paths if value not in set(removed)
+            ]
+            receipt = LOCAL_HANDOFF_DIR / manifest.name
+            validate_state_paths(receipt)
+            if receipt.is_symlink():
+                raise ValueError(f"local handoff receipt is a symlink: {receipt}")
             plans.append((manifest, data, removed, remaining, remaining_remote))
+        return plans, locks
+    except Exception:
+        for lock in reversed(locks):
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+            lock.close()
+        raise
 
+
+def release_manifest_locks(locks: list[object]) -> None:
+    for lock in reversed(locks):
+        fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+        lock.close()
+
+
+def prepare_retirement_intent(
+    worktree: Path,
+    repository: Path,
+    verified_head: str,
+    remote: str,
+    base: str,
+    *,
+    branch: str | None = None,
+    expect_active: bool,
+    dry_run: bool,
+) -> tuple[dict, Path | None, list[Path]]:
+    worktree, repository = validate_retirement_target(
+        worktree, repository, expect_active=expect_active
+    )
+    base_ref, fetched_base_oid = fetched_remote_base(repository, remote, base)
+    canonical_head, canonical_base = canonical_retirement_commits(
+        repository, verified_head, fetched_base_oid
+    )
+    plans, locks = manifest_reconciliation_plans(worktree)
+    try:
+        touched = [plan[0] for plan in plans]
+        intent = retirement_intent_path(worktree, canonical_head, canonical_base)
+        result = retirement_result(repository)
+        result.update(
+            action="retirement-prepared" if not dry_run else "retirement-prepare-ready",
+            manifests=len(plans),
+            files=sum(len(plan[2]) for plan in plans),
+            detail=str(intent),
+        )
         if dry_run:
-            result.update(
-                action="retirement-reconcile-ready",
-                alert=None,
-                manifests=len(plans),
-                files=sum(len(plan[2]) for plan in plans),
-            )
-            return [result], [plan[0] for plan in plans]
+            return result, None, touched
+        prepared_at = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+        reconciler_hash = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+        atomic_json(
+            intent,
+            {
+                "schema_version": 2,
+                "state": "prepared",
+                "mode": "normal" if expect_active else "recovery",
+                "worktree": str(worktree),
+                "repository": str(repository),
+                "head": canonical_head,
+                "remote": remote,
+                "base_ref": base_ref,
+                "base_oid": canonical_base,
+                "branch": branch,
+                "prepared_at": prepared_at,
+                "reconciler_sha256": reconciler_hash,
+                "manifests_preflight": [str(path) for path in touched],
+                "paths_preflight": sum(len(plan[2]) for plan in plans),
+            },
+        )
+        return result, intent, touched
+    finally:
+        release_manifest_locks(locks)
 
+
+def load_retirement_intent(intent: Path) -> dict:
+    intent = lexical_absolute(intent)
+    expected_root = lexical_absolute(RETIREMENT_DIR)
+    try:
+        intent.relative_to(expected_root)
+    except ValueError as exc:
+        raise ValueError("retirement intent is outside the retirement state directory") from exc
+    validate_state_paths(expected_root, intent)
+    if intent.is_symlink() or not intent.is_file():
+        raise ValueError(f"retirement intent is unavailable or unsafe: {intent}")
+    data = json.loads(intent.read_text(encoding="utf-8"))
+    if data.get("schema_version") != 2 or data.get("state") not in {
+        "prepared",
+        "completed",
+    }:
+        raise ValueError("retirement intent schema or state is invalid")
+    return data
+
+
+def complete_retirement_intent(intent: Path) -> tuple[dict, list[Path]]:
+    intent = lexical_absolute(intent)
+    data = load_retirement_intent(intent)
+    repository = Path(str(data.get("repository") or ""))
+    result = retirement_result(repository)
+    if data["state"] == "completed":
+        result.update(
+            action="retired-worktree-reconciled",
+            manifests=len(data.get("manifests", [])),
+            files=int(data.get("paths_removed", 0)),
+            detail=str(intent),
+        )
+        return result, [Path(value) for value in data.get("manifests", [])]
+
+    worktree, repository = validate_retirement_target(
+        Path(str(data.get("worktree") or "")), repository, expect_active=False
+    )
+    remote = data.get("remote")
+    base_ref = data.get("base_ref")
+    if (
+        not isinstance(remote, str)
+        or not isinstance(base_ref, str)
+        or not base_ref.startswith(f"refs/remotes/{remote}/")
+    ):
+        raise ValueError("retirement intent has no valid remote-tracking authority")
+    canonical_head, canonical_base = canonical_retirement_commits(
+        repository,
+        str(data.get("head") or ""),
+        str(data.get("base_oid") or ""),
+    )
+    if intent != retirement_intent_path(worktree, canonical_head, canonical_base):
+        raise ValueError("retirement intent filename does not match its identity")
+    plans, locks = manifest_reconciliation_plans(worktree)
+    try:
         reconciled_at = time.strftime("%Y-%m-%dT%H:%M:%S%z")
         touched: list[Path] = []
         removed_count = 0
-        for manifest, data, removed, remaining, remaining_remote in plans:
+        for manifest, manifest_data, removed, remaining, remaining_remote in plans:
             receipt = LOCAL_HANDOFF_DIR / manifest.name
             if os.path.lexists(receipt):
                 receipt.unlink()
+                fsync_directory(receipt.parent)
             removed_count += len(removed)
             touched.append(manifest)
             if not remaining:
                 manifest.unlink(missing_ok=True)
+                fsync_directory(manifest.parent)
                 continue
-            history = data.get("retired_worktrees", [])
+            history = manifest_data.get("retired_worktrees", [])
             history.append(
                 {
+                    "intent": str(intent),
                     "worktree": str(worktree),
                     "repository": str(repository),
                     "head": canonical_head,
-                    "base": base,
+                    "base_ref": data.get("base_ref"),
+                    "base_oid": canonical_base,
                     "reconciled_at": reconciled_at,
                     "paths_removed": len(removed),
                 }
             )
-            data.update(
+            manifest_data.update(
                 updated_at=reconciled_at,
                 paths=remaining,
                 remote_paths=remaining_remote,
                 retired_worktrees=history,
             )
-            atomic_json(manifest, data)
+            atomic_json(manifest, manifest_data)
 
-        retirement_record = RETIREMENT_DIR / (
-            hashlib.sha256(str(worktree).encode("utf-8")).hexdigest()
-            + f"-{canonical_head[:12]}.json"
+        data.update(
+            state="completed",
+            completed_at=reconciled_at,
+            manifests=[str(path) for path in touched],
+            paths_removed=removed_count,
         )
-        atomic_json(
-            retirement_record,
-            {
-                "schema_version": 1,
-                "worktree": str(worktree),
-                "repository": str(repository),
-                "head": canonical_head,
-                "base": base,
-                "reconciled_at": reconciled_at,
-                "manifests": [str(path) for path in touched],
-                "paths_removed": removed_count,
-            },
-        )
+        atomic_json(intent, data)
         result.update(
             action="retired-worktree-reconciled",
-            alert=None,
             manifests=len(touched),
             files=removed_count,
-            detail=str(retirement_record),
+            detail=str(intent),
         )
-        return [result], touched
+        return result, touched
+    finally:
+        release_manifest_locks(locks)
+
+
+def reconcile_retired_worktree(
+    worktree: Path,
+    repository: Path,
+    verified_head: str,
+    base: str,
+    *,
+    remote: str = "origin",
+    dry_run: bool,
+) -> tuple[list[dict], list[Path]]:
+    """Recover a retirement that predates durable prepared-intent records."""
+
+    result = retirement_result(repository)
+    try:
+        with lifecycle_lock():
+            prepared, intent, touched = prepare_retirement_intent(
+                worktree,
+                repository,
+                verified_head,
+                remote,
+                base,
+                expect_active=False,
+                dry_run=dry_run,
+            )
+            if dry_run:
+                return [prepared], touched
+            assert intent is not None
+            completed, reconciled = complete_retirement_intent(intent)
+            return [completed], reconciled
     except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
         result["alert"] = str(exc)
         return [result], []
-    finally:
-        for lock in reversed(locks):
-            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
-            lock.close()
 
 
 def checkpoint_explicit_paths(repo: Path, paths: list[Path], cfg: dict, *, dry_run: bool) -> dict:
@@ -729,7 +995,9 @@ def file_evidence(path: Path) -> dict[str, object]:
     }
 
 
-def local_handoff_checkpoint(payload: dict, cfg: dict) -> tuple[list[dict], Path | None]:
+def _local_handoff_checkpoint_unlocked(
+    payload: dict, cfg: dict
+) -> tuple[list[dict], Path | None]:
     """Record LOCAL_READY evidence without committing or using the network."""
     session_id = payload.get("session_id")
     if not isinstance(session_id, str) or not session_id:
@@ -789,7 +1057,14 @@ def local_handoff_checkpoint(payload: dict, cfg: dict) -> tuple[list[dict], Path
     return results, manifest
 
 
-def flush_all_pending(cfg: dict, *, dry_run: bool) -> tuple[list[dict], list[Path]]:
+def local_handoff_checkpoint(payload: dict, cfg: dict) -> tuple[list[dict], Path | None]:
+    with lifecycle_lock():
+        return _local_handoff_checkpoint_unlocked(payload, cfg)
+
+
+def _flush_all_pending_unlocked(
+    cfg: dict, *, dry_run: bool
+) -> tuple[list[dict], list[Path]]:
     """Batch every pending session into one exact-path commit per repository."""
     manifests = sorted(PENDING_DIR.glob("*.json")) if PENDING_DIR.is_dir() else []
     all_paths: list[Path] = []
@@ -800,11 +1075,13 @@ def flush_all_pending(cfg: dict, *, dry_run: bool) -> tuple[list[dict], list[Pat
     try:
         for manifest in manifests:
             lock_path = manifest.with_suffix(".lock")
-            if lock_path.is_symlink():
-                errors.append({"repo": str(lock_path), "name": "pending-session", "action": "failed", "alert": "pending manifest lock is a symlink"})
+            try:
+                descriptor = open_lock_file(lock_path)
+            except (OSError, ValueError) as exc:
+                errors.append({"repo": str(lock_path), "name": "pending-session", "action": "failed", "alert": str(exc)})
                 continue
-            lock = lock_path.open("a+", encoding="utf-8")
-            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            lock = os.fdopen(descriptor, "a+", encoding="utf-8")
             locks.append(lock)
             if manifest.is_symlink():
                 errors.append({"repo": str(manifest), "name": "pending-session", "action": "failed", "alert": "pending manifest is a symlink"})
@@ -855,6 +1132,11 @@ def flush_all_pending(cfg: dict, *, dry_run: bool) -> tuple[list[dict], list[Pat
         for lock in reversed(locks):
             fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
             lock.close()
+
+
+def flush_all_pending(cfg: dict, *, dry_run: bool) -> tuple[list[dict], list[Path]]:
+    with lifecycle_lock():
+        return _flush_all_pending_unlocked(cfg, dry_run=dry_run)
 
 
 def source_paths_remote_ready(paths: list[Path]) -> list[dict]:
@@ -976,53 +1258,54 @@ def source_paths_remote_ready(paths: list[Path]) -> list[dict]:
 
 def record_producer_path(path: Path, cfg: dict) -> tuple[list[dict], Path | None]:
     """Record a console or other non-agent producer write as local state."""
-    target = path.expanduser().resolve(strict=False)
-    root = repo_root_for_path(target)
-    if root is None:
-        return [
+    with lifecycle_lock():
+        target = path.expanduser().resolve(strict=False)
+        root = repo_root_for_path(target)
+        if root is None:
+            return [
+                {
+                    "repo": str(target),
+                    "name": "producer",
+                    "action": "failed",
+                    "alert": "producer path is not inside an available git worktree",
+                }
+            ], None
+        configured, reason = configured_repo_identity(root, cfg)
+        if not configured:
+            return [
+                {
+                    "repo": str(root),
+                    "name": root.name,
+                    "action": "guard-rejected",
+                    "alert": reason,
+                }
+            ], None
+        ok, reason = remote_guard(root, cfg["allowed_remote_prefixes"])
+        if not ok:
+            return [
+                {
+                    "repo": str(root),
+                    "name": root.name,
+                    "action": "guard-rejected",
+                    "alert": f"remote guard: {reason}",
+                }
+            ], None
+        session_id = f"producer:{os.getpid()}:{time.time_ns()}"
+        manifest = pending_manifest_path(session_id)
+        atomic_json(
+            manifest,
             {
-                "repo": str(target),
-                "name": "producer",
-                "action": "failed",
-                "alert": "producer path is not inside an available git worktree",
-            }
-        ], None
-    configured, reason = configured_repo_identity(root, cfg)
-    if not configured:
-        return [
-            {
-                "repo": str(root),
-                "name": root.name,
-                "action": "guard-rejected",
-                "alert": reason,
-            }
-        ], None
-    ok, reason = remote_guard(root, cfg["allowed_remote_prefixes"])
-    if not ok:
-        return [
-            {
-                "repo": str(root),
-                "name": root.name,
-                "action": "guard-rejected",
-                "alert": f"remote guard: {reason}",
-            }
-        ], None
-    session_id = f"producer:{os.getpid()}:{time.time_ns()}"
-    manifest = pending_manifest_path(session_id)
-    atomic_json(
-        manifest,
-        {
-            "schema_version": 2,
-            "session_id": session_id,
-            "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
-            "paths": [str(target)],
-            "remote_paths": [str(target)],
-            "producer": True,
-        },
-    )
-    return local_handoff_checkpoint(
-        {"session_id": session_id, "cwd": str(root)}, cfg
-    )
+                "schema_version": 2,
+                "session_id": session_id,
+                "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "paths": [str(target)],
+                "remote_paths": [str(target)],
+                "producer": True,
+            },
+        )
+        return _local_handoff_checkpoint_unlocked(
+            {"session_id": session_id, "cwd": str(root)}, cfg
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1052,7 +1335,6 @@ def generic_alert_ping(alert_count: int, speak: bool, notify: bool) -> None:
 # ---------------------------------------------------------------------------
 
 def write_state(mode: str, results: list[dict], running: bool) -> None:
-    STATE_DIR.mkdir(parents=True, exist_ok=True)
     payload = {
         "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
         "host": socket.gethostname(),
@@ -1061,9 +1343,7 @@ def write_state(mode: str, results: list[dict], running: bool) -> None:
         "results": results,
         "alerts": [r for r in results if r.get("alert")],
     }
-    tmp = STATE_FILE.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(payload, indent=2) + "\n")
-    tmp.replace(STATE_FILE)
+    atomic_json(STATE_FILE, payload)
 
 
 # ---------------------------------------------------------------------------
@@ -1096,6 +1376,18 @@ def main() -> int:
         help="Remove paths beneath one verified retired worktree from pending manifests",
     )
     ap.add_argument(
+        "--prepare-worktree-retirement",
+        type=Path,
+        default=None,
+        help="Write a durable retirement intent before removing an active worktree",
+    )
+    ap.add_argument(
+        "--complete-worktree-retirement",
+        type=Path,
+        default=None,
+        help="Complete or resume reconciliation from a durable retirement intent",
+    )
+    ap.add_argument(
         "--retirement-repository",
         type=Path,
         default=None,
@@ -1109,7 +1401,17 @@ def main() -> int:
     ap.add_argument(
         "--retirement-base",
         default=None,
-        help="Fetched base ref that contains the retired head",
+        help="Fetched remote-tracking ref that contains the retired head",
+    )
+    ap.add_argument(
+        "--retirement-remote",
+        default="origin",
+        help="Remote whose freshly fetched tracking ref is the ancestry authority",
+    )
+    ap.add_argument(
+        "--retirement-branch",
+        default=None,
+        help="Branch checked out by the prepared worktree",
     )
     ap.add_argument(
         "--now",
@@ -1132,7 +1434,28 @@ def main() -> int:
 
     cfg = resolve_config(args.config.expanduser())
 
-    if args.reconcile_retired_worktree is not None:
+    retirement_modes = [
+        args.reconcile_retired_worktree is not None,
+        args.prepare_worktree_retirement is not None,
+        args.complete_worktree_retirement is not None,
+    ]
+    if sum(retirement_modes) > 1:
+        if not args.quiet:
+            print("checkpoint_sync: choose exactly one retirement mode", file=sys.stderr)
+        return 2
+
+    if args.complete_worktree_retirement is not None:
+        try:
+            with lifecycle_lock():
+                result, _manifests = complete_retirement_intent(
+                    args.complete_worktree_retirement
+                )
+            results = [result]
+        except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            failed = retirement_result(args.retirement_repository or "unknown")
+            failed["alert"] = str(exc)
+            results = [failed]
+    elif args.prepare_worktree_retirement is not None:
         if not (
             args.retirement_repository
             and args.retirement_head
@@ -1140,7 +1463,37 @@ def main() -> int:
         ):
             if not args.quiet:
                 print(
-                    "checkpoint_sync: retired-worktree reconciliation requires "
+                    "checkpoint_sync: retirement preparation requires "
+                    "--retirement-repository, --retirement-head, and --retirement-base",
+                    file=sys.stderr,
+                )
+            return 2
+        try:
+            with lifecycle_lock():
+                result, _intent, _manifests = prepare_retirement_intent(
+                    args.prepare_worktree_retirement,
+                    args.retirement_repository,
+                    args.retirement_head,
+                    args.retirement_remote,
+                    args.retirement_base,
+                    branch=args.retirement_branch,
+                    expect_active=True,
+                    dry_run=args.dry_run,
+                )
+            results = [result]
+        except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+            failed = retirement_result(args.retirement_repository)
+            failed["alert"] = str(exc)
+            results = [failed]
+    elif args.reconcile_retired_worktree is not None:
+        if not (
+            args.retirement_repository
+            and args.retirement_head
+            and args.retirement_base
+        ):
+            if not args.quiet:
+                print(
+                    "checkpoint_sync: retired-worktree recovery requires "
                     "--retirement-repository, --retirement-head, and --retirement-base",
                     file=sys.stderr,
                 )
@@ -1150,8 +1503,11 @@ def main() -> int:
             args.retirement_repository,
             args.retirement_head,
             args.retirement_base,
+            remote=args.retirement_remote,
             dry_run=args.dry_run,
         )
+
+    if any(retirement_modes):
         alerts = [result for result in results if result.get("alert")]
         if not args.quiet:
             if args.json:

--- a/skills/synthesis-repo-guard/checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/checkpoint_sync.py
@@ -61,6 +61,7 @@ QUIET_AUDIO_FLAG = SYNTHESIS_HOME / "quiet-audio"
 PENDING_DIR = STATE_DIR / "pending"
 LOCAL_HANDOFF_DIR = STATE_DIR / "local-handoff"
 REMOTE_HANDOFF_STATE = STATE_DIR / "remote-handoff-last.json"
+RETIREMENT_DIR = STATE_DIR / "retired-worktrees"
 
 DEFAULTS = {
     "repos": [],
@@ -384,6 +385,240 @@ def repo_root_for_path(path: Path) -> Path | None:
     probe = path if path.is_dir() else path.parent
     rc, output, _ = git(probe, "rev-parse", "--show-toplevel")
     return Path(output).resolve() if rc == 0 and output else None
+
+
+def path_is_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=False))
+        return True
+    except ValueError:
+        return False
+
+
+def listed_worktree_roots(repository: Path) -> tuple[list[Path], str | None]:
+    rc, output, error = git(repository, "worktree", "list", "--porcelain")
+    if rc != 0:
+        return [], error or output or "git worktree list failed"
+    roots = [
+        Path(line.partition(" ")[2]).resolve(strict=False)
+        for line in output.splitlines()
+        if line.startswith("worktree ")
+    ]
+    return roots, None
+
+
+def reconcile_retired_worktree(
+    worktree: Path,
+    repository: Path,
+    verified_head: str,
+    base: str,
+    *,
+    dry_run: bool,
+) -> tuple[list[dict], list[Path]]:
+    """Remove only remotely verified, retired-worktree paths from manifests.
+
+    A missing pending path remains a hard failure unless the lifecycle helper
+    proves that the exact worktree was clean, removed, and already contained in
+    the stated base. Dry-run mode is the helper's pre-removal validation pass.
+    """
+
+    worktree = worktree.expanduser().resolve(strict=False)
+    repository_input = repository.expanduser()
+    result = {
+        "repo": str(repository_input),
+        "name": "retired-worktree",
+        "action": "retirement-reconcile-failed",
+        "alert": None,
+    }
+
+    try:
+        if repository_input.is_symlink():
+            raise ValueError("repository path is a symlink")
+        repository = repository_input.resolve(strict=True)
+    except OSError as exc:
+        result["alert"] = f"repository is unavailable: {exc}"
+        return [result], []
+
+    unsafe_roots = {Path("/").resolve(), Path.home().resolve(), Path.cwd().resolve()}
+    if worktree in unsafe_roots:
+        result["alert"] = f"unsafe retired-worktree root: {worktree}"
+        return [result], []
+    if (
+        worktree == repository
+        or worktree in repository.parents
+        or repository in worktree.parents
+    ):
+        result["alert"] = "retired worktree overlaps the repository root"
+        return [result], []
+
+    top_rc, top, top_error = git(repository, "rev-parse", "--show-toplevel")
+    if top_rc != 0 or not top or Path(top).resolve() != repository:
+        result["alert"] = top_error or "repository is not its git toplevel"
+        return [result], []
+
+    worktrees, worktree_error = listed_worktree_roots(repository)
+    if worktree_error:
+        result["alert"] = worktree_error
+        return [result], []
+    target_is_active = worktree in worktrees
+    if dry_run:
+        if not target_is_active or not worktree.is_dir() or worktree.is_symlink():
+            result["alert"] = "retirement preflight requires the exact active worktree"
+            return [result], []
+    elif target_is_active or os.path.lexists(worktree):
+        result["alert"] = "retired worktree still exists or remains registered"
+        return [result], []
+
+    head_rc, canonical_head, head_error = git(
+        repository, "rev-parse", "--verify", f"{verified_head}^{{commit}}"
+    )
+    base_rc, _canonical_base, base_error = git(
+        repository, "rev-parse", "--verify", f"{base}^{{commit}}"
+    )
+    if head_rc != 0 or not canonical_head:
+        result["alert"] = head_error or "verified retirement head does not resolve"
+        return [result], []
+    if base_rc != 0:
+        result["alert"] = base_error or "retirement base does not resolve"
+        return [result], []
+    ancestry_rc, _, ancestry_error = git(
+        repository, "merge-base", "--is-ancestor", canonical_head, base
+    )
+    if ancestry_rc != 0:
+        result["alert"] = ancestry_error or "retired head is not contained in the verification base"
+        return [result], []
+
+    manifests = sorted(PENDING_DIR.glob("*.json")) if PENDING_DIR.is_dir() else []
+    plans: list[tuple[Path, dict, list[str], list[str], list[str]]] = []
+    locks = []
+    try:
+        for manifest in manifests:
+            lock_path = manifest.with_suffix(".lock")
+            if lock_path.is_symlink():
+                raise ValueError(f"pending manifest lock is a symlink: {lock_path}")
+            lock = lock_path.open("a+", encoding="utf-8")
+            fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+            locks.append(lock)
+            if manifest.is_symlink():
+                raise ValueError(f"pending manifest is a symlink: {manifest}")
+            if not manifest.exists():
+                continue
+            data = json.loads(manifest.read_text(encoding="utf-8"))
+            session_id = data.get("session_id")
+            if (
+                not isinstance(session_id, str)
+                or pending_manifest_path(session_id) != manifest
+            ):
+                raise ValueError(f"pending manifest filename or session mismatch: {manifest}")
+            paths = data.get("paths")
+            remote_paths = data.get("remote_paths", paths)
+            if not isinstance(paths, list) or not isinstance(remote_paths, list):
+                raise ValueError(f"pending manifest path arrays are invalid: {manifest}")
+            if any(
+                not isinstance(value, str) or not Path(value).expanduser().is_absolute()
+                for value in [*paths, *remote_paths]
+            ):
+                raise ValueError(
+                    f"pending manifest paths must be absolute strings: {manifest}"
+                )
+
+            removed = [
+                str(value)
+                for value in paths
+                if path_is_within(Path(str(value)).expanduser(), worktree)
+            ]
+            if not removed:
+                continue
+            remaining = [
+                str(value)
+                for value in paths
+                if not path_is_within(Path(str(value)).expanduser(), worktree)
+            ]
+            remaining_remote = [
+                str(value)
+                for value in remote_paths
+                if not path_is_within(Path(str(value)).expanduser(), worktree)
+            ]
+            receipt = LOCAL_HANDOFF_DIR / manifest.name
+            if receipt.is_symlink():
+                raise ValueError(f"local handoff receipt is a symlink: {receipt}")
+            history = data.get("retired_worktrees", [])
+            if not isinstance(history, list):
+                raise ValueError(f"retired_worktrees history is invalid: {manifest}")
+            plans.append((manifest, data, removed, remaining, remaining_remote))
+
+        if dry_run:
+            result.update(
+                action="retirement-reconcile-ready",
+                alert=None,
+                manifests=len(plans),
+                files=sum(len(plan[2]) for plan in plans),
+            )
+            return [result], [plan[0] for plan in plans]
+
+        reconciled_at = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+        touched: list[Path] = []
+        removed_count = 0
+        for manifest, data, removed, remaining, remaining_remote in plans:
+            receipt = LOCAL_HANDOFF_DIR / manifest.name
+            if os.path.lexists(receipt):
+                receipt.unlink()
+            removed_count += len(removed)
+            touched.append(manifest)
+            if not remaining:
+                manifest.unlink(missing_ok=True)
+                continue
+            history = data.get("retired_worktrees", [])
+            history.append(
+                {
+                    "worktree": str(worktree),
+                    "repository": str(repository),
+                    "head": canonical_head,
+                    "base": base,
+                    "reconciled_at": reconciled_at,
+                    "paths_removed": len(removed),
+                }
+            )
+            data.update(
+                updated_at=reconciled_at,
+                paths=remaining,
+                remote_paths=remaining_remote,
+                retired_worktrees=history,
+            )
+            atomic_json(manifest, data)
+
+        retirement_record = RETIREMENT_DIR / (
+            hashlib.sha256(str(worktree).encode("utf-8")).hexdigest()
+            + f"-{canonical_head[:12]}.json"
+        )
+        atomic_json(
+            retirement_record,
+            {
+                "schema_version": 1,
+                "worktree": str(worktree),
+                "repository": str(repository),
+                "head": canonical_head,
+                "base": base,
+                "reconciled_at": reconciled_at,
+                "manifests": [str(path) for path in touched],
+                "paths_removed": removed_count,
+            },
+        )
+        result.update(
+            action="retired-worktree-reconciled",
+            alert=None,
+            manifests=len(touched),
+            files=removed_count,
+            detail=str(retirement_record),
+        )
+        return [result], touched
+    except (OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        result["alert"] = str(exc)
+        return [result], []
+    finally:
+        for lock in reversed(locks):
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+            lock.close()
 
 
 def checkpoint_explicit_paths(repo: Path, paths: list[Path], cfg: dict, *, dry_run: bool) -> dict:
@@ -855,6 +1090,28 @@ def main() -> int:
         help="Commit and push all session-attributed context paths for remote handoff",
     )
     ap.add_argument(
+        "--reconcile-retired-worktree",
+        type=Path,
+        default=None,
+        help="Remove paths beneath one verified retired worktree from pending manifests",
+    )
+    ap.add_argument(
+        "--retirement-repository",
+        type=Path,
+        default=None,
+        help="Main repository that owned the retired worktree",
+    )
+    ap.add_argument(
+        "--retirement-head",
+        default=None,
+        help="Exact commit that the retirement helper verified on the remote base",
+    )
+    ap.add_argument(
+        "--retirement-base",
+        default=None,
+        help="Fetched base ref that contains the retired head",
+    )
+    ap.add_argument(
         "--now",
         action="store_true",
         help="Compatibility flag for local post-write producer mode",
@@ -874,6 +1131,40 @@ def main() -> int:
     args = ap.parse_args()
 
     cfg = resolve_config(args.config.expanduser())
+
+    if args.reconcile_retired_worktree is not None:
+        if not (
+            args.retirement_repository
+            and args.retirement_head
+            and args.retirement_base
+        ):
+            if not args.quiet:
+                print(
+                    "checkpoint_sync: retired-worktree reconciliation requires "
+                    "--retirement-repository, --retirement-head, and --retirement-base",
+                    file=sys.stderr,
+                )
+            return 2
+        results, _manifests = reconcile_retired_worktree(
+            args.reconcile_retired_worktree,
+            args.retirement_repository,
+            args.retirement_head,
+            args.retirement_base,
+            dry_run=args.dry_run,
+        )
+        alerts = [result for result in results if result.get("alert")]
+        if not args.quiet:
+            if args.json:
+                print(json.dumps(results, indent=2))
+            else:
+                for result in results:
+                    line = f"{result['name']}: {result['action']}"
+                    if result.get("files") is not None:
+                        line += f" ({result['files']} path(s))"
+                    if result.get("alert"):
+                        line += f"  ⚠ {result['alert']}"
+                    print(line)
+        return 1 if alerts else 0
 
     if args.hook:
         try:

--- a/skills/synthesis-repo-guard/checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/checkpoint_sync.py
@@ -772,15 +772,6 @@ def complete_retirement_intent(intent: Path) -> tuple[dict, list[Path]]:
     data = load_retirement_intent(intent)
     repository = Path(str(data.get("repository") or ""))
     result = retirement_result(repository)
-    if data["state"] == "completed":
-        result.update(
-            action="retired-worktree-reconciled",
-            manifests=len(data.get("manifests", [])),
-            files=int(data.get("paths_removed", 0)),
-            detail=str(intent),
-        )
-        return result, [Path(value) for value in data.get("manifests", [])]
-
     worktree, repository = validate_retirement_target(
         Path(str(data.get("worktree") or "")), repository, expect_active=False
     )
@@ -799,6 +790,23 @@ def complete_retirement_intent(intent: Path) -> tuple[dict, list[Path]]:
     )
     if intent != retirement_intent_path(worktree, canonical_head, canonical_base):
         raise ValueError("retirement intent filename does not match its identity")
+    reconciler_hash = data.get("reconciler_sha256")
+    current_hash = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+    if (
+        not isinstance(reconciler_hash, str)
+        or len(reconciler_hash) != 64
+        or any(character not in "0123456789abcdef" for character in reconciler_hash)
+        or reconciler_hash != current_hash
+    ):
+        raise ValueError("retirement intent is not running under its pinned reconciler")
+    if data["state"] == "completed":
+        result.update(
+            action="retired-worktree-reconciled",
+            manifests=len(data.get("manifests", [])),
+            files=int(data.get("paths_removed", 0)),
+            detail=str(intent),
+        )
+        return result, [Path(value) for value in data.get("manifests", [])]
     plans, locks = manifest_reconciliation_plans(worktree)
     try:
         reconciled_at = time.strftime("%Y-%m-%dT%H:%M:%S%z")

--- a/skills/synthesis-repo-guard/test_checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/test_checkpoint_sync.py
@@ -4,7 +4,10 @@ import importlib.util
 import json
 import subprocess
 import sys
+import threading
 from pathlib import Path
+
+import pytest
 
 
 MODULE_PATH = Path(__file__).with_name("checkpoint_sync.py")
@@ -301,6 +304,119 @@ def test_reconcile_retired_worktree_refuses_unpublished_head(
     assert "not contained" in results[0]["alert"]
     assert touched == []
     assert manifest.exists()
+
+
+def test_retirement_intent_resumes_after_removal_gap(tmp_path: Path, monkeypatch) -> None:
+    repo, _remote, _cfg = repository(tmp_path)
+    worktree = tmp_path / "resumable-worktree"
+    command("git", "worktree", "add", "-qb", "feature/resumable", str(worktree), cwd=repo)
+    retired_path = worktree / "change.txt"
+    retired_path.write_text("change\n", encoding="utf-8")
+    command("git", "add", "change.txt", cwd=worktree)
+    command("git", "commit", "-qm", "change", cwd=worktree)
+    head = command("git", "rev-parse", "HEAD", cwd=worktree)
+    command("git", "merge", "-q", "--no-edit", "feature/resumable", cwd=repo)
+    branch = command("git", "branch", "--show-current", cwd=repo)
+    command("git", "push", "-q", "origin", branch, cwd=repo)
+
+    state = tmp_path / "state"
+    pending = state / "pending"
+    receipts = state / "local-handoff"
+    retirements = state / "retired-worktrees"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    monkeypatch.setattr(MODULE, "LOCAL_HANDOFF_DIR", receipts)
+    monkeypatch.setattr(MODULE, "RETIREMENT_DIR", retirements)
+    pending.mkdir(parents=True)
+    session_id = "session-resumable"
+    manifest = MODULE.pending_manifest_path(session_id)
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": session_id,
+                "paths": [str(retired_path)],
+                "remote_paths": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with MODULE.lifecycle_lock():
+        prepared, intent, _touched = MODULE.prepare_retirement_intent(
+            worktree,
+            repo,
+            head,
+            "origin",
+            "origin/main",
+            expect_active=True,
+            dry_run=False,
+        )
+    assert prepared["action"] == "retirement-prepared"
+    assert intent is not None
+    assert json.loads(intent.read_text(encoding="utf-8"))["state"] == "prepared"
+
+    command("git", "worktree", "remove", str(worktree), cwd=repo)
+    with MODULE.lifecycle_lock():
+        completed, touched = MODULE.complete_retirement_intent(intent)
+
+    assert completed["action"] == "retired-worktree-reconciled"
+    assert touched == [manifest]
+    assert not manifest.exists()
+    assert json.loads(intent.read_text(encoding="utf-8"))["state"] == "completed"
+
+
+def test_retirement_recovery_rejects_local_base_ref(tmp_path: Path, monkeypatch) -> None:
+    repo, _remote, _cfg = repository(tmp_path)
+    worktree = tmp_path / "local-base-worktree"
+    command("git", "worktree", "add", "-qb", "feature/local-base", str(worktree), cwd=repo)
+    command("git", "worktree", "remove", str(worktree), cwd=repo)
+    monkeypatch.setattr(MODULE, "PENDING_DIR", tmp_path / "state" / "pending")
+    monkeypatch.setattr(MODULE, "LOCAL_HANDOFF_DIR", tmp_path / "state" / "local-handoff")
+    monkeypatch.setattr(MODULE, "RETIREMENT_DIR", tmp_path / "state" / "retired-worktrees")
+    head = command("git", "rev-parse", "HEAD", cwd=repo)
+
+    results, touched = MODULE.reconcile_retired_worktree(
+        worktree, repo, head, "HEAD", dry_run=False
+    )
+
+    assert results[0]["action"] == "retirement-reconcile-failed"
+    assert "remote-tracking ref" in results[0]["alert"]
+    assert touched == []
+
+
+def test_lifecycle_lock_serializes_threads(tmp_path: Path, monkeypatch) -> None:
+    state = tmp_path / "state"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", state / "pending")
+    monkeypatch.setattr(MODULE, "LOCAL_HANDOFF_DIR", state / "local-handoff")
+    monkeypatch.setattr(MODULE, "RETIREMENT_DIR", state / "retired-worktrees")
+    entered = threading.Event()
+
+    def contender() -> None:
+        with MODULE.lifecycle_lock():
+            entered.set()
+
+    with MODULE.lifecycle_lock():
+        thread = threading.Thread(target=contender)
+        thread.start()
+        assert not entered.wait(0.1)
+    thread.join(timeout=2)
+    assert entered.is_set()
+
+
+def test_lifecycle_lock_rejects_symlinked_state_ancestor(
+    tmp_path: Path, monkeypatch
+) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    linked = tmp_path / "linked"
+    linked.symlink_to(real, target_is_directory=True)
+    monkeypatch.setattr(MODULE, "PENDING_DIR", linked / "pending")
+    monkeypatch.setattr(MODULE, "LOCAL_HANDOFF_DIR", linked / "local-handoff")
+    monkeypatch.setattr(MODULE, "RETIREMENT_DIR", linked / "retired-worktrees")
+
+    with pytest.raises(ValueError, match="symlink component"):
+        with MODULE.lifecycle_lock():
+            pass
 
 
 def test_offline_push_preserves_local_commit_and_manifest(tmp_path: Path, monkeypatch) -> None:

--- a/skills/synthesis-repo-guard/test_checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/test_checkpoint_sync.py
@@ -163,6 +163,146 @@ def test_local_handoff_rejects_dangling_manifest_symlink(
     assert "symlink" in results[0]["alert"]
 
 
+def test_reconcile_retired_worktree_repairs_prior_removal(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo, _remote, _cfg = repository(tmp_path)
+    worktree = tmp_path / "retired-worktree"
+    command("git", "worktree", "add", "-qb", "feature/retired", str(worktree), cwd=repo)
+    retired_path = worktree / "change.txt"
+    retired_path.write_text("change\n", encoding="utf-8")
+    command("git", "add", "change.txt", cwd=worktree)
+    command("git", "commit", "-qm", "change", cwd=worktree)
+    head = command("git", "rev-parse", "HEAD", cwd=worktree)
+    command("git", "merge", "-q", "--no-edit", "feature/retired", cwd=repo)
+    branch = command("git", "branch", "--show-current", cwd=repo)
+    command("git", "push", "-q", "origin", branch, cwd=repo)
+
+    pending = tmp_path / "state" / "pending"
+    receipts = tmp_path / "state" / "local-handoff"
+    retirements = tmp_path / "state" / "retired-worktrees"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    monkeypatch.setattr(MODULE, "LOCAL_HANDOFF_DIR", receipts)
+    monkeypatch.setattr(MODULE, "RETIREMENT_DIR", retirements)
+    pending.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    manifest = MODULE.pending_manifest_path("session-retired")
+    survivor = repo / "projects" / "alpha" / "CONTEXT.md"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": "session-retired",
+                "paths": [str(retired_path), str(survivor)],
+                "remote_paths": [str(survivor)],
+            }
+        ),
+        encoding="utf-8",
+    )
+    receipt = receipts / manifest.name
+    receipt.write_text("{}\n", encoding="utf-8")
+    command("git", "worktree", "remove", str(worktree), cwd=repo)
+
+    results, touched = MODULE.reconcile_retired_worktree(
+        worktree, repo, head, "origin/main", dry_run=False
+    )
+
+    assert results[0]["action"] == "retired-worktree-reconciled"
+    assert touched == [manifest]
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    assert payload["paths"] == [str(survivor)]
+    assert not receipt.exists()
+    assert len(list(retirements.glob("*.json"))) == 1
+
+
+def test_reconcile_retired_worktree_removes_retired_only_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo, _remote, _cfg = repository(tmp_path)
+    worktree = tmp_path / "retired-only-worktree"
+    command("git", "worktree", "add", "-qb", "feature/retired-only", str(worktree), cwd=repo)
+    retired_path = worktree / "change.txt"
+    retired_path.write_text("change\n", encoding="utf-8")
+    command("git", "add", "change.txt", cwd=worktree)
+    command("git", "commit", "-qm", "change", cwd=worktree)
+    head = command("git", "rev-parse", "HEAD", cwd=worktree)
+    command("git", "merge", "-q", "--no-edit", "feature/retired-only", cwd=repo)
+    branch = command("git", "branch", "--show-current", cwd=repo)
+    command("git", "push", "-q", "origin", branch, cwd=repo)
+
+    pending = tmp_path / "state" / "pending"
+    receipts = tmp_path / "state" / "local-handoff"
+    retirements = tmp_path / "state" / "retired-worktrees"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    monkeypatch.setattr(MODULE, "LOCAL_HANDOFF_DIR", receipts)
+    monkeypatch.setattr(MODULE, "RETIREMENT_DIR", retirements)
+    pending.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    manifest = MODULE.pending_manifest_path("session-retired-only")
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": "session-retired-only",
+                "paths": [str(retired_path)],
+                "remote_paths": [str(retired_path)],
+            }
+        ),
+        encoding="utf-8",
+    )
+    receipt = receipts / manifest.name
+    receipt.write_text("{}\n", encoding="utf-8")
+    command("git", "worktree", "remove", str(worktree), cwd=repo)
+
+    results, touched = MODULE.reconcile_retired_worktree(
+        worktree, repo, head, "origin/main", dry_run=False
+    )
+
+    assert results[0]["action"] == "retired-worktree-reconciled"
+    assert touched == [manifest]
+    assert not manifest.exists()
+    assert not receipt.exists()
+    assert len(list(retirements.glob("*.json"))) == 1
+
+
+def test_reconcile_retired_worktree_refuses_unpublished_head(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo, _remote, _cfg = repository(tmp_path)
+    worktree = tmp_path / "unpublished-worktree"
+    command("git", "worktree", "add", "-qb", "feature/unpublished", str(worktree), cwd=repo)
+    retired_path = worktree / "change.txt"
+    retired_path.write_text("change\n", encoding="utf-8")
+    command("git", "add", "change.txt", cwd=worktree)
+    command("git", "commit", "-qm", "change", cwd=worktree)
+    head = command("git", "rev-parse", "HEAD", cwd=worktree)
+    pending = tmp_path / "state" / "pending"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    pending.mkdir(parents=True)
+    manifest = MODULE.pending_manifest_path("session-unpublished")
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": "session-unpublished",
+                "paths": [str(retired_path)],
+                "remote_paths": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    command("git", "worktree", "remove", str(worktree), cwd=repo)
+
+    results, touched = MODULE.reconcile_retired_worktree(
+        worktree, repo, head, "origin/main", dry_run=False
+    )
+
+    assert results[0]["action"] == "retirement-reconcile-failed"
+    assert "not contained" in results[0]["alert"]
+    assert touched == []
+    assert manifest.exists()
+
+
 def test_offline_push_preserves_local_commit_and_manifest(tmp_path: Path, monkeypatch) -> None:
     repo, remote, cfg = repository(tmp_path)
     context = repo / "projects" / "alpha" / "CONTEXT.md"

--- a/skills/synthesis-repo-guard/test_checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/test_checkpoint_sync.py
@@ -365,6 +365,62 @@ def test_retirement_intent_resumes_after_removal_gap(tmp_path: Path, monkeypatch
     assert json.loads(intent.read_text(encoding="utf-8"))["state"] == "completed"
 
 
+def test_retirement_completion_rejects_reconciler_digest_mismatch(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo, _remote, _cfg = repository(tmp_path)
+    worktree = tmp_path / "digest-mismatch-worktree"
+    command("git", "worktree", "add", "-qb", "feature/digest", str(worktree), cwd=repo)
+    changed = worktree / "change.txt"
+    changed.write_text("change\n", encoding="utf-8")
+    command("git", "add", "change.txt", cwd=worktree)
+    command("git", "commit", "-qm", "change", cwd=worktree)
+    head = command("git", "rev-parse", "HEAD", cwd=worktree)
+    command("git", "merge", "-q", "--no-edit", "feature/digest", cwd=repo)
+    branch = command("git", "branch", "--show-current", cwd=repo)
+    command("git", "push", "-q", "origin", branch, cwd=repo)
+
+    state = tmp_path / "state"
+    monkeypatch.setattr(MODULE, "PENDING_DIR", state / "pending")
+    monkeypatch.setattr(MODULE, "LOCAL_HANDOFF_DIR", state / "local-handoff")
+    monkeypatch.setattr(MODULE, "RETIREMENT_DIR", state / "retired-worktrees")
+    MODULE.PENDING_DIR.mkdir(parents=True)
+    manifest = MODULE.pending_manifest_path("session-digest-mismatch")
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": "session-digest-mismatch",
+                "paths": [str(changed)],
+                "remote_paths": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with MODULE.lifecycle_lock():
+        _prepared, intent, _touched = MODULE.prepare_retirement_intent(
+            worktree,
+            repo,
+            head,
+            "origin",
+            "origin/main",
+            expect_active=True,
+            dry_run=False,
+        )
+    assert intent is not None
+    payload = json.loads(intent.read_text(encoding="utf-8"))
+    payload["reconciler_sha256"] = "0" * 64
+    intent.write_text(json.dumps(payload), encoding="utf-8")
+    command("git", "worktree", "remove", str(worktree), cwd=repo)
+
+    with MODULE.lifecycle_lock():
+        with pytest.raises(ValueError, match="pinned reconciler"):
+            MODULE.complete_retirement_intent(intent)
+
+    assert manifest.exists()
+
+
 def test_retirement_recovery_rejects_local_base_ref(tmp_path: Path, monkeypatch) -> None:
     repo, _remote, _cfg = repository(tmp_path)
     worktree = tmp_path / "local-base-worktree"


### PR DESCRIPTION
## What changed

- Makes verified worktree retirement a lifecycle-locked prepare, remove, and complete transaction.
- Pins a freshly fetched remote-tracking commit; local refs and offline proof are rejected.
- Fsyncs a resumable intent before removal and lets the same helper complete it idempotently after interruption.
- Stages and probes the exact reconciler outside the target before removal.
- Invalidates stale receipts, preserves unrelated manifest paths, and rejects symlinked state ancestry.
- Keeps unexplained missing or unpublished paths as blocking Stop failures.

## Verification

- 315 tests passed.
- 186 source-conformance checks passed.
- Isolated installer suite passed.
- A copied live-manifest shape removed exactly eight verified retired paths, preserved current paths, and recorded a completed recovery intent pinned to the fetched public main commit.