### PR TITLE
Add deterministic cached GGUF recovery

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.0",
+  "version": "4.43.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.0",
+  "version": "4.43.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.43.1] - 2026-08-23
+
+### Fixed
+
+- `synthesis-local-model-runtime` **v1.0.1** can recover from a failed Hugging
+  Face Ollama registry transaction after the large GGUF layers are already
+  cached. Catalog-pinned layer digests, media types, and exact sizes gate a
+  supported local multi-GGUF import; every layer is re-hashed, hard links avoid
+  a second model-sized copy, temporary import links are removed, and the
+  runtime-resolved model identity is verified before inventory is updated.
+
 ## [4.43.0] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,8 +11,16 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Registry timeouts do not waste completed GGUF downloads (August 2026).**
+Release **4.43.1** adds a catalog-pinned local-import recovery to
+`synthesis-local-model-runtime` **v1.0.1**. If a Hugging Face registry
+transaction fails after its GGUF layers are cached, the installer verifies
+every full digest and size, uses Ollama's supported multi-file importer without
+duplicating model-sized data, and records the resolved local identity only
+after success. See the [4.43.1 release notes](CHANGELOG.md).
+
 **Local model selection is a measured machine decision (August 2026).** Release
-**4.43.0** adds `synthesis-local-model-runtime` **v1.0.0**: a privacy-safe
+**4.43.0** added `synthesis-local-model-runtime` **v1.0.0**: a privacy-safe
 profiler, dated artifact catalog, machine-fit planner, dry-run-first installer,
 per-computer inventory, exact resolver, and bounded benchmark receipts. It
 keeps model weights out of iCloud and source workspaces, records upstream model

--- a/skills/synthesis-local-model-runtime/SKILL.md
+++ b/skills/synthesis-local-model-runtime/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.0.0"
+  version: "1.0.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -35,6 +35,9 @@ every workload.
 7. Run bounded functional and performance checks one model at a time. Unload
    each model after testing.
 8. Update the per-machine inventory only after verified state transitions.
+9. When a Hugging Face registry pull fails after catalog-pinned GGUF layers are
+   cached, permit the deterministic local-import recovery only after every full
+   digest and exact size matches. Never import an unpinned partial download.
 
 ## Quick start
 
