### PR TITLE
Make bounded benchmarks final-response first

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.3",
+  "version": "4.43.4",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.3",
+  "version": "4.43.4",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.43.4] - 2026-08-23
+
+### Fixed
+
+- `synthesis-local-model-runtime` **v1.0.4** now disables reasoning traces by
+  default in bounded benchmarks and records the setting in each receipt. This
+  keeps the token budget focused on the requested final response for
+  thinking-capable models; `--think` remains an explicit opt-in.
+
 ## [4.43.3] - 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Benchmarks spend their budget on the final response (August 2026).** Release
+**4.43.4** disables reasoning traces by default for bounded local samples and
+records that choice in the receipt. Operators can still opt in with `--think`.
+See the [4.43.4 release notes](CHANGELOG.md).
+
 **Separate installs preserve the complete machine selection (August 2026).**
 Release **4.43.3** makes installation transitions merge each verified artifact
 into the machine's selected set. Explicit inventory refreshes still replace

--- a/skills/synthesis-local-model-runtime/SKILL.md
+++ b/skills/synthesis-local-model-runtime/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.0.3"
+  version: "1.0.4"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -93,6 +93,11 @@ python3 scripts/local_model_runtime.py benchmark \
   --artifact qwen3.8-27b-q8-0 \
   --output-dir /path/outside/the/source/repository
 ```
+
+Benchmarks set the Ollama `think` field to `false` by default so a bounded token
+budget measures the requested final response. Pass `--think` only when the
+reasoning trace is itself the workload under evaluation; the receipt records
+the chosen mode.
 
 ## Recommendation rules
 

--- a/skills/synthesis-local-model-runtime/references/architecture.md
+++ b/skills/synthesis-local-model-runtime/references/architecture.md
@@ -23,6 +23,10 @@ The catalog predicts. The runtime receipt establishes what is present. The
 benchmark establishes what happened in one bounded run. Keep these claims
 separate.
 
+Bounded final-response benchmarks disable optional model thinking by default
+and record the setting. Reasoning-trace evaluation is an explicit opt-in
+because it changes both the workload and token-budget interpretation.
+
 ## Runtime adapter contract
 
 An adapter must implement:

--- a/skills/synthesis-local-model-runtime/scripts/local_model_runtime.py
+++ b/skills/synthesis-local-model-runtime/scripts/local_model_runtime.py
@@ -1319,6 +1319,7 @@ def benchmark_artifact(
     prompt: str,
     num_predict: int,
     num_ctx: int,
+    think: bool = False,
 ) -> dict[str, Any]:
     if num_predict <= 0 or num_predict > 2048:
         raise LocalModelError("num-predict must be between 1 and 2048")
@@ -1330,6 +1331,7 @@ def benchmark_artifact(
             "model": artifact["runtime_model"],
             "prompt": prompt,
             "stream": False,
+            "think": think,
             "keep_alive": 0,
             "options": {
                 "temperature": 0,
@@ -1357,6 +1359,7 @@ def benchmark_artifact(
         "output_sha256": hashlib.sha256(output.encode("utf-8")).hexdigest(),
         "num_predict": num_predict,
         "num_ctx": num_ctx,
+        "think": think,
         "done_reason": response.get("done_reason"),
         "load_duration_ns": response.get("load_duration"),
         "prompt_eval_count": response.get("prompt_eval_count"),
@@ -1438,6 +1441,11 @@ def build_parser() -> argparse.ArgumentParser:
     benchmark_parser.add_argument("--output-dir", type=Path)
     benchmark_parser.add_argument("--num-predict", type=int, default=256)
     benchmark_parser.add_argument("--num-ctx", type=int, default=8192)
+    benchmark_parser.add_argument(
+        "--think",
+        action="store_true",
+        help="Include model reasoning when the reasoning trace is the benchmark workload",
+    )
     return parser
 
 
@@ -1534,7 +1542,12 @@ def main(argv: list[str] | None = None) -> int:
             )
             emit(
                 benchmark_artifact(
-                    artifact, args.output_dir, prompt, args.num_predict, args.num_ctx
+                    artifact,
+                    args.output_dir,
+                    prompt,
+                    args.num_predict,
+                    args.num_ctx,
+                    think=args.think,
                 )
             )
             return 0

--- a/skills/synthesis-local-model-runtime/scripts/test_local_model_runtime.py
+++ b/skills/synthesis-local-model-runtime/scripts/test_local_model_runtime.py
@@ -461,6 +461,22 @@ class RuntimeTests(unittest.TestCase):
         with self.assertRaises(runtime.LocalModelError):
             runtime.benchmark_artifact(artifacts[0], None, "test", 0, 8192)
 
+    def test_benchmark_disables_thinking_by_default_and_records_it(self):
+        _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)
+        response = {
+            "response": "bounded final response",
+            "done_reason": "stop",
+            "eval_count": 3,
+            "eval_duration": 1_000_000_000,
+        }
+        with mock.patch.object(runtime, "api_json", return_value=response) as api:
+            receipt = runtime.benchmark_artifact(
+                artifacts[0], None, "test prompt", 16, 8192
+            )
+        request = api.call_args.args[1]
+        self.assertIs(request["think"], False)
+        self.assertIs(receipt["think"], False)
+
     def test_resolve_enforces_current_machine_selection_and_installation(self):
         _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)
         artifact_id = "qwen3-8b-q8-0"


### PR DESCRIPTION
Disables optional reasoning traces by default in bounded local-model benchmarks and records the setting in every receipt. This keeps the token budget focused on the requested final response while preserving an explicit --think opt-in for reasoning-trace workloads.\n\nValidation: 27 focused tests and 195 source-conformance checks pass.