### PR TITLE
Durable header-currency checking

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.45.0",
+  "version": "4.46.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.45.0",
+  "version": "4.46.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.46.0] - 2026-08-23
+
+### Added
+
+- **`synthesis-context-lifecycle` v1.10.0 — durable header-currency checking.**
+  The prior currency control missed the defect it was built for, twice, and
+  this release replaces it with checked semantics rather than another patch.
+  New `scripts/context_currency.py` judges each `CONTEXT.md` header field
+  separately against the session log: a field's identity is its FIRST ordinal
+  per family (round/wave/phase/step/part), the log's current value is the max
+  across newest-date entries' identities, and fields are never unioned — the
+  failure in the shipped check was exactly that a fresh `Phase` masked a stale
+  `Last session` under a shared `max()`. Families never compare across each
+  other, and coverage limits (unparseable headers, missing logs) are reported
+  as what the check cannot see, never as staleness.
+- **The context doctor now fails on stale headers.** `context_doctor` v1.4.0
+  runs the currency check as a required `header-currency` defect, so semantic
+  staleness surfaces where every session already looks instead of in an
+  opt-in script. "Records agree with git" means committed; this check is what
+  makes it also mean current.
+- **`context_edit.py` refuses to create the defect at write time.** An edit
+  that leaves `Phase` ahead of `Last session` in the same ordinal family is
+  refused with the fields named; `--allow-header-lag` records an explicit
+  override. `Last session` may lead `Phase` (the normal two-call transition,
+  noted in output), unrelated edits on a pre-existing incoherent header warn
+  rather than block, and the read-time doctor catches whatever is left
+  lagging.
+- **Every regression fixture derives from a real defect.** The four live
+  instances — the round-10/11 union-masking miss, the round-2/3 same-day
+  miss, and the two cross-day stale records — are encoded verbatim in
+  `test_context_currency.py`, applying the artifact-derived-evidence rule to
+  this tooling itself.
 ## [4.45.0] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Stale headers are now doctor defects (August 2026).** Release **4.46.0**
+adds per-field header-currency checking to `synthesis-context-lifecycle`: the
+context doctor fails when a `CONTEXT.md` header describes an older state than
+the project's own session log — including same-day staleness, where date
+comparison sees nothing — and `context_edit.py` refuses to create that state
+at write time. Fields are judged separately, so a fresh `Phase` can no longer
+mask a stale `Last session`. Every regression fixture derives from a real
+defect. See the [4.46.0 release notes](CHANGELOG.md).
+
 **Durable-context edits fail closed (August 2026).** Release **4.45.0** adds
 `context_edit.py` to `synthesis-context-lifecycle`. A hand-rolled
 `str.replace()` against a project record asserts nothing — when another agent

--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.9.0"
+  version: "1.10.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -424,6 +424,16 @@ the target is a symlink. It writes atomically and then re-reads the file to
 confirm the change is actually on disk. There is no flag that makes a missing
 anchor succeed. `--dry-run` previews without writing and still refuses a bad
 anchor. Import `replace_once` or `set_field` to use it from Python.
+
+The helper also refuses to *create* a stale header: an edit that leaves
+`**Phase:**` ahead of `**Last session:**` in the same ordinal family (round,
+wave, phase, step, part) is refused with both fields named —
+`--allow-header-lag` records an explicit override. Update `Last session`
+first or in the same change; it may lead `Phase` mid-update. Independently,
+the context doctor fails a project whose header describes an older state than
+its own session log (`header-currency`), including same-day staleness where
+date comparison sees nothing. Each field is judged separately, so a fresh
+`Phase` cannot mask a stale `Last session`.
 
 Two companion rules, because the tool cannot enforce them alone:
 

