### PR TITLE
Improve local model runtime fit checks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.5",
+  "version": "4.43.6",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.43.5",
+  "version": "4.43.6",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.43.6] - 2026-08-23
+
+### Fixed
+
+- `synthesis-local-model-runtime` **v1.0.5** now treats effective Ollama
+  KV-cache configuration as a model-fit constraint. Kimi Linear artifacts
+  declare their `f16` requirement; an incompatible Homebrew service blocks the
+  plan instead of failing only at generation time.
+- A dry-run-first `configure-ollama` command validates the standard current-user
+  Homebrew LaunchAgent, backs it up, applies one allowlisted KV-cache setting,
+  reloads it, proves loopback health, and rolls back on failure. Ollama HTTP
+  error bodies are retained with a fixed size bound for actionable diagnostics.
+- Benchmark receipts now distinguish a complete final response from a bounded
+  performance sample. A length stop or raw `<think>` markup in a
+  reasoning-disabled run is preserved but cannot pass the final-response gate.
+
 ## [4.43.5] - 2026-08-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Runtime configuration is part of model fit (August 2026).** Release
+**4.43.6** detects Ollama KV-cache incompatibilities during planning. Its
+dry-run-first Homebrew adapter can apply one validated setting with a private
+backup, health check, and rollback. Benchmark receipts also reject truncated
+responses and reasoning markup that leaks through a disabled-thinking request. See the
+[4.43.6 release notes](CHANGELOG.md).
+
 **Empty final responses fail closed in provenance runs (August 2026).** Release
 **4.43.5** prevents a thinking model from producing a valid provenance manifest
 for zero bytes of final text. The local OpenAI-compatible runner also records

--- a/skills/synthesis-local-model-runtime/SKILL.md
+++ b/skills/synthesis-local-model-runtime/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.0.4"
+  version: "1.0.5"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -25,7 +25,8 @@ every workload.
 2. Validate the bundled catalog before using it:
    `scripts/local_model_runtime.py catalog`.
 3. Load any local policy and create a dry-run plan. Recommendation applies
-   exclusions first, then hard memory and storage gates, then quality ordering.
+   exclusions first, then hard memory, storage, and runtime-configuration
+   gates, then quality ordering.
 4. Present the exact artifacts, quantizations, distribution channels, disk
    estimate, remaining free space, runtime prerequisites, and reasons.
 5. Install only after the user authorizes the downloads. `install` is dry-run
@@ -97,7 +98,27 @@ python3 scripts/local_model_runtime.py benchmark \
 Benchmarks set the Ollama `think` field to `false` by default so a bounded token
 budget measures the requested final response. Pass `--think` only when the
 reasoning trace is itself the workload under evaluation; the receipt records
-the chosen mode.
+the chosen mode. The receipt rejects length-stopped output and detects raw
+`<think>` markup. When reasoning was requested off, leaked markup is preserved
+as evidence but is not accepted as a final-response benchmark.
+
+Some model architectures require a specific Ollama KV-cache representation.
+The planner compares catalog requirements with the effective service setting
+and blocks an incompatible plan. On a macOS Homebrew service, inspect the
+validated change before applying it:
+
+```bash
+python3 scripts/local_model_runtime.py configure-ollama \
+  --kv-cache-type f16
+python3 scripts/local_model_runtime.py configure-ollama \
+  --kv-cache-type f16 \
+  --yes
+```
+
+The mutating command accepts only the standard current-user Homebrew
+LaunchAgent with the expected label and `ollama serve` command. It writes a
+private backup, changes one allowlisted environment value, reloads the service,
+waits for a healthy loopback API, and restores the prior plist if reload fails.
 
 ## Recommendation rules
 
@@ -191,4 +212,7 @@ into an evasion or watermark-removal loop.
 - A failed pull never creates an installed inventory record.
 - A model absent from the runtime after a reported pull is a failure.
 - A functional check and a benchmark are separate. Preserve both results.
+- Installed metadata is not a functional pass. A model that cannot generate
+  under the effective runtime configuration remains unusable until that
+  incompatibility is resolved and the bounded benchmark passes.
 - If disk, runtime, or model state changes after planning, rerun the plan.

