### PR TITLE
Release 4.40.0: project-name contradiction guard

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.39.0",
+  "version": "4.40.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.39.0",
+  "version": "4.40.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.40.0] - 2026-08-20
+
+### Added
+
+- `synthesis-project-management` v2.4.0: the **project-name contradiction
+  guard** in Project Discovery. When a request names a project that
+  contradicts the session's own evidence — the conversation's established
+  project, the chat or session name, the active-project pointer, the task's
+  working directory — the agent surfaces the contradiction and asks a
+  one-line clarifying question instead of silently resolving to the name.
+  Names are one signal, not an override: humans navigate many
+  similarly-named projects, and sibling projects in one program share
+  vocabulary. Silent resolution stays correct only when name and session
+  evidence agree, or the session carries no project evidence at all. Origin:
+  a misnamed sibling project sent an entire working session's output to the
+  wrong project's records while the intended project's ask went unfulfilled.
+  Companion Common Mistakes row added.
+
+### Changed
+
+- `synthesis-agent-conformance` v1.6.1: the SessionStart stopped-task
+  recovery guidance carries the same exception — automatic resolution of a
+  user-named project now explicitly excludes the case where the name
+  contradicts the session's established context, closing the gap where the
+  emitted guidance instructed the exact behavior the discovery protocol now
+  forbids.
+
 ## [4.39.0] - 2026-08-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A named project is one signal, not an override (August 2026).** Release
+**4.40.0** adds the project-name contradiction guard to
+`synthesis-project-management` **v2.4.0**: when a request names a project
+that contradicts the session's own evidence — its established conversation,
+session name, active-project pointer, or working directory — the agent asks
+a one-line clarifying question instead of silently switching. Humans
+navigate many similarly-named projects, and sibling projects share
+vocabulary; a wrong silent resolution sends a whole session's work to the
+wrong project's records. The SessionStart recovery guidance
+(`synthesis-agent-conformance` v1.6.1) now carries the same exception, so
+the emitted guidance can no longer instruct the behavior the discovery
+protocol forbids. See the [4.40.0 release notes](CHANGELOG.md).
+
 **The chief-of-staff AI speaks as you; the EA AI speaks for you (August 2026).**
 Release **4.39.0** gives `synthesis-agent-correspondence` **v3.0.0** a voice
 axis: an assistant-archetype persona (the chief of staff) writes in the

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.6.0"
+  version: "1.6.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-agent-conformance/scripts/session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/session_context.py
@@ -406,7 +406,12 @@ def build(
                 "Stopped-task recovery remains available: when the user names a "
                 "synthesis project, resolve it from the git-tracked projects/index.yaml "
                 "and run the Session Start Protocol automatically; never ask the user "
-                "to run a context-lifecycle command or save state manually."
+                "to run a context-lifecycle command or save state manually. One "
+                "exception to automatic resolution: if the named project contradicts "
+                "this session's own established context (its prior conversation, "
+                "active project, or task directory), surface the contradiction and "
+                "confirm which project is meant before switching - never silently "
+                "resolve the name over the session's evidence."
             )
         return "\n".join(lines)
 

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.3.0"
+  version: "2.4.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -494,10 +494,29 @@ When a user mentions a project:
 
 1. Read `projects/index.yaml`
 2. Match user's phrase against project `name`, `description`, `id`, `tags`
