### PR TITLE
Body currency: as-of markers, write-time gate, honest completion signal

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.46.0",
+  "version": "4.47.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.46.0",
+  "version": "4.47.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.47.0] - 2026-08-24
+
+### Added
+
+- **`synthesis-context-lifecycle` v1.11.0 — body currency.** Third occurrence
+  of the stale-record defect, and the diagnosis finally names the design
+  flaw: the prior fixes addressed *header* currency, while the defect moved
+  to the *body* — `Current State` and `What's Next` kept routing agents to
+  superseded work under a fully current header, which is a stronger false
+  receipt than an obviously stale file. Worse, the edit helper had
+  mechanized the easy half of the record update and printed unqualified
+  success for it, manufacturing a completion signal for partial work.
+
+  Operational sections now end with an as-of marker —
+  `*State as of: 2026-08-24 (round 14)*` — which converts prose currency
+  into the per-field, first-ordinal comparison the header already gets:
+
+  - the context doctor (v1.5.0) fails a section whose marker lags the
+    session log (`body-currency` defect) and warns when an ordinal-paced
+    record carries no markers at all — unverifiable is reported as
+    unverifiable, never as clean;
+  - `context_edit.py` refuses a header advance that leaves a marker behind
+    (`--allow-stale-body` records an explicit override) — the control that
+    would have interrupted all three real occurrences, which each advanced
+    the header and stopped;
+  - advancing a marker while its section's prose is byte-identical requires
+    `--state-reviewed`, recording the assertion that the section was re-read
+    and still holds, so the marker cannot be bumped as mechanically as the
+    header was;
+  - every gated edit's success line now names the body state, because a
+    completion signal must say what it did not verify.
+
+  Regression fixtures derive from all three real occurrences, including the
+  third encoded verbatim from the live record in both its literal markerless
+  form (must surface as unverifiable) and its marked form (must be a
+  staleness defect while every header check passes).
 ## [4.46.0] - 2026-08-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Body currency: stale prose is now checkable (August 2026).** Release
+**4.47.0** extends durable-context currency from headers to the operational
+body. `Current State` and `What's Next` end with an as-of marker that the
+doctor compares against the session log, `context_edit.py` refuses a header
+advance that leaves a marker behind, and advancing a marker without changing
+the prose requires a recorded review assertion. Success output always names
+the body state — a completion signal that says less than it verified
+manufactures completion for partial work. See the
+[4.47.0 release notes](CHANGELOG.md).
+
 **Stale headers are now doctor defects (August 2026).** Release **4.46.0**
 adds per-field header-currency checking to `synthesis-context-lifecycle`: the
 context doctor fails when a `CONTEXT.md` header describes an older state than

--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.10.0"
+  version: "1.11.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -117,6 +117,8 @@ For session history: see [sessions/](sessions/)
 
 - **Production:** [version, deployment status]
 - **Blockers:** [if any]
+
+*State as of: YYYY-MM-DD (round N)*  ← as-of marker; see Editing below
 
 ## What's Next — Prioritized
 
@@ -434,6 +436,32 @@ the context doctor fails a project whose header describes an older state than
 its own session log (`header-currency`), including same-day staleness where
 date comparison sees nothing. Each field is judged separately, so a fresh
 `Phase` cannot mask a stale `Last session`.
+
+**Body currency.** Header freshness is necessary, not sufficient: three
+real defects advanced the header while `Current State` kept routing agents to
+superseded work — and a current header above stale operational sections is a
+*stronger* false receipt than an obviously stale file. Operational sections
+(`## Current State`, `## What's Next`) therefore end with an as-of marker:
+
+```markdown
+*State as of: 2026-08-24 (round 14)*
+```
+
+The marker converts prose currency into the structured comparison the header
+already gets. With it in place: the doctor fails a section whose marker lags
+the session log (`body-currency`); `context_edit.py` refuses a header advance
+that leaves a marker behind (`--allow-stale-body` records an override); and
+advancing a marker while its section's prose is byte-identical requires
+`--state-reviewed`, which records the assertion that the section was re-read
+and still holds — a silent bump would recreate the header defect one level
+down. Markerless records are reported as *unverifiable*, never as clean.
+
+The completion signal is deliberately honest: every gated edit's success line
+names the body state (`as-of markers current`, `body lags`, or `body currency
+unverifiable`). A tool that mechanizes the easy half of a task and prints
+unqualified success for it manufactures a completion signal for partial work
+— that mechanism-shaped failure caused all three real occurrences, and the
+signal is the part of this design that addresses it.
 
 Two companion rules, because the tool cannot enforce them alone:
 

