### PR TITLE
Share the stopped-task record contract between pointer activation and local continuity

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.25.3",
+  "version": "4.26.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.25.3",
+  "version": "4.26.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.26.0] - 2026-08-17
+
+### Changed
+
+- **`synthesis-agent-conformance` v1.3.0 — pointer activation accepts the
+  attributed stopped-task record** — the active-project pointer and local
+  continuity now share one record contract. `activate` and pointer validation
+  accept uncommitted project edits exactly when session-attributed pending
+  manifests record every dirty path (the `LOCAL_READY` /
+  `LOCAL_RECOVERABLE` states), and keep failing closed on any unattributed
+  path or unreadable manifest. Previously activation rejected the same
+  attributed dirty record that local continuity accepted, so a live owner
+  mid-switch could not hold a pointer without an off-contract commit. The
+  attribution primitives (`porcelain_paths`, `project_pending_manifests`,
+  `unattributed_dirty_issues`) now live in `active_project.py` and the
+  continuity checks import them, so the two contracts cannot drift apart; a
+  regression test asserts their agreement on the same fixtures. Workspace
+  claims on the coordination board may carry the conventional trailing
+  parenthetical annotation — `repo @ branch (new branch)` — without breaking
+  exact worktree/branch matching.
+
 ## [4.25.3] - 2026-08-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**The pointer and continuity share one stopped-task contract (August 2026).**
+Release **4.26.0** lets the active-project pointer accept the same
+session-attributed uncommitted record that local continuity accepts, so a live
+owner can activate mid-handoff without an off-contract commit. Unattributed
+edits still fail closed, the attribution primitives are shared so the two
+contracts cannot drift, and board workspace claims may carry their
+conventional parenthetical annotations. See the
+[4.26.0 release notes](CHANGELOG.md).
+
 **Claude Code SessionStart evidence follows the real lifecycle (August 2026).**
 Release **4.25.3** records the genuine hook event even when Claude creates its
 transcript immediately after the hook returns. Acceptance still requires that

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.2.2"
+  version: "1.3.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -86,6 +86,12 @@ The command writes a local pointer only. `CONTEXT.md`, `REFERENCE.md`,
 `sessions/`, and plan artifacts remain the source of truth. The pointer records
 the owning session and coordination-board lease URL, plus its worktree,
 branch, and source commit; `pointer` verifies those fields against disk.
+Activation and pointer validation share the local-continuity record contract:
+uncommitted project edits are acceptable exactly when session-attributed
+pending manifests record every dirty path, and any unattributed path fails
+closed. A live owner holding an attributed stopped-task record
+(`LOCAL_READY` or `LOCAL_RECOVERABLE`) can therefore activate without
+committing first.
 
 Before activation writes, read and claim the source areas on
 `~/.synthesis/coordination/active-sessions.md`. Conformance validates the board