-3. If match found, read the project's `CONTEXT.md`
-4. Summarize current state and next steps
-5. **Re-verify scope before dispatching work, especially for a paused project.** CONTEXT.md's "N items remaining" (or any count a plan document asserts is current) is a claim made at write time, not a live query — it goes stale the moment anything else touches the same corpus, even a workstream that has nothing to do with this project and doesn't know it exists. Before batch-dispatching agents against a stated scope, re-derive it from live state with a cheap direct check (`find`, `grep`, `wc -l` against the actual files or repos) rather than trusting the document's count. This is cheapest immediately before dispatch — the highest-leverage moment to catch drift, before agent-hours are spent at the wrong scope — and it applies even within a single session, since a count computed early in a long run can go stale by the time a later phase acts on it. If the recount disagrees with the document, update the document in the same pass rather than silently working around the discrepancy. (Distinct from context-lifecycle's Session Start Protocol, which verifies CONTEXT.md's own freshness against this project's git log — that catches a stale *file*; this catches a stale *scope claim* that can drift even when the file itself looks current.)
-6. Begin work from where it left off
+3. **Check the match against the session's own context before switching.** A
+   session usually carries project evidence of its own: the conversation's
+   established project, the chat or session name, the active-project pointer,
+   the task's working directory. When the named project *contradicts* that
+   evidence — the phrase matches project X while everything about the session
+   says project Y — surface the contradiction and ask; never silently resolve
+   to the name. Project names are typed by humans navigating many
+   similarly-named projects, and sibling projects in one program often share
+   vocabulary, so a name is one signal, not an override. A one-line question
+   ("This session has been working project Y — did you mean X, or should this
+   stay in Y?") costs seconds; a silent wrong resolution sends a full
+   session's work to the wrong project's records and leaves the right
+   project's ask unfulfilled. Resolve without asking only when the name and
+   the session's evidence agree, or when the session carries no project
+   evidence at all (fresh session, no pointer, neutral directory). Origin:
+   2026-08-20 — a request that misnamed a sibling project was resolved over
+   the session's own identity, and an entire working session landed in the
+   wrong project.
+4. If match found (and confirmed where step 3 required it), read the
+   project's `CONTEXT.md`
+5. Summarize current state and next steps
+6. **Re-verify scope before dispatching work, especially for a paused project.** CONTEXT.md's "N items remaining" (or any count a plan document asserts is current) is a claim made at write time, not a live query — it goes stale the moment anything else touches the same corpus, even a workstream that has nothing to do with this project and doesn't know it exists. Before batch-dispatching agents against a stated scope, re-derive it from live state with a cheap direct check (`find`, `grep`, `wc -l` against the actual files or repos) rather than trusting the document's count. This is cheapest immediately before dispatch — the highest-leverage moment to catch drift, before agent-hours are spent at the wrong scope — and it applies even within a single session, since a count computed early in a long run can go stale by the time a later phase acts on it. If the recount disagrees with the document, update the document in the same pass rather than silently working around the discrepancy. (Distinct from context-lifecycle's Session Start Protocol, which verifies CONTEXT.md's own freshness against this project's git log — that catches a stale *file*; this catches a stale *scope claim* that can drift even when the file itself looks current.)
+7. Begin work from where it left off
 
 ---
 
@@ -514,6 +533,7 @@ When a user mentions a project:
 | Trusting a paused project's stated remaining-scope count | Batch-dispatches the wrong amount of work — wastes agent-hours on already-done items, or silently leaves new items undone | Re-derive the count from live disk/repo state immediately before dispatch, even when the document looks current |
 | Bare `git commit` in a repo where sub-agents dispatch concurrently | Sweeps another agent's staged work into your commit | `git status --short` / `git diff --cached --name-only` before every commit; commit only your own paths |
 | Editing before reading or claiming the coordination board | Two root sessions overwrite or invalidate each other's work | Read at SessionStart/checkpoint; claim source-area globs before writes |
+| Resolving a named project over the session's own contradicting context | A full session's work lands in the wrong project's records while the intended project's ask goes unfulfilled | When the name and the session's evidence disagree, ask a one-line clarifying question before switching (Project Discovery step 3) |
 
 ---
 


### PR DESCRIPTION
## Summary

When a request names a project that contradicts the session's own evidence — its established conversation, chat/session name, active-project pointer, or task working directory — the agent must surface the contradiction and ask a one-line clarifying question, never silently resolve to the name. Names are typed by humans navigating many similarly-named projects; sibling projects in one program share vocabulary; a silent wrong resolution sends a full session's work to the wrong project's records while the intended ask goes unfulfilled. Origin: exactly that incident, 2026-08-20.

- `synthesis-project-management` v2.4.0: new Project Discovery step 3 (the guard, with the resolve-without-asking conditions stated), renumbered following steps, companion Common Mistakes row.
- `synthesis-agent-conformance` v1.6.1: the SessionStart stopped-task recovery guidance now carries the same exception — previously it instructed automatic resolution unconditionally ("never ask"), the exact behavior the discovery protocol now forbids.
- Plugin 4.39.0 → 4.40.0, CHANGELOG, README release note.

## Test plan

- [x] conformance `source` 189/189 (includes changelog-version-parity across both manifests)
- [x] 183 tests green: full conformance suite (test_session_context.py asserts the preserved guidance phrase) + coordination suite
- [x] compileall clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)