### PR TITLE
Repair Claude SessionStart receipt binding

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.25.2",
+  "version": "4.25.3",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.25.2",
+  "version": "4.25.3",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.25.3] - 2026-08-15
+
+### Fixed
+
+- **`synthesis-agent-conformance` v1.2.2 — Claude Code live SessionStart
+  evidence** — preserve the client-delivered
+  receipt when Claude names its client-owned transcript before creating or
+  populating the JSONL file. The receipt records whether the binding existed
+  at hook time; conformance still fails closed until that exact transcript
+  binds the same session UUID. Canonical root-transcript shape validation
+  rejects subagent descendants, symlinks, and existing contradictory UUIDs.
+  Static script output without a real matching client transcript remains
+  insufficient.
+
 ## [4.25.2] - 2026-08-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Claude Code SessionStart evidence follows the real lifecycle (August 2026).**
+Release **4.25.3** records the genuine hook event even when Claude creates its
+transcript immediately after the hook returns. Acceptance still requires that
+exact client-owned transcript to bind the same session UUID, so a static script
+probe cannot satisfy the live gate. See the [4.25.3 release notes](CHANGELOG.md).
+
 **Verified cleanup is part of continuity (August 2026).** Release **4.25.2**
 makes worktree retirement a resumable handoff transaction. One lifecycle lock
 spans durable intent, removal, manifest reconciliation, and receipt

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.2.1"
+  version: "1.2.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -146,9 +146,15 @@ behavior-producing implementation. The script:
 - extracts the current phase, status, plan, and next actions from durable files;
 - emits a compact context anchor;
 - writes atomic generic and client-specific live receipts only when the client
-  supplies a genuine `SessionStart` event and session id. Release conformance
-  requires current public-plugin receipts from both Claude Code and Codex,
-  plus the private Codex control-plane receipt.
+  supplies a genuine `SessionStart` event and session id. Claude may name its
+  client-owned transcript before creating its first JSONL record; the receipt
+  preserves that lifecycle event and records whether the binding existed at
+  hook time. Release conformance still requires the exact transcript to bind
+  the same session UUID. Claude evidence must use the canonical
+  `projects/<encoded-cwd>/<session-id>.jsonl` root shape; subagent descendants,
+  symlinks, and contradictory UUID declarations fail closed. Current
+  public-plugin receipts from both Claude Code and Codex, plus the private
+  Codex control-plane receipt, are required.
 
 Claude calls the same script from its native `SessionStart` hook. Client hook
 configuration remains an adapter; the context-producing behavior is shared.

--- a/skills/synthesis-agent-conformance/references/architecture.md
+++ b/skills/synthesis-agent-conformance/references/architecture.md
@@ -75,7 +75,13 @@ Codex hook definitions outside managed policy require human hash review. Query
 the client-owned `hooks/list` response for the normalized current hash and trust
 reason; do not duplicate its private hashing algorithm or write its trust file.
 A simulated hook event verifies a script contract, not client delivery. Live