--- a/skills/synthesis-local-model-runtime/assets/model_catalog.json
+++ b/skills/synthesis-local-model-runtime/assets/model_catalog.json
@@ -184,6 +184,11 @@
       "recommended_memory_gib": 64,
       "planning_context_tokens": 32768,
       "minimum_runtime_version": "0.30.0",
+      "runtime_requirements": {
+        "ollama_kv_cache_types": [
+          "f16"
+        ]
+      },
       "quality_rank": 40,
       "roles": ["long-context", "writing", "reasoning"],
       "expected_digest_prefix": null,
@@ -220,6 +225,11 @@
       "recommended_memory_gib": 80,
       "planning_context_tokens": 32768,
       "minimum_runtime_version": "0.30.0",
+      "runtime_requirements": {
+        "ollama_kv_cache_types": [
+          "f16"
+        ]
+      },
       "quality_rank": 50,
       "roles": ["high-quality-long-context", "writing", "reasoning"],
       "expected_digest_prefix": null,

--- a/skills/synthesis-local-model-runtime/references/architecture.md
+++ b/skills/synthesis-local-model-runtime/references/architecture.md
@@ -2,9 +2,9 @@
 
 ## Layers
 
-1. **Safe profile:** read-only hardware, storage, and runtime facts. The output
-   schema deliberately has no field for a hostname, serial, hardware UUID,
-   account, or network address.
+1. **Safe profile:** read-only hardware, storage, runtime, and effective
+   serving-configuration facts. The output schema deliberately has no field
+   for a hostname, serial, hardware UUID, account, or network address.
 2. **Catalog:** dated, reviewable artifact facts. An entry identifies the
    upstream model and the separately accountable quantization publisher.
 3. **Policy:** local choices such as required families, excluded organizations,
@@ -23,9 +23,16 @@ The catalog predicts. The runtime receipt establishes what is present. The
 benchmark establishes what happened in one bounded run. Keep these claims
 separate.
 
+Runtime fit includes configuration, not just the executable version. Catalog
+entries may constrain the Ollama KV-cache types that can represent their head
+dimensions. The planner blocks a mismatch before installation or use.
+
 Bounded final-response benchmarks disable optional model thinking by default
 and record the setting. Reasoning-trace evaluation is an explicit opt-in
-because it changes both the workload and token-budget interpretation.
+because it changes both the workload and token-budget interpretation. A clean
+final-response pass requires a non-empty stop-completed response. Raw thinking
+markup makes a reasoning-disabled run non-accepted even when final prose follows;
+the original output remains unchanged for diagnosis.
 
 ## Runtime adapter contract
 
@@ -38,6 +45,15 @@ An adapter must implement:
 - resolved artifact metadata including a local digest or content identity;
 - a loopback-only bounded generation call;
 - explicit unload.
+
+The macOS Homebrew configuration adapter is narrower than the serving adapter.
+It accepts only the expected current-user LaunchAgent label and two-argument
+`ollama serve` command, changes only an allowlisted KV-cache value, creates a
+private backup, reloads through `launchctl`, and proves API health. A failed
+reload restores the original plist. Because Ollama exposes the KV-cache type as
+a global service setting, the planner evaluates every selected artifact against
+the same effective value. Re-profile after Homebrew upgrades or service
+regeneration.
 
 Version 1.0 implements this contract for Ollama. Hugging Face GGUF ids remain
 Ollama artifacts after import, so the inventory records the full runtime name

--- a/skills/synthesis-local-model-runtime/references/security-and-privacy.md
+++ b/skills/synthesis-local-model-runtime/references/security-and-privacy.md
@@ -43,3 +43,16 @@ Do not infer that a symlink points somewhere safe from its visible prefix.
 Generation and metadata calls use loopback HTTP only. The executable has no
 option to send prompts to a remote host. A future remote adapter is a separate
 capability and requires its own disclosure and credential review.
+
+HTTP error bodies are preserved only up to a fixed bound so architecture and
+cache incompatibilities remain diagnosable without allowing an unbounded local
+service response into logs.
+
+## Runtime service changes
+
+Runtime configuration is dry-run-first and requires `--yes`. The Homebrew
+adapter rejects symlinks, foreign ownership, unexpected labels, unexpected
+commands, and values outside its KV-cache allowlist. It writes atomically,
+stores the original plist under the private state directory, and restores that
+original if unload, reload, or health verification fails. It never edits the
+Homebrew formula or a system-wide service.