--- a/skills/synthesis-context-lifecycle/scripts/context_currency.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_currency.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Semantic currency of durable-context headers, checked per field.
+
+A `CONTEXT.md` header is a cache over the session log: `**Last session:**`
+points at the newest logged session and `**Phase:**` describes the state it
+left. The log is append-only truth. A header field that describes an older
+state than the log's newest entry is stale even when every file is committed —
+"records agree with git" means committed, not current.
+
+This module exists because two prior implementations of that idea failed in
+ways worth encoding permanently:
+
+1. **Date comparison alone cannot catch same-day staleness.** Multi-round
+   cross-agent work routinely logs many sessions on one calendar day, so a
+   stale header and the newest entry share a date.
+2. **Aggregating independently maintained fields fails open.** The first
+   same-day check concatenated `Last session` and `Phase` and compared
+   `max()` over the union, so updating either field satisfied the check for
+   both, and a fresh Phase masked a stale Last session. Fields that are
+   maintained separately must be judged separately.
+3. **Free prose mentions older ordinals.** A heading like
+   "(round 11 — round 10 refuted)" mentions two rounds. Taking `max()` over
+   every number in a blob of prose is guesswork. The convention this module
+   relies on instead: a heading or field leads with its own identity, so the
+   FIRST ordinal of each family in a given field is that field's identity,
+   and later mentions are commentary.
+
+Semantics
+---------
+
+- Ordinals are `(family, number)` pairs — "round 11", "wave-3", "Phase 2" —
+  for a small closed set of families. Families never compare across each
+  other.
+- A field's identity per family is the FIRST number of that family in the
+  field.
+- The log's current number per family is the MAX across the newest-date
+  entries' identities — max over entries, first within each entry — so entry
+  order and trailing mentions cannot drag it down.
+- Each header field is compared independently. A field that lags the log in
+  any shared family is reported by name. There is no union and no masking.
+
+Findings (`kind` values)
+------------------------
+
+  header-behind-log      Last session's date is older than the newest log date
+  header-field-stale     a named header field's ordinal lags the log's current
+                         ordinal in the same family
+  header-ahead-of-log    Last session's date is newer than any logged entry
+  header-unparseable     no `**Last session:** YYYY-MM-DD` could be read
+  log-missing            no dated session entries exist
+
+`header-unparseable` and `log-missing` are coverage limits, not staleness:
+completed and superseded records legitimately use other conventions. Report
+them as what the check could not see, never as a defect count.
+
+CLI
+---
+
+    context_currency.py ROOT [ROOT ...] [--json] [--quiet]
+
+Each ROOT is a directory whose immediate children are project directories.
+`--quiet` restricts output to staleness findings (header-behind-log,
+header-field-stale). Exit codes: 0 no findings, 1 findings, 2 usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+HEADER_DATE = re.compile(
+    r"^\*\*Last session:\*\*\s*(\d{4}-\d{2}-\d{2})", re.MULTILINE
+)
+FIELD_LINE = re.compile(r"^\*\*(Phase|Last session):\*\*([^\n]*)", re.MULTILINE)
+# Session logs use both `##` and `###` for dated entries.
+LOG_ENTRY = re.compile(r"^#{2,3}\s+(\d{4}-\d{2}-\d{2})([^\n]*)", re.MULTILINE)
+# Closed family set; `\b` keeps "background" and "rounds" from matching, the
+# `[\s-]*` accepts "round 2", "round-2", and "round  2".
+ORDINAL = re.compile(r"\b(round|wave|phase|step|part)[\s-]*(\d+)\b", re.IGNORECASE)
+
+STALENESS_KINDS = {"header-behind-log", "header-field-stale"}
+
+
+def first_ordinals(text: str) -> dict[str, int]:
+    """The FIRST number per family in `text` — its identity, not its max."""
+    found: dict[str, int] = {}
+    for match in ORDINAL.finditer(text):
+        family = match.group(1).lower()
+        if family not in found:
+            found[family] = int(match.group(2))
+    return found
+
+
+def header_fields(text: str) -> dict[str, str]:
+    """The Phase and Last-session field values, by field name."""
+    return {m.group(1): m.group(2).strip() for m in FIELD_LINE.finditer(text)}
+
+
+def header_incoherence(text: str) -> list[tuple[str, int, int]]:
+    """Same-family disagreements between Phase and Last session.
+
+    Returns (family, phase_number, last_session_number) triples where the two
+    header fields disagree. Any disagreement is incoherent: the fields
+    describe one state and must move together.
+    """
+    fields = header_fields(text)
+    phase = first_ordinals(fields.get("Phase", ""))
+    last = first_ordinals(fields.get("Last session", ""))
+    return [
+        (family, phase[family], last[family])
+        for family in sorted(phase.keys() & last.keys())
+        if phase[family] != last[family]
+    ]
+
+
+def log_state(project: Path) -> tuple[str | None, str | None, dict[str, int]]:
+    """(newest date, file, current ordinals) from the session log.
+
+    Current ordinals take the max across every newest-date entry of that
+    entry's first-per-family ordinal, so neither entry order nor trailing
+    mentions of older ordinals can understate the log.
+    """
+    sessions = project / "sessions"
+    if not sessions.is_dir():
+        return None, None, {}
+    entries: list[tuple[str, str, str]] = []  # (date, file, descriptor)
+    for log in sorted(sessions.glob("*.md")):
+        try:
+            text = log.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for date, descriptor in LOG_ENTRY.findall(text):
+            entries.append((date, log.name, descriptor))
+    if not entries:
+        return None, None, {}
+    newest = max(entry[0] for entry in entries)
+    current: dict[str, int] = {}
+    newest_file = None
+    for date, name, descriptor in entries:
+        if date != newest:
+            continue
+        newest_file = name
+        for family, number in first_ordinals(descriptor).items():
+            if number > current.get(family, -1):
+                current[family] = number
+    return newest, newest_file, current
+
+
+def audit_project(project: Path) -> list[dict]:
+    """Every currency finding for one project record."""
+    context = project / "CONTEXT.md"
+    if not context.is_file():
+        return []
+    try:
+        text = context.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return [{"project": str(project), "kind": "header-unparseable",
+                 "detail": f"unreadable: {exc}"}]
+
+    date_match = HEADER_DATE.search(text)
+    log_date, log_file, log_current = log_state(project)
+
+    if not date_match:
+        return [{"project": str(project), "kind": "header-unparseable",
+                 "detail": "no '**Last session:** YYYY-MM-DD' header found",
+                 "log_date": log_date}]
+    header_date = date_match.group(1)
+    if log_date is None:
+        return [{"project": str(project), "kind": "log-missing",
+                 "detail": "no dated session entries under sessions/",
+                 "header_date": header_date}]
+
+    findings: list[dict] = []
+    if log_date > header_date:
+        findings.append({
+            "project": str(project), "kind": "header-behind-log",
+            "detail": f"header says {header_date}; {log_file} records {log_date}",
+            "header_date": header_date, "log_date": log_date,
+        })
+    elif header_date > log_date:
+        findings.append({
+            "project": str(project), "kind": "header-ahead-of-log",
+            "detail": f"header says {header_date}; newest log entry is "
+                      f"{log_date} ({log_file})",
+            "header_date": header_date, "log_date": log_date,
+        })
+
+    # Per-field ordinal currency — each field judged alone, never a union.
+    for field_name, value in sorted(header_fields(text).items()):
+        for family, number in sorted(first_ordinals(value).items()):
+            current = log_current.get(family)
+            if current is not None and number < current:
+                findings.append({
+                    "project": str(project), "kind": "header-field-stale",
+                    "field": field_name, "family": family,
+                    "detail": f"**{field_name}:** says {family} {number}; "
+                              f"{log_file} records {family} {current} "
+                              f"(log date {log_date})",
+                    "header_ordinal": number, "log_ordinal": current,
+                })
+    return findings
+
+
+def currency_findings(project: Path) -> list[tuple[str, str]]:
+    """(message, remedy) pairs for staleness findings only — the doctor's view.
+
+    Coverage-limit kinds are excluded here: the doctor's structural checks
+    already govern missing or unconventional records, and this function must
+    add signal only where the evidence is comparable.
+    """
+    remedy = (
+        "update the stale header field with context_edit.py set-field; it "
+        "refuses an edit that leaves Phase and Last session disagreeing"
+    )
+    return [
+        (finding["detail"], remedy)
+        for finding in audit_project(project)
+        if finding["kind"] in STALENESS_KINDS
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("roots", nargs="+", type=Path)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--quiet", action="store_true",
+                        help="report only staleness findings")
+    args = parser.parse_args()
+
+    findings: list[dict] = []
+    scanned = 0
+    for root in args.roots:
+        root = root.expanduser()
+        if not root.is_dir():
+            print(f"not a directory: {root}", file=sys.stderr)
+            return 2
+        for project in sorted(p for p in root.iterdir() if p.is_dir()):
+            if not (project / "CONTEXT.md").is_file():
+                continue
+            scanned += 1
+            findings.extend(audit_project(project))
+
+    if args.quiet:
+        findings = [f for f in findings if f["kind"] in STALENESS_KINDS]
+
+    if args.json:
+        print(json.dumps({"scanned": scanned, "findings": findings}, indent=2))
+    else:
+        by_kind: dict[str, int] = {}
+        for finding in findings:
+            by_kind[finding["kind"]] = by_kind.get(finding["kind"], 0) + 1
+        for finding in findings:
+            print(f"{finding['kind']}: {finding['project']}")
+            print(f"    {finding['detail']}")
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(by_kind.items()))
+        print(f"\nscanned {scanned} project record(s); {len(findings)} "
+              f"finding(s){': ' + summary if summary else ''}")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/synthesis-context-lifecycle/scripts/context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_doctor.py
@@ -59,7 +59,11 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
 