--- a/skills/synthesis-context-lifecycle/scripts/context_currency.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_currency.py
@@ -45,6 +45,11 @@ Findings (`kind` values)
   header-behind-log      Last session's date is older than the newest log date
   header-field-stale     a named header field's ordinal lags the log's current
                          ordinal in the same family
+  body-marker-stale      a section's `*State as of: ...*` marker lags the log
+                         by date or by same-family ordinal
+  body-marker-absent     an ordinal-paced record carries no as-of markers, so
+                         its body currency is unverifiable (coverage, not
+                         staleness)
   header-ahead-of-log    Last session's date is newer than any logged entry
   header-unparseable     no `**Last session:** YYYY-MM-DD` could be read
   log-missing            no dated session entries exist
@@ -80,8 +85,19 @@ LOG_ENTRY = re.compile(r"^#{2,3}\s+(\d{4}-\d{2}-\d{2})([^\n]*)", re.MULTILINE)
 # Closed family set; `\b` keeps "background" and "rounds" from matching, the
 # `[\s-]*` accepts "round 2", "round-2", and "round  2".
 ORDINAL = re.compile(r"\b(round|wave|phase|step|part)[\s-]*(\d+)\b", re.IGNORECASE)
+# Body sections that describe operational state end with an emphasis line:
+#   *State as of: 2026-08-24 (round 14)*
+# The marker converts unstructured prose currency into the structured problem
+# this module already solves. Prose without a marker cannot be judged for
+# truth; that absence is itself surfaced, because a current header above stale
+# operational sections is a stronger false receipt than an obviously stale
+# file.
+STATE_AS_OF = re.compile(
+    r"^\*State as of:\s*(\d{4}-\d{2}-\d{2})([^\n*]*)\*\s*$", re.MULTILINE
+)
+SECTION_HEADING = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
 
-STALENESS_KINDS = {"header-behind-log", "header-field-stale"}
+STALENESS_KINDS = {"header-behind-log", "header-field-stale", "body-marker-stale"}
 
 
 def first_ordinals(text: str) -> dict[str, int]:
@@ -114,6 +130,25 @@ def header_incoherence(text: str) -> list[tuple[str, int, int]]:
         for family in sorted(phase.keys() & last.keys())
         if phase[family] != last[family]
     ]
+
+
+def body_markers(text: str) -> list[dict]:
+    """Every `*State as of: ...*` marker, attributed to its section heading."""
+    headings = [(m.start(), m.group(1)) for m in SECTION_HEADING.finditer(text)]
+    markers: list[dict] = []
+    for match in STATE_AS_OF.finditer(text):
+        section = "(top)"
+        for start, title in headings:
+            if start < match.start():
+                section = title
+            else:
+                break
+        markers.append({
+            "section": section,
+            "date": match.group(1),
+            "ordinals": first_ordinals(match.group(2)),
+        })
+    return markers
 
 
 def log_state(project: Path) -> tuple[str | None, str | None, dict[str, int]]:
@@ -201,6 +236,42 @@ def audit_project(project: Path) -> list[dict]:
                               f"(log date {log_date})",
                     "header_ordinal": number, "log_ordinal": current,
                 })
+
+    # Body currency — each as-of marker judged like a header field. Header
+    # freshness is necessary, not sufficient: three real occurrences advanced
+    # the header while the body kept routing agents to superseded work.
+    markers = body_markers(text)
+    for marker in markers:
+        if marker["date"] < log_date:
+            findings.append({
+                "project": str(project), "kind": "body-marker-stale",
+                "section": marker["section"],
+                "detail": f"'{marker['section']}' is marked as of "
+                          f"{marker['date']}; {log_file} records {log_date}",
+                "marker_date": marker["date"], "log_date": log_date,
+            })
+            continue
+        for family, number in sorted(marker["ordinals"].items()):
+            current = log_current.get(family)
+            if current is not None and number < current:
+                findings.append({
+                    "project": str(project), "kind": "body-marker-stale",
+                    "section": marker["section"], "family": family,
+                    "detail": f"'{marker['section']}' is marked as of "
+                              f"{family} {number}; {log_file} records "
+                              f"{family} {current}",
+                    "marker_ordinal": number, "log_ordinal": current,
+                })
+    if not markers and (
+        first_ordinals(" ".join(header_fields(text).values())) or log_current
+    ):
+        findings.append({
+            "project": str(project), "kind": "body-marker-absent",
+            "detail": "ordinal-paced record has no '*State as of: ...*' "
+                      "markers — body currency is unverifiable; a current "
+                      "header above unmarked operational sections cannot be "
+                      "distinguished from a stale one",
+        })
     return findings
 
 