--- a/skills/synthesis-local-model-runtime/scripts/local_model_runtime.py
+++ b/skills/synthesis-local-model-runtime/scripts/local_model_runtime.py
@@ -29,6 +29,8 @@ SKILL_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_CATALOG = SKILL_ROOT / "assets" / "model_catalog.json"
 DEFAULT_STATE_DIR = Path.home() / ".synthesis" / "local-models"
 OLLAMA_API = "http://127.0.0.1:11434"
+HOMEBREW_OLLAMA_LABEL = "homebrew.mxcl.ollama"
+OLLAMA_KV_CACHE_TYPES = {"f16", "q8_0", "q4_0"}
 GIB = 1024**3
 CATALOG_SCHEMA = 1
 POLICY_SCHEMA = 1
@@ -118,6 +120,26 @@ def atomic_text_write(path: Path, value: str) -> None:
             stream.write(value)
             stream.flush()
             os.fsync(stream.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def atomic_bytes_write(path: Path, value: bytes, mode: int | None = None) -> None:
+    reject_symlink_components(path.parent, path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    reject_symlink_components(path.parent, path)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(value)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if mode is not None:
+            os.chmod(temporary_path, mode)
         os.replace(temporary_path, path)
     finally:
         temporary_path.unlink(missing_ok=True)
@@ -262,12 +284,23 @@ def validate_model_store(store: Path, explicit_roots: list[str] | None = None) -
     return [display_path(root) for root in protected_roots(explicit_roots)]
 
 
-def macos_homebrew_ollama_store() -> Path | None:
+def macos_homebrew_ollama_service() -> tuple[Path, dict[str, Any]] | None:
     plist_path = Path.home() / "Library" / "LaunchAgents" / "homebrew.mxcl.ollama.plist"
     try:
+        reject_symlink_components(plist_path.parent, plist_path)
         payload = plistlib.loads(plist_path.read_bytes())
     except (FileNotFoundError, plistlib.InvalidFileException, OSError):
         return None
+    if not isinstance(payload, dict):
+        return None
+    return plist_path, payload
+
+
+def macos_homebrew_ollama_store() -> Path | None:
+    service = macos_homebrew_ollama_service()
+    if service is None:
+        return None
+    _, payload = service
     environment = payload.get("EnvironmentVariables", {})
     if not isinstance(environment, dict):
         return None
@@ -435,8 +468,42 @@ def api_json(path: str, payload: dict[str, Any] | None = None, timeout: int = 5)
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
             return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        try:
+            body = exc.read().decode("utf-8", errors="replace")
+        except OSError:
+            body = ""
+        detail = body.strip()[:2000] or str(exc)
+        raise LocalModelError(
+            f"Ollama loopback API returned HTTP {exc.code} for {path}: {detail}"
+        ) from exc
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
         raise LocalModelError(f"Ollama loopback API unavailable for {path}: {exc}") from exc
+
+
+def ollama_service_configuration() -> dict[str, Any]:
+    if platform.system() == "Darwin":
+        service = macos_homebrew_ollama_service()
+        if service is not None:
+            _, payload = service
+            environment = payload.get("EnvironmentVariables", {})
+            if isinstance(environment, dict):
+                return {
+                    "source": "homebrew-service",
+                    "kv_cache_type": str(
+                        environment.get("OLLAMA_KV_CACHE_TYPE") or "f16"
+                    ),
+                    "flash_attention": str(
+                        environment.get("OLLAMA_FLASH_ATTENTION") or "0"
+                    ),
+                }
+    return {
+        "source": "process-environment"
+        if os.environ.get("OLLAMA_KV_CACHE_TYPE")
+        else "runtime-default",
+        "kv_cache_type": os.environ.get("OLLAMA_KV_CACHE_TYPE", "f16"),
+        "flash_attention": os.environ.get("OLLAMA_FLASH_ATTENTION", "0"),
+    }
 
 
 def runtime_profile() -> dict[str, Any]:
@@ -460,6 +527,7 @@ def runtime_profile() -> dict[str, Any]:
             "available": bool(ollama),
             "version": api_version or ollama_version,
             "api_reachable": api_reachable,
+            "configuration": ollama_service_configuration(),
         },
         "llama_cpp": {
             "available": bool(llama_cli),
@@ -622,6 +690,30 @@ def validate_catalog(catalog: dict[str, Any]) -> list[dict[str, Any]]:
             isinstance(role, str) and role for role in artifact["roles"]
         ):
             raise LocalModelError(f"{artifact_id}.roles must be non-empty strings")
+        requirements = artifact.get("runtime_requirements")
+        if requirements is not None:
+            if not isinstance(requirements, dict):
+                raise LocalModelError(
+                    f"{artifact_id}.runtime_requirements must be an object"
+                )
+            unknown_requirements = sorted(
+                set(requirements) - {"ollama_kv_cache_types"}
+            )
+            if unknown_requirements:
+                raise LocalModelError(
+                    f"{artifact_id}.runtime_requirements has unknown fields: "
+                    + ", ".join(unknown_requirements)
+                )
+            cache_types = requirements.get("ollama_kv_cache_types")
+            if not isinstance(cache_types, list) or not cache_types:
+                raise LocalModelError(
+                    f"{artifact_id}.runtime_requirements.ollama_kv_cache_types "
+                    "must be a non-empty list"
+                )
+            if any(value not in OLLAMA_KV_CACHE_TYPES for value in cache_types):
+                raise LocalModelError(
+                    f"{artifact_id} has an unsupported Ollama KV cache requirement"
+                )
         fallback = artifact.get("local_import_fallback")
         if fallback is not None:
             if artifact["distribution_channel"] != "huggingface-gguf":
@@ -744,6 +836,16 @@ def artifact_fit(artifact: dict[str, Any], profile: dict[str, Any], policy: dict
             f"runtime {artifact['runtime']} {runtime.get('version') or 'unknown'} is below "
             f"{artifact['minimum_runtime_version']}"
         )
+    requirements = artifact.get("runtime_requirements", {})
+    allowed_cache_types = requirements.get("ollama_kv_cache_types")
+    if allowed_cache_types:
+        current_cache_type = runtime.get("configuration", {}).get("kv_cache_type")
+        if current_cache_type not in allowed_cache_types:
+            runtime_blockers.append(
+                f"runtime {artifact['runtime']} KV cache is "
+                f"{current_cache_type or 'unknown'}; artifact requires one of "
+                f"{', '.join(allowed_cache_types)}"
+            )
     return {
         "fit": fit,
         "blockers": blockers + runtime_blockers,
@@ -819,6 +921,7 @@ def recommend(
                 "fit": fit["fit"],
                 "effective_memory_gib": fit["effective_memory_gib"],
                 "minimum_runtime_version": candidate["minimum_runtime_version"],
+                "runtime_requirements": candidate.get("runtime_requirements", {}),
                 "roles": candidate["roles"],
             }
         )
@@ -899,6 +1002,7 @@ def plan_explicit(
                 "fit": fit["fit"],
                 "effective_memory_gib": fit.get("effective_memory_gib"),
                 "minimum_runtime_version": artifact["minimum_runtime_version"],
+                "runtime_requirements": artifact.get("runtime_requirements", {}),
                 "roles": artifact["roles"],
             }
         )