@@ -58,6 +61,23 @@ python3 scripts/local_model_runtime.py install \
   --artifact glm-4.7-flash-q8-0 \
   --yes
 ```
+
+If an authorized Hugging Face pull already cached every catalog-pinned GGUF
+layer but failed during final registry metadata retrieval, inspect the dry run
+and then recover without repeating the network request:
+
+```bash
+python3 scripts/local_model_runtime.py install \
+  --artifact qwen3.8-27b-q8-0 \
+  --recover-cached
+python3 scripts/local_model_runtime.py install \
+  --artifact qwen3.8-27b-q8-0 \
+  --recover-cached \
+  --yes
+```
+
+Recovery fails closed unless every required cached layer matches the catalog's
+full SHA-256 digest and exact byte size.
 
 To verify and benchmark an installed artifact:
 
@@ -87,6 +107,10 @@ python3 scripts/local_model_runtime.py benchmark \
   the artifact publisher, then capture the resolved local digest.
 - Never silently replace a requested artifact or quantization. A changed plan
   requires a new visible diff.
+- A local-import recovery preserves the catalog artifact id and runtime model
+  name but records `catalog-pinned-local-import` as the installation method.
+  It is a recovery path for verified cached layers, not another acquisition
+  channel.
 
 ## Storage guard
 

--- a/skills/synthesis-local-model-runtime/assets/model_catalog.json
+++ b/skills/synthesis-local-model-runtime/assets/model_catalog.json
@@ -53,6 +53,21 @@
       "quality_rank": 40,
       "roles": ["writing", "coding", "professional-work"],
       "expected_digest_prefix": null,
+      "local_import_fallback": {
+        "registry_manifest_url": "https://huggingface.co/v2/bartowski/Qwen3.8-27B-GGUF/manifests/Q4_K_M",
+        "gguf_layers": [
+          {
+            "digest": "sha256:e103abf9d914d1d7b2f2592f055f2759a71195c350a01c135f71aaae86bca52b",
+            "media_type": "application/vnd.ollama.image.model",
+            "size_bytes": 17772537440
+          },
+          {
+            "digest": "sha256:cb0a71fe9b84af2552fc6260acf8e9773a29d115c683aba01c72a7ac537b212b",
+            "media_type": "application/vnd.ollama.image.projector",
+            "size_bytes": 927607008
+          }
+        ]
+      },
       "status": "verified"
     },
     {
@@ -79,6 +94,21 @@
       "quality_rank": 50,
       "roles": ["high-quality-writing", "coding", "professional-work"],
       "expected_digest_prefix": null,
+      "local_import_fallback": {
+        "registry_manifest_url": "https://huggingface.co/v2/bartowski/Qwen3.8-27B-GGUF/manifests/Q8_0",
+        "gguf_layers": [
+          {
+            "digest": "sha256:a830e736efa71ce29589ff20b8713333a427e0d46ab774723be23800ad54362d",
+            "media_type": "application/vnd.ollama.image.model",
+            "size_bytes": 29116388960
+          },
+          {
+            "digest": "sha256:cb0a71fe9b84af2552fc6260acf8e9773a29d115c683aba01c72a7ac537b212b",
+            "media_type": "application/vnd.ollama.image.projector",
+            "size_bytes": 927607008
+          }
+        ]
+      },
       "status": "verified"
     },
     {
@@ -157,6 +187,16 @@
       "quality_rank": 40,
       "roles": ["long-context", "writing", "reasoning"],
       "expected_digest_prefix": null,
+      "local_import_fallback": {
+        "registry_manifest_url": "https://huggingface.co/v2/bartowski/moonshotai_Kimi-Linear-48B-A3B-Instruct-GGUF/manifests/Q4_K_M",
+        "gguf_layers": [
+          {
+            "digest": "sha256:a1a7d865370652221f937163f7e94c99e1f114861335ba4f8666606843f1620f",
+            "media_type": "application/vnd.ollama.image.model",
+            "size_bytes": 30061058720
+          }
+        ]
+      },
       "status": "verified"
     },
     {
@@ -183,6 +223,16 @@
       "quality_rank": 50,
       "roles": ["high-quality-long-context", "writing", "reasoning"],
       "expected_digest_prefix": null,
+      "local_import_fallback": {
+        "registry_manifest_url": "https://huggingface.co/v2/bartowski/moonshotai_Kimi-Linear-48B-A3B-Instruct-GGUF/manifests/Q6_K",
+        "gguf_layers": [
+          {
+            "digest": "sha256:d44b7f92fe57bca9e034456a576a530b57f036c85f9ce615f90bc3e6827fae9a",
+            "media_type": "application/vnd.ollama.image.model",
+            "size_bytes": 40460212128
+          }
+        ]
+      },
       "status": "verified"
     },
     {

--- a/skills/synthesis-local-model-runtime/references/architecture.md
+++ b/skills/synthesis-local-model-runtime/references/architecture.md
@@ -35,6 +35,13 @@ Version 1.0 implements this contract for Ollama. Hugging Face GGUF ids remain
 Ollama artifacts after import, so the inventory records the full runtime name
 and resolved Ollama digest in addition to upstream and publisher metadata.
 
+For Hugging Face registry timeouts after all large layers are present, the
+adapter may use Ollama's supported local multi-GGUF create path. The catalog
+pins the registry manifest URL plus each GGUF model/projector layer's full
+digest, media type, and size. The adapter re-hashes every cached layer, creates
+same-volume temporary hard links, imports the directory, removes the links,
+and then applies the normal runtime identity and inventory gates.
+
 ## Schema evolution
 
 Catalog and inventory schemas carry integer `schema_version` fields. A future

--- a/skills/synthesis-local-model-runtime/references/catalog-maintenance.md
+++ b/skills/synthesis-local-model-runtime/references/catalog-maintenance.md
@@ -27,6 +27,12 @@ inventory captures the digest resolved after installation.
 6. Run the planner against 16, 24, 32, 64, 96, and 128 GiB fixtures.
 7. Record the user-visible catalog change in the plugin release notes.
 
+For a Hugging Face artifact with local-import recovery, fetch its public
+Ollama-compatible registry manifest and pin only GGUF model/projector layers.
+Record each full digest, media type, and byte size plus the manifest URL. Do not
+pin a layer from terminal progress output or infer it from a repository file
+name.
+
 ## Retirement
 
 Mark a removed or superseded artifact `retired`; do not delete its record while

--- a/skills/synthesis-local-model-runtime/references/security-and-privacy.md
+++ b/skills/synthesis-local-model-runtime/references/security-and-privacy.md
@@ -29,6 +29,11 @@ Do not infer that a symlink points somewhere safe from its visible prefix.
   runtime returns none.
 - Preserve partial-download diagnostics, but do not write a false installed
   record.
+- A registry-timeout recovery must use only catalog-pinned cached GGUF layers,
+  verify their full SHA-256 digests and exact sizes, and create same-volume
+  temporary hard links. `--recover-cached` must skip acquisition rather than
+  retrying the failed registry request. Never accept a filename or a completed
+  progress bar as content verification.
 
 ## Local API
 

--- a/skills/synthesis-local-model-runtime/scripts/local_model_runtime.py
+++ b/skills/synthesis-local-model-runtime/scripts/local_model_runtime.py
@@ -123,6 +123,14 @@ def atomic_text_write(path: Path, value: str) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def command_output(arguments: list[str], timeout: int = 8) -> str | None:
     try:
         result = subprocess.run(
@@ -614,6 +622,54 @@ def validate_catalog(catalog: dict[str, Any]) -> list[dict[str, Any]]:
             isinstance(role, str) and role for role in artifact["roles"]
         ):
             raise LocalModelError(f"{artifact_id}.roles must be non-empty strings")
+        fallback = artifact.get("local_import_fallback")
+        if fallback is not None:
+            if artifact["distribution_channel"] != "huggingface-gguf":
+                raise LocalModelError(
+                    f"{artifact_id}.local_import_fallback is only valid for huggingface-gguf"
+                )
+            if not isinstance(fallback, dict):
+                raise LocalModelError(f"{artifact_id}.local_import_fallback must be an object")
+            validate_https_url(
+                fallback.get("registry_manifest_url"),
+                f"{artifact_id}.local_import_fallback.registry_manifest_url",
+            )
+            layers = fallback.get("gguf_layers")
+            if not isinstance(layers, list) or not layers:
+                raise LocalModelError(
+                    f"{artifact_id}.local_import_fallback.gguf_layers must be non-empty"
+                )
+            media_types: list[str] = []
+            layer_digests: set[str] = set()
+            for layer in layers:
+                if not isinstance(layer, dict):
+                    raise LocalModelError(f"{artifact_id} fallback layer must be an object")
+                media_type = layer.get("media_type")
+                if media_type not in {
+                    "application/vnd.ollama.image.model",
+                    "application/vnd.ollama.image.projector",
+                }:
+                    raise LocalModelError(f"{artifact_id} fallback layer has unsafe media type")
+                layer_digest = layer.get("digest")
+                if not isinstance(layer_digest, str) or not re.fullmatch(
+                    r"sha256:[0-9a-f]{64}", layer_digest
+                ):
+                    raise LocalModelError(f"{artifact_id} fallback layer has invalid digest")
+                size_bytes = layer.get("size_bytes")
+                if (
+                    not isinstance(size_bytes, int)
+                    or isinstance(size_bytes, bool)
+                    or size_bytes <= 0
+                ):
+                    raise LocalModelError(f"{artifact_id} fallback layer has invalid size")
+                if layer_digest in layer_digests:
+                    raise LocalModelError(f"{artifact_id} fallback layer digest is duplicated")
+                layer_digests.add(layer_digest)
+                media_types.append(media_type)
+            if media_types.count("application/vnd.ollama.image.model") != 1:
+                raise LocalModelError(f"{artifact_id} fallback must contain exactly one model")
+            if media_types.count("application/vnd.ollama.image.projector") > 1:
+                raise LocalModelError(f"{artifact_id} fallback has multiple projectors")
     return artifacts
 
 
@@ -1044,12 +1100,86 @@ def update_inventory(
     return inventory
 
 
+def model_store_from_profile(profile: dict[str, Any]) -> Path:
+    value = profile.get("storage", {}).get("model_store")
+    if not isinstance(value, str) or not value:
+        raise LocalModelError("Resolved model store is absent from the machine profile")
+    if value == "~":
+        return Path.home()
+    if value.startswith("~/"):
+        return Path.home() / value[2:]
+    path = Path(value)
+    if not path.is_absolute():
+        raise LocalModelError("Resolved model store path must be absolute or home-relative")
+    return path
+
+
+def import_cached_gguf_layers(
+    artifact: dict[str, Any],
+    profile: dict[str, Any],
+    executable: str,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> None:
+    fallback = artifact.get("local_import_fallback")
+    if not isinstance(fallback, dict):
+        raise LocalModelError(f"{artifact['id']} has no catalog-pinned local import fallback")
+    layers = fallback.get("gguf_layers")
+    if not isinstance(layers, list) or not layers:
+        raise LocalModelError(f"{artifact['id']} fallback has no GGUF layers")
+    store = model_store_from_profile(profile).expanduser().resolve(strict=False)
+    blobs = store / "blobs"
+    import_parent = store.parent / ".synthesis-local-model-imports"
+    reject_symlink_components(store, blobs, import_parent)
+    import_parent.mkdir(parents=True, exist_ok=True)
+    reject_symlink_components(import_parent)
+    with tempfile.TemporaryDirectory(prefix=f"{artifact['id']}-", dir=import_parent) as value:
+        import_dir = Path(value)
+        for index, layer in enumerate(layers):
+            digest = layer["digest"].removeprefix("sha256:")
+            source = blobs / f"sha256-{digest}"
+            reject_symlink_components(source)
+            if not source.is_file() or source.is_symlink():
+                raise LocalModelError(
+                    f"Catalog-pinned fallback blob is absent for {artifact['id']}: {digest}"
+                )
+            observed_size = source.stat().st_size
+            if observed_size != layer["size_bytes"]:
+                raise LocalModelError(
+                    f"Fallback blob size mismatch for {artifact['id']}: {digest}"
+                )
+            if sha256_file(source) != digest:
+                raise LocalModelError(
+                    f"Fallback blob digest mismatch for {artifact['id']}: {digest}"
+                )
+            suffix = (
+                "model"
+                if layer["media_type"] == "application/vnd.ollama.image.model"
+                else "projector"
+            )
+            destination = import_dir / f"{index:02d}-{suffix}.gguf"
+            os.link(source, destination)
+        modelfile = import_dir / "Modelfile"
+        atomic_text_write(modelfile, f"FROM {import_dir}\n")
+        created = runner(
+            [executable, "create", artifact["runtime_model"], "-f", str(modelfile)],
+            check=False,
+            text=True,
+            shell=False,
+        )
+        if created.returncode != 0:
+            raise LocalModelError(
+                f"Ollama local import failed for {artifact['id']} with exit code "
+                f"{created.returncode}"
+            )
+
+
 def perform_install(
     plan: dict[str, Any],
     artifacts: list[dict[str, Any]],
     profile: dict[str, Any],
     state_dir: Path,
     label: str | None,
+    recover_cached: bool = False,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> dict[str, Any]:
     if not plan["ready"]:
@@ -1061,16 +1191,29 @@ def perform_install(
     installed: dict[str, dict[str, Any]] = {}
     for selection in plan["selections"]:
         artifact = by_id[selection["artifact_id"]]
-        result = runner(
-            [executable, "pull", artifact["runtime_model"]],
-            check=False,
-            text=True,
-            shell=False,
-        )
-        if result.returncode != 0:
-            raise LocalModelError(
-                f"Ollama pull failed for {artifact['id']} with exit code {result.returncode}"
+        if recover_cached:
+            if not artifact.get("local_import_fallback"):
+                raise LocalModelError(
+                    f"{artifact['id']} has no catalog-pinned cached-layer recovery"
+                )
+            import_cached_gguf_layers(artifact, profile, executable, runner)
+            installation_method = "catalog-pinned-local-import"
+        else:
+            installation_method = "ollama-pull"
+            result = runner(
+                [executable, "pull", artifact["runtime_model"]],
+                check=False,
+                text=True,
+                shell=False,
             )
+            if result.returncode != 0:
+                if not artifact.get("local_import_fallback"):
+                    raise LocalModelError(
+                        f"Ollama pull failed for {artifact['id']} with exit code "
+                        f"{result.returncode}"
+                    )
+                import_cached_gguf_layers(artifact, profile, executable, runner)
+                installation_method = "catalog-pinned-local-import"
         metadata = find_installed(artifact["runtime_model"], ollama_tags())
         if metadata is None:
             raise LocalModelError(
@@ -1091,6 +1234,7 @@ def perform_install(
             "verified_at": utc_now(),
             "runtime": "ollama",
             "runtime_version": profile["runtimes"]["ollama"]["version"],
+            "installation_method": installation_method,
             **safe,
         }
         update_inventory(state_dir, profile, plan["selections"], installed, label)
@@ -1223,6 +1367,11 @@ def build_parser() -> argparse.ArgumentParser:
     add_common(install_parser)
     install_parser.add_argument("--artifact", action="append", default=[])
     install_parser.add_argument("--yes", action="store_true")
+    install_parser.add_argument(
+        "--recover-cached",
+        action="store_true",
+        help="Skip acquisition and import only catalog-pinned cached GGUF layers",
+    )
     install_parser.add_argument("--machine-label")
 
     inventory_parser = commands.add_parser("inventory", help="Register or refresh this machine mapping")
@@ -1294,10 +1443,24 @@ def main(argv: list[str] | None = None) -> int:
             if args.artifact:
                 plan = plan_explicit(artifacts, args.artifact, profile, policy)
             if not args.yes:
-                emit({"execute": False, "authorization_required": True, "plan": plan})
+                emit(
+                    {
+                        "execute": False,
+                        "authorization_required": True,
+                        "recovery": (
+                            "catalog-pinned-cached-layers" if args.recover_cached else None
+                        ),
+                        "plan": plan,
+                    }
+                )
                 return 0 if plan["ready"] else 2
             result = perform_install(
-                plan, artifacts, profile, args.state_dir.expanduser(), args.machine_label
+                plan,
+                artifacts,
+                profile,
+                args.state_dir.expanduser(),
+                args.machine_label,
+                recover_cached=args.recover_cached,
             )
             emit({"execute": True, "plan": plan, **result})
             return 0

--- a/skills/synthesis-local-model-runtime/scripts/test_local_model_runtime.py
+++ b/skills/synthesis-local-model-runtime/scripts/test_local_model_runtime.py
@@ -225,6 +225,190 @@ class RuntimeTests(unittest.TestCase):
                 )
             self.assertFalse((Path(directory) / "machines.json").exists())
 
+    def test_failed_registry_pull_uses_pinned_cached_gguf_import(self):
+        _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)
+        artifact = dict(
+            next(item for item in artifacts if item["id"] == "qwen3.8-27b-q8-0")
+        )
+        model_bytes = b"GGUF-model-fixture"
+        projector_bytes = b"GGUF-projector-fixture"
+        model_digest = runtime.hashlib.sha256(model_bytes).hexdigest()
+        projector_digest = runtime.hashlib.sha256(projector_bytes).hexdigest()
+        artifact["local_import_fallback"] = {
+            "registry_manifest_url": "https://example.test/manifest",
+            "gguf_layers": [
+                {
+                    "digest": f"sha256:{model_digest}",
+                    "media_type": "application/vnd.ollama.image.model",
+                    "size_bytes": len(model_bytes),
+                },
+                {
+                    "digest": f"sha256:{projector_digest}",
+                    "media_type": "application/vnd.ollama.image.projector",
+                    "size_bytes": len(projector_bytes),
+                },
+            ],
+        }
+        plan = {
+            "ready": True,
+            "blockers": [],
+            "selections": [{"artifact_id": artifact["id"]}],
+        }
+
+        class Result:
+            def __init__(self, returncode):
+                self.returncode = returncode
+
+        calls = []
+
+        def runner(arguments, **_kwargs):
+            calls.append(arguments)
+            if arguments[1] == "pull":
+                return Result(1)
+            self.assertEqual(arguments[1], "create")
+            modelfile = Path(arguments[-1])
+            imported = sorted(modelfile.parent.glob("*.gguf"))
+            self.assertEqual([path.read_bytes() for path in imported], [model_bytes, projector_bytes])
+            self.assertIn(f"FROM {modelfile.parent}", modelfile.read_text(encoding="utf-8"))
+            return Result(0)
+
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            runtime.shutil, "which", return_value="/usr/local/bin/ollama"
+        ), mock.patch.object(
+            runtime,
+            "ollama_tags",
+            return_value=[
+                {
+                    "name": artifact["runtime_model"],
+                    "digest": "resolved-local-import-digest",
+                    "size": len(model_bytes) + len(projector_bytes),
+                    "details": {"format": "gguf", "quantization_level": "Q8_0"},
+                }
+            ],
+        ):
+            root = Path(directory)
+            store = root / "models"
+            blobs = store / "blobs"
+            blobs.mkdir(parents=True)
+            (blobs / f"sha256-{model_digest}").write_bytes(model_bytes)
+            (blobs / f"sha256-{projector_digest}").write_bytes(projector_bytes)
+            profile = fixture_profile()
+            profile["storage"]["model_store"] = str(store)
+            result = runtime.perform_install(
+                plan,
+                [artifact],
+                profile,
+                root / "state",
+                None,
+                runner=runner,
+            )
+            installed = result["installed"][artifact["id"]]
+            self.assertEqual(
+                installed["installation_method"], "catalog-pinned-local-import"
+            )
+            self.assertEqual([call[1] for call in calls], ["pull", "create"])
+
+    def test_explicit_cached_recovery_skips_registry_pull(self):
+        _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)
+        artifact = dict(
+            next(item for item in artifacts if item["id"] == "qwen3.8-27b-q8-0")
+        )
+        model_bytes = b"GGUF-cached-recovery-fixture"
+        digest = runtime.hashlib.sha256(model_bytes).hexdigest()
+        artifact["local_import_fallback"] = {
+            "registry_manifest_url": "https://example.test/manifest",
+            "gguf_layers": [
+                {
+                    "digest": f"sha256:{digest}",
+                    "media_type": "application/vnd.ollama.image.model",
+                    "size_bytes": len(model_bytes),
+                }
+            ],
+        }
+        plan = {
+            "ready": True,
+            "blockers": [],
+            "selections": [{"artifact_id": artifact["id"]}],
+        }
+
+        class Result:
+            returncode = 0
+
+        calls = []
+
+        def runner(arguments, **_kwargs):
+            calls.append(arguments)
+            self.assertEqual(arguments[1], "create")
+            return Result()
+
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            runtime.shutil, "which", return_value="/usr/local/bin/ollama"
+        ), mock.patch.object(
+            runtime,
+            "ollama_tags",
+            return_value=[
+                {
+                    "name": artifact["runtime_model"],
+                    "digest": "resolved-cached-recovery-digest",
+                    "size": len(model_bytes),
+                    "details": {"format": "gguf", "quantization_level": "Q8_0"},
+                }
+            ],
+        ):
+            root = Path(directory)
+            store = root / "models"
+            blobs = store / "blobs"
+            blobs.mkdir(parents=True)
+            (blobs / f"sha256-{digest}").write_bytes(model_bytes)
+            profile = fixture_profile()
+            profile["storage"]["model_store"] = str(store)
+            result = runtime.perform_install(
+                plan,
+                [artifact],
+                profile,
+                root / "state",
+                None,
+                recover_cached=True,
+                runner=runner,
+            )
+            installed = result["installed"][artifact["id"]]
+            self.assertEqual(
+                installed["installation_method"], "catalog-pinned-local-import"
+            )
+            self.assertEqual([call[1] for call in calls], ["create"])
+
+    def test_cached_gguf_import_rejects_digest_mismatch(self):
+        _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)
+        artifact = dict(
+            next(item for item in artifacts if item["id"] == "qwen3.8-27b-q8-0")
+        )
+        expected = runtime.hashlib.sha256(b"expected").hexdigest()
+        artifact["local_import_fallback"] = {
+            "registry_manifest_url": "https://example.test/manifest",
+            "gguf_layers": [
+                {
+                    "digest": f"sha256:{expected}",
+                    "media_type": "application/vnd.ollama.image.model",
+                    "size_bytes": len(b"tampered"),
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = root / "models"
+            blobs = store / "blobs"
+            blobs.mkdir(parents=True)
+            (blobs / f"sha256-{expected}").write_bytes(b"tampered")
+            profile = fixture_profile()
+            profile["storage"]["model_store"] = str(store)
+            with self.assertRaises(runtime.LocalModelError):
+                runtime.import_cached_gguf_layers(
+                    artifact,
+                    profile,
+                    "/usr/local/bin/ollama",
+                    runner=mock.Mock(),
+                )
+
     def test_benchmark_bounds_fail_before_network(self):
         _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)
         with self.assertRaises(runtime.LocalModelError):


### PR DESCRIPTION
Adds a fail-closed recovery path for completed, catalog-pinned GGUF layers when registry finalization fails. The installer verifies full hashes and exact sizes, uses supported local import without another model-sized copy, verifies runtime identity, and only then updates inventory.\n\nValidation: release preflight and required checks pass.