### PR TITLE
Report cached recovery disk materialization

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.1",
+  "version": "4.43.2",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.1",
+  "version": "4.43.2",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.43.2] - 2026-08-23
+
+### Fixed
+
+- `synthesis-local-model-runtime` **v1.0.2** reports cached recovery as a
+  zero-network operation with explicit worst-case runtime materialization.
+  Ollama can normalize a verified GGUF into a new runtime layer and retain the
+  original registry cache, so recovery plans no longer imply that hard-linked
+  staging prevents all model-sized disk growth.
+
 ## [4.43.1] - 2026-08-23
 
 ### Fixed
@@ -12,7 +22,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   Face Ollama registry transaction after the large GGUF layers are already
   cached. Catalog-pinned layer digests, media types, and exact sizes gate a
   supported local multi-GGUF import; every layer is re-hashed, hard links avoid
-  a second model-sized copy, temporary import links are removed, and the
+  a separate staging copy, temporary import links are removed, and the
   runtime-resolved model identity is verified before inventory is updated.
 
 ## [4.43.0] - 2026-08-23

--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Cached recovery now accounts for Ollama normalization (August 2026).**
+Release **4.43.2** makes the recovery receipt distinguish zero network transfer
+from possible runtime-layer materialization. Hard links avoid a separate
+staging copy, but Ollama may normalize the GGUF into a model-sized runtime layer
+and retain the registry cache. See the [4.43.2 release notes](CHANGELOG.md).
+
 **Registry timeouts do not waste completed GGUF downloads (August 2026).**
 Release **4.43.1** adds a catalog-pinned local-import recovery to
 `synthesis-local-model-runtime` **v1.0.1**. If a Hugging Face registry
 transaction fails after its GGUF layers are cached, the installer verifies
 every full digest and size, uses Ollama's supported multi-file importer without
-duplicating model-sized data, and records the resolved local identity only
-after success. See the [4.43.1 release notes](CHANGELOG.md).
+a separate staging copy, and records the resolved local identity only after
+success. See the [4.43.1 release notes](CHANGELOG.md).
 
 **Local model selection is a measured machine decision (August 2026).** Release
 **4.43.0** added `synthesis-local-model-runtime` **v1.0.0**: a privacy-safe

--- a/skills/synthesis-local-model-runtime/SKILL.md
+++ b/skills/synthesis-local-model-runtime/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.0.1"
+  version: "1.0.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -77,7 +77,10 @@ python3 scripts/local_model_runtime.py install \
 ```
 
 Recovery fails closed unless every required cached layer matches the catalog's
-full SHA-256 digest and exact byte size.
+full SHA-256 digest and exact byte size. Its receipt reports zero network
+transfer separately from worst-case additional runtime materialization. Ollama
+may normalize the GGUF into a new runtime layer and retain the original cache;
+hard links eliminate only a separate staging copy.
 
 To verify and benchmark an installed artifact:
 
@@ -111,6 +114,8 @@ python3 scripts/local_model_runtime.py benchmark \
   name but records `catalog-pinned-local-import` as the installation method.
   It is a recovery path for verified cached layers, not another acquisition
   channel.
+- Never equate zero recovery download with zero disk growth. Budget the exact
+  cached-layer total as worst-case additional runtime materialization.
 
 ## Storage guard
 

--- a/skills/synthesis-local-model-runtime/references/architecture.md
+++ b/skills/synthesis-local-model-runtime/references/architecture.md
@@ -41,6 +41,9 @@ pins the registry manifest URL plus each GGUF model/projector layer's full
 digest, media type, and size. The adapter re-hashes every cached layer, creates
 same-volume temporary hard links, imports the directory, removes the links,
 and then applies the normal runtime identity and inventory gates.
+The hard links eliminate a separate staging copy. Ollama may still normalize a
+GGUF into a new runtime layer and retain the registry cache, so the recovery
+receipt budgets the full layer total as possible additional disk use.
 
 ## Schema evolution
 

--- a/skills/synthesis-local-model-runtime/references/security-and-privacy.md
+++ b/skills/synthesis-local-model-runtime/references/security-and-privacy.md
@@ -34,6 +34,9 @@ Do not infer that a symlink points somewhere safe from its visible prefix.
   temporary hard links. `--recover-cached` must skip acquisition rather than
   retrying the failed registry request. Never accept a filename or a completed
   progress bar as content verification.