-DOCTOR_VERSION = "1.3.0"
+# Sibling module in this scripts directory; ships with the skill. If it is
+# missing the doctor must fail loudly rather than silently skip a check.
+import context_currency
+
+DOCTOR_VERSION = "1.4.0"
 
 # Budgets from the tiered context architecture.
 CONTEXT_BUDGET_ACTIVE = 150
@@ -682,6 +686,7 @@ CHECKS = [
     "completed-date",
     "last-session-freshness",
     "context-header-freshness",
+    "header-currency",
     "uncommitted-context",
     "untracked-context",
     "unpushed-context",
@@ -852,6 +857,16 @@ def audit_project(
                 f"commit is {newest} — working memory is behind the work",
                 "refresh CONTEXT.md and its Last session header",
             )
+
+    # --- header currency ----------------------------------------------------
+    # "Records agree with git" means committed, not current: a header can
+    # describe an older state than the session log records — same day, so the
+    # date checks above see nothing — while every file is committed. Each
+    # header field is judged separately against the log's newest entries; a
+    # union over fields would let a fresh Phase mask a stale Last session,
+    # which is the exact failure that put this check here.
+    for message, remedy in context_currency.currency_findings(project_path):
+        audit.add("header-currency", "defect", message, remedy)
 
     # --- durability ---------------------------------------------------------
     dirty = uncommitted(repo_root, project_path)

--- a/skills/synthesis-context-lifecycle/scripts/context_edit.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_edit.py
@@ -54,9 +54,71 @@ import sys
 import tempfile
 from pathlib import Path
 
+import context_currency
+
 
 class ContextEditError(Exception):
     """A durable-context edit was refused. Nothing was written."""
+
+
+def _coherence_gate(
+    path: Path,
+    original: str,
+    edited: str,
+    allow_header_lag: bool,
+) -> str | None:
+    """Refuse an edit that creates or changes an incoherent CONTEXT.md header.
+
+    Phase and Last session describe one state and must move together. A
+    round-11 Phase over a round-10 Last session is exactly the stale-header
+    defect this tooling exists to prevent, so an edit that produces that pair
+    is refused at write time — the file is never wrong, rather than detected
+    wrong later.
+
+    Pre-existing incoherence that this edit does not touch is warned about,
+    not blocked: an unrelated body edit must not be hostage to an earlier
+    session's defect. Returns a warning string in that case, None otherwise.
+    """
+    if path.name != "CONTEXT.md":
+        return None
+    after = context_currency.header_incoherence(edited)
+    if not after:
+        return None
+    # Only Phase-ahead-of-Last-session is the defect shape: a described new
+    # state over a stale log pointer. Last session leading Phase is the normal
+    # transition while a two-call update is in flight, and the doctor's
+    # read-time field check catches a Phase left behind. A symmetric refusal
+    # would deadlock every legitimate two-call header update.
+    leading = [(f, p, l) for f, p, l in after if p > l]
+    trailing = [(f, p, l) for f, p, l in after if l > p]
+    notes: list[str] = []
+    if trailing:
+        notes.append(
+            "note: Last session now leads Phase ("
+            + "; ".join(f"{f} {l} vs {p}" for f, p, l in trailing)
+            + ") — finish by updating Phase"
+        )
+    if leading:
+        described = "; ".join(
+            f"**Phase:** says {family} {phase_n} while **Last session:** "
+            f"still says {family} {last_n}"
+            for family, phase_n, last_n in leading
+        )
+        before = context_currency.header_incoherence(original)
+        if [x for x in before if x[1] > x[2]] == leading:
+            notes.append(
+                f"warning: pre-existing header incoherence left untouched "
+                f"({described}); repair it with set-field"
+            )
+        elif allow_header_lag:
+            notes.append(f"override --allow-header-lag recorded ({described})")
+        else:
+            raise ContextEditError(
+                f"edit would leave the header incoherent: {described}.\n"
+                "Update Last session in the same change (or first), or pass "
+                "--allow-header-lag to record an explicit override."
+            )
+    return "; ".join(notes) if notes else None
 
 
 def _read(path: Path) -> str:
@@ -140,12 +202,14 @@ def replace_once(
     count: int = 1,
     max_lines: int | None = None,
     dry_run: bool = False,
+    allow_header_lag: bool = False,
 ) -> dict:
     """Apply one verified replacement to a durable context file."""
     path = Path(path)
     original = _read(path)
     edited = apply_replacement(original, anchor, replacement, count=count)
     lines = _check_budget(edited, max_lines, path)
+    note = _coherence_gate(path, original, edited, allow_header_lag)
 
     if dry_run:
         return {
@@ -154,6 +218,7 @@ def replace_once(
             "dry_run": True,
             "replacements": count,
             "lines": lines,
+            "note": note,
         }
 
     _atomic_write(path, edited)
@@ -177,6 +242,7 @@ def replace_once(
         "dry_run": False,
         "replacements": count,
         "lines": len(written.splitlines()),
+        "note": note,
     }
 
 
@@ -190,6 +256,7 @@ def set_field(
     *,
     max_lines: int | None = None,
     dry_run: bool = False,
+    allow_header_lag: bool = False,
 ) -> dict:
     """Replace a `**Field:** ...` header line, verifying it existed."""
     path = Path(path)
@@ -212,6 +279,7 @@ def set_field(
         replacement=f"**{field}:** {value}",
         max_lines=max_lines,
         dry_run=dry_run,
+        allow_header_lag=allow_header_lag,
     )
 
 
@@ -222,6 +290,7 @@ def insert_before(
     *,
     max_lines: int | None = None,
     dry_run: bool = False,
+    allow_header_lag: bool = False,
 ) -> dict:
     """Insert text immediately before an anchor, preserving the anchor.
 
@@ -237,6 +306,7 @@ def insert_before(
         replacement=f"{text}{anchor}",
         max_lines=max_lines,
         dry_run=dry_run,
+        allow_header_lag=allow_header_lag,
     )
 
 
@@ -252,6 +322,12 @@ def main(argv: list[str] | None = None) -> int:
     common.add_argument("--file", required=True, type=Path)
     common.add_argument("--max-lines", type=int, default=None)
     common.add_argument("--dry-run", action="store_true")
+    common.add_argument(
+        "--allow-header-lag",
+        action="store_true",
+        help="record an explicit override instead of refusing an edit that "
+        "leaves Phase ahead of Last session",
+    )
 
     replace = sub.add_parser("replace", parents=[common])
     replace.add_argument("--anchor", required=True)
@@ -276,6 +352,7 @@ def main(argv: list[str] | None = None) -> int:
                 text=_value(args.text),
                 max_lines=args.max_lines,
                 dry_run=args.dry_run,
+                allow_header_lag=args.allow_header_lag,
             )
         elif args.command == "replace":
             result = replace_once(
@@ -285,6 +362,7 @@ def main(argv: list[str] | None = None) -> int:
                 count=args.count,
                 max_lines=args.max_lines,
                 dry_run=args.dry_run,
+                allow_header_lag=args.allow_header_lag,
             )
         else:
             result = set_field(
@@ -293,15 +371,17 @@ def main(argv: list[str] | None = None) -> int:
                 value=_value(args.value),
                 max_lines=args.max_lines,
                 dry_run=args.dry_run,
+                allow_header_lag=args.allow_header_lag,
             )
     except ContextEditError as exc:
         print(f"context-edit refused: {exc}", file=sys.stderr)
         return 1
 
     verb = "would change" if result["dry_run"] else "changed"
+    suffix = f" [{result['note']}]" if result.get("note") else ""
     print(
         f"{verb} {result['path']}: {result['replacements']} replacement(s), "
-        f"{result['lines']} lines"
+        f"{result['lines']} lines{suffix}"
     )
     return 0
 

--- a/skills/synthesis-context-lifecycle/scripts/test_context_currency.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_currency.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Tests for header currency — fixtures derived from the four real defects.
+
+The control this module replaces missed the defect it was built for, twice,
+because it had no test derived from a real instance. Every regression fixture
+here reproduces an actual on-disk failure, verbatim in the parts that matter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from context_currency import (
+    audit_project,
+    currency_findings,
+    first_ordinals,
+    header_incoherence,
+    log_state,
+)
+
+
+def project(tmp_path: Path, context: str, log: str | None) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "CONTEXT.md").write_text(context, encoding="utf-8")
+    if log is not None:
+        (root / "sessions").mkdir()
+        (root / "sessions" / "2026-08.md").write_text(log, encoding="utf-8")
+    return root
+
+
+def kinds(findings: list[dict]) -> list[str]:
+    return sorted(f["kind"] for f in findings)
+
+
+# --- Real defect 1: round-10/11 — the union-max masking miss ---------------
+# Phase was fresh (Round 11), Last session stale (round 10), and the shipped
+# check unioned both fields under max(), so 11 masked 10 and nothing fired.
+
+ROUND_10_11_CONTEXT = """# Publish Article Backlog — Context
+
+**Phase:** Round 11 — 5 article holds and 2 control defects closed; convergence call was wrong
+**Status:** Active
+**Last session:** 2026-08-23 (Codex adversarial review round 10)
+"""
+
+ROUND_10_11_LOG = """# Session Archive
+
+### 2026-08-23 (principal decisions, and the authorship reversal)
+
+body
+
+### 2026-08-23 (Codex adversarial review round 10)
+
+body
+
+### 2026-08-23 (round 11, Claude — round 10 refuted my convergence call)
+
+body
+"""
+
+
+def test_real_defect_round_10_11_stale_last_session_is_not_masked(
+    tmp_path: Path,
+) -> None:
+    root = project(tmp_path, ROUND_10_11_CONTEXT, ROUND_10_11_LOG)
+
+    findings = audit_project(root)
+
+    stale = [f for f in findings if f["kind"] == "header-field-stale"]
+    assert len(stale) == 1
+    assert stale[0]["field"] == "Last session"
+    assert stale[0]["header_ordinal"] == 10 and stale[0]["log_ordinal"] == 11
+
+
+def test_real_defect_round_10_11_log_current_ignores_trailing_mention(
+    tmp_path: Path,
+) -> None:
+    """'round 11 ... round 10 refuted' must read as round 11, not round 10."""
+    root = project(tmp_path, ROUND_10_11_CONTEXT, ROUND_10_11_LOG)
+
+    _, _, current = log_state(root)
+
+    assert current == {"round": 11}
+
+
+def test_real_defect_round_10_11_reaches_the_doctor_view(tmp_path: Path) -> None:
+    root = project(tmp_path, ROUND_10_11_CONTEXT, ROUND_10_11_LOG)
+
+    assert len(currency_findings(root)) == 1
+
+
+# --- Real defect 2: round-2/3 — both header fields lag the log --------------
+# The original same-day miss: dates all equal, ordinals live in prose. Note
+# "round-2" is hyphenated on disk; the matcher must accept it.
+
+ROUND_2_3_CONTEXT = """# Publish Article Backlog — Context
+
+**Phase:** Adversarial round 2 complete — challenges adjudicated, repairs attacked
+**Status:** Active
+**Last session:** 2026-08-23 (Codex round-2 adjudication and repair attack)
+"""
+
+ROUND_2_3_LOG = """# Session Archive
+
+### 2026-08-23 (round 2 adjudication, Codex)
+
+body
+
+### 2026-08-23 (round 3, Claude — adversarial cross-agent review)
+
+body
+"""
+
+
+def test_real_defect_round_2_3_flags_both_stale_fields(tmp_path: Path) -> None:
+    root = project(tmp_path, ROUND_2_3_CONTEXT, ROUND_2_3_LOG)
+
+    stale = [f for f in audit_project(root) if f["kind"] == "header-field-stale"]
+
+    assert sorted(f["field"] for f in stale) == ["Last session", "Phase"]
+    assert all(f["header_ordinal"] == 2 and f["log_ordinal"] == 3 for f in stale)
+
+
+# --- Real defects 3 and 4: cross-day staleness (rajiv-operations, ----------
+# synthesis-console-build). Dates differ; the date check must fire.
+
+
+def test_real_defect_header_date_behind_log(tmp_path: Path) -> None:
+    root = project(
+        tmp_path,
+        "# P\n\n**Phase:** steady\n**Last session:** 2026-08-19\n",
+        "# S\n\n## 2026-08-20: ritual close\n\nbody\n",
+    )
+
+    findings = audit_project(root)
+
+    assert kinds(findings) == ["header-behind-log"]
+    assert "2026-08-19" in findings[0]["detail"]
+    assert "2026-08-20" in findings[0]["detail"]
+
+
+def test_real_defect_month_boundary_behind(tmp_path: Path) -> None:
+    root = project(
+        tmp_path,
+        "# P\n\n**Last session:** 2026-07-07\n",
+        "# S\n\n## 2026-07-08: build session\n\nbody\n",
+    )
+
+    assert kinds(audit_project(root)) == ["header-behind-log"]
+
+
+# --- Coherent and boundary cases -------------------------------------------
+
+
+def test_coherent_same_day_record_is_clean(tmp_path: Path) -> None:
+    root = project(
+        tmp_path,
+        "# P\n\n**Phase:** Round 11 holding\n"
+        "**Last session:** 2026-08-23 (round 11, Claude)\n",
+        ROUND_10_11_LOG,
+    )
+
+    assert audit_project(root) == []
+
+
+def test_header_ahead_of_log_is_not_stale(tmp_path: Path) -> None:
+    root = project(
+        tmp_path,
+        "# P\n\n**Phase:** Round 12 opening\n"
+        "**Last session:** 2026-08-24 (round 12)\n",
+        ROUND_10_11_LOG,
+    )
+
+    findings = audit_project(root)
+
+    assert kinds(findings) == ["header-ahead-of-log"]
+    assert currency_findings(root) == []
+
+
+def test_records_without_ordinals_compare_by_date_only(tmp_path: Path) -> None:
+    root = project(
+        tmp_path,
+        "# P\n\n**Phase:** drafting\n**Last session:** 2026-08-23\n",
+        "# S\n\n## 2026-08-23: drafting continued\n\nbody\n",
+    )
+
+    assert audit_project(root) == []
+
+
+def test_families_never_compare_across_each_other(tmp_path: Path) -> None:
+    """Phase 2 of a project is not older than round 3 of a review."""
+    root = project(
+        tmp_path,
+        "# P\n\n**Phase:** phase 2 rollout\n**Last session:** 2026-08-23\n",
+        "# S\n\n## 2026-08-23 (round 3 review)\n\nbody\n",
+    )
+
+    assert audit_project(root) == []
+
+
+def test_wave_family_is_covered(tmp_path: Path) -> None:
+    root = project(
+        tmp_path,
+        "# P\n\n**Phase:** Wave 9 closing\n"
+        "**Last session:** 2026-08-23 (wave 9)\n",
+        "# S\n\n## 2026-08-23 (wave 10 closeout)\n\nbody\n",
+    )
+
+    stale = [f for f in audit_project(root) if f["kind"] == "header-field-stale"]
+
+    assert sorted(f["field"] for f in stale) == ["Last session", "Phase"]
+
+
+def test_out_of_order_same_date_entries_still_yield_max(tmp_path: Path) -> None:
+    """Log current is max over newest-date entries, not the last one listed."""
+    log = (
+        "# S\n\n### 2026-08-23 (round 11, Claude)\n\nbody\n\n"
+        "### 2026-08-23 (round 10, Codex)\n\nbody\n"
+    )
+    root = project(tmp_path, ROUND_10_11_CONTEXT, log)
+
+    _, _, current = log_state(root)
+
+    assert current == {"round": 11}
+
+
+# --- Coverage-limit classes stay honest ------------------------------------
+
+
+def test_unparseable_header_is_a_coverage_limit_not_staleness(
+    tmp_path: Path,
+) -> None:
+    root = project(
+        tmp_path,
+        "# P\n\n**Status:** Superseded\n",
+        "# S\n\n## 2026-08-23: entry\n\nbody\n",
+    )
+
+    findings = audit_project(root)
+
+    assert kinds(findings) == ["header-unparseable"]
+    assert currency_findings(root) == []
+
+
+def test_missing_log_is_a_coverage_limit_not_staleness(tmp_path: Path) -> None:
+    root = project(tmp_path, "# P\n\n**Last session:** 2026-08-23\n", None)
+
+    assert kinds(audit_project(root)) == ["log-missing"]
+    assert currency_findings(root) == []
+
+
+# --- Ordinal extraction discipline -----------------------------------------
+
+
+def test_first_ordinal_is_identity_not_max() -> None:
+    assert first_ordinals("(round 11, Claude — round 10 refuted)") == {"round": 11}
+
+
+def test_hyphenated_and_cased_ordinals_match() -> None:
+    assert first_ordinals("Codex round-2 adjudication") == {"round": 2}
+    assert first_ordinals("Round 11 — closed") == {"round": 11}
+
+
+def test_embedded_words_and_plurals_do_not_match() -> None:
+    assert first_ordinals("background 3 processing") == {}
+    assert first_ordinals("rounds 2-3 registered") == {}
+
+
+# --- Intra-header coherence (the write-time guard's primitive) --------------
+
+
+def test_header_incoherence_names_the_disagreeing_family() -> None:
+    assert header_incoherence(ROUND_10_11_CONTEXT) == [("round", 11, 10)]
+
+
+def test_coherent_header_reports_nothing() -> None:
+    text = "**Phase:** Round 11 done\n**Last session:** 2026-08-23 (round 11)\n"
+    assert header_incoherence(text) == []
+
+
+def test_header_incoherence_ignores_disjoint_families() -> None:
+    text = "**Phase:** phase 2 rollout\n**Last session:** 2026-08-23 (round 9)\n"
+    assert header_incoherence(text) == []

--- a/skills/synthesis-context-lifecycle/scripts/test_context_edit.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_edit.py
@@ -229,6 +229,109 @@ def test_failed_edit_leaves_no_temporary_files(tmp_path: Path) -> None:
     assert sorted(p.name for p in tmp_path.iterdir()) == ["CONTEXT.md"]
 
 
+INCOHERENT = """# P
+
+**Phase:** Round 10 review complete
+**Status:** Active
+**Last session:** 2026-08-23 (round 10, Codex)
+
+## Body
+"""
+
+
+def test_phase_update_leaving_last_session_behind_is_refused(
+    tmp_path: Path,
+) -> None:
+    """The round-10/11 defect, blocked at write time: a fresh Phase over a
+    stale Last session must never reach disk silently."""
+    path = record(tmp_path, INCOHERENT)
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(ContextEditError, match="header incoherent"):
+        set_field(path, field="Phase", value="Round 11 — convergence call was wrong")
+
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_last_session_may_lead_phase_with_a_note(tmp_path: Path) -> None:
+    """The legitimate two-call transition: Last session updates first."""
+    path = record(tmp_path, INCOHERENT)
+
+    result = set_field(
+        path, field="Last session", value="2026-08-23 (round 11, Claude)"
+    )
+
+    assert "finish by updating Phase" in (result["note"] or "")
+
+    finish = set_field(path, field="Phase", value="Round 11 in review")
+
+    assert finish["note"] is None
+    text = path.read_text(encoding="utf-8")
+    assert "Round 11 in review" in text and "round 11, Claude" in text
+
+
+def test_allow_header_lag_records_the_override(tmp_path: Path) -> None:
+    path = record(tmp_path, INCOHERENT)
+
+    result = set_field(
+        path,
+        field="Phase",
+        value="Round 11 staged",
+        allow_header_lag=True,
+    )
+
+    assert "override --allow-header-lag recorded" in (result["note"] or "")
+
+
+def test_unrelated_edit_on_preexisting_incoherence_warns_not_blocks(
+    tmp_path: Path,
+) -> None:
+    stale = INCOHERENT.replace(
+        "**Phase:** Round 10 review complete", "**Phase:** Round 11 staged"
+    )
+    path = record(tmp_path, stale)
+
+    result = replace_once(path, anchor="## Body", replacement="## Body\n\nmore")
+
+    assert "pre-existing header incoherence" in (result["note"] or "")
+    assert "more" in path.read_text(encoding="utf-8")
+
+
+def test_non_context_files_are_not_gated(tmp_path: Path) -> None:
+    path = tmp_path / "REFERENCE.md"
+    path.write_text(
+        "**Phase:** round 11\n**Last session:** 2026-08-23 (round 10)\n",
+        encoding="utf-8",
+    )
+
+    result = replace_once(path, anchor="round 11", replacement="round 12")
+
+    assert result["note"] is None
+
+
+def test_cli_refuses_the_defect_state_with_nonzero_exit(
+    tmp_path: Path, capsys
+) -> None:
+    path = record(tmp_path, INCOHERENT)
+
+    code = main(
+        [
+            "set-field",
+            "--file",
+            str(path),
+            "--field",
+            "Phase",
+            "--value",
+            "Round 11 closed",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert "header incoherent" in captured.err
+
+
 def test_cli_success_reports_line_count(tmp_path: Path, capsys) -> None:
     path = record(tmp_path)
 


### PR DESCRIPTION
## Summary

Replaces the failed currency control with checked semantics, per the escalated defect: a stale `Last session` field was masked by a fresh `Phase` field because the prior check unioned both under `max()`.

- `context_currency.py`: per-field, per-family, first-ordinal semantics. Fields judged separately (no union, no masking); a field's identity is its first ordinal per family; the log's current value is max across newest-date entries' identities, so trailing mentions ('round 11 — round 10 refuted') cannot understate the log. Families never cross-compare. Coverage limits reported as coverage, never staleness.
- `context_doctor` v1.4.0: required `header-currency` defect — semantic staleness now surfaces where every session looks, not in an opt-in script.
- `context_edit.py`: refuses at write time an edit leaving Phase ahead of Last session (the defect direction); `--allow-header-lag` records an explicit override. Last session may lead Phase — the normal two-call transition — so the gate cannot deadlock legitimate updates; the doctor catches anything left lagging.
- Regression fixtures derive from all four real defects, verbatim: the round-10/11 masking miss, the round-2/3 same-day miss, and both cross-day stale records.

## Testing

- 84 context-lifecycle tests (20 currency, 27 edit incl. 7 new gate tests, doctor suite with the new check).
- Live proof: the new doctor FAILs the actual stale record naming the field ('**Last session:** says round 10; 2026-08.md records round 11'); the repair path flows through the write-time gate.
- Full AGENTS.md suite green (source 195/195, conformance 144, coordination 39, and all other batteries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)