@@ -212,8 +283,9 @@ def currency_findings(project: Path) -> list[tuple[str, str]]:
     add signal only where the evidence is comparable.
     """
     remedy = (
-        "update the stale header field with context_edit.py set-field; it "
-        "refuses an edit that leaves Phase and Last session disagreeing"
+        "bring the stale field or section up to date with context_edit.py — "
+        "rewrite the section prose, then advance its '*State as of:*' marker "
+        "in the same edit"
     )
     return [
         (finding["detail"], remedy)

--- a/skills/synthesis-context-lifecycle/scripts/context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_doctor.py
@@ -63,7 +63,7 @@ from pathlib import Path
 # missing the doctor must fail loudly rather than silently skip a check.
 import context_currency
 
-DOCTOR_VERSION = "1.4.0"
+DOCTOR_VERSION = "1.5.0"
 
 # Budgets from the tiered context architecture.
 CONTEXT_BUDGET_ACTIVE = 150
@@ -687,6 +687,7 @@ CHECKS = [
     "last-session-freshness",
     "context-header-freshness",
     "header-currency",
+    "body-currency",
     "uncommitted-context",
     "untracked-context",
     "unpushed-context",
@@ -858,15 +859,40 @@ def audit_project(
                 "refresh CONTEXT.md and its Last session header",
             )
 
-    # --- header currency ----------------------------------------------------
-    # "Records agree with git" means committed, not current: a header can
-    # describe an older state than the session log records — same day, so the
-    # date checks above see nothing — while every file is committed. Each
-    # header field is judged separately against the log's newest entries; a
-    # union over fields would let a fresh Phase mask a stale Last session,
-    # which is the exact failure that put this check here.
-    for message, remedy in context_currency.currency_findings(project_path):
-        audit.add("header-currency", "defect", message, remedy)
+    # --- header and body currency -------------------------------------------
+    # "Records agree with git" means committed, not current: a header or a
+    # Current-State section can describe an older state than the session log
+    # records — same day, so the date checks above see nothing — while every
+    # file is committed. Header fields are judged separately (a union let a
+    # fresh Phase mask a stale Last session), and body sections are judged by
+    # their '*State as of:*' markers, because header freshness is necessary
+    # but not sufficient: a current header above stale operational sections is
+    # a stronger false receipt than an obviously stale file.
+    for finding in context_currency.audit_project(project_path):
+        kind = finding["kind"]
+        if kind in ("header-behind-log", "header-field-stale"):
+            audit.add(
+                "header-currency",
+                "defect",
+                finding["detail"],
+                "update the stale header field with context_edit.py set-field",
+            )
+        elif kind == "body-marker-stale":
+            audit.add(
+                "body-currency",
+                "defect",
+                finding["detail"],
+                "rewrite the section for current state, then advance its "
+                "'*State as of:*' marker in the same edit",
+            )
+        elif kind == "body-marker-absent":
+            audit.add(
+                "body-currency",
+                "warning",
+                finding["detail"],
+                "add '*State as of:*' markers to Current State and What's "
+                "Next per the tiered-context template",
+            )
 
     # --- durability ---------------------------------------------------------
     dirty = uncommitted(repo_root, project_path)

--- a/skills/synthesis-context-lifecycle/scripts/context_edit.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_edit.py
@@ -66,6 +66,8 @@ def _coherence_gate(
     original: str,
     edited: str,
     allow_header_lag: bool,
+    allow_stale_body: bool = False,
+    state_reviewed: bool = False,
 ) -> str | None:
     """Refuse an edit that creates or changes an incoherent CONTEXT.md header.
 
