### PR TITLE
Fail-closed durable-context edits

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.44.0",
+  "version": "4.45.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.44.0",
+  "version": "4.45.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.45.0] - 2026-08-23
+
+### Added
+
+- **`synthesis-context-lifecycle` v1.9.0 — fail-closed durable-context edits.**
+  New `scripts/context_edit.py` replaces hand-rolled `str.replace()` when a
+  script edits `CONTEXT.md`, `REFERENCE.md`, or a session log. A bare replace
+  asserts nothing: when an anchor no longer matches — because another agent
+  legitimately rewrote that region between sessions — the edit silently becomes
+  a no-op while the surrounding "updated" message stays false. The result gets
+  committed, and record-versus-git checks still pass, because the file *is*
+  committed; it is simply not current. This is an unverified success claim
+  about the agent's own action, a class nothing else in the system checks,
+  because a claim about one's own completed action has no natural contradictor.
+
+  The helper refuses, without writing, when the anchor is absent, matches a
+  different number of times than declared, would leave the file
+  byte-identical, would exceed a stated line budget, or targets a symlink. It
+  writes atomically and then re-reads the file to confirm the change reached
+  disk. No flag makes a missing anchor succeed; `--dry-run` still refuses a bad
+  one. `replace_once` and `set_field` are importable for use from Python.
+
+  `SKILL.md` gains a mandatory section for scripted edits, with the two rules a
+  tool cannot enforce alone: re-read a record before editing it when another
+  agent may have touched it, and never report success you did not verify.
+
 ## [4.44.0] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Durable-context edits fail closed (August 2026).** Release **4.45.0** adds
+`context_edit.py` to `synthesis-context-lifecycle`. A hand-rolled
+`str.replace()` against a project record asserts nothing — when another agent
+has rewritten the anchored region, the edit silently no-ops while the script
+still reports success, and the stale record then passes every
+committed-versus-git check. The helper refuses a missing, ambiguous, or
+no-op edit without writing, writes atomically, and re-reads the file to
+confirm the change landed. See the [4.45.0 release notes](CHANGELOG.md).
+
 **Managed runtime choice and verified model updates (August 2026).** Release
 **4.44.0** keeps Ollama as the default while adding an LM Studio adapter for
 catalog planning, exact downloads, JSON inventory, and runtime-metadata

--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.8.0"
+  version: "1.9.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -392,6 +392,48 @@ When any of these fire, run the Mid-Session Refresh Protocol unconditionally.
 **Delegation.** When the `synthesis-checkpoint` skill is available, prefer invoking it — it is the canonical codification of this protocol, runs the same steps every time, and produces consistent visible output the user can spot. Use the inline fallback only when synthesis-checkpoint is not loaded.
 
 ---
+
+## Editing a Durable Context File — MANDATORY for scripted edits
+
+A scripted edit to `CONTEXT.md`, `REFERENCE.md`, or a session log is an
+assertion that a specific change was made. A bare `str.replace()` asserts
+nothing: when an anchor no longer matches — because another agent legitimately
+rewrote that region between sessions — the replacement silently becomes a
+no-op while the surrounding "updated" message stays cheerful and false. The
+result is committed, and record-versus-git checks still pass, because the file
+is committed. It is simply not current.
+
+**Never hand-roll replacement logic against a durable context file.** Use
+`scripts/context_edit.py`, which fails closed:
+
+```bash
+python3 scripts/context_edit.py set-field --file CONTEXT.md \
+  --field Phase --value "Round 3 complete"
+
+python3 scripts/context_edit.py replace --file CONTEXT.md \
+  --anchor "$OLD" --replacement "$NEW" [--count N] [--max-lines 150]
+
+python3 scripts/context_edit.py insert-before --file sessions/2026-08.md \
+  --anchor "## 2026-08-20" --text "$NEW_ENTRY"
+```
+
+It refuses, without writing, when the anchor is absent, when it matches a
+different number of times than declared, when the replacement would leave the
+file byte-identical, when the result would exceed a stated line budget, or when
+the target is a symlink. It writes atomically and then re-reads the file to
+confirm the change is actually on disk. There is no flag that makes a missing
+anchor succeed. `--dry-run` previews without writing and still refuses a bad
+anchor. Import `replace_once` or `set_field` to use it from Python.
+
+Two companion rules, because the tool cannot enforce them alone:
+
+- **Re-read before editing.** When re-taking a claim on a project another
+  agent may have touched, read the current file and build anchors from what it
+  says now — never from strings you remember writing. Alternating agents on
+  one `CONTEXT.md` is a standing pattern in cross-agent work, not an accident.
+- **Never report success you did not verify.** A message saying a record was
+  updated is a claim about your own action, and nothing else in the system
+  checks it.
 
 ## The Archival Protocol
 