-delivery requires a receipt that can be created only from a real event payload.
+delivery requires a receipt from a real event payload and a matching
+client-owned transcript. Claude Code may create the transcript after its
+SessionStart hook returns, so receipt creation and transcript binding are a
+two-phase assertion; conformance accepts it only after both are true. Claude
+root-session evidence additionally requires the canonical
+`projects/<encoded-cwd>/<session-id>.jsonl` shape because subagent transcripts
+also carry their parent session UUID.
 
 ## 5. Durable project handoff
 

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -53,7 +53,10 @@ from active_project import (
 from codex_hook_audit import audit as codex_hook_audit
 from codex_skill_catalog import audit as codex_skill_catalog_audit
 from capability_evidence import sanitize_detail
-from live_receipt import transcript_binds_session
+from live_receipt import (
+    claude_root_transcript_path,
+    transcript_binds_session,
+)
 from project_context import next_actions, record_freshness
 from pointer_lock import locked_pointer
 
@@ -857,6 +860,7 @@ def _receipt_check(
         client = payload.get("client")
         provenance = payload.get("provenance_env")
         transcript_path = payload.get("transcript_path")
+        transcript_bound_at_record = payload.get("transcript_bound_at_record")
         plugin_root = payload.get("plugin_root")
         try:
             uuid.UUID(str(session_id))
@@ -884,6 +888,12 @@ def _receipt_check(
                     ok
                     and transcript.is_absolute()
                     and transcript.is_file()
+                    and (
+                        expected_client != "claude"
+                        or claude_root_transcript_path(
+                            transcript, transcript_root, str(session_id)
+                        )
+                    )
                     and transcript_binds_session(
                         transcript, expected_client, str(session_id)
                     )
@@ -919,6 +929,7 @@ def _receipt_check(
             f"plugin_version={actual_version}; expected_plugin_version={expected_plugin_version}; "
             f"plugin_root={plugin_root}; expected_plugin_root={expected_plugin_root}; "
             f"provenance_env={provenance}; transcript_path={transcript_path}; "
+            f"transcript_bound_at_record={transcript_bound_at_record}; "
             f"recorded_at={recorded_at}; age_seconds="
             f"{int(age_seconds) if age_seconds is not None else 'invalid'}"
         )

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -906,7 +906,10 @@ def _receipt_check(
                 ok
                 and actual_version == expected_plugin_version
                 and plugin_root
+                and isinstance(transcript_bound_at_record, bool)
             )
+            if expected_client == "codex":
+                ok = bool(ok and transcript_bound_at_record is True)
             if expected_plugin_root is None:
                 ok = False
             else:

--- a/skills/synthesis-agent-conformance/scripts/live_receipt.py
+++ b/skills/synthesis-agent-conformance/scripts/live_receipt.py
@@ -10,15 +10,56 @@ from pathlib import Path
 MAX_BINDING_LINES = 1_000
 
 
-def transcript_binds_session(
-    transcript: Path, client: str, session_id: str
+def claude_root_transcript_path(
+    transcript: Path, transcript_root: Path, session_id: str
 ) -> bool:
-    """Return whether a client transcript declares the claimed session id.
+    """Return whether a path is Claude's canonical root-session transcript.
 
-    Both clients write the binding at the start of their JSONL transcript.
-    The bounded scan fails closed on malformed or unexpectedly shaped files
-    without reading an arbitrarily large transcript during SessionStart.
+    Root transcripts use ``projects/<encoded-cwd>/<session-id>.jsonl``.
+    Claude subagent transcripts also carry the parent session UUID, so root
+    containment plus a matching JSON field is not sufficient provenance.
     """
+    if not transcript.is_absolute() or not session_id:
+        return False
+    root = transcript_root.expanduser().absolute()
+    candidate = transcript.expanduser().absolute()
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError:
+        return False
+    if (
+        len(relative.parts) != 3
+        or relative.parts[0] != "projects"
+        or any(part in {".", ".."} for part in relative.parts)
+        or relative.parts[-1] != f"{session_id}.jsonl"
+    ):
+        return False
+    current = root
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink():
+            return False
+    try:
+        candidate.resolve(strict=False).relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def transcript_binding_state(
+    transcript: Path, client: str, session_id: str
+) -> str:
+    """Return ``bound``, ``pending``, ``conflicting``, or ``invalid``.
+
+    ``pending`` covers a transcript Claude has not created or populated yet.
+    Once a transcript declares any different session id, the state is
+    ``conflicting`` and must not be preserved as genuine evidence.
+    """
+    if not transcript.exists():
+        return "pending"
+    if transcript.is_symlink() or not transcript.is_file():
+        return "invalid"
+    declared: set[str] = set()
     try:
         with transcript.open(encoding="utf-8") as handle:
             for index, line in enumerate(handle):
@@ -32,15 +73,37 @@ def transcript_binds_session(
                     continue
                 if client == "codex":
                     metadata = payload.get("payload")
-                    if (
-                        payload.get("type") == "session_meta"
-                        and isinstance(metadata, dict)
-                        and session_id
-                        in {str(metadata.get("id") or ""), str(metadata.get("session_id") or "")}
+                    if payload.get("type") == "session_meta" and isinstance(
+                        metadata, dict
                     ):
-                        return True
-                elif client == "claude" and str(payload.get("sessionId") or "") == session_id:
-                    return True
+                        declared.update(
+                            value
+                            for value in (
+                                str(metadata.get("id") or ""),
+                                str(metadata.get("session_id") or ""),
+                            )
+                            if value
+                        )
+                elif client == "claude":
+                    value = str(payload.get("sessionId") or "")
+                    if value:
+                        declared.add(value)
     except (OSError, UnicodeError):
-        return False
-    return False
+        return "invalid"
+    if declared == {session_id}:
+        return "bound"
+    if declared:
+        return "conflicting"
+    return "pending"
+
+
+def transcript_binds_session(
+    transcript: Path, client: str, session_id: str
+) -> bool:
+    """Return whether a client transcript declares the claimed session id.
+
+    Both clients write the binding at the start of their JSONL transcript.
+    The bounded scan fails closed on malformed or unexpectedly shaped files
+    without reading an arbitrarily large transcript during SessionStart.
+    """
+    return transcript_binding_state(transcript, client, session_id) == "bound"

--- a/skills/synthesis-agent-conformance/scripts/session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/session_context.py
@@ -19,7 +19,11 @@ if str(SCRIPTS_DIR) not in sys.path:
 
 from project_context import extract, next_actions, record_freshness
 from active_project import load_and_validate
-from live_receipt import transcript_binds_session
+from live_receipt import (
+    claude_root_transcript_path,
+    transcript_binding_state,
+    transcript_binds_session,
+)
 
 
 DEFAULT_POINTER = Path.home() / ".synthesis" / "active-project.json"
@@ -100,9 +104,41 @@ def client_provenance(
             transcript.resolve().relative_to(transcript_root.resolve())
         except (OSError, ValueError):
             continue
+        if client == "claude" and not claude_root_transcript_path(
+            transcript, transcript_root, session_id
+        ):
+            continue
         if transcript_binds_session(transcript, client, session_id):
             return client, f"{client}-transcript"
     return None
+
+
+def deferred_claude_provenance(
+    payload: dict[str, object], session_id: str
+) -> tuple[str, str] | None:
+    """Validate Claude's transcript destination before its first JSONL write.
+
+    Claude invokes SessionStart hooks before it creates or populates the
+    transcript named in the hook payload.  The receipt can therefore preserve
+    the client-delivered event before the binding exists, while conformance
+    still requires that exact client-owned transcript to bind the session id
+    before accepting the evidence.
+    """
+    transcript_text = str(payload.get("transcript_path") or "")
+    transcript = Path(transcript_text).expanduser()
+    claude_root = Path(
+        os.environ.get("CLAUDE_CONFIG_DIR", str(Path.home() / ".claude"))
+    ).expanduser()
+    if not transcript_text or not claude_root_transcript_path(
+        transcript, claude_root, session_id
+    ):
+        return None
+    if transcript_binding_state(transcript, "claude", session_id) not in {
+        "pending",
+        "bound",
+    }:
+        return None
+    return "claude", "claude-transcript"
 
 
 def record_live_receipt(payload: dict[str, object], destination: Path) -> bool:
@@ -122,9 +158,18 @@ def record_live_receipt(payload: dict[str, object], destination: Path) -> bool:
         return False
     provenance = client_provenance(payload, session_id)
     if provenance is None:
+        provenance = deferred_claude_provenance(payload, session_id)
+    if provenance is None:
         return False
     version, plugin_root = plugin_identity()
     client, provenance_env = provenance
+    transcript = Path(str(payload.get("transcript_path") or "")).expanduser()
+    binding_state = transcript_binding_state(transcript, client, session_id)
+    if binding_state != "bound" and not (
+        client == "claude" and binding_state == "pending"
+    ):
+        return False
+    transcript_bound_at_record = binding_state == "bound"
     receipt = {
         "hook_event_name": event,
         "session_id": session_id,
@@ -132,6 +177,7 @@ def record_live_receipt(payload: dict[str, object], destination: Path) -> bool:
         "cwd": payload.get("cwd"),
         "source": payload.get("source"),
         "transcript_path": payload.get("transcript_path"),
+        "transcript_bound_at_record": transcript_bound_at_record,
         "provenance_env": provenance_env,
         "plugin_version": version,
         "plugin_root": plugin_root,

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -840,6 +840,7 @@ def test_hook_live_checks_reject_static_absence_and_accept_receipts(
                 "plugin_root": str(installed_roots["codex"]),
                 "provenance_env": "codex-transcript",
                 "transcript_path": str(transcripts["codex"]),
+                "transcript_bound_at_record": True,
                 "recorded_at": recorded_at,
             }
         ),
@@ -855,6 +856,7 @@ def test_hook_live_checks_reject_static_absence_and_accept_receipts(
                 "plugin_root": str(installed_roots["claude"]),
                 "provenance_env": "claude-transcript",
                 "transcript_path": str(transcripts["claude"]),
+                "transcript_bound_at_record": True,
                 "recorded_at": recorded_at,
             }
         ),
@@ -877,6 +879,43 @@ def test_hook_live_checks_reject_static_absence_and_accept_receipts(
         public_codex, public_claude, private, source
     )
     assert all(check.ok for check in present)
+
+    valid_codex = json.loads(public_codex.read_text(encoding="utf-8"))
+    invalid_codex = dict(valid_codex)
+    invalid_codex["transcript_bound_at_record"] = False
+    public_codex.write_text(json.dumps(invalid_codex), encoding="utf-8")
+    invalid_codex_checks = MODULE.hook_live_checks(
+        public_codex, public_claude, private, source
+    )
+    assert next(
+        check for check in invalid_codex_checks
+        if check.name == "hook-live.public-codex-sessionstart"
+    ).ok is False
+
+    missing_codex_flag = dict(valid_codex)
+    missing_codex_flag.pop("transcript_bound_at_record")
+    public_codex.write_text(json.dumps(missing_codex_flag), encoding="utf-8")
+    missing_codex_checks = MODULE.hook_live_checks(
+        public_codex, public_claude, private, source
+    )
+    assert next(
+        check for check in missing_codex_checks
+        if check.name == "hook-live.public-codex-sessionstart"
+    ).ok is False
+    public_codex.write_text(json.dumps(valid_codex), encoding="utf-8")
+
+    valid_claude = json.loads(public_claude.read_text(encoding="utf-8"))
+    invalid_claude = dict(valid_claude)
+    invalid_claude["transcript_bound_at_record"] = "true"
+    public_claude.write_text(json.dumps(invalid_claude), encoding="utf-8")
+    invalid_claude_checks = MODULE.hook_live_checks(
+        public_codex, public_claude, private, source
+    )
+    assert next(
+        check for check in invalid_claude_checks
+        if check.name == "hook-live.public-claude-sessionstart"
+    ).ok is False
+    public_claude.write_text(json.dumps(valid_claude), encoding="utf-8")
 
     stale = json.loads(public_codex.read_text(encoding="utf-8"))
     stale["recorded_at"] = (
@@ -994,6 +1033,7 @@ def test_claude_receipt_rejects_subagent_transcript_with_parent_uuid(
                 "plugin_root": str(installed_root),
                 "provenance_env": "claude-transcript",
                 "transcript_path": str(transcript),
+                "transcript_bound_at_record": True,
                 "recorded_at": datetime.now(timezone.utc).isoformat(),
             }
         ),
@@ -1040,6 +1080,7 @@ def test_claude_receipt_rejects_lexical_parent_transcript_path(
                 "plugin_root": str(installed_root),
                 "provenance_env": "claude-transcript",
                 "transcript_path": str(lexical_transcript),
+                "transcript_bound_at_record": True,
                 "recorded_at": datetime.now(timezone.utc).isoformat(),
             }
         ),

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -782,7 +782,10 @@ def test_hook_live_checks_reject_static_absence_and_accept_receipts(
     claude_home = tmp_path / ".claude"
     transcripts = {
         "codex": codex_home / "sessions" / "public-1.jsonl",
-        "claude": claude_home / "projects" / "public-2.jsonl",
+        "claude": claude_home
+        / "projects"
+        / "workspace"
+        / "019fff79-5858-7993-a329-b301bccf5d32.jsonl",
         "private": codex_home / "sessions" / "private.jsonl",
     }
     for transcript in transcripts.values():
@@ -887,6 +890,173 @@ def test_hook_live_checks_reject_static_absence_and_accept_receipts(
         check for check in expired
         if check.name == "hook-live.public-codex-sessionstart"
     ).ok is False
+
+
+def test_deferred_claude_receipt_requires_eventual_transcript_binding(
+    tmp_path: Path, monkeypatch
+) -> None:
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d36"
+    transcript = claude_home / "projects" / "workspace" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    installed_root = tmp_path / "plugin" / "1.2.3"
+    installed_root.mkdir(parents=True)
+    receipt = tmp_path / "public-sessionstart-claude.json"
+    receipt.write_text(
+        json.dumps(
+            {
+                "hook_event_name": "SessionStart",
+                "session_id": session_id,
+                "client": "claude",
+                "plugin_version": "1.2.3",
+                "plugin_root": str(installed_root),
+                "provenance_env": "claude-transcript",
+                "transcript_path": str(transcript),
+                "transcript_bound_at_record": False,
+                "recorded_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    before: list[MODULE.Check] = []
+    MODULE._receipt_check(
+        before,
+        "hook-live.public-claude-sessionstart",
+        receipt,
+        expected_client="claude",
+        expected_plugin_version="1.2.3",
+        expected_plugin_root=installed_root,
+    )
+    assert before[0].ok is False
+
+    transcript.write_text(
+        json.dumps({"sessionId": "019fff79-5858-7993-a329-b301bccf5d99"})
+        + "\n",
+        encoding="utf-8",
+    )
+    conflicting: list[MODULE.Check] = []
+    MODULE._receipt_check(
+        conflicting,
+        "hook-live.public-claude-sessionstart",
+        receipt,
+        expected_client="claude",
+        expected_plugin_version="1.2.3",
+        expected_plugin_root=installed_root,
+    )
+    assert conflicting[0].ok is False
+
+    transcript.write_text(
+        json.dumps({"sessionId": session_id}) + "\n",
+        encoding="utf-8",
+    )
+    after: list[MODULE.Check] = []
+    MODULE._receipt_check(
+        after,
+        "hook-live.public-claude-sessionstart",
+        receipt,
+        expected_client="claude",
+        expected_plugin_version="1.2.3",
+        expected_plugin_root=installed_root,
+    )
+    assert after[0].ok is True
+
+
+def test_claude_receipt_rejects_subagent_transcript_with_parent_uuid(
+    tmp_path: Path, monkeypatch
+) -> None:
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d40"
+    transcript = (
+        claude_home
+        / "projects"
+        / "workspace"
+        / session_id
+        / "subagents"
+        / "agent-a1.jsonl"
+    )
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        json.dumps({"sessionId": session_id, "agentId": "a1"}) + "\n",
+        encoding="utf-8",
+    )
+    installed_root = tmp_path / "plugin" / "1.2.3"
+    installed_root.mkdir(parents=True)
+    receipt = tmp_path / "public-sessionstart-claude.json"
+    receipt.write_text(
+        json.dumps(
+            {
+                "hook_event_name": "SessionStart",
+                "session_id": session_id,
+                "client": "claude",
+                "plugin_version": "1.2.3",
+                "plugin_root": str(installed_root),
+                "provenance_env": "claude-transcript",
+                "transcript_path": str(transcript),
+                "recorded_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    checks: list[MODULE.Check] = []
+    MODULE._receipt_check(
+        checks,
+        "hook-live.public-claude-sessionstart",
+        receipt,
+        expected_client="claude",
+        expected_plugin_version="1.2.3",
+        expected_plugin_root=installed_root,
+    )
+    assert checks[0].ok is False
+
+
+def test_claude_receipt_rejects_lexical_parent_transcript_path(
+    tmp_path: Path, monkeypatch
+) -> None:
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d44"
+    (claude_home / "projects").mkdir(parents=True)
+    actual_transcript = claude_home / f"{session_id}.jsonl"
+    actual_transcript.write_text(
+        json.dumps({"sessionId": session_id}) + "\n",
+        encoding="utf-8",
+    )
+    lexical_transcript = (
+        claude_home / "projects" / ".." / f"{session_id}.jsonl"
+    )
+    installed_root = tmp_path / "plugin" / "1.2.3"
+    installed_root.mkdir(parents=True)
+    receipt = tmp_path / "public-sessionstart-claude.json"
+    receipt.write_text(
+        json.dumps(
+            {
+                "hook_event_name": "SessionStart",
+                "session_id": session_id,
+                "client": "claude",
+                "plugin_version": "1.2.3",
+                "plugin_root": str(installed_root),
+                "provenance_env": "claude-transcript",
+                "transcript_path": str(lexical_transcript),
+                "recorded_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    checks: list[MODULE.Check] = []
+    MODULE._receipt_check(
+        checks,
+        "hook-live.public-claude-sessionstart",
+        receipt,
+        expected_client="claude",
+        expected_plugin_version="1.2.3",
+        expected_plugin_root=installed_root,
+    )
+    assert checks[0].ok is False
 
 
 def test_public_hook_live_checks_do_not_require_private_control_plane(

--- a/skills/synthesis-agent-conformance/scripts/test_session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/test_session_context.py
@@ -169,7 +169,10 @@ def test_live_receipt_records_real_sessionstart_shape(
         json.dumps(
             {
                 "type": "session_meta",
-                "payload": {"id": "019fff79-5858-7993-a329-b301bccf5d31"},
+                "payload": {
+                    "id": "019fff79-5858-7993-a329-b301bccf5d31",
+                    "session_id": "019fff79-5858-7993-a329-b301bccf5d31",
+                },
             }
         )
         + "\n",
@@ -199,6 +202,43 @@ def test_live_receipt_records_real_sessionstart_shape(
     assert recorded["transcript_path"] == str(transcript)
     assert Path(recorded["plugin_root"]).resolve() == MODULE.SCRIPTS_DIR.parents[2]
     assert not list(receipt.parent.glob("*.tmp"))
+
+
+def test_live_receipt_rejects_codex_subagent_transcript(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    codex_home = tmp_path / ".codex"
+    root_session_id = "019fff79-5858-7993-a329-b301bccf5d45"
+    subagent_id = "01a00767-fe9f-7543-b996-a6bd625f9645"
+    transcript = codex_home / "sessions" / "subagent.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": subagent_id,
+                    "session_id": root_session_id,
+                    "source": {"subagent": "review"},
+                    "thread_source": "subagent",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    assert not MODULE.record_live_receipt(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": root_session_id,
+            "transcript_path": str(transcript),
+        },
+        receipt,
+    )
+    assert not receipt.exists()
 
 
 def test_claude_signal_wins_over_inherited_codex_home(tmp_path: Path, monkeypatch) -> None:

--- a/skills/synthesis-agent-conformance/scripts/test_session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/test_session_context.py
@@ -195,6 +195,7 @@ def test_live_receipt_records_real_sessionstart_shape(
     assert recorded["hook_event_name"] == "SessionStart"
     assert recorded["plugin_version"]
     assert recorded["provenance_env"] == "codex-transcript"
+    assert recorded["transcript_bound_at_record"] is True
     assert recorded["transcript_path"] == str(transcript)
     assert Path(recorded["plugin_root"]).resolve() == MODULE.SCRIPTS_DIR.parents[2]
     assert not list(receipt.parent.glob("*.tmp"))
@@ -202,11 +203,11 @@ def test_live_receipt_records_real_sessionstart_shape(
 
 def test_claude_signal_wins_over_inherited_codex_home(tmp_path: Path, monkeypatch) -> None:
     claude_home = tmp_path / ".claude"
-    transcript = claude_home / "projects" / "session.jsonl"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d32"
+    transcript = claude_home / "projects" / "workspace" / f"{session_id}.jsonl"
     transcript.parent.mkdir(parents=True, exist_ok=True)
     transcript.write_text(
-        json.dumps({"sessionId": "019fff79-5858-7993-a329-b301bccf5d32"})
-        + "\n",
+        json.dumps({"sessionId": session_id}) + "\n",
         encoding="utf-8",
     )
     monkeypatch.delenv("PLUGIN_ROOT", raising=False)
@@ -216,8 +217,216 @@ def test_claude_signal_wins_over_inherited_codex_home(tmp_path: Path, monkeypatc
 
     assert MODULE.client_provenance(
         {"transcript_path": str(transcript)},
-        "019fff79-5858-7993-a329-b301bccf5d32",
+        session_id,
     ) == ("claude", "claude-transcript")
+
+
+def test_live_receipt_preserves_claude_event_before_transcript_exists(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d34"
+    transcript = claude_home / "projects" / "workspace" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    assert MODULE.record_live_receipt(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": session_id,
+            "cwd": "/tmp/repo",
+            "source": "startup",
+            "transcript_path": str(transcript),
+        },
+        receipt,
+    )
+    recorded = json.loads(receipt.read_text(encoding="utf-8"))
+    assert recorded["client"] == "claude"
+    assert recorded["provenance_env"] == "claude-transcript"
+    assert recorded["transcript_bound_at_record"] is False
+    assert receipt.with_name("receipt-claude.json").is_file()
+
+    transcript.write_text(
+        json.dumps({"sessionId": session_id}) + "\n",
+        encoding="utf-8",
+    )
+    assert MODULE.client_provenance(
+        {"transcript_path": str(transcript)}, session_id
+    ) == ("claude", "claude-transcript")
+
+
+def test_live_receipt_preserves_empty_claude_transcript_until_binding(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d37"
+    transcript = claude_home / "projects" / "workspace" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.touch()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    assert MODULE.record_live_receipt(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": session_id,
+            "transcript_path": str(transcript),
+        },
+        receipt,
+    )
+    recorded = json.loads(receipt.read_text(encoding="utf-8"))
+    assert recorded["transcript_bound_at_record"] is False
+
+
+def test_live_receipt_rejects_conflicting_claude_transcript_without_overwrite(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    receipt.write_text('{"preserve": true}\n', encoding="utf-8")
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d38"
+    transcript = claude_home / "projects" / "workspace" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        json.dumps({"sessionId": "019fff79-5858-7993-a329-b301bccf5d99"})
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    assert not MODULE.record_live_receipt(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": session_id,
+            "transcript_path": str(transcript),
+        },
+        receipt,
+    )
+    assert json.loads(receipt.read_text(encoding="utf-8")) == {"preserve": True}
+
+
+def test_live_receipt_rejects_transcript_that_conflicts_during_recording(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    receipt.write_text('{"preserve": true}\n', encoding="utf-8")
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d42"
+    transcript = claude_home / "projects" / "workspace" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+    states = iter(("pending", "conflicting"))
+    monkeypatch.setattr(MODULE, "transcript_binding_state", lambda *args: next(states))
+
+    assert not MODULE.record_live_receipt(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": session_id,
+            "transcript_path": str(transcript),
+        },
+        receipt,
+    )
+    assert json.loads(receipt.read_text(encoding="utf-8")) == {"preserve": True}
+
+
+def test_deferred_claude_receipt_rejects_lexical_parent_directory(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d43"
+    transcript = claude_home / "projects" / ".." / f"{session_id}.jsonl"
+    claude_home.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    assert not MODULE.record_live_receipt(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": session_id,
+            "transcript_path": str(transcript),
+        },
+        receipt,
+    )
+    assert not receipt.exists()
+
+
+def test_live_receipt_rejects_claude_subagent_transcript(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d39"
+    transcript = (
+        claude_home
+        / "projects"
+        / "workspace"
+        / session_id
+        / "subagents"
+        / "agent-a1.jsonl"
+    )
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        json.dumps({"sessionId": session_id, "agentId": "a1"}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    assert not MODULE.record_live_receipt(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": session_id,
+            "transcript_path": str(transcript),
+        },
+        receipt,
+    )
+    assert not receipt.exists()
+
+
+def test_live_receipt_rejects_symlinked_claude_root_transcript(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d41"
+    target = tmp_path / "real.jsonl"
+    target.write_text(
+        json.dumps({"sessionId": session_id}) + "\n",
+        encoding="utf-8",
+    )
+    transcript = claude_home / "projects" / "workspace" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.symlink_to(target)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    assert not MODULE.record_live_receipt(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": session_id,
+            "transcript_path": str(transcript),
+        },
+        receipt,
+    )
+    assert not receipt.exists()
+
+
+def test_deferred_claude_receipt_rejects_path_outside_client_root(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "receipt.json"
+    claude_home = tmp_path / ".claude"
+    claude_home.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    assert not MODULE.record_live_receipt(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "019fff79-5858-7993-a329-b301bccf5d35",
+            "transcript_path": str(tmp_path / "outside.jsonl"),
+        },
+        receipt,
+    )
+    assert not receipt.exists()
 
 
 def test_live_receipt_rejects_forged_payload_without_client_owned_roots(


### PR DESCRIPTION
## Summary
- preserve genuine Claude SessionStart evidence when the client-owned transcript is created after the hook returns
- keep eventual exact transcript binding mandatory for conformance
- reject subagent descendants, symlinked paths, lexical parent traversal, and conflicting UUIDs
- release synthesis-skills 4.25.3 and synthesis-agent-conformance 1.2.2

## Verification
- 332 tests passed
- 74 focused conformance tests passed
- 186 source checks passed
- compile and diff hygiene passed
- independent adversarial review: CLEAN REVIEW