### PR TITLE
Retain per-session lifecycle evidence

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.26.0",
+  "version": "4.27.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.26.0",
+  "version": "4.27.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.27.0] - 2026-08-17
+
+### Added
+
+- **`synthesis-agent-conformance` v1.4.0 — retained SessionStart evidence** —
+  every genuine Claude Code or Codex SessionStart now creates a preserved
+  per-session event before monotonic latest pointers advance. `hook-live`
+  keeps its unqualified current-health semantics and adds exact Claude and
+  Codex session selectors for release and handoff reverification. A later
+  unrelated start can therefore surface current drift without making an
+  earlier accepted session unreachable. Event identity, transcript binding,
+  plugin version/root, UUID shape, atomicity, and fail-closed registry parsing
+  remain part of the live-evidence gate.
+
+### Changed
+
+- **`synthesis-checkpoint` v1.4.0 — explicit evidence scopes** — checkpoint
+  recovery reports current global hook health separately from any exact
+  accepted-session evidence named by the durable project record. Neither scope
+  may stand in for the other. A ten-minute inter-turn pause is the default
+  automatic freshness boundary when timestamps are available, and installed
+  plugin changes still require a genuinely fresh client task before live
+  acceptance.
+
 ## [4.26.0] - 2026-08-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Accepted SessionStart evidence is no longer a singleton (August 2026).**