+- Do not delete a retained registry blob from the runtime-owned store. Report
+  it as possible reclaimable cache; cleanup requires a separate, bounded
+  reference audit and explicit authorization.
 
 ## Local API
 

--- a/skills/synthesis-local-model-runtime/scripts/local_model_runtime.py
+++ b/skills/synthesis-local-model-runtime/scripts/local_model_runtime.py
@@ -1173,6 +1173,29 @@ def import_cached_gguf_layers(
             )
 
 
+def cached_recovery_receipt(
+    plan: dict[str, Any], artifacts: list[dict[str, Any]]
+) -> dict[str, Any]:
+    by_id = {artifact["id"]: artifact for artifact in artifacts}
+    layer_bytes = 0
+    for selection in plan["selections"]:
+        artifact = by_id[selection["artifact_id"]]
+        fallback = artifact.get("local_import_fallback")
+        if not isinstance(fallback, dict):
+            raise LocalModelError(
+                f"{artifact['id']} has no catalog-pinned cached-layer recovery"
+            )
+        layer_bytes += sum(layer["size_bytes"] for layer in fallback["gguf_layers"])
+    return {
+        "mode": "catalog-pinned-cached-layers",
+        "network_download_gib": 0.0,
+        "possible_additional_runtime_gib": round(layer_bytes / GIB, 2),
+        "cache_retention": (
+            "Ollama may retain registry cache after materializing normalized runtime layers"
+        ),
+    }
+
+
 def perform_install(
     plan: dict[str, Any],
     artifacts: list[dict[str, Any]],
@@ -1442,14 +1465,15 @@ def main(argv: list[str] | None = None) -> int:
         if args.command == "install":
             if args.artifact:
                 plan = plan_explicit(artifacts, args.artifact, profile, policy)
+            recovery = (
+                cached_recovery_receipt(plan, artifacts) if args.recover_cached else None
+            )
             if not args.yes:
                 emit(
                     {
                         "execute": False,
                         "authorization_required": True,
-                        "recovery": (
-                            "catalog-pinned-cached-layers" if args.recover_cached else None
-                        ),
+                        "recovery": recovery,
                         "plan": plan,
                     }
                 )
@@ -1462,7 +1486,7 @@ def main(argv: list[str] | None = None) -> int:
                 args.machine_label,
                 recover_cached=args.recover_cached,
             )
-            emit({"execute": True, "plan": plan, **result})
+            emit({"execute": True, "recovery": recovery, "plan": plan, **result})
             return 0
         if args.command == "inventory":
             if not args.save:

--- a/skills/synthesis-local-model-runtime/scripts/test_local_model_runtime.py
+++ b/skills/synthesis-local-model-runtime/scripts/test_local_model_runtime.py
@@ -377,6 +377,27 @@ class RuntimeTests(unittest.TestCase):
             )
             self.assertEqual([call[1] for call in calls], ["create"])
 
+    def test_cached_recovery_receipt_separates_network_and_runtime_disk(self):
+        _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)
+        artifact = next(
+            item for item in artifacts if item["id"] == "qwen3.8-27b-q8-0"
+        )
+        plan = {
+            "selections": [{"artifact_id": artifact["id"]}],
+        }
+        receipt = runtime.cached_recovery_receipt(plan, artifacts)
+        expected = round(
+            sum(
+                layer["size_bytes"]
+                for layer in artifact["local_import_fallback"]["gguf_layers"]
+            )
+            / runtime.GIB,
+            2,
+        )
+        self.assertEqual(receipt["network_download_gib"], 0.0)
+        self.assertEqual(receipt["possible_additional_runtime_gib"], expected)
+        self.assertIn("retain", receipt["cache_retention"])
+
     def test_cached_gguf_import_rejects_digest_mismatch(self):
         _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)
         artifact = dict(


### PR DESCRIPTION
Corrects recovery accounting based on live Ollama behavior. Receipts now distinguish zero network transfer from possible normalized runtime-layer materialization, and documentation states that hard links eliminate staging copies but not necessarily runtime disk growth.\n\nValidation: 25 focused tests and 195 source-conformance checks pass.