### PR TITLE
Fail closed on empty provenance output

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.4",
+  "version": "4.43.5",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.4",
+  "version": "4.43.5",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.43.5] - 2026-08-23
+
+### Fixed
+
+- `synthesis-text-provenance` **v1.0.1** now rejects an empty or
+  whitespace-only final response instead of sealing a zero-byte output as a
+  successful generation. Its OpenAI-compatible runner also accepts an explicit
+  `--reasoning-effort` control and records that request parameter, allowing
+  Ollama thinking models to reserve the bounded output budget for final text.
+
 ## [4.43.4] - 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Empty final responses fail closed in provenance runs (August 2026).** Release
+**4.43.5** prevents a thinking model from producing a valid provenance manifest
+for zero bytes of final text. The local OpenAI-compatible runner also records
+an explicit reasoning-effort request. See the
+[4.43.5 release notes](CHANGELOG.md).
+
 **Benchmarks spend their budget on the final response (August 2026).** Release
 **4.43.4** disables reasoning traces by default for bounded local samples and
 records that choice in the receipt. Operators can still opt in with `--think`.

--- a/skills/synthesis-text-provenance/SKILL.md
+++ b/skills/synthesis-text-provenance/SKILL.md
@@ -11,7 +11,7 @@ license: Apache-2.0
 depends_on: []
 metadata:
   author: Rajiv Pant
-  version: 1.0.0
+  version: 1.0.1
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -185,6 +185,7 @@ python3 scripts/local_generate.py \
   --runtime ollama \
   --runtime-receipt ollama-metadata.json \
   --model example-model \
+  --reasoning-effort none \
   --prompt-file prompt.txt \
   --output-file output.txt \
   --manifest provenance.json
@@ -193,6 +194,10 @@ python3 scripts/local_generate.py \
 The runner records one generation. It does not call a detector, regenerate
 selectively, or optimize against provenance results. Non-loopback endpoints are
 rejected unless the operator passes `--allow-non-loopback` deliberately.
+An empty or whitespace-only final response is a failed generation and produces
+no output or manifest. `--reasoning-effort` is optional because not every
+OpenAI-compatible endpoint implements it; when supplied, it is included in the
+request and manifest parameters.
 
 The receipt preserves the runtime version, model digest, size, quantization,
 license and template hashes, selected model metadata, and declared unknowns.

--- a/skills/synthesis-text-provenance/references/open-weight-runner-contract.md
+++ b/skills/synthesis-text-provenance/references/open-weight-runner-contract.md
@@ -15,6 +15,8 @@ contract intentionally has no detector-feedback or rewrite loop.
 - endpoint URL;
 - native runtime-receipt file for local generation;
 - temperature, maximum output tokens, and optional seed;
+- optional OpenAI-compatible reasoning effort (`none`, `low`, `medium`, or
+  `high`);
 - output path and manifest path.
 
 ## Model-selection evidence
@@ -45,6 +47,9 @@ The endpoint must return JSON with:
 The returned model field may be absent. Record `null`; do not infer it from the
 request. Record `finish_reason`, `usage`, and `system_fingerprint` when the
 endpoint returns them; an absent field remains `null`.
+`choices[0].message.content` must contain non-whitespace final text. A response
+that exhausts its allowance in reasoning and returns no final content is a
+failed generation, not valid zero-byte evidence.
 
 ## Endpoint safety
 

--- a/skills/synthesis-text-provenance/scripts/local_generate.py
+++ b/skills/synthesis-text-provenance/scripts/local_generate.py
@@ -75,6 +75,8 @@ def build_request(args: argparse.Namespace) -> dict[str, Any]:
     }
     if args.seed is not None:
         request["seed"] = args.seed
+    if args.reasoning_effort is not None:
+        request["reasoning_effort"] = args.reasoning_effort
     return request
 
 
@@ -113,6 +115,8 @@ def extract_content(result: dict[str, Any]) -> tuple[str, str | None, dict[str, 
         raise ValueError("endpoint response lacks choices[0].message.content") from exc
     if not isinstance(content, str):
         raise ValueError("choices[0].message.content must be a string")
+    if not content.strip():
+        raise ValueError("choices[0].message.content must contain final text")
     returned_model = result.get("model")
     if returned_model is not None and not isinstance(returned_model, str):
         raise ValueError("response model must be a string or absent")
@@ -152,6 +156,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--temperature", type=float, default=0.7)
     parser.add_argument("--max-tokens", type=int, default=2048)
     parser.add_argument("--seed", type=int)
+    parser.add_argument(
+        "--reasoning-effort",
+        choices=("none", "low", "medium", "high"),
+        help="optional OpenAI-compatible reasoning control",
+    )
     parser.add_argument("--timeout", type=float, default=300.0)
     parser.add_argument("--note", action="append", default=[])
     return parser
@@ -197,6 +206,7 @@ def main(argv: list[str] | None = None) -> int:
             "temperature": args.temperature,
             "max_tokens": args.max_tokens,
             "seed": args.seed,
+            "reasoning_effort": args.reasoning_effort,
             "system_prompt_supplied": bool(args.system_file),
             "reported_response": response_metadata,
         }

--- a/skills/synthesis-text-provenance/scripts/test_provenance_tools.py
+++ b/skills/synthesis-text-provenance/scripts/test_provenance_tools.py
@@ -362,6 +362,20 @@ class _Handler(BaseHTTPRequestHandler):
 
 
 class LocalRunnerTests(unittest.TestCase):
+    def test_rejects_empty_final_content(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must contain final text"):
+            lg.extract_content(
+                {
+                    "model": "thinking-model",
+                    "choices": [
+                        {
+                            "finish_reason": "length",
+                            "message": {"content": "  \n"},
+                        }
+                    ],
+                }
+            )
+
     def test_rejects_non_loopback_by_default(self) -> None:
         with self.assertRaises(ValueError):
             lg.endpoint_class("https://example.com/v1/chat/completions", False)
@@ -445,6 +459,7 @@ class LocalRunnerTests(unittest.TestCase):
                     "--output-file", str(output),
                     "--manifest", str(manifest),
                     "--seed", "7",
+                    "--reasoning-effort", "none",
                 ])
                 self.assertEqual(0, code)
                 self.assertEqual("A recorded local response.\n", output.read_text(encoding="utf-8"))
@@ -459,6 +474,7 @@ class LocalRunnerTests(unittest.TestCase):
                 self.assertEqual(pm.sha256_file(receipt), data["runtime_receipt"]["sha256"])
                 self.assertEqual([], pm.verify_manifest_files(manifest, data))
                 self.assertEqual("requested-test-model", _Handler.received["model"])
+                self.assertEqual("none", _Handler.received["reasoning_effort"])
         finally:
             server.shutdown()
             server.server_close()


### PR DESCRIPTION
Prevents a thinking model from sealing a successful provenance manifest when it returns no final text. The OpenAI-compatible runner also accepts and records an explicit reasoning-effort value so supported local runtimes can reserve the bounded allowance for final output.\n\nValidation: 26 provenance tests, 27 local-model tests, and 195 source-conformance checks pass.