+Release **4.27.0** preserves every genuine Claude Code and Codex SessionStart
+under its client and session identity, while retaining separate monotonic
+latest pointers for current-health checks. Conformance can now reverify exact
+accepted sessions without hiding drift in the newest unrelated start. See the
+[4.27.0 release notes](CHANGELOG.md).
+
 **The pointer and continuity share one stopped-task contract (August 2026).**
 Release **4.26.0** lets the active-project pointer accept the same
 session-attributed uncommitted record that local continuity accepts, so a live

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.3.0"
+  version: "1.4.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -56,6 +56,25 @@ python3 scripts/conformance.py coordination
 python3 scripts/conformance.py capabilities --repo-root <repo>
 python3 scripts/conformance.py surfaces
 ```
+
+`hook-live` without selectors answers the current-health question: it checks
+the newest Claude and Codex receipt pointers and keeps the 24-hour freshness
+gate. To reverify a release or handoff against its exact accepted sessions,
+select the preserved event records explicitly:
+
+```bash
+python3 scripts/conformance.py hook-live \
+  --claude-receipt-session-id <claude-session-uuid> \
+  --codex-receipt-session-id <codex-session-uuid>
+```
+
+Do not substitute one scope for the other. A newer unrelated start may make
+current health fail without erasing an earlier accepted event; an accepted
+session check does not establish that the newest global start is healthy.
+Preserved events are local runtime evidence and have no automatic age-based
+deletion. Exact-session checks waive only the 24-hour freshness limit; they
+still require the original client-owned transcript, matching session UUID,
+plugin version, and exact plugin root to validate.
 
 Use `--json` for a machine-readable report. Each check carries a plane and one
 of PASS, FAIL, WARN, UNKNOWN, or UNSUPPORTED. A required UNKNOWN fails the
@@ -151,16 +170,21 @@ behavior-producing implementation. The script:
 - verifies that the project still exists;
 - extracts the current phase, status, plan, and next actions from durable files;
 - emits a compact context anchor;
-- writes atomic generic and client-specific live receipts only when the client
-  supplies a genuine `SessionStart` event and session id. Claude may name its
+- appends an immutable event record for every genuine `SessionStart`, then
+  advances atomic generic and client-specific latest pointers monotonically.
+  Exact-session conformance reads the event registry, so a later unrelated
+  start cannot erase the addressability of accepted evidence. Claude may name its
   client-owned transcript before creating its first JSONL record; the receipt
   preserves that lifecycle event and records whether the binding existed at
   hook time. Release conformance still requires the exact transcript to bind
   the same session UUID. Claude evidence must use the canonical
   `projects/<encoded-cwd>/<session-id>.jsonl` root shape; subagent descendants,
-  symlinks, and contradictory UUID declarations fail closed. Current
-  public-plugin receipts from both Claude Code and Codex, plus the private
-  Codex control-plane receipt, are required.
+  symlinks, and contradictory UUID declarations fail closed. Current-health
+  checks still require the latest public-plugin receipts from both Claude Code
+  and Codex. Release and handoff reverification must select the exact durable
+  session UUIDs rather than trusting whichever global receipt happens to be
+  newest. The private Codex control-plane receipt remains a separate opt-in
+  check.
 
 Claude calls the same script from its native `SessionStart` hook. Client hook
 configuration remains an adapter; the context-producing behavior is shared.

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -57,6 +57,8 @@ from codex_skill_catalog import audit as codex_skill_catalog_audit
 from capability_evidence import sanitize_detail
 from live_receipt import (
     claude_root_transcript_path,
+    receipt_registry_root,
+    session_receipt_path,
     transcript_binds_session,
 )
 from project_context import next_actions, record_freshness
@@ -853,9 +855,12 @@ def _receipt_check(
     expected_client: str | None = None,
     expected_plugin_version: str | None = None,
     expected_plugin_root: Path | None = None,
-    max_age_hours: int = 24,
+    max_age_hours: int | None = 24,
+    receipt_scope: str = "latest",
 ) -> None:
     try:
+        if path.is_symlink():
+            raise ValueError(f"receipt path is a symlink: {path}")
         payload = json.loads(path.read_text(encoding="utf-8"))
         event = payload.get("hook_event_name")
         session_id = payload.get("session_id")
@@ -926,11 +931,19 @@ def _receipt_check(
             if recorded.tzinfo is None:
                 recorded = recorded.replace(tzinfo=timezone.utc)
             age_seconds = (datetime.now(timezone.utc) - recorded).total_seconds()
-            ok = ok and -300 <= age_seconds <= max_age_hours * 60 * 60
+            ok = bool(
+                ok
+                and age_seconds >= -300
+                and (
+                    max_age_hours is None
+                    or age_seconds <= max_age_hours * 60 * 60
+                )
+            )
         except ValueError:
             ok = False
         detail = (
-            f"receipt={path}; client={client}; session_id={session_id}; "
+            f"scope={receipt_scope}; receipt={path}; client={client}; "
+            f"session_id={session_id}; "
             f"plugin_version={actual_version}; expected_plugin_version={expected_plugin_version}; "
             f"plugin_root={plugin_root}; expected_plugin_root={expected_plugin_root}; "
             f"provenance_env={provenance}; transcript_path={transcript_path}; "
@@ -944,7 +957,8 @@ def _receipt_check(
             checks,
             name,
             None,
-            f"no live receipt at {path}; static probes are not accepted",
+            f"scope={receipt_scope}; no live receipt at {path}; "
+            "static probes are not accepted",
         )
     except Exception as exc:
         add(checks, name, False, f"{path}: {exc}")
@@ -1003,8 +1017,10 @@ def hook_live_checks(
     private_codex_receipt: Path | None = None,
     source_root: Path = DEFAULT_SOURCE_ROOT,
     home: Path | None = None,
+    codex_receipt_session_id: str | None = None,
+    claude_receipt_session_id: str | None = None,
 ) -> list[Check]:
-    """Require receipts produced only by genuine SessionStart payloads."""
+    """Require genuine latest or exact-session SessionStart evidence."""
     checks: list[Check] = []
     try:
         source_version = str(
@@ -1024,21 +1040,73 @@ def hook_live_checks(
         return checks
     codex_root = _enabled_plugin_root("codex", source_version, home)
     claude_root = _enabled_plugin_root("claude", source_version, home)
+    try:
+        selected_codex = (
+            session_receipt_path(
+                public_codex_receipt,
+                "codex",
+                codex_receipt_session_id,
+                expected_plugin_version=source_version,
+                expected_plugin_root=codex_root,
+            )
+            if codex_receipt_session_id
+            else public_codex_receipt
+        )
+        selected_claude = (
+            session_receipt_path(
+                public_claude_receipt,
+                "claude",
+                claude_receipt_session_id,
+                expected_plugin_version=source_version,
+                expected_plugin_root=claude_root,
+            )
+            if claude_receipt_session_id
+            else public_claude_receipt
+        )
+    except ValueError as exc:
+        add(checks, "hook-live.receipt-registry", False, str(exc))
+        return checks
+    if codex_receipt_session_id and selected_codex is None:
+        selected_codex = (
+            receipt_registry_root(public_codex_receipt, "codex")
+            / "codex"
+            / codex_receipt_session_id
+            / "*.json"
+        )
+    if claude_receipt_session_id and selected_claude is None:
+        selected_claude = (
+            receipt_registry_root(public_claude_receipt, "claude")
+            / "claude"
+            / claude_receipt_session_id
+            / "*.json"
+        )
     _receipt_check(
         checks,
         "hook-live.public-codex-sessionstart",
-        public_codex_receipt,
+        selected_codex,
         expected_client="codex",
         expected_plugin_version=source_version,
         expected_plugin_root=codex_root,
+        max_age_hours=None if codex_receipt_session_id else 24,
+        receipt_scope=(
+            f"session:{codex_receipt_session_id}"
+            if codex_receipt_session_id
+            else "latest"
+        ),
     )
     _receipt_check(
         checks,
         "hook-live.public-claude-sessionstart",
-        public_claude_receipt,
+        selected_claude,
         expected_client="claude",
         expected_plugin_version=source_version,
         expected_plugin_root=claude_root,
+        max_age_hours=None if claude_receipt_session_id else 24,
+        receipt_scope=(
+            f"session:{claude_receipt_session_id}"
+            if claude_receipt_session_id
+            else "latest"
+        ),
     )
     if private_codex_receipt is not None:
         _receipt_check(
@@ -2135,6 +2203,20 @@ def parser() -> argparse.ArgumentParser:
         help="Opt in to a private control-plane SessionStart receipt check.",
     )
     result.add_argument(
+        "--codex-receipt-session-id",
+        help=(
+            "Select preserved public Codex SessionStart evidence for this exact "
+            "session instead of the current latest pointer."
+        ),
+    )
+    result.add_argument(
+        "--claude-receipt-session-id",
+        help=(
+            "Select preserved public Claude SessionStart evidence for this exact "
+            "session instead of the current latest pointer."
+        ),
+    )
+    result.add_argument(
         "--capability-evidence",
         type=Path,
         default=DEFAULT_CAPABILITY_EVIDENCE,
@@ -2155,6 +2237,13 @@ def parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = parser().parse_args()
+    if args.command != "hook-live" and (
+        args.codex_receipt_session_id or args.claude_receipt_session_id
+    ):
+        raise SystemExit(
+            "exact receipt session selectors are valid only with hook-live; "
+            "the all command always measures current latest health"
+        )
     checks: list[Check] = []
     if args.command in {"source", "all"}:
         checks.extend(source_checks(args.source_root.resolve()))
@@ -2175,6 +2264,8 @@ def main() -> int:
                 if args.private_codex_sessionstart_receipt
                 else None,
                 args.source_root.resolve(),
+                codex_receipt_session_id=args.codex_receipt_session_id,
+                claude_receipt_session_id=args.claude_receipt_session_id,
             )
         )
     if args.command in {"catalog", "all"}:

--- a/skills/synthesis-agent-conformance/scripts/live_receipt.py
+++ b/skills/synthesis-agent-conformance/scripts/live_receipt.py
@@ -4,10 +4,194 @@
 from __future__ import annotations
 
 import json
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 
 MAX_BINDING_LINES = 1_000
+RECEIPT_CLIENTS = {"claude", "codex"}
+
+
+def latest_receipt_paths(destination: Path, client: str) -> tuple[Path, Path]:
+    """Return the generic and client-specific latest receipt paths."""
+    if client not in RECEIPT_CLIENTS:
+        raise ValueError(f"unsupported receipt client: {client}")
+    suffix = f"-{client}"
+    generic = destination
+    if destination.stem.endswith(suffix):
+        generic = destination.with_name(
+            f"{destination.stem[: -len(suffix)]}{destination.suffix}"
+        )
+    client_path = generic.with_name(
+        f"{generic.stem}-{client}{generic.suffix}"
+    )
+    return generic, client_path
+
+
+def receipt_registry_root(latest_receipt: Path, client: str) -> Path:
+    """Return the event registry shared by a client's latest receipt pointer."""
+    generic, _ = latest_receipt_paths(latest_receipt, client)
+    return generic.parent / f"{generic.stem}-events"
+
+
+def receipt_event_path(
+    latest_receipt: Path,
+    *,
+    client: str,
+    session_id: str,
+    event_id: str,
+) -> Path:
+    """Return the immutable path for one genuine SessionStart event."""
+    if client not in RECEIPT_CLIENTS:
+        raise ValueError(f"unsupported receipt client: {client}")
+    try:
+        uuid.UUID(session_id)
+        uuid.UUID(event_id)
+    except ValueError as exc:
+        raise ValueError("receipt session and event ids must be UUIDs") from exc
+    return (
+        receipt_registry_root(latest_receipt, client)
+        / client
+        / session_id
+        / f"{event_id}.json"
+    )
+
+
+def validate_receipt_event_directory(
+    latest_receipt: Path,
+    client: str,
+    session_id: str,
+) -> Path:
+    """Reject symlinked or wrongly typed registry ancestors."""
+    try:
+        uuid.UUID(session_id)
+    except ValueError as exc:
+        raise ValueError(f"invalid {client} session id: {session_id}") from exc
+    root = receipt_registry_root(latest_receipt, client)
+    directory = root / client / session_id
+    for path in (root, root / client, directory):
+        if path.exists() and (path.is_symlink() or not path.is_dir()):
+            raise ValueError(f"receipt registry path is unsafe: {path}")
+    return directory
+
+
+def receipt_recorded_order(
+    payload: dict[str, object], path: Path
+) -> tuple[datetime, str]:
+    recorded_at = payload.get("recorded_at")
+    event_id = str(payload.get("receipt_event_id") or "")
+    try:
+        recorded = datetime.fromisoformat(str(recorded_at))
+        if recorded.tzinfo is None:
+            recorded = recorded.replace(tzinfo=timezone.utc)
+        if event_id:
+            uuid.UUID(event_id)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid receipt ordering fields: {path}") from exc
+    return recorded.astimezone(timezone.utc), event_id
+
+
+def session_receipt_path(
+    latest_receipt: Path,
+    client: str,
+    session_id: str,
+    *,
+    expected_plugin_version: str | None = None,
+    expected_plugin_root: Path | None = None,
+) -> Path | None:
+    """Resolve the newest preserved event for one exact client session.
+
+    The latest pointer remains a current-health cache.  The event registry is
+    the durable runtime evidence. When a source version or enabled plugin root
+    is supplied, selection stays within that exact release identity before
+    choosing the newest resume event. A matching legacy latest receipt is
+    accepted only as a migration fallback for receipts created before the
+    registry.
+    """
+    if client not in RECEIPT_CLIENTS:
+        raise ValueError(f"unsupported receipt client: {client}")
+    try:
+        uuid.UUID(session_id)
+    except ValueError as exc:
+        raise ValueError(f"invalid {client} session id: {session_id}") from exc
+
+    directory = validate_receipt_event_directory(
+        latest_receipt, client, session_id
+    )
+    if directory.exists():
+        candidates: list[tuple[tuple[datetime, str], Path]] = []
+        for path in sorted(directory.glob("*.json")):
+            if path.is_symlink() or not path.is_file():
+                raise ValueError(f"receipt event is unsafe: {path}")
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                raise ValueError(f"receipt event is unreadable: {path}") from exc
+            if not isinstance(payload, dict):
+                raise ValueError(f"receipt event is not an object: {path}")
+            if (
+                payload.get("client") != client
+                or payload.get("session_id") != session_id
+                or path.stem != str(payload.get("receipt_event_id") or "")
+            ):
+                raise ValueError(f"receipt event identity mismatch: {path}")
+            if (
+                expected_plugin_version is not None
+                and payload.get("plugin_version") != expected_plugin_version
+            ):
+                continue
+            if expected_plugin_root is not None:
+                actual_root_text = payload.get("plugin_root")
+                if not isinstance(actual_root_text, str) or not actual_root_text:
+                    continue
+                try:
+                    actual_root = Path(actual_root_text).resolve()
+                    required_root = expected_plugin_root.resolve()
+                except OSError as exc:
+                    raise ValueError(
+                        f"receipt event plugin root is invalid: {path}"
+                    ) from exc
+                if actual_root != required_root:
+                    continue
+            candidates.append((receipt_recorded_order(payload, path), path))
+        if candidates:
+            return max(candidates)[1]
+
+    if latest_receipt.is_symlink():
+        raise ValueError(f"latest receipt is unsafe: {latest_receipt}")
+    try:
+        legacy = json.loads(latest_receipt.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as exc:
+        raise ValueError(f"latest receipt is unreadable: {latest_receipt}") from exc
+    if not isinstance(legacy, dict):
+        raise ValueError(f"latest receipt is not an object: {latest_receipt}")
+    legacy_matches = (
+        legacy.get("client") == client
+        and legacy.get("session_id") == session_id
+        and (
+            expected_plugin_version is None
+            or legacy.get("plugin_version") == expected_plugin_version
+        )
+    )
+    if legacy_matches and expected_plugin_root is not None:
+        legacy_root = legacy.get("plugin_root")
+        if not isinstance(legacy_root, str) or not legacy_root:
+            legacy_matches = False
+        try:
+            if legacy_matches:
+                legacy_matches = (
+                    Path(legacy_root).resolve() == expected_plugin_root.resolve()
+                )
+        except OSError as exc:
+            raise ValueError(
+                f"latest receipt plugin root is invalid: {latest_receipt}"
+            ) from exc
+    if legacy_matches:
+        return latest_receipt
+    return None
 
 
 def claude_root_transcript_path(

--- a/skills/synthesis-agent-conformance/scripts/session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/session_context.py
@@ -10,8 +10,19 @@ import re
 import sys
 import tempfile
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows only
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX only
+    msvcrt = None
 
 SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(SCRIPTS_DIR) not in sys.path:
@@ -21,8 +32,12 @@ from project_context import extract, next_actions, record_freshness
 from active_project import load_and_validate
 from live_receipt import (
     claude_root_transcript_path,
+    latest_receipt_paths,
+    receipt_event_path,
+    receipt_recorded_order,
     transcript_binding_state,
     transcript_binds_session,
+    validate_receipt_event_directory,
 )
 
 
@@ -62,6 +77,57 @@ def atomic_json_write(destination: Path, payload: dict[str, object]) -> None:
     finally:
         if temporary_name and os.path.exists(temporary_name):
             os.unlink(temporary_name)
+
+
+@contextmanager
+def receipt_registry_lock(destination: Path):
+    """Serialize event creation and monotonic latest-pointer updates."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.parent.is_symlink():
+        raise ValueError(
+            f"receipt registry parent is a symlink: {destination.parent}"
+        )
+    lock_path = destination.parent / f".{destination.stem}-events.lock"
+    if lock_path.is_symlink():
+        raise ValueError(f"receipt registry lock is a symlink: {lock_path}")
+    with lock_path.open("a+b") as handle:
+        if fcntl is not None:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        elif msvcrt is not None:  # pragma: no cover - Windows only
+            if handle.seek(0, os.SEEK_END) == 0:
+                handle.write(b"\0")
+                handle.flush()
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        else:  # pragma: no cover - unsupported Python platform
+            raise RuntimeError("receipt registry locking is unavailable")
+        try:
+            yield
+        finally:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            elif msvcrt is not None:  # pragma: no cover - Windows only
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _write_latest_if_newer(
+    destination: Path, receipt: dict[str, object]
+) -> None:
+    if destination.exists():
+        if destination.is_symlink() or not destination.is_file():
+            raise ValueError(f"latest receipt path is unsafe: {destination}")
+        try:
+            current = json.loads(destination.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise ValueError(f"latest receipt is unreadable: {destination}") from exc
+        if not isinstance(current, dict):
+            raise ValueError(f"latest receipt is not an object: {destination}")
+        if receipt_recorded_order(
+            current, destination
+        ) >= receipt_recorded_order(receipt, destination):
+            return
+    atomic_json_write(destination, receipt)
 
 
 def plugin_identity() -> tuple[str | None, str]:
@@ -170,7 +236,10 @@ def record_live_receipt(payload: dict[str, object], destination: Path) -> bool:
     ):
         return False
     transcript_bound_at_record = binding_state == "bound"
+    event_id = str(uuid.uuid4())
     receipt = {
+        "receipt_schema": 2,
+        "receipt_event_id": event_id,
         "hook_event_name": event,
         "session_id": session_id,
         "client": client,
@@ -183,13 +252,20 @@ def record_live_receipt(payload: dict[str, object], destination: Path) -> bool:
         "plugin_root": plugin_root,
         "recorded_at": datetime.now(timezone.utc).isoformat(),
     }
-    destinations = [destination]
-    if client in {"claude", "codex"} and not destination.stem.endswith(f"-{client}"):
-        destinations.append(
-            destination.with_name(f"{destination.stem}-{client}{destination.suffix}")
-        )
-    for receipt_path in destinations:
-        atomic_json_write(receipt_path, receipt)
+    generic_latest, client_latest = latest_receipt_paths(destination, client)
+    event_path = receipt_event_path(
+        client_latest,
+        client=client,
+        session_id=session_id,
+        event_id=event_id,
+    )
+    with receipt_registry_lock(generic_latest):
+        validate_receipt_event_directory(client_latest, client, session_id)
+        if event_path.exists():
+            raise FileExistsError(f"receipt event already exists: {event_path}")
+        atomic_json_write(event_path, receipt)
+        _write_latest_if_newer(client_latest, receipt)
+        _write_latest_if_newer(generic_latest, receipt)
     return True
 
 

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -8,6 +8,8 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+
 
 MODULE_PATH = Path(__file__).with_name("conformance.py")
 SPEC = importlib.util.spec_from_file_location("conformance", MODULE_PATH)
@@ -1000,6 +1002,230 @@ def test_deferred_claude_receipt_requires_eventual_transcript_binding(
         expected_plugin_root=installed_root,
     )
     assert after[0].ok is True
+
+
+def test_hook_live_distinguishes_latest_drift_from_preserved_session_evidence(
+    tmp_path: Path, monkeypatch
+) -> None:
+    source = tmp_path / "source"
+    (source / ".codex-plugin").mkdir(parents=True)
+    (source / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"version": "1.2.3"}), encoding="utf-8"
+    )
+    installed_roots = {
+        "codex": tmp_path / "codex-cache" / "1.2.3",
+        "claude": tmp_path / "claude-cache" / "1.2.3",
+    }
+    for root in installed_roots.values():
+        root.mkdir(parents=True)
+    monkeypatch.setattr(
+        MODULE,
+        "_enabled_plugin_root",
+        lambda client, version, home=None: installed_roots[client],
+    )
+
+    codex_home = tmp_path / ".codex"
+    claude_home = tmp_path / ".claude"
+    codex_session = "019fff79-5858-7993-a329-b301bccf5d61"
+    accepted_claude_session = "019fff79-5858-7993-a329-b301bccf5d62"
+    unrelated_claude_session = "019fff79-5858-7993-a329-b301bccf5d63"
+    codex_transcript = codex_home / "sessions" / f"{codex_session}.jsonl"
+    accepted_transcript = (
+        claude_home
+        / "projects"
+        / "workspace"
+        / f"{accepted_claude_session}.jsonl"
+    )
+    unrelated_transcript = (
+        claude_home
+        / "projects"
+        / "workspace"
+        / f"{unrelated_claude_session}.jsonl"
+    )
+    codex_transcript.parent.mkdir(parents=True)
+    accepted_transcript.parent.mkdir(parents=True)
+    codex_transcript.write_text(
+        json.dumps(
+            {"type": "session_meta", "payload": {"id": codex_session}}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    accepted_transcript.write_text(
+        json.dumps({"sessionId": accepted_claude_session}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+
+    public_codex = tmp_path / "public-sessionstart-codex.json"
+    public_claude = tmp_path / "public-sessionstart-claude.json"
+    now = datetime.now(timezone.utc).isoformat()
+    public_codex.write_text(
+        json.dumps(
+            {
+                "hook_event_name": "SessionStart",
+                "session_id": codex_session,
+                "client": "codex",
+                "plugin_version": "1.2.3",
+                "plugin_root": str(installed_roots["codex"]),
+                "provenance_env": "codex-transcript",
+                "transcript_path": str(codex_transcript),
+                "transcript_bound_at_record": True,
+                "recorded_at": now,
+            }
+        ),
+        encoding="utf-8",
+    )
+    public_claude.write_text(
+        json.dumps(
+            {
+                "hook_event_name": "SessionStart",
+                "session_id": unrelated_claude_session,
+                "client": "claude",
+                "plugin_version": "1.2.3",
+                "plugin_root": str(installed_roots["claude"]),
+                "provenance_env": "claude-transcript",
+                "transcript_path": str(unrelated_transcript),
+                "transcript_bound_at_record": False,
+                "recorded_at": now,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def store_event(
+        latest: Path,
+        *,
+        client: str,
+        session_id: str,
+        event_id: str,
+        version: str,
+        plugin_root: Path,
+        transcript: Path,
+        age_hours: int,
+    ) -> Path:
+        event = (
+            MODULE.receipt_registry_root(latest, client)
+            / client
+            / session_id
+            / f"{event_id}.json"
+        )
+        event.parent.mkdir(parents=True, exist_ok=True)
+        event.write_text(
+            json.dumps(
+                {
+                    "receipt_schema": 2,
+                    "receipt_event_id": event_id,
+                    "hook_event_name": "SessionStart",
+                    "session_id": session_id,
+                    "client": client,
+                    "plugin_version": version,
+                    "plugin_root": str(plugin_root),
+                    "provenance_env": f"{client}-transcript",
+                    "transcript_path": str(transcript),
+                    "transcript_bound_at_record": True,
+                    "recorded_at": (
+                        datetime.now(timezone.utc) - timedelta(hours=age_hours)
+                    ).isoformat(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        return event
+
+    accepted_claude_event = store_event(
+        public_claude,
+        client="claude",
+        session_id=accepted_claude_session,
+        event_id="019fff79-5858-7993-a329-b301bccf5d64",
+        version="1.2.3",
+        plugin_root=installed_roots["claude"],
+        transcript=accepted_transcript,
+        age_hours=48,
+    )
+    store_event(
+        public_claude,
+        client="claude",
+        session_id=accepted_claude_session,
+        event_id="019fff79-5858-7993-a329-b301bccf5d65",
+        version="1.2.4",
+        plugin_root=tmp_path / "claude-cache" / "1.2.4",
+        transcript=accepted_transcript,
+        age_hours=1,
+    )
+    accepted_codex_event = store_event(
+        public_codex,
+        client="codex",
+        session_id=codex_session,
+        event_id="019fff79-5858-7993-a329-b301bccf5d66",
+        version="1.2.3",
+        plugin_root=installed_roots["codex"],
+        transcript=codex_transcript,
+        age_hours=48,
+    )
+    store_event(
+        public_codex,
+        client="codex",
+        session_id=codex_session,
+        event_id="019fff79-5858-7993-a329-b301bccf5d67",
+        version="1.2.4",
+        plugin_root=tmp_path / "codex-cache" / "1.2.4",
+        transcript=codex_transcript,
+        age_hours=1,
+    )
+
+    latest = MODULE.hook_live_checks(
+        public_codex, public_claude, source_root=source
+    )
+    latest_claude = next(
+        check
+        for check in latest
+        if check.name == "hook-live.public-claude-sessionstart"
+    )
+    assert latest_claude.ok is False
+    assert "scope=latest" in latest_claude.detail
+
+    accepted = MODULE.hook_live_checks(
+        public_codex,
+        public_claude,
+        source_root=source,
+        codex_receipt_session_id=codex_session,
+        claude_receipt_session_id=accepted_claude_session,
+    )
+    assert all(check.ok for check in accepted)
+    accepted_claude = next(
+        check
+        for check in accepted
+        if check.name == "hook-live.public-claude-sessionstart"
+    )
+    assert f"scope=session:{accepted_claude_session}" in accepted_claude.detail
+    assert f"receipt={accepted_claude_event}" in accepted_claude.detail
+    accepted_codex = next(
+        check
+        for check in accepted
+        if check.name == "hook-live.public-codex-sessionstart"
+    )
+    assert f"scope=session:{codex_session}" in accepted_codex.detail
+    assert f"receipt={accepted_codex_event}" in accepted_codex.detail
+
+
+def test_exact_receipt_selectors_cannot_replace_all_current_health(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "conformance.py",
+            "all",
+            "--claude-receipt-session-id",
+            "019fff79-5858-7993-a329-b301bccf5d62",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="only with hook-live"):
+        MODULE.main()
 
 
 def test_claude_receipt_rejects_subagent_transcript_with_parent_uuid(

--- a/skills/synthesis-agent-conformance/scripts/test_session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/test_session_context.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+import pytest
 
 
 MODULE_PATH = Path(__file__).with_name("session_context.py")
@@ -201,7 +205,129 @@ def test_live_receipt_records_real_sessionstart_shape(
     assert recorded["transcript_bound_at_record"] is True
     assert recorded["transcript_path"] == str(transcript)
     assert Path(recorded["plugin_root"]).resolve() == MODULE.SCRIPTS_DIR.parents[2]
+    event_path = (
+        receipt.parent
+        / "receipt-events"
+        / "codex"
+        / payload["session_id"]
+        / f"{recorded['receipt_event_id']}.json"
+    )
+    assert event_path.is_file()
+    assert json.loads(event_path.read_text(encoding="utf-8")) == recorded
     assert not list(receipt.parent.glob("*.tmp"))
+
+
+def test_live_receipt_preserves_prior_session_when_latest_advances(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "live" / "public-sessionstart.json"
+    codex_home = tmp_path / ".codex"
+    first_session = "019fff79-5858-7993-a329-b301bccf5d51"
+    second_session = "019fff79-5858-7993-a329-b301bccf5d52"
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    def record(session_id: str) -> None:
+        transcript = codex_home / "sessions" / f"{session_id}.jsonl"
+        transcript.parent.mkdir(parents=True, exist_ok=True)
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "session_meta",
+                    "payload": {"id": session_id, "session_id": session_id},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        assert MODULE.record_live_receipt(
+            {
+                "hook_event_name": "SessionStart",
+                "session_id": session_id,
+                "source": "startup",
+                "transcript_path": str(transcript),
+            },
+            receipt,
+        )
+
+    record(first_session)
+    first_events = list(
+        (receipt.parent / "public-sessionstart-events" / "codex" / first_session)
+        .glob("*.json")
+    )
+    assert len(first_events) == 1
+    first_contents = first_events[0].read_bytes()
+
+    record(second_session)
+
+    assert first_events[0].read_bytes() == first_contents
+    second_events = list(
+        (receipt.parent / "public-sessionstart-events" / "codex" / second_session)
+        .glob("*.json")
+    )
+    assert len(second_events) == 1
+    assert (
+        json.loads(receipt.read_text(encoding="utf-8"))["session_id"]
+        == second_session
+    )
+    client_latest = receipt.with_name("public-sessionstart-codex.json")
+    assert (
+        json.loads(client_latest.read_text(encoding="utf-8"))["session_id"]
+        == second_session
+    )
+
+
+def test_latest_receipt_pointer_never_moves_backward(tmp_path: Path) -> None:
+    destination = tmp_path / "latest.json"
+    newer = {
+        "receipt_event_id": "019fff79-5858-7993-a329-b301bccf5d71",
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+    }
+    older = {
+        "receipt_event_id": "019fff79-5858-7993-a329-b301bccf5d72",
+        "recorded_at": (
+            datetime.now(timezone.utc) - timedelta(minutes=1)
+        ).isoformat(),
+    }
+    MODULE.atomic_json_write(destination, newer)
+
+    MODULE._write_latest_if_newer(destination, older)
+
+    assert json.loads(destination.read_text(encoding="utf-8")) == newer
+
+
+def test_live_receipt_rejects_symlinked_event_registry(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "live" / "public-sessionstart.json"
+    receipt.parent.mkdir(parents=True)
+    target = tmp_path / "outside-events"
+    target.mkdir()
+    (receipt.parent / "public-sessionstart-events").symlink_to(
+        target, target_is_directory=True
+    )
+    codex_home = tmp_path / ".codex"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d73"
+    transcript = codex_home / "sessions" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": session_id}})
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    with pytest.raises(ValueError, match="receipt registry path is unsafe"):
+        MODULE.record_live_receipt(
+            {
+                "hook_event_name": "SessionStart",
+                "session_id": session_id,
+                "transcript_path": str(transcript),
+            },
+            receipt,
+        )
+
+    assert not receipt.exists()
+    assert not list(target.iterdir())
 
 
 def test_live_receipt_rejects_codex_subagent_transcript(
@@ -317,6 +443,46 @@ def test_live_receipt_preserves_empty_claude_transcript_until_binding(
     )
     recorded = json.loads(receipt.read_text(encoding="utf-8"))
     assert recorded["transcript_bound_at_record"] is False
+
+
+def test_same_claude_session_retains_pending_and_bound_events(
+    tmp_path: Path, monkeypatch
+) -> None:
+    receipt = tmp_path / "live" / "public-sessionstart.json"
+    claude_home = tmp_path / ".claude"
+    session_id = "019fff79-5858-7993-a329-b301bccf5d74"
+    transcript = claude_home / "projects" / "workspace" / f"{session_id}.jsonl"
+    transcript.parent.mkdir(parents=True)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+    payload = {
+        "hook_event_name": "SessionStart",
+        "session_id": session_id,
+        "source": "startup",
+        "transcript_path": str(transcript),
+    }
+
+    assert MODULE.record_live_receipt(payload, receipt)
+    time.sleep(0.002)
+    transcript.write_text(
+        json.dumps({"sessionId": session_id}) + "\n", encoding="utf-8"
+    )
+    payload["source"] = "resume"
+    assert MODULE.record_live_receipt(payload, receipt)
+
+    event_directory = (
+        receipt.parent / "public-sessionstart-events" / "claude" / session_id
+    )
+    events = list(event_directory.glob("*.json"))
+    assert len(events) == 2
+    selected = sys.modules["live_receipt"].session_receipt_path(
+        receipt.with_name("public-sessionstart-claude.json"),
+        "claude",
+        session_id,
+    )
+    assert selected is not None
+    selected_payload = json.loads(selected.read_text(encoding="utf-8"))
+    assert selected_payload["source"] == "resume"
+    assert selected_payload["transcript_bound_at_record"] is True
 
 
 def test_live_receipt_rejects_conflicting_claude_transcript_without_overwrite(

--- a/skills/synthesis-checkpoint/SKILL.md
+++ b/skills/synthesis-checkpoint/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.3.0"
+  version: "1.4.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -41,7 +41,11 @@ Invoke synthesis-checkpoint when any of these conditions fire:
 **Triggered by the agent's own self-monitoring:**
 - Before generating any time-interval claim ("N days ago", "yesterday", "last session", "this week")
 - Before quoting any project status from cached memory
-- After a noticeable gap in conversation (model can check `date` to compare against perceived time)
+- After at least 10 minutes between user turns when the client exposes message
+  timestamps. Ten minutes is the default freshness boundary: long enough to
+  avoid checkpointing ordinary back-and-forth, short enough to catch another
+  client session changing shared state. If timestamps are unavailable, any
+  resume/continue phrasing after an apparent pause triggers the checkpoint.
 - After ~25 substantive tool calls, regardless of perceived need
 - When the model says or thinks "I don't recall" about a recent decision
 - When a file read reveals content the model didn't expect (state drift signal)
@@ -112,11 +116,19 @@ If there's a planning artifact (a plan file, a design doc, a checklist) referenc
 
 Before reporting, if `synthesis-agent-conformance` is installed, run its
 `hook-live`, `catalog`, and `instruction-budget` modes against the current
-source/repository. Compare the latest SessionStart receipt's plugin version
-with current source and installed truth. A mismatch means this task has a stale
-startup registry: save the durable checkpoint and require a new Claude Code
-session or Codex task. Do not describe an in-place cache update as a task
-reload.
+source/repository. The unqualified `hook-live` result is current global health.
+If the durable release or handoff record names accepted Claude and Codex
+session UUIDs, also run `hook-live` with
+`--claude-receipt-session-id` and `--codex-receipt-session-id`. Report the two
+scopes separately: a newer unrelated receipt can fail current health without
+revoking preserved accepted evidence, while an exact-session failure means the
+record can no longer be reverified from live artifacts. Never replace the
+current-health result with the selected historical result.
+
+Compare this task's own SessionStart receipt plugin version with current source
+and installed truth. A mismatch means this task has a stale startup registry:
+save the durable checkpoint and require a new Claude Code session or Codex
+task. Do not describe an in-place cache update as a task reload.
 
 In one short paragraph in the next response to the user, state:
 - Today's verified date and time


### PR DESCRIPTION
Adds append-only SessionStart event records, monotonic current-health pointers, and exact release-scoped selectors for Claude Code and Codex. Updates checkpoint freshness behavior and preserves the fresh-task registry boundary. Verified with 343 tests, full repository validation, installer checks, and a 24-writer concurrency probe.