### PR TITLE
Preserve selections across separate model installs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.2",
+  "version": "4.43.3",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.2",
+  "version": "4.43.3",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.43.3] - 2026-08-23
+
+### Fixed
+
+- `synthesis-local-model-runtime` **v1.0.3** now merges verified selections
+  across separate installation commands. Installing several explicitly named
+  artifacts one at a time no longer leaves only the last artifact resolvable;
+  an explicit inventory refresh still replaces the selection set with the
+  current policy plan.
+
 ## [4.43.2] - 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Separate installs preserve the complete machine selection (August 2026).**
+Release **4.43.3** makes installation transitions merge each verified artifact
+into the machine's selected set. Explicit inventory refreshes still replace
+that set with the current policy plan. See the
+[4.43.3 release notes](CHANGELOG.md).
+
 **Cached recovery now accounts for Ollama normalization (August 2026).**
 Release **4.43.2** makes the recovery receipt distinguish zero network transfer
 from possible runtime-layer materialization. Hard links avoid a separate

--- a/skills/synthesis-local-model-runtime/SKILL.md
+++ b/skills/synthesis-local-model-runtime/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.0.2"
+  version: "1.0.3"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -35,6 +35,8 @@ every workload.
 7. Run bounded functional and performance checks one model at a time. Unload
    each model after testing.
 8. Update the per-machine inventory only after verified state transitions.
+   Separate installation commands merge their verified selections; an
+   explicit inventory refresh replaces selections with the current plan.
 9. When a Hugging Face registry pull fails after catalog-pinned GGUF layers are
    cached, permit the deterministic local-import recovery only after every full
    digest and exact size matches. Never import an unpinned partial download.

--- a/skills/synthesis-local-model-runtime/references/architecture.md
+++ b/skills/synthesis-local-model-runtime/references/architecture.md
@@ -15,6 +15,10 @@
 6. **Inventory:** an atomic map from an opaque locally generated machine id to
    the safe profile, intended selections, and resolved installed artifacts.
 
+Installation transitions merge selections so an explicit one-model command
+cannot erase earlier verified choices. A deliberate inventory refresh replaces
+the selection set with the policy's current recommendation.
+
 The catalog predicts. The runtime receipt establishes what is present. The
 benchmark establishes what happened in one bounded run. Keep these claims
 separate.

--- a/skills/synthesis-local-model-runtime/scripts/local_model_runtime.py
+++ b/skills/synthesis-local-model-runtime/scripts/local_model_runtime.py
@@ -1069,6 +1069,8 @@ def update_inventory(
     selections: list[dict[str, Any]],
     installed: dict[str, dict[str, Any]] | None = None,
     label: str | None = None,
+    *,
+    merge_selections: bool = False,
 ) -> dict[str, Any]:
     identifier = machine_id(state_dir)
     inventory_path = state_dir / "machines.json"
@@ -1085,11 +1087,19 @@ def update_inventory(
     previous_installed = previous.get("installed", {})
     if not isinstance(previous_installed, dict):
         raise LocalModelError("Current machine installed-artifact map is invalid")
+    selection_ids = [item["artifact_id"] for item in selections]
+    if merge_selections:
+        previous_selections = previous.get("selections", [])
+        if not isinstance(previous_selections, list) or not all(
+            isinstance(item, str) and item for item in previous_selections
+        ):
+            raise LocalModelError("Current machine selection list is invalid")
+        selection_ids = list(dict.fromkeys([*previous_selections, *selection_ids]))
     record = {
         "label": label if label is not None else previous.get("label"),
         "updated_at": utc_now(),
         "profile": profile,
-        "selections": [item["artifact_id"] for item in selections],
+        "selections": selection_ids,
         "installed": dict(previous_installed),
     }
     if installed:
@@ -1260,7 +1270,14 @@ def perform_install(
             "installation_method": installation_method,
             **safe,
         }
-        update_inventory(state_dir, profile, plan["selections"], installed, label)
+        update_inventory(
+            state_dir,
+            profile,
+            plan["selections"],
+            installed,
+            label,
+            merge_selections=True,
+        )
     return {"installed": installed, "inventory": display_path(state_dir / "machines.json")}
 
 

--- a/skills/synthesis-local-model-runtime/scripts/test_local_model_runtime.py
+++ b/skills/synthesis-local-model-runtime/scripts/test_local_model_runtime.py
@@ -166,6 +166,32 @@ class PrivacyAndStorageTests(unittest.TestCase):
             mode = os.stat(state / "machine-id").st_mode & 0o777
             self.assertEqual(mode, 0o600)
 
+    def test_install_transitions_merge_selections_but_refresh_replaces(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            first = [{"artifact_id": "qwen3-8b-q8-0"}]
+            second = [{"artifact_id": "glm-4.7-flash-q4-k-m"}]
+            runtime.update_inventory(
+                state,
+                fixture_profile(),
+                first,
+                merge_selections=True,
+            )
+            merged = runtime.update_inventory(
+                state,
+                fixture_profile(),
+                second,
+                merge_selections=True,
+            )
+            record = next(iter(merged["machines"].values()))
+            self.assertEqual(
+                record["selections"],
+                ["qwen3-8b-q8-0", "glm-4.7-flash-q4-k-m"],
+            )
+            refreshed = runtime.update_inventory(state, fixture_profile(), second)
+            record = next(iter(refreshed["machines"].values()))
+            self.assertEqual(record["selections"], ["glm-4.7-flash-q4-k-m"])
+
     def test_inventory_rejects_symlinked_state_root(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
Fixes the per-machine inventory transition for one-artifact-at-a-time installation. Verified install transitions now merge selections, while an explicit inventory refresh still replaces them with the current policy plan.\n\nValidation: 26 focused tests and 195 source-conformance checks pass.