--- a/skills/synthesis-agent-conformance/scripts/active_project.py
+++ b/skills/synthesis-agent-conformance/scripts/active_project.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
-"""Validation primitives for the leased active-project pointer."""
+"""Validation primitives for the leased active-project pointer.
+
+The pointer and same-machine continuity share one record contract: an
+uncommitted project edit is acceptable exactly when a session-attributed
+pending manifest records it. The attribution primitives live here so the
+pointer validator and the continuity checks cannot drift apart.
+"""
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -11,6 +19,114 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 TERMINAL_STATUSES = {"released", "complete", "completed", "closed"}
+
+
+def repo_guard_state_root() -> Path:
+    """Root of the session-attributed local handoff state."""
+    return (
+        Path(os.environ.get("SYNTHESIS_HOME", str(Path.home() / ".synthesis")))
+        / "repo-guard"
+    )
+
+
+def porcelain_paths(output: str, repo_root: Path) -> set[Path]:
+    """Resolve `git status --porcelain=v1` lines to absolute paths."""
+    paths: set[Path] = set()
+    for line in output.splitlines():
+        if len(line) < 4:
+            continue
+        value = line[3:]
+        if " -> " in value:
+            value = value.split(" -> ", 1)[1]
+        value = value.strip().strip('"')
+        if value:
+            paths.add((repo_root / value).resolve(strict=False))
+    return paths
+
+
+def manifest_records_project(data: dict[str, object], project: Path) -> bool:
+    """True when a pending manifest records any path inside the project."""
+    project_root = project.resolve()
+    values = data.get("remote_paths", data.get("paths", []))
+    if not isinstance(values, list):
+        return False
+    for value in values:
+        try:
+            Path(str(value)).expanduser().resolve(strict=False).relative_to(
+                project_root
+            )
+            return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
+def project_pending_manifests(
+    project: Path, state_root: Path
+) -> list[tuple[Path, dict]]:
+    """Validated pending session manifests that record this project."""
+    pending = state_root / "pending"
+    found: list[tuple[Path, dict]] = []
+    if not pending.is_dir():
+        return found
+    for path in sorted(pending.glob("*.json")):
+        if path.is_symlink():
+            raise ValueError(f"pending handoff manifest is a symlink: {path}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        session_id = data.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError(f"pending handoff manifest has no session id: {path}")
+        if not isinstance(data.get("paths"), list):
+            raise ValueError(f"pending handoff manifest paths are invalid: {path}")
+        if "remote_paths" in data and not isinstance(data.get("remote_paths"), list):
+            raise ValueError(
+                f"pending handoff manifest remote_paths are invalid: {path}"
+            )
+        expected = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+        if path.name != expected:
+            raise ValueError(f"pending handoff manifest name mismatch: {path}")
+        if manifest_records_project(data, project):
+            found.append((path, data))
+    return found
+
+
+def unattributed_dirty_issues(
+    project: Path,
+    repo_root: Path,
+    porcelain_output: str,
+    state_root: Path,
+) -> list[str]:
+    """Apply the local-continuity attribution rule to a dirty project record.
+
+    Same-machine continuity accepts a stopped or interrupted task whose
+    uncommitted project edits are all recorded by session-attributed pending
+    manifests (`LOCAL_READY` with a current Stop receipt, `LOCAL_RECOVERABLE`
+    without one). The pointer accepts exactly that state. Any dirty path
+    without an attributed manifest still fails closed.
+    """
+    dirty = porcelain_paths(porcelain_output, repo_root)
+    try:
+        manifests = project_pending_manifests(project, state_root)
+    except (OSError, ValueError, TypeError) as exc:
+        return [f"project attribution check failed: {exc}"]
+    if not manifests:
+        return [
+            "project record has uncommitted or untracked changes with no "
+            "session-attributed pending manifest"
+        ]
+    attributed = {
+        Path(str(value)).expanduser().resolve(strict=False)
+        for _, data in manifests
+        for value in data.get("paths", [])
+    }
+    unattributed = sorted(dirty - attributed)
+    if unattributed:
+        preview = ", ".join(str(path) for path in unattributed[:5])
+        return [
+            "project record has unattributed uncommitted or untracked changes: "
+            + preview
+        ]
+    return []
 
 
 def lease_url(board: Path) -> str | None:
@@ -122,7 +238,10 @@ def _workspace_claims(value: str) -> list[tuple[Path, str]]:
         if " @ " not in clean:
             continue
         path, branch = clean.rsplit(" @ ", 1)
-        claims.append((Path(path.strip()).expanduser(), branch.strip()))
+        # Board rows conventionally annotate entries — "repo @ branch (new
+        # branch)". The trailing parenthetical is commentary, not branch name.
+        branch = re.sub(r"\s*\([^()]*\)$", "", branch.strip())
+        claims.append((Path(path.strip()).expanduser(), branch))
     return claims
 
 
@@ -133,6 +252,7 @@ def validate(
     stale_after_minutes: int = 240,
     now: datetime | None = None,
     refresh_lease: bool = True,
+    state_root: Path | None = None,
 ) -> list[str]:
     """Return every reason the pointer is unsafe to inject."""
     issues: list[str] = []
@@ -232,8 +352,10 @@ def validate(
                 "git",
                 "-C",
                 str(worktree),
+                "-c",
+                "core.quotePath=false",
                 "status",
-                "--porcelain",
+                "--porcelain=v1",
                 "--untracked-files=all",
                 "--",
                 str(project),
@@ -245,7 +367,22 @@ def validate(
                 + (project_status.stderr.strip() or f"exit={project_status.returncode}")
             )
         elif project_status.stdout.strip():
-            issues.append("project record has uncommitted or untracked changes")
+            toplevel = _run(
+                ["git", "-C", str(worktree), "rev-parse", "--show-toplevel"]
+            )
+            repo_root = (
+                Path(toplevel.stdout.strip())
+                if toplevel.returncode == 0 and toplevel.stdout.strip()
+                else worktree
+            )
+            issues.extend(
+                unattributed_dirty_issues(
+                    project,
+                    repo_root,
+                    project_status.stdout,
+                    repo_guard_state_root() if state_root is None else state_root,
+                )
+            )
         head = _run(["git", "-C", str(worktree), "rev-parse", "HEAD"])
         branch = _run(["git", "-C", str(worktree), "branch", "--show-current"])
         if head.returncode != 0:
@@ -319,7 +456,11 @@ def validate(
 
 
 def load_and_validate(
-    pointer: Path, board: Path, *, stale_after_minutes: int = 240
+    pointer: Path,
+    board: Path,
+    *,
+    stale_after_minutes: int = 240,
+    state_root: Path | None = None,
 ) -> tuple[dict[str, object], list[str]]:
     if pointer.is_symlink():
         return {}, [f"active-project pointer must not be a symlink: {pointer}"]
@@ -328,5 +469,8 @@ def load_and_validate(
     except Exception as exc:
         return {}, [f"active-project pointer is unreadable: {pointer}: {exc}"]
     return payload, validate(
-        payload, board, stale_after_minutes=stale_after_minutes
+        payload,
+        board,
+        stale_after_minutes=stale_after_minutes,
+        state_root=state_root,
     )

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -47,6 +47,8 @@ from client_binaries import missing_binary_detail, resolve_client_binary
 from active_project import (
     lease_url,
     load_and_validate,
+    porcelain_paths,
+    project_pending_manifests,
     sessions as coordination_sessions,
     validate as validate_active_project,
 )
@@ -1617,44 +1619,6 @@ def stopped_payload_parity(
     return True, "Claude and Codex reconstruct the same durable record without a pointer"
 
 
-def _manifest_records_project(data: dict[str, object], project: Path) -> bool:
-    project_root = project.resolve()
-    values = data.get("remote_paths", data.get("paths", []))
-    if not isinstance(values, list):
-        return False
-    for value in values:
-        try:
-            Path(str(value)).expanduser().resolve(strict=False).relative_to(project_root)
-            return True
-        except (OSError, ValueError):
-            continue
-    return False
-
-
-def project_pending_manifests(project: Path, state_root: Path) -> list[tuple[Path, dict]]:
-    pending = state_root / "pending"
-    found: list[tuple[Path, dict]] = []
-    if not pending.is_dir():
-        return found
-    for path in sorted(pending.glob("*.json")):
-        if path.is_symlink():
-            raise ValueError(f"pending handoff manifest is a symlink: {path}")
-        data = json.loads(path.read_text(encoding="utf-8"))
-        session_id = data.get("session_id")
-        if not isinstance(session_id, str) or not session_id:
-            raise ValueError(f"pending handoff manifest has no session id: {path}")
-        if not isinstance(data.get("paths"), list):
-            raise ValueError(f"pending handoff manifest paths are invalid: {path}")
-        if "remote_paths" in data and not isinstance(data.get("remote_paths"), list):
-            raise ValueError(f"pending handoff manifest remote_paths are invalid: {path}")
-        expected = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
-        if path.name != expected:
-            raise ValueError(f"pending handoff manifest name mismatch: {path}")
-        if _manifest_records_project(data, project):
-            found.append((path, data))
-    return found
-
-
 def _file_receipt_matches(item: dict[str, object]) -> bool:
     path = Path(str(item.get("path") or "")).expanduser()
     state = item.get("state")
@@ -1705,20 +1669,6 @@ def valid_local_receipt(session_id: str, state_root: Path) -> bool:
         return True
     except (OSError, ValueError, TypeError):
         return False
-
-
-def porcelain_paths(output: str, repo_root: Path) -> set[Path]:
-    paths: set[Path] = set()
-    for line in output.splitlines():
-        if len(line) < 4:
-            continue
-        value = line[3:]
-        if " -> " in value:
-            value = value.split(" -> ", 1)[1]
-        value = value.strip().strip('"')
-        if value:
-            paths.add((repo_root / value).resolve(strict=False))
-    return paths
 
 
 def continuity_readiness_checks(

--- a/skills/synthesis-agent-conformance/scripts/test_active_project.py
+++ b/skills/synthesis-agent-conformance/scripts/test_active_project.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 from datetime import datetime, timedelta
@@ -20,6 +21,28 @@ def git(repo: Path, *args: str) -> str:
         text=True,
     )
     return result.stdout.strip()
+
+
+def attribute(
+    tmp_path: Path, paths: list[Path], session_id: str = "fixture-session-0001"
+) -> Path:
+    """Write a session-attributed pending manifest covering the given paths."""
+    state_root = tmp_path / "repo-guard"
+    pending = state_root / "pending"
+    pending.mkdir(parents=True, exist_ok=True)
+    name = hashlib.sha256(session_id.encode("utf-8")).hexdigest() + ".json"
+    (pending / name).write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "session_id": session_id,
+                "paths": [str(path) for path in paths],
+                "remote_paths": [str(path) for path in paths],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return state_root
 
 
 def fixture(tmp_path: Path) -> tuple[dict[str, object], Path]:
@@ -187,14 +210,92 @@ def test_pointer_rejects_unpushed_head(tmp_path: Path) -> None:
     assert any("not reachable from any fetched remote ref" in issue for issue in issues)
 
 
-def test_pointer_rejects_dirty_project_record(tmp_path: Path) -> None:
+def test_pointer_rejects_unattributed_dirty_project_record(tmp_path: Path) -> None:
     payload, board = fixture(tmp_path)
     plan = Path(str(payload["plan"]))
     plan.write_text("# Changed but uncommitted\n", encoding="utf-8")
 
-    issues = validate(payload, board, refresh_lease=False)
+    issues = validate(
+        payload, board, refresh_lease=False, state_root=tmp_path / "repo-guard"
+    )
 
-    assert any("project record has uncommitted" in issue for issue in issues)
+    assert any(
+        "no session-attributed pending manifest" in issue for issue in issues
+    )
+
+
+def test_pointer_accepts_attributed_dirty_project_record(tmp_path: Path) -> None:
+    payload, board = fixture(tmp_path)
+    plan = Path(str(payload["plan"]))
+    plan.write_text("# Attributed uncommitted progress\n", encoding="utf-8")
+    state_root = attribute(tmp_path, [plan])
+
+    assert validate(payload, board, refresh_lease=False, state_root=state_root) == []
+
+
+def test_pointer_rejects_partially_attributed_dirty_record(tmp_path: Path) -> None:
+    payload, board = fixture(tmp_path)
+    plan = Path(str(payload["plan"]))
+    plan.write_text("# Attributed uncommitted progress\n", encoding="utf-8")
+    stray = plan.parent / "stray-note.md"
+    stray.write_text("# Nothing attributes this file\n", encoding="utf-8")
+    state_root = attribute(tmp_path, [plan])
+
+    issues = validate(payload, board, refresh_lease=False, state_root=state_root)
+
+    assert any(
+        "unattributed uncommitted or untracked changes" in issue
+        and "stray-note.md" in issue
+        for issue in issues
+    )
+
+
+def test_pointer_agrees_with_local_continuity_classification(tmp_path: Path) -> None:
+    import conformance
+
+    payload, board = fixture(tmp_path)
+    project = Path(str(payload["project"]))
+    plan = Path(str(payload["plan"]))
+    plan.write_text("# Attributed uncommitted progress\n", encoding="utf-8")
+    state_root = attribute(tmp_path, [plan])
+
+    continuity = conformance.continuity_readiness_checks(
+        project, "local", state_root=state_root
+    )
+    accepted = any(
+        check.name == "continuity.local-state" and check.ok for check in continuity
+    )
+    issues = validate(payload, board, refresh_lease=False, state_root=state_root)
+
+    assert accepted and issues == []
+
+    stray = plan.parent / "stray-note.md"
+    stray.write_text("# Nothing attributes this file\n", encoding="utf-8")
+    continuity = conformance.continuity_readiness_checks(
+        project, "local", state_root=state_root
+    )
+    rejected = any(
+        check.name == "continuity.local-state" and not check.ok
+        for check in continuity
+    )
+    issues = validate(payload, board, refresh_lease=False, state_root=state_root)
+
+    assert rejected and any(
+        "unattributed uncommitted or untracked changes" in issue for issue in issues
+    )
+
+
+def test_workspace_claim_tolerates_parenthetical_annotation(tmp_path: Path) -> None:
+    payload, board = fixture(tmp_path)
+    worktree = str(payload["worktree"])
+    board.write_text(
+        board.read_text(encoding="utf-8").replace(
+            f"{worktree} @ feature/test", f"{worktree} @ feature/test (new branch)"
+        ),
+        encoding="utf-8",
+    )
+
+    assert validate(payload, board, refresh_lease=False) == []
 
 
 def test_pointer_rejects_prefix_only_workspace_claim(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `conformance.py activate` and pointer validation now accept uncommitted project edits exactly when session-attributed pending manifests record every dirty path — the same rule `continuity.local-state` applies for `LOCAL_READY` / `LOCAL_RECOVERABLE`. Previously activation rejected the attributed dirty record that local continuity accepted, so a live owner mid-handoff could not hold a pointer without an off-contract commit.
- Unattributed dirty paths and unreadable manifests still fail closed, with the offending paths named.
- The attribution primitives (`porcelain_paths`, `project_pending_manifests`, `manifest_records_project`, `unattributed_dirty_issues`) moved into `active_project.py`; the continuity checks import them, so the two contracts share one implementation and cannot drift. A regression test asserts pointer/continuity agreement on identical fixtures.
- Board workspace claims may carry the conventional trailing parenthetical annotation (`repo @ branch (new branch)`) without breaking exact worktree/branch matching.
- Release 4.26.0; `synthesis-agent-conformance` v1.3.0.

## Testing

- `python3 -m pytest skills/synthesis-agent-conformance/scripts/test_*.py -q` — 135 passed (4 new: attributed-accept, unattributed-reject, partial-attribution-reject, cross-contract agreement; annotation tolerance).
- Full AGENTS.md verification suite: conformance source 186/186, instructions 2/2, coordination 32, kb-edit/okf 8, rituals/message-guard/git-hooks 38, onboarding 22, transcripts 42, installer, compileall, inbox batteries — all green.
- Isolated before/after fixture reproduces the v4.25.3 divergence and confirms agreement on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)