--- a/skills/synthesis-context-lifecycle/scripts/context_edit.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_edit.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Fail-closed edits to durable context files.
+
+A scripted edit to `CONTEXT.md`, `REFERENCE.md`, or a session log is an
+assertion that a specific change was made. Hand-rolled `str.replace()` does not
+assert anything: when an anchor no longer matches — because another agent
+legitimately rewrote that region between sessions — the replacement silently
+becomes a no-op, and any surrounding "updated" message is false. That output
+then gets committed, and record-versus-git checks still pass, because the file
+is committed; it is simply not current.
+
+This helper makes the assertion real. Every operation verifies that the anchor
+matched the expected number of times, that content actually changed, and that
+the change is present in the file after writing. Anything else exits non-zero
+without writing. There is no flag to make a missing anchor succeed.
+
+Use it from any session or script that edits a durable context file, rather
+than reimplementing replacement logic per project.
+
+Command line
+------------
+
+    context_edit.py replace --file F --anchor TEXT --replacement TEXT
+                            [--count N] [--max-lines N] [--dry-run]
+    context_edit.py set-field --file F --field Phase --value TEXT
+                            [--max-lines N] [--dry-run]
+    context_edit.py insert-before --file F --anchor TEXT --text TEXT
+                            [--max-lines N] [--dry-run]
+
+Use `insert-before` to prepend a section — a changelog release, a session-log
+entry — rather than a `replace` that restates the anchor inside its own
+replacement. Forgetting to restate it deletes the heading you anchored on, and
+the edit still reports success because content did change.
+
+Value arguments accept `-` to read from stdin, which keeps multi-line and
+quote-heavy content out of shell escaping.
+
+Python
+------
+
+    from context_edit import replace_once, ContextEditError
+
+    replace_once(path, anchor="**Phase:** old", replacement="**Phase:** new")
+
+Exit codes: 0 changed, 1 refused (nothing written), 2 usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+
+class ContextEditError(Exception):
+    """A durable-context edit was refused. Nothing was written."""
+
+
+def _read(path: Path) -> str:
+    if path.is_symlink():
+        raise ContextEditError(f"refusing to edit a symlink: {path}")
+    if not path.is_file():
+        raise ContextEditError(f"not a file: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Write via a temp file in the same directory, then rename.
+
+    A durable record must never be left half-written by an interrupted edit.
+    """
+    directory = path.parent
+    handle = tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=directory, delete=False
+    )
+    try:
+        with handle as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(handle.name, path)
+    except BaseException:
+        Path(handle.name).unlink(missing_ok=True)
+        raise
+
+
+def apply_replacement(
+    text: str,
+    anchor: str,
+    replacement: str,
+    *,
+    count: int = 1,
+) -> str:
+    """Return edited text, or raise ContextEditError explaining the refusal."""
+    if not anchor:
+        raise ContextEditError("anchor must not be empty")
+    if count < 1:
+        raise ContextEditError(f"count must be at least 1, got {count}")
+
+    found = text.count(anchor)
+    if found == 0:
+        raise ContextEditError(
+            f"anchor not found: {anchor[:80]!r}\n"
+            "The record may have been rewritten by another session. Re-read "
+            "the current file and build the anchor from it rather than from "
+            "remembered content."
+        )
+    if found != count:
+        raise ContextEditError(
+            f"anchor matched {found} time(s), expected {count}: {anchor[:80]!r}\n"
+            "Narrow the anchor, or pass --count to confirm the intended number."
+        )
+
+    edited = text.replace(anchor, replacement, count)
+    if edited == text:
+        raise ContextEditError(
+            "replacement leaves the file byte-identical; nothing to change"
+        )
+    return edited
+
+
+def _check_budget(text: str, max_lines: int | None, path: Path) -> int:
+    lines = len(text.splitlines())
+    if max_lines is not None and lines > max_lines:
+        raise ContextEditError(
+            f"edit would leave {path.name} at {lines} lines, over the "
+            f"{max_lines}-line budget; trim in the same edit"
+        )
+    return lines
+
+
+def replace_once(
+    path: Path,
+    anchor: str,
+    replacement: str,
+    *,
+    count: int = 1,
+    max_lines: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Apply one verified replacement to a durable context file."""
+    path = Path(path)
+    original = _read(path)
+    edited = apply_replacement(original, anchor, replacement, count=count)
+    lines = _check_budget(edited, max_lines, path)
+
+    if dry_run:
+        return {
+            "path": str(path),
+            "changed": False,
+            "dry_run": True,
+            "replacements": count,
+            "lines": lines,
+        }
+
+    _atomic_write(path, edited)
+
+    # Verify against the file on disk, not against the in-memory value we
+    # intended to write. This is the whole point of the helper.
+    written = _read(path)
+    if written != edited:
+        raise ContextEditError(
+            f"post-write verification failed for {path}: on-disk content does "
+            "not match the intended edit"
+        )
+    if replacement and replacement not in written:
+        raise ContextEditError(
+            f"post-write verification failed for {path}: replacement text is "
+            "absent from the file"
+        )
+    return {
+        "path": str(path),
+        "changed": True,
+        "dry_run": False,
+        "replacements": count,
+        "lines": len(written.splitlines()),
+    }
+
+
+FIELD = "^\\*\\*{name}:\\*\\*[^\\n]*"
+
+
+def set_field(
+    path: Path,
+    field: str,
+    value: str,
+    *,
+    max_lines: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Replace a `**Field:** ...` header line, verifying it existed."""
+    path = Path(path)
+    original = _read(path)
+    pattern = re.compile(FIELD.format(name=re.escape(field)), re.MULTILINE)
+    matches = pattern.findall(original)
+    if not matches:
+        raise ContextEditError(
+            f"header field not found: **{field}:**\n"
+            "Re-read the current file; the record may use a different header."
+        )
+    if len(matches) > 1:
+        raise ContextEditError(
+            f"header field **{field}:** appears {len(matches)} times; "
+            "the record is ambiguous and must be repaired by hand"
+        )
+    return replace_once(
+        path,
+        anchor=matches[0],
+        replacement=f"**{field}:** {value}",
+        max_lines=max_lines,
+        dry_run=dry_run,
+    )
+
+
+def insert_before(
+    path: Path,
+    anchor: str,
+    text: str,
+    *,
+    max_lines: int | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Insert text immediately before an anchor, preserving the anchor.
+
+    Prepending a new section — a changelog release, a session-log entry — with
+    a raw replace requires restating the anchor inside the replacement, and
+    forgetting to do so deletes the very heading you anchored on. The edit
+    still "succeeds", because content did change. This operation removes that
+    footgun by construction: the anchor is never consumed.
+    """
+    return replace_once(
+        path,
+        anchor=anchor,
+        replacement=f"{text}{anchor}",
+        max_lines=max_lines,
+        dry_run=dry_run,
+    )
+
+
+def _value(raw: str) -> str:
+    return sys.stdin.read() if raw == "-" else raw
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--file", required=True, type=Path)
+    common.add_argument("--max-lines", type=int, default=None)
+    common.add_argument("--dry-run", action="store_true")
+
+    replace = sub.add_parser("replace", parents=[common])
+    replace.add_argument("--anchor", required=True)
+    replace.add_argument("--replacement", required=True)
+    replace.add_argument("--count", type=int, default=1)
+
+    field = sub.add_parser("set-field", parents=[common])
+    field.add_argument("--field", required=True)
+    field.add_argument("--value", required=True)
+
+    insert = sub.add_parser("insert-before", parents=[common])
+    insert.add_argument("--anchor", required=True)
+    insert.add_argument("--text", required=True)
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "insert-before":
+            result = insert_before(
+                args.file,
+                anchor=_value(args.anchor),
+                text=_value(args.text),
+                max_lines=args.max_lines,
+                dry_run=args.dry_run,
+            )
+        elif args.command == "replace":
+            result = replace_once(
+                args.file,
+                anchor=_value(args.anchor),
+                replacement=_value(args.replacement),
+                count=args.count,
+                max_lines=args.max_lines,
+                dry_run=args.dry_run,
+            )
+        else:
+            result = set_field(
+                args.file,
+                field=args.field,
+                value=_value(args.value),
+                max_lines=args.max_lines,
+                dry_run=args.dry_run,
+            )
+    except ContextEditError as exc:
+        print(f"context-edit refused: {exc}", file=sys.stderr)
+        return 1
+
+    verb = "would change" if result["dry_run"] else "changed"
+    print(
+        f"{verb} {result['path']}: {result['replacements']} replacement(s), "
+        f"{result['lines']} lines"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/synthesis-context-lifecycle/scripts/test_context_edit.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_edit.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Tests for fail-closed durable-context edits."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from context_edit import (
+    ContextEditError,
+    apply_replacement,
+    insert_before,
+    main,
+    replace_once,
+    set_field,
+)
+
+RECORD = """# Project — Context
+
+**Phase:** Adversarial round 2 complete
+**Status:** Active
+**Last session:** 2026-08-23
+
+## Body
+
+Round 2 findings were adjudicated.
+"""
+
+
+def record(tmp_path: Path, text: str = RECORD) -> Path:
+    path = tmp_path / "CONTEXT.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_replaces_and_verifies_on_disk(tmp_path: Path) -> None:
+    path = record(tmp_path)
+
+    result = replace_once(
+        path,
+        anchor="**Phase:** Adversarial round 2 complete",
+        replacement="**Phase:** Adversarial round 3 complete",
+    )
+
+    assert result["changed"] is True
+    assert "round 3 complete" in path.read_text(encoding="utf-8")
+
+
+def test_missing_anchor_refuses_and_leaves_file_untouched(tmp_path: Path) -> None:
+    """The routed defect: another agent rewrote the header between sessions.
+
+    A bare str.replace() would no-op here and any surrounding success message
+    would be false. The helper must refuse instead.
+    """
+    path = record(tmp_path)
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(ContextEditError, match="anchor not found"):
+        replace_once(
+            path,
+            anchor="**Phase:** Adversarial round 1 complete",
+            replacement="**Phase:** Adversarial round 3 complete",
+        )
+
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_cli_missing_anchor_exits_nonzero_without_success_output(
+    tmp_path: Path, capsys
+) -> None:
+    path = record(tmp_path)
+
+    code = main(
+        [
+            "replace",
+            "--file",
+            str(path),
+            "--anchor",
+            "text that is not present",
+            "--replacement",
+            "new text",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert "refused" in captured.err
+    assert path.read_text(encoding="utf-8") == RECORD
+
+
+def test_ambiguous_anchor_refuses_without_explicit_count(tmp_path: Path) -> None:
+    path = record(tmp_path, "alpha\nalpha\n")
+
+    with pytest.raises(ContextEditError, match="matched 2 time"):
+        replace_once(path, anchor="alpha", replacement="beta")
+
+    assert path.read_text(encoding="utf-8") == "alpha\nalpha\n"
+
+
+def test_ambiguous_anchor_allowed_with_explicit_count(tmp_path: Path) -> None:
+    path = record(tmp_path, "alpha\nalpha\n")
+
+    result = replace_once(path, anchor="alpha", replacement="beta", count=2)
+
+    assert result["replacements"] == 2
+    assert path.read_text(encoding="utf-8") == "beta\nbeta\n"
+
+
+def test_identical_replacement_refuses(tmp_path: Path) -> None:
+    path = record(tmp_path)
+
+    with pytest.raises(ContextEditError, match="byte-identical"):
+        replace_once(path, anchor="**Status:** Active", replacement="**Status:** Active")
+
+
+def test_symlink_is_refused(tmp_path: Path) -> None:
+    target = record(tmp_path)
+    link = tmp_path / "LINK.md"
+    link.symlink_to(target)
+
+    with pytest.raises(ContextEditError, match="symlink"):
+        replace_once(link, anchor="**Status:** Active", replacement="**Status:** Done")
+
+
+def test_missing_file_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(ContextEditError, match="not a file"):
+        replace_once(tmp_path / "absent.md", anchor="a", replacement="b")
+
+
+def test_empty_anchor_is_refused(tmp_path: Path) -> None:
+    path = record(tmp_path)
+
+    with pytest.raises(ContextEditError, match="must not be empty"):
+        replace_once(path, anchor="", replacement="b")
+
+
+def test_budget_violation_refuses_before_writing(tmp_path: Path) -> None:
+    path = record(tmp_path)
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(ContextEditError, match="line budget"):
+        replace_once(
+            path,
+            anchor="## Body",
+            replacement="## Body\n" + "\n".join(f"line {n}" for n in range(50)),
+            max_lines=20,
+        )
+
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_dry_run_reports_without_writing(tmp_path: Path) -> None:
+    path = record(tmp_path)
+
+    result = replace_once(
+        path,
+        anchor="**Status:** Active",
+        replacement="**Status:** Complete",
+        dry_run=True,
+    )
+
+    assert result["changed"] is False and result["dry_run"] is True
+    assert path.read_text(encoding="utf-8") == RECORD
+
+
+def test_dry_run_still_refuses_a_missing_anchor(tmp_path: Path) -> None:
+    path = record(tmp_path)
+
+    with pytest.raises(ContextEditError, match="anchor not found"):
+        replace_once(path, anchor="absent", replacement="x", dry_run=True)
+
+
+def test_set_field_replaces_whole_header_line(tmp_path: Path) -> None:
+    path = record(tmp_path)
+
+    set_field(path, field="Phase", value="Adversarial round 3 complete")
+
+    text = path.read_text(encoding="utf-8")
+    assert "**Phase:** Adversarial round 3 complete" in text
+    assert "round 2" not in text
+
+
+def test_set_field_refuses_absent_field(tmp_path: Path) -> None:
+    path = record(tmp_path)
+
+    with pytest.raises(ContextEditError, match="header field not found"):
+        set_field(path, field="Milestone", value="x")
+
+
+def test_set_field_refuses_duplicated_field(tmp_path: Path) -> None:
+    path = record(tmp_path, "**Phase:** one\n**Phase:** two\n")
+
+    with pytest.raises(ContextEditError, match="appears 2 times"):
+        set_field(path, field="Phase", value="three")
+
+
+def test_insert_before_preserves_the_anchor(tmp_path: Path) -> None:
+    """Prepending a section must not consume the heading it anchors on."""
+    path = record(tmp_path, "## [1.1.0]\n\nold release\n")
+
+    insert_before(path, anchor="## [1.1.0]", text="## [1.2.0]\n\nnew release\n\n")
+
+    text = path.read_text(encoding="utf-8")
+    assert text.index("## [1.2.0]") < text.index("## [1.1.0]")
+    assert "old release" in text and "new release" in text
+
+
+def test_insert_before_refuses_a_missing_anchor(tmp_path: Path) -> None:
+    path = record(tmp_path, "## [1.1.0]\n")
+
+    with pytest.raises(ContextEditError, match="anchor not found"):
+        insert_before(path, anchor="## [9.9.9]", text="x\n")
+
+
+def test_apply_replacement_is_pure(tmp_path: Path) -> None:
+    edited = apply_replacement("alpha beta", "beta", "gamma")
+
+    assert edited == "alpha gamma"
+
+
+def test_failed_edit_leaves_no_temporary_files(tmp_path: Path) -> None:
+    path = record(tmp_path)
+
+    with pytest.raises(ContextEditError):
+        replace_once(path, anchor="absent", replacement="x")
+
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["CONTEXT.md"]
+
+
+def test_cli_success_reports_line_count(tmp_path: Path, capsys) -> None:
+    path = record(tmp_path)
+
+    code = main(
+        [
+            "set-field",
+            "--file",
+            str(path),
+            "--field",
+            "Status",
+            "--value",
+            "Complete",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "changed" in captured.out and "1 replacement(s)" in captured.out
+    assert "**Status:** Complete" in path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Adds `context_edit.py` to `synthesis-context-lifecycle` (v1.9.0), released as 4.45.0.

A hand-rolled `str.replace()` against a project record asserts nothing. When another agent has legitimately rewritten the anchored region between sessions, the edit silently becomes a no-op while the surrounding "updated" message stays false — and the stale record then passes committed-versus-git checks, because the file *is* committed; it is simply not current. This is an unverified success claim about the agent's own action, a class nothing else in the system checks.

The helper refuses, without writing, on: absent anchor, anchor matching a different count than declared, replacement leaving the file byte-identical, result exceeding a stated line budget, symlink target. It writes atomically and re-reads the file to confirm the change reached disk. No flag makes a missing anchor succeed; `--dry-run` still refuses a bad one.

`insert-before` exists because prepending a section via raw `replace` requires restating the anchor inside the replacement — and forgetting to do so deletes the heading you anchored on while still reporting success. That happened while writing this changelog entry, so the operation removes the footgun by construction.

`SKILL.md` gains a mandatory section with the two rules the tool cannot enforce alone: re-read a record before editing when another agent may have touched it, and never report success you did not verify.

## Testing

- 20 new tests in `test_context_edit.py`, including the routed-defect regression (missing anchor refuses, file untouched, CLI exits non-zero and prints no success line).
- Verified end-to-end against a copy of the real stale record: the round-1 anchor that silently no-opped is now refused with the file unchanged.
- Full AGENTS.md suite green: source 195/195, instructions 2/2, conformance 144, coordination 39, context-lifecycle 58, plus rituals/guard/hooks, onboarding, transcripts, installer, compileall, inbox batteries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)