@@ -1345,6 +1449,20 @@ def benchmark_artifact(
     if not isinstance(response, dict) or not isinstance(response.get("response"), str):
         raise LocalModelError("Ollama generation returned an unexpected response")
     output = response["response"]
+    done_reason = response.get("done_reason")
+    reasoning_markup = bool(re.search(r"</?think(?:\s[^>]*)?>", output, re.IGNORECASE))
+    final_after_reasoning = False
+    if reasoning_markup:
+        closing_tags = list(re.finditer(r"</think\s*>", output, re.IGNORECASE))
+        final_after_reasoning = bool(
+            closing_tags and output[closing_tags[-1].end() :].strip()
+        )
+    final_response_complete = bool(
+        output.strip()
+        and done_reason == "stop"
+        and (not reasoning_markup or final_after_reasoning)
+    )
+    accepted = final_response_complete and (think or not reasoning_markup)
     eval_count = response.get("eval_count")
     eval_duration = response.get("eval_duration")
     tokens_per_second = None
@@ -1360,7 +1478,11 @@ def benchmark_artifact(
         "num_predict": num_predict,
         "num_ctx": num_ctx,
         "think": think,
-        "done_reason": response.get("done_reason"),
+        "done_reason": done_reason,
+        "reasoning_markup_detected": reasoning_markup,
+        "reasoning_suppression_honored": None if think else not reasoning_markup,
+        "final_response_complete": final_response_complete,
+        "accepted": accepted,
         "load_duration_ns": response.get("load_duration"),
         "prompt_eval_count": response.get("prompt_eval_count"),
         "prompt_eval_duration_ns": response.get("prompt_eval_duration"),
@@ -1383,6 +1505,151 @@ def benchmark_artifact(
         receipt["output_path"] = str(output_path)
         receipt["receipt_path"] = str(receipt_path)
     return receipt
+
+
+def validate_homebrew_ollama_service(
+    path: Path, payload: dict[str, Any]
+) -> tuple[list[str], dict[str, Any]]:
+    reject_symlink_components(path.parent, path)
+    if path.stat().st_uid != os.getuid():
+        raise LocalModelError("Homebrew Ollama service is not owned by the current user")
+    if payload.get("Label") != HOMEBREW_OLLAMA_LABEL:
+        raise LocalModelError("Unexpected Homebrew Ollama service label")
+    arguments = payload.get("ProgramArguments")
+    if (
+        not isinstance(arguments, list)
+        or len(arguments) != 2
+        or not isinstance(arguments[0], str)
+        or Path(arguments[0]).name != "ollama"
+        or arguments[1] != "serve"
+    ):
+        raise LocalModelError("Unexpected Homebrew Ollama service command")
+    environment = payload.get("EnvironmentVariables", {})
+    if not isinstance(environment, dict):
+        raise LocalModelError("Homebrew Ollama service environment is malformed")
+    return arguments, dict(environment)
+
+
+def wait_for_ollama_api(timeout: float = 30.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            response = api_json("/api/version", timeout=2)
+            if isinstance(response, dict) and response.get("version"):
+                return True
+        except LocalModelError:
+            pass
+        time.sleep(0.25)
+    return False
+
+
+def configure_homebrew_ollama(
+    kv_cache_type: str,
+    execute: bool,
+    state_dir: Path,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    waiter: Callable[[], bool] = wait_for_ollama_api,
+) -> dict[str, Any]:
+    if platform.system() != "Darwin":
+        raise LocalModelError("Homebrew Ollama service configuration is macOS-only")
+    if kv_cache_type not in OLLAMA_KV_CACHE_TYPES:
+        raise LocalModelError(
+            "kv-cache-type must be one of: " + ", ".join(sorted(OLLAMA_KV_CACHE_TYPES))
+        )
+    service = macos_homebrew_ollama_service()
+    if service is None:
+        raise LocalModelError("Standard Homebrew Ollama LaunchAgent was not found")
+    plist_path, payload = service
+    _, environment = validate_homebrew_ollama_service(plist_path, payload)
+    current = str(environment.get("OLLAMA_KV_CACHE_TYPE") or "f16")
+    plan = {
+        "schema_version": 1,
+        "execute": execute,
+        "service": HOMEBREW_OLLAMA_LABEL,
+        "service_path": display_path(plist_path),
+        "current_kv_cache_type": current,
+        "desired_kv_cache_type": kv_cache_type,
+        "changed": current != kv_cache_type,
+        "authorization_required": not execute and current != kv_cache_type,
+    }
+    if not execute or current == kv_cache_type:
+        return plan
+
+    original = plist_path.read_bytes()
+    original_mode = plist_path.stat().st_mode & 0o777
+    backup_name = (
+        "homebrew.mxcl.ollama."
+        + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        + ".plist"
+    )
+    backup_path = state_dir.expanduser() / "backups" / backup_name
+    atomic_bytes_write(backup_path, original, 0o600)
+
+    updated = plistlib.loads(original)
+    updated_environment = dict(updated.get("EnvironmentVariables", {}))
+    updated_environment["OLLAMA_KV_CACHE_TYPE"] = kv_cache_type
+    updated["EnvironmentVariables"] = updated_environment
+    updated_bytes = plistlib.dumps(updated, fmt=plistlib.FMT_XML, sort_keys=True)
+    domain = f"gui/{os.getuid()}"
+
+    def launchctl(arguments: list[str]) -> subprocess.CompletedProcess[str]:
+        return runner(
+            ["launchctl", *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            shell=False,
+        )
+
+    def restore_original() -> subprocess.CompletedProcess[str]:
+        launchctl(["bootout", domain, str(plist_path)])
+        atomic_bytes_write(plist_path, original, original_mode)
+        return launchctl(["bootstrap", domain, str(plist_path)])
+
+    atomic_bytes_write(plist_path, updated_bytes, original_mode)
+    bootout = launchctl(["bootout", domain, str(plist_path)])
+    if bootout.returncode != 0:
+        atomic_bytes_write(plist_path, original, original_mode)
+        raise LocalModelError(
+            "Could not unload the Homebrew Ollama service; restored its plist: "
+            + (bootout.stderr.strip() or bootout.stdout.strip() or "unknown launchctl error")
+        )
+    bootstrap = launchctl(["bootstrap", domain, str(plist_path)])
+    if bootstrap.returncode != 0:
+        restored = restore_original()
+        if restored.returncode != 0:
+            raise LocalModelError(
+                "Could not reload Ollama or restart the restored service; manual service "
+                "recovery is required. Initial error: "
+                + (bootstrap.stderr.strip() or bootstrap.stdout.strip() or "unknown")
+                + "; restore error: "
+                + (restored.stderr.strip() or restored.stdout.strip() or "unknown")
+            )
+        raise LocalModelError(
+            "Could not reload the Homebrew Ollama service; restored its prior configuration: "
+            + (bootstrap.stderr.strip() or bootstrap.stdout.strip() or "unknown launchctl error")
+        )
+    if not waiter():
+        restored = restore_original()
+        if restored.returncode != 0 or not waiter():
+            raise LocalModelError(
+                "Ollama did not become healthy and the restored service did not recover; "
+                "manual service recovery is required"
+            )
+        raise LocalModelError(
+            "Ollama did not become healthy after reload; restored its prior configuration"
+        )
+    plan.update(
+        {
+            "applied_at": utc_now(),
+            "backup_path": display_path(backup_path),
+            "authorization_required": False,
+            "runtime_healthy": True,
+        }
+    )
+    return plan
 
 
 def add_common(parser: argparse.ArgumentParser) -> None:
@@ -1446,6 +1713,15 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Include model reasoning when the reasoning trace is the benchmark workload",
     )
+    configure_parser = commands.add_parser(
+        "configure-ollama",
+        help="Plan or apply a validated Homebrew Ollama KV-cache setting",
+    )
+    add_common(configure_parser)
+    configure_parser.add_argument(
+        "--kv-cache-type", choices=sorted(OLLAMA_KV_CACHE_TYPES), required=True
+    )
+    configure_parser.add_argument("--yes", action="store_true")
     return parser
 
 
@@ -1471,6 +1747,15 @@ def main(argv: list[str] | None = None) -> int:
                     "families": families,
                     "status": "valid",
                 }
+            )
+            return 0
+        if args.command == "configure-ollama":
+            emit(
+                configure_homebrew_ollama(
+                    args.kv_cache_type,
+                    args.yes,
+                    args.state_dir.expanduser(),
+                )
             )
             return 0
         if args.command == "resolve":
@@ -1540,17 +1825,16 @@ def main(argv: list[str] | None = None) -> int:
                 if args.prompt_file
                 else "Explain one practical benefit and one limitation of running an open-weight language model locally."
             )
-            emit(
-                benchmark_artifact(
-                    artifact,
-                    args.output_dir,
-                    prompt,
-                    args.num_predict,
-                    args.num_ctx,
-                    think=args.think,
-                )
+            receipt = benchmark_artifact(
+                artifact,
+                args.output_dir,
+                prompt,
+                args.num_predict,
+                args.num_ctx,
+                think=args.think,
             )
-            return 0
+            emit(receipt)
+            return 0 if receipt["accepted"] else 2
         raise LocalModelError(f"Unknown command: {args.command}")
     except LocalModelError as exc:
         emit({"error": str(exc), "status": "blocked"})

--- a/skills/synthesis-local-model-runtime/scripts/test_local_model_runtime.py
+++ b/skills/synthesis-local-model-runtime/scripts/test_local_model_runtime.py
@@ -1,4 +1,5 @@
 import importlib.util
+import io
 import json
 import os
 import tempfile
@@ -19,7 +20,16 @@ def fixture_profile(memory=128, free=2000, version="0.31.2"):
         "memory": {"total_gib": memory, "unified": True},
         "storage": {"model_store": "~/.ollama/models", "free_gib": free},
         "runtimes": {
-            "ollama": {"available": True, "version": version, "api_reachable": True}
+            "ollama": {
+                "available": True,
+                "version": version,
+                "api_reachable": True,
+                "configuration": {
+                    "source": "test",
+                    "kv_cache_type": "f16",
+                    "flash_attention": "1",
+                },
+            }
         },
     }
 
@@ -86,6 +96,20 @@ class RecommendationTests(unittest.TestCase):
         plan = runtime.recommend(self.artifacts, fixture_profile(version="0.23.2"), policy)
         self.assertFalse(plan["ready"])
         self.assertIn("below 0.30.0", " ".join(plan["blockers"]))
+
+    def test_kimi_requires_compatible_ollama_kv_cache(self):
+        policy = dict(runtime.DEFAULT_POLICY)
+        policy.update(
+            {
+                "required_families": ["kimi"],
+                "artifact_overrides": {"kimi": "kimi-linear-48b-a3b-q6-k"},
+            }
+        )
+        profile = fixture_profile()
+        profile["runtimes"]["ollama"]["configuration"]["kv_cache_type"] = "q8_0"
+        plan = runtime.recommend(self.artifacts, profile, policy)
+        self.assertFalse(plan["ready"])
+        self.assertIn("requires one of f16", " ".join(plan["blockers"]))
 
     def test_disk_reserve_blocks_oversized_batch(self):
         policy = dict(runtime.DEFAULT_POLICY)
@@ -476,6 +500,139 @@ class RuntimeTests(unittest.TestCase):
         request = api.call_args.args[1]
         self.assertIs(request["think"], False)
         self.assertIs(receipt["think"], False)
+        self.assertTrue(receipt["accepted"])
+        self.assertTrue(receipt["reasoning_suppression_honored"])
+
+    def test_benchmark_rejects_unsuppressed_reasoning_markup(self):
+        _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)
+        response = {
+            "response": "<think>private trace</think>final response",
+            "done_reason": "stop",
+            "eval_count": 8,
+            "eval_duration": 1_000_000_000,
+        }
+        with mock.patch.object(runtime, "api_json", return_value=response):
+            receipt = runtime.benchmark_artifact(
+                artifacts[0], None, "test prompt", 16, 8192
+            )
+        self.assertTrue(receipt["final_response_complete"])
+        self.assertFalse(receipt["reasoning_suppression_honored"])
+        self.assertFalse(receipt["accepted"])
+
+    def test_benchmark_rejects_length_stop_without_final_response(self):
+        _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)
+        response = {
+            "response": "<think>unfinished private trace",
+            "done_reason": "length",
+            "eval_count": 16,
+            "eval_duration": 1_000_000_000,
+        }
+        with mock.patch.object(runtime, "api_json", return_value=response):
+            receipt = runtime.benchmark_artifact(
+                artifacts[0], None, "test prompt", 16, 8192, think=True
+            )
+        self.assertFalse(receipt["final_response_complete"])
+        self.assertFalse(receipt["accepted"])
+
+    def test_api_http_error_preserves_bounded_runtime_detail(self):
+        error = runtime.urllib.error.HTTPError(
+            "http://127.0.0.1:11434/api/generate",
+            500,
+            "Internal Server Error",
+            {},
+            io.BytesIO(b'{"error":"KV cache mismatch"}'),
+        )
+        with mock.patch.object(runtime.urllib.request, "urlopen", side_effect=error):
+            with self.assertRaisesRegex(runtime.LocalModelError, "KV cache mismatch"):
+                runtime.api_json("/api/generate", {"model": "test"})
+
+    def test_homebrew_ollama_configuration_dry_run_does_not_write(self):
+        payload = {
+            "Label": runtime.HOMEBREW_OLLAMA_LABEL,
+            "ProgramArguments": ["/opt/homebrew/bin/ollama", "serve"],
+            "EnvironmentVariables": {"OLLAMA_KV_CACHE_TYPE": "q8_0"},
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            plist = Path(directory) / "homebrew.mxcl.ollama.plist"
+            original = runtime.plistlib.dumps(payload)
+            plist.write_bytes(original)
+            with mock.patch.object(runtime.platform, "system", return_value="Darwin"), mock.patch.object(
+                runtime, "macos_homebrew_ollama_service", return_value=(plist, payload)
+            ):
+                result = runtime.configure_homebrew_ollama(
+                    "f16", False, Path(directory) / "state"
+                )
+            self.assertTrue(result["authorization_required"])
+            self.assertEqual(plist.read_bytes(), original)
+
+    def test_homebrew_ollama_configuration_applies_and_backs_up(self):
+        payload = {
+            "Label": runtime.HOMEBREW_OLLAMA_LABEL,
+            "ProgramArguments": ["/opt/homebrew/bin/ollama", "serve"],
+            "EnvironmentVariables": {
+                "OLLAMA_FLASH_ATTENTION": "1",
+                "OLLAMA_KV_CACHE_TYPE": "q8_0",
+            },
+        }
+        calls = []
+
+        def runner(arguments, **_kwargs):
+            calls.append(arguments)
+            return runtime.subprocess.CompletedProcess(arguments, 0, "", "")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            plist = root / "homebrew.mxcl.ollama.plist"
+            original = runtime.plistlib.dumps(payload)
+            plist.write_bytes(original)
+            with mock.patch.object(runtime.platform, "system", return_value="Darwin"), mock.patch.object(
+                runtime, "macos_homebrew_ollama_service", return_value=(plist, payload)
+            ):
+                result = runtime.configure_homebrew_ollama(
+                    "f16", True, root / "state", runner=runner, waiter=lambda: True
+                )
+            updated = runtime.plistlib.loads(plist.read_bytes())
+            self.assertEqual(
+                updated["EnvironmentVariables"]["OLLAMA_KV_CACHE_TYPE"], "f16"
+            )
+            backups = list((root / "state" / "backups").glob("*.plist"))
+            self.assertEqual(len(backups), 1)
+            self.assertEqual(backups[0].read_bytes(), original)
+            self.assertTrue(result["runtime_healthy"])
+            self.assertEqual([call[1] for call in calls], ["bootout", "bootstrap"])
+
+    def test_homebrew_ollama_configuration_rolls_back_failed_reload(self):
+        payload = {
+            "Label": runtime.HOMEBREW_OLLAMA_LABEL,
+            "ProgramArguments": ["/opt/homebrew/bin/ollama", "serve"],
+            "EnvironmentVariables": {"OLLAMA_KV_CACHE_TYPE": "q8_0"},
+        }
+        calls = []
+
+        def runner(arguments, **_kwargs):
+            calls.append(arguments)
+            returncode = 1 if len(calls) == 2 else 0
+            return runtime.subprocess.CompletedProcess(
+                arguments, returncode, "", "reload failed" if returncode else ""
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            plist = root / "homebrew.mxcl.ollama.plist"
+            original = runtime.plistlib.dumps(payload)
+            plist.write_bytes(original)
+            with mock.patch.object(runtime.platform, "system", return_value="Darwin"), mock.patch.object(
+                runtime, "macos_homebrew_ollama_service", return_value=(plist, payload)
+            ):
+                with self.assertRaisesRegex(runtime.LocalModelError, "restored"):
+                    runtime.configure_homebrew_ollama(
+                        "f16", True, root / "state", runner=runner, waiter=lambda: True
+                    )
+            self.assertEqual(plist.read_bytes(), original)
+            self.assertEqual(
+                [call[1] for call in calls],
+                ["bootout", "bootstrap", "bootout", "bootstrap"],
+            )
 
     def test_resolve_enforces_current_machine_selection_and_installation(self):
         _, artifacts = runtime.load_catalog(runtime.DEFAULT_CATALOG)


### PR DESCRIPTION
## Summary
- make effective Ollama KV-cache configuration part of catalog fit planning
- add a dry-run-first, validated Homebrew service configuration path with backup and rollback
- reject truncated or reasoning-leaking final-response benchmarks while preserving raw evidence

## Verification
- 34 focused unit tests pass
- release preflight, conformance, coordination, ritual/guard/hook, and compile checks pass