@@ -81,9 +83,13 @@ def _coherence_gate(
     """
     if path.name != "CONTEXT.md":
         return None
+    notes_out: list[str] = []
     after = context_currency.header_incoherence(edited)
     if not after:
-        return None
+        notes_out.extend(
+            _body_gate(original, edited, allow_stale_body, state_reviewed)
+        )
+        return "; ".join(notes_out) if notes_out else None
     # Only Phase-ahead-of-Last-session is the defect shape: a described new
     # state over a stale log pointer. Last session leading Phase is the normal
     # transition while a two-call update is in flight, and the doctor's
@@ -118,7 +124,138 @@ def _coherence_gate(
                 "Update Last session in the same change (or first), or pass "
                 "--allow-header-lag to record an explicit override."
             )
+    notes.extend(_body_gate(original, edited, allow_stale_body, state_reviewed))
     return "; ".join(notes) if notes else None
+
+
+def _header_identity(text: str) -> tuple[str | None, dict[str, int]]:
+    """(Last-session date, per-family header ordinal) for gate comparisons.
+
+    Per family, the identity is the max of Phase and Last session — by the
+    time the header gate has passed, the two agree; mid-edit, the larger one
+    is the state the edit is advancing toward.
+    """
+    fields = context_currency.header_fields(text)
+    date_match = context_currency.HEADER_DATE.search(text)
+    identity: dict[str, int] = {}
+    for value in fields.values():
+        for family, number in context_currency.first_ordinals(value).items():
+            if number > identity.get(family, -1):
+                identity[family] = number
+    return (date_match.group(1) if date_match else None), identity
+
+
+def _section_prose(text: str, section: str) -> str:
+    """A section's text minus its as-of marker lines, for change detection."""
+    lines = text.splitlines()
+    collected: list[str] = []
+    inside = section == "(top)"
+    for line in lines:
+        heading = context_currency.SECTION_HEADING.match(line)
+        if heading:
+            inside = heading.group(1) == section
+            continue
+        if inside and not context_currency.STATE_AS_OF.match(line):
+            collected.append(line)
+    return "\n".join(collected).strip()
+
+
+def _body_gate(
+    original: str,
+    edited: str,
+    allow_stale_body: bool,
+    state_reviewed: bool,
+) -> list[str]:
+    """Gate the body's as-of markers against the header the edit produces.
+
+    Returns note strings; raises ContextEditError on the defect shape. Three
+    rules, each tied to a real occurrence:
+
+    - A header advance over a lagging marker is refused: in all three real
+      occurrences the agent advanced the header and stopped, so this is the
+      control that interrupts exactly that motion.
+    - A marker advanced (or added) while its section's prose is byte-identical
+      requires --state-reviewed: the marker is an assertion that the section
+      was re-read and still holds, and bumping it mechanically would just
+      recreate the header defect one level down. The flag converts a silent
+      bump into a recorded assertion.
+    - Whatever happens, the completion signal names the body state, because a
+      success message that says less than it verified manufactures completion
+      for partial work.
+    """
+    notes: list[str] = []
+    new_date, new_ordinals = _header_identity(edited)
+    old_date, old_ordinals = _header_identity(original)
+    header_advanced = bool(
+        (new_date and old_date and new_date > old_date)
+        or any(
+            number > old_ordinals.get(family, number)
+            for family, number in new_ordinals.items()
+        )
+    )
+
+    markers = context_currency.body_markers(edited)
+    if not markers:
+        notes.append(
+            "body: no *State as of:* markers — body currency unverifiable"
+        )
+        return notes
+
+    old_markers = {
+        m["section"]: m for m in context_currency.body_markers(original)
+    }
+    stale: list[str] = []
+    for marker in markers:
+        lag = (new_date and marker["date"] < new_date) or any(
+            number < new_ordinals.get(family, number)
+            for family, number in marker["ordinals"].items()
+        )
+        if lag:
+            stale.append(marker["section"])
+        previous = old_markers.get(marker["section"])
+        advanced = previous is None or (
+            marker["date"] > previous["date"]
+            or any(
+                number > previous["ordinals"].get(family, -1)
+                for family, number in marker["ordinals"].items()
+            )
+        )
+        if advanced:
+            before = _section_prose(original, marker["section"])
+            after = _section_prose(edited, marker["section"])
+            if before == after and before != "":
+                if state_reviewed:
+                    notes.append(
+                        f"reviewed-no-change recorded for "
+                        f"'{marker['section']}'"
+                    )
+                else:
+                    raise ContextEditError(
+                        f"the as-of marker in '{marker['section']}' advanced "
+                        "while the section's prose is unchanged. The marker "
+                        "asserts the section was re-read and still holds — "
+                        "pass --state-reviewed to record that assertion, or "
+                        "update the prose in the same edit."
+                    )
+
+    if stale:
+        named = ", ".join(f"'{s}'" for s in stale)
+        if header_advanced and not allow_stale_body:
+            raise ContextEditError(
+                f"edit advances the header while the body lags: {named} "
+                "still carry an older *State as of:* marker. Rewrite those "
+                "sections (or record a no-change review) in the same change, "
+                "or pass --allow-stale-body to record an explicit override."
+            )
+        prefix = (
+            "override --allow-stale-body recorded"
+            if header_advanced
+            else "warning: body lags the header"
+        )
+        notes.append(f"{prefix} ({named} behind the current state)")
+    else:
+        notes.append("body: as-of markers current")
+    return notes
 
 
 def _read(path: Path) -> str:
@@ -203,13 +340,22 @@ def replace_once(
     max_lines: int | None = None,
     dry_run: bool = False,
     allow_header_lag: bool = False,
+    allow_stale_body: bool = False,
+    state_reviewed: bool = False,
 ) -> dict:
     """Apply one verified replacement to a durable context file."""
     path = Path(path)
     original = _read(path)
     edited = apply_replacement(original, anchor, replacement, count=count)
     lines = _check_budget(edited, max_lines, path)
-    note = _coherence_gate(path, original, edited, allow_header_lag)
+    note = _coherence_gate(
+        path,
+        original,
+        edited,
+        allow_header_lag,
+        allow_stale_body,
+        state_reviewed,
+    )
 
     if dry_run:
         return {
@@ -257,6 +403,8 @@ def set_field(
     max_lines: int | None = None,
     dry_run: bool = False,
     allow_header_lag: bool = False,
+    allow_stale_body: bool = False,
+    state_reviewed: bool = False,
 ) -> dict:
     """Replace a `**Field:** ...` header line, verifying it existed."""
     path = Path(path)
@@ -280,6 +428,8 @@ def set_field(
         max_lines=max_lines,
         dry_run=dry_run,
         allow_header_lag=allow_header_lag,
+        allow_stale_body=allow_stale_body,
+        state_reviewed=state_reviewed,
     )
 
 
@@ -291,6 +441,8 @@ def insert_before(
     max_lines: int | None = None,
     dry_run: bool = False,
     allow_header_lag: bool = False,
+    allow_stale_body: bool = False,
+    state_reviewed: bool = False,
 ) -> dict:
     """Insert text immediately before an anchor, preserving the anchor.
 
@@ -307,6 +459,8 @@ def insert_before(
         max_lines=max_lines,
         dry_run=dry_run,
         allow_header_lag=allow_header_lag,
+        allow_stale_body=allow_stale_body,
+        state_reviewed=state_reviewed,
     )
 
 
@@ -327,6 +481,18 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="record an explicit override instead of refusing an edit that "
         "leaves Phase ahead of Last session",
+    )
+    common.add_argument(
+        "--allow-stale-body",
+        action="store_true",
+        help="record an explicit override instead of refusing a header "
+        "advance that leaves a *State as of:* marker behind",
+    )
+    common.add_argument(
+        "--state-reviewed",
+        action="store_true",
+        help="record that a section was re-read and still holds, when "
+        "advancing its *State as of:* marker without changing its prose",
     )
 
     replace = sub.add_parser("replace", parents=[common])
@@ -353,6 +519,8 @@ def main(argv: list[str] | None = None) -> int:
                 max_lines=args.max_lines,
                 dry_run=args.dry_run,
                 allow_header_lag=args.allow_header_lag,
+                allow_stale_body=args.allow_stale_body,
+                state_reviewed=args.state_reviewed,
             )
         elif args.command == "replace":
             result = replace_once(
@@ -363,6 +531,8 @@ def main(argv: list[str] | None = None) -> int:
                 max_lines=args.max_lines,
                 dry_run=args.dry_run,
                 allow_header_lag=args.allow_header_lag,
+                allow_stale_body=args.allow_stale_body,
+                state_reviewed=args.state_reviewed,
             )
         else:
             result = set_field(
@@ -372,6 +542,8 @@ def main(argv: list[str] | None = None) -> int:
                 max_lines=args.max_lines,
                 dry_run=args.dry_run,
                 allow_header_lag=args.allow_header_lag,
+                allow_stale_body=args.allow_stale_body,
+                state_reviewed=args.state_reviewed,
             )
     except ContextEditError as exc:
         print(f"context-edit refused: {exc}", file=sys.stderr)

--- a/skills/synthesis-context-lifecycle/scripts/test_body_currency.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_body_currency.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Body-currency regressions — fixtures from the three real occurrences.
+
+Acceptance rule set by the third occurrence's escalation: a fixture set that
+does not flag the state found at current HEAD is not a fix. Occurrence 3 is
+therefore encoded verbatim from the live record (repo `d918071d`), in both
+its literal markerless form (which must surface a coverage finding, because
+unmarked prose cannot be judged for truth) and its marked form (which must be
+a staleness defect).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from context_currency import audit_project, body_markers
+from context_edit import ContextEditError, replace_once, set_field
+
+
+def project(tmp_path: Path, context: str, log: str) -> Path:
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "CONTEXT.md").write_text(context, encoding="utf-8")
+    (root / "sessions").mkdir()
+    (root / "sessions" / "2026-08.md").write_text(log, encoding="utf-8")
+    return root
+
+
+def kinds(findings: list[dict]) -> list[str]:
+    return sorted(f["kind"] for f in findings)
+
+
+# --- Occurrence 3, verbatim from HEAD d918071d ------------------------------
+# Header and log both current at round 14; the body still routes the next
+# agent to the three holds that round 14 closed or re-scoped.
+
+OCC3_HEADER = """# Publish Article Backlog — Context
+
+**Phase:** Round 14 — all 30 article bodies quality-clear; controls repaired, one contract change open
+**Status:** Active
+**Last session:** 2026-08-24 (round 14: all 30 bodies clear; gate re-scoped with a build authority)
+
+## Current State
+
+Set A wrote 30 articles across staging, builds, and the 455-post calendar.
+Three non-article holds remain: the promotion gate has a marker-view defect,
+the schedule authority labels are incomplete, and the source-grade rows are
+uncorrected.
+{marker}
+## What's Next
+
+0. [ ] **Set A — repair and independently re-verify three control/evidence
+   holds.** All three controls/evidence defects hold the program; nothing
+   publishes until they clear.
+"""
+
+OCC3_LOG = """# Session Archive
+
+### 2026-08-24 (Codex adversarial review round 13)
+
+body
+
+### 2026-08-24 (round 14, Claude — all 30 bodies clear; gate re-scoped with a build authority)
+
+body
+"""
+
+
+def test_occurrence_3_literal_head_state_is_not_silent(tmp_path: Path) -> None:
+    """The exact HEAD state: markerless stale prose under a current header.
+
+    Unmarked prose cannot be judged for truth — pretending otherwise would be
+    this control's own unverified claim. What the check CAN do is refuse to
+    stay silent: the record must surface as unverifiable, never as clean.
+    """
+    root = project(tmp_path, OCC3_HEADER.format(marker=""), OCC3_LOG)
+
+    findings = audit_project(root)
+
+    assert kinds(findings) == ["body-marker-absent"]
+
+
+def test_occurrence_3_with_the_marker_it_would_have_carried(
+    tmp_path: Path,
+) -> None:
+    """The same body, marked as of round 13 when it was last true, is a
+    staleness defect against the round-14 log — while every header check
+    passes."""
+    marked = OCC3_HEADER.format(marker="\n*State as of: 2026-08-24 (round 13)*\n")
+    root = project(tmp_path, marked, OCC3_LOG)
+
+    findings = audit_project(root)
+
+    stale = [f for f in findings if f["kind"] == "body-marker-stale"]
+    assert len(stale) == 1
+    assert stale[0]["section"] == "Current State"
+    assert not any(f["kind"].startswith("header-") for f in findings)
+
+
+def test_occurrence_3_current_marker_is_clean(tmp_path: Path) -> None:
+    marked = OCC3_HEADER.format(marker="\n*State as of: 2026-08-24 (round 14)*\n")
+    root = project(tmp_path, marked, OCC3_LOG)
+
+    assert kinds(audit_project(root)) == []
+
+
+# --- Occurrences 1 and 2: header and body stale together --------------------
+
+
+def test_occurrence_1_shape_body_and_header_both_stale(tmp_path: Path) -> None:
+    context = (
+        "# P\n\n**Phase:** Adversarial round 2 complete\n"
+        "**Last session:** 2026-08-23 (round 2)\n\n"
+        "## Current State\n\nRound 2 repairs are under review.\n\n"
+        "*State as of: 2026-08-23 (round 2)*\n"
+    )
+    log = "# S\n\n### 2026-08-23 (round 3, Claude)\n\nbody\n"
+    root = project(tmp_path, context, log)
+
+    findings = audit_project(root)
+
+    assert "body-marker-stale" in kinds(findings)
+    assert "header-field-stale" in kinds(findings)
+
+
+# --- The write-time control that would have stopped all three ---------------
+
+GATED = """# P
+
+**Phase:** Round 13 review complete
+**Status:** Active
+**Last session:** 2026-08-24 (round 13)
+
+## Current State
+
+Round 13 findings are being repaired.
+
+*State as of: 2026-08-24 (round 13)*
+"""
+
+
+def test_header_advance_over_lagging_body_is_refused(tmp_path: Path) -> None:
+    """In all three occurrences the agent advanced the header and stopped.
+    This is the control that interrupts exactly that motion."""
+    path = tmp_path / "CONTEXT.md"
+    path.write_text(GATED, encoding="utf-8")
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(ContextEditError, match="body lags"):
+        set_field(
+            path,
+            field="Last session",
+            value="2026-08-24 (round 14: bodies clear)",
+        )
+
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_header_advance_with_body_updated_in_same_edit_passes(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "CONTEXT.md"
+    path.write_text(GATED, encoding="utf-8")
+
+    result = replace_once(
+        path,
+        anchor=(
+            "**Last session:** 2026-08-24 (round 13)\n\n## Current State\n\n"
+            "Round 13 findings are being repaired.\n\n"
+            "*State as of: 2026-08-24 (round 13)*"
+        ),
+        replacement=(
+            "**Last session:** 2026-08-24 (round 14)\n\n## Current State\n\n"
+            "Round 14 closed the review; one contract change remains open.\n\n"
+            "*State as of: 2026-08-24 (round 14)*"
+        ),
+    )
+
+    assert "as-of markers current" in (result["note"] or "")
+
+
+def test_allow_stale_body_records_the_override(tmp_path: Path) -> None:
+    path = tmp_path / "CONTEXT.md"
+    path.write_text(GATED, encoding="utf-8")
+
+    result = set_field(
+        path,
+        field="Last session",
+        value="2026-08-24 (round 14: bodies clear)",
+        allow_stale_body=True,
+    )
+
+    assert "override --allow-stale-body recorded" in (result["note"] or "")
+
+
+def test_marker_bump_with_unchanged_prose_requires_state_reviewed(
+    tmp_path: Path,
+) -> None:
+    """Bumping the marker as mechanically as the header would recreate the
+    defect one level down; the flag converts a silent bump into a recorded
+    assertion."""
+    path = tmp_path / "CONTEXT.md"
+    path.write_text(GATED, encoding="utf-8")
+
+    with pytest.raises(ContextEditError, match="prose is unchanged"):
+        replace_once(
+            path,
+            anchor="*State as of: 2026-08-24 (round 13)*",
+            replacement="*State as of: 2026-08-24 (round 14)*",
+        )
+
+    result = replace_once(
+        path,
+        anchor="*State as of: 2026-08-24 (round 13)*",
+        replacement="*State as of: 2026-08-24 (round 14)*",
+        state_reviewed=True,
+    )
+
+    assert "reviewed-no-change recorded" in (result["note"] or "")
+
+
+def test_completion_signal_names_missing_markers(tmp_path: Path) -> None:
+    """The honest completion signal: success output must name what it did not
+    verify, because an unqualified success message manufactures completion
+    for partial work."""
+    path = tmp_path / "CONTEXT.md"
+    path.write_text(
+        "# P\n\n**Phase:** Round 13 done\n"
+        "**Last session:** 2026-08-24 (round 13)\n\n## Current State\n\n"
+        "prose without a marker\n",
+        encoding="utf-8",
+    )
+
+    result = set_field(path, field="Phase", value="Round 13 done and recorded")
+
+    assert "body currency unverifiable" in (result["note"] or "")
+
+
+def test_marker_parsing_attributes_sections(tmp_path: Path) -> None:
+    text = GATED
+    markers = body_markers(text)
+
+    assert [(m["section"], m["date"]) for m in markers] == [
+        ("Current State", "2026-08-24")
+    ]
+    assert markers[0]["ordinals"] == {"round": 13}

--- a/skills/synthesis-context-lifecycle/scripts/test_context_currency.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_currency.py
@@ -11,12 +11,17 @@ from __future__ import annotations
 from pathlib import Path
 
 from context_currency import (
+    STALENESS_KINDS,
     audit_project,
     currency_findings,
     first_ordinals,
     header_incoherence,
     log_state,
 )
+
+
+def staleness(findings: list[dict]) -> list[dict]:
+    return [f for f in findings if f["kind"] in STALENESS_KINDS]
 
 
 def project(tmp_path: Path, context: str, log: str | None) -> Path:
@@ -161,7 +166,12 @@ def test_coherent_same_day_record_is_clean(tmp_path: Path) -> None:
         ROUND_10_11_LOG,
     )
 
-    assert audit_project(root) == []
+    findings = audit_project(root)
+
+    assert staleness(findings) == []
+    # Markerless ordinal-paced records surface a coverage finding, never
+    # silence: body currency cannot be verified without markers.
+    assert kinds(findings) == ["body-marker-absent"]
 
 
 def test_header_ahead_of_log_is_not_stale(tmp_path: Path) -> None:
@@ -174,7 +184,7 @@ def test_header_ahead_of_log_is_not_stale(tmp_path: Path) -> None:
 
     findings = audit_project(root)
 
-    assert kinds(findings) == ["header-ahead-of-log"]
+    assert kinds(findings) == ["body-marker-absent", "header-ahead-of-log"]
     assert currency_findings(root) == []
 
 
@@ -196,7 +206,7 @@ def test_families_never_compare_across_each_other(tmp_path: Path) -> None:
         "# S\n\n## 2026-08-23 (round 3 review)\n\nbody\n",
     )
 
-    assert audit_project(root) == []
+    assert staleness(audit_project(root)) == []
 
 
 def test_wave_family_is_covered(tmp_path: Path) -> None:

--- a/skills/synthesis-context-lifecycle/scripts/test_context_edit.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_edit.py
@@ -265,7 +265,8 @@ def test_last_session_may_lead_phase_with_a_note(tmp_path: Path) -> None:
 
     finish = set_field(path, field="Phase", value="Round 11 in review")
 
-    assert finish["note"] is None
+    # The completion signal always names body status on CONTEXT.md now.
+    assert "body currency unverifiable" in (finish["note"] or "")
     text = path.read_text(encoding="utf-8")
     assert "Round 11 in review" in text and "round 11, Claude" in text
 


### PR DESCRIPTION
## Summary

Third occurrence of the stale-record defect; the diagnosis names the design flaw: prior fixes addressed header currency while the defect moved to the body, and the edit helper had mechanized the easy half of the update while printing unqualified success — manufacturing a completion signal for partial work. A current header above stale operational sections is a stronger false receipt than an obviously stale file (round-13 reviewer's framing, adopted).

- As-of markers (`*State as of: 2026-08-24 (round 14)*`) convert body currency into the per-field first-ordinal comparison headers already get.
- Doctor v1.5.0: `body-currency` defect for a lagging marker; warning for markerless ordinal-paced records — unverifiable reported as unverifiable, never as clean.
- `context_edit.py`: refuses a header advance leaving a marker behind (`--allow-stale-body` records an override) — the control that would have interrupted all three occurrences; a marker advanced over byte-identical prose requires `--state-reviewed` (a recorded assertion, so the marker can't be bumped as mechanically as the header was); every gated edit's success line names the body state.
- Fixtures derive from all three real occurrences; occurrence 3 is encoded verbatim from the live record in both markerless (unverifiable) and marked (staleness-defect) forms.

## Testing

94 context-lifecycle tests (10 new occurrence-derived); full AGENTS.md suite green; live doctor run on the actual record surfaces the unverifiable body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)