### PR TITLE
Correct stopped-task aggregate conformance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.28.0",
+  "version": "4.28.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.28.0",
+  "version": "4.28.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.28.1] - 2026-08-17
+
+### Fixed
+
+- **Aggregate local continuity without an active pointer** — the complete
+  conformance command now honors the stopped-task contract when the optional
+  active-project cache is absent. The explicit `pointer` command remains
+  strict, and an existing malformed pointer still fails in every scope.
+
 ## [4.28.0] - 2026-08-17
 
 ### Added

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.5.0"
+  version: "1.5.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -1928,9 +1928,17 @@ def pointer_checks(
     project: Path,
     pointer: Path,
     coordination_board: Path = DEFAULT_COORDINATION_BOARD,
+    require_pointer: bool = True,
 ) -> list[Check]:
-    """Validate pointer content, ownership, and checkout identity."""
+    """Validate pointer content, ownership, and checkout identity.
+
+    The explicit ``pointer`` command requires the cache. The aggregate ``all``
+    command accepts its documented absence and validates stopped-task handoff
+    instead; an existing malformed pointer still fails in both scopes.
+    """
     checks = handoff_checks(project, pointer, coordination_board)
+    if not require_pointer and not pointer.exists():
+        return checks
     try:
         payload = json.loads(pointer.read_text(encoding="utf-8"))
     except Exception as exc:
@@ -2327,6 +2335,7 @@ def main() -> int:
                 args.project.resolve(),
                 args.active_project_file.expanduser(),
                 args.coordination_board.expanduser(),
+                require_pointer=args.command == "pointer",
             )
         )
     if args.command == "handoff":

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -575,8 +575,7 @@ def test_payload_parity_reports_broken_pointer(tmp_path: Path) -> None:
     assert "payload failed" in detail
 
 
-def test_stopped_handoff_passes_without_active_pointer(tmp_path: Path) -> None:
-    subprocess = __import__("subprocess")
+def write_stopped_project(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     project = repo / "projects" / "demo"
     plan = project / "resources" / "artifacts" / "demo-plan.md"
@@ -607,6 +606,11 @@ def test_stopped_handoff_passes_without_active_pointer(tmp_path: Path) -> None:
         ["git", "-C", str(repo), "update-ref", "refs/remotes/origin/main", "HEAD"],
         check=True,
     )
+    return project
+
+
+def test_stopped_handoff_passes_without_active_pointer(tmp_path: Path) -> None:
+    project = write_stopped_project(tmp_path)
 
     checks = MODULE.handoff_checks(
         project,
@@ -618,6 +622,29 @@ def test_stopped_handoff_passes_without_active_pointer(tmp_path: Path) -> None:
     named = {check.name: check for check in checks}
     assert named["handoff.stopped-task-payload"].ok
     assert named["handoff.pointer-cache"].ok
+
+
+def test_aggregate_pointer_scope_accepts_documented_cache_absence(
+    tmp_path: Path,
+) -> None:
+    project = write_stopped_project(tmp_path)
+    pointer = tmp_path / "missing-pointer.json"
+
+    aggregate = MODULE.pointer_checks(
+        project,
+        pointer,
+        tmp_path / "missing-board.md",
+        require_pointer=False,
+    )
+    explicit = MODULE.pointer_checks(
+        project,
+        pointer,
+        tmp_path / "missing-board.md",
+    )
+
+    assert all(check.ok for check in aggregate if check.required)
+    assert "pointer.schema" not in {check.name for check in aggregate}
+    assert not {check.name: check for check in explicit}["pointer.schema"].ok
 
 
 def test_local_continuity_recovers_interrupted_attributed_edits(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve strict validation for explicit active-pointer checks
- let aggregate conformance honor the documented stopped-task path when the optional pointer cache is absent
- keep malformed existing pointer state fail-closed

## Verification
- 353 tests passed
- source conformance: 186/186 passed