### PR TITLE
Add adversarial review protocol and release 4.50.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.49.0",
+  "version": "4.50.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.49.0",
+  "version": "4.50.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.50.0] - 2026-08-26
+
+### Added
+
+- **`synthesis-adversarial-review` v1.0.0 — bounded, outcome-focused review.**
+  The new protocol gives differently shaped agents a closed artifact universe,
+  rotating attack planes, explicit concessions, per-artifact dispositions,
+  production-topology handoffs, sufficiency rulings, and a bounded
+  post-publication acceptance phase. Review ends at the principal's outcome;
+  reviewer satisfaction and unbounded control growth are not completion
+  criteria.
+- **A fail-closed finding ledger.** `finding_ledger.py` records separate
+  authority labels, enforcement outcomes, and `ship-blocking` versus
+  `ship-improving` classifications. Compare-before-write transitions,
+  evidence-bearing principal-courier counts, strict schema validation, and
+  atomic read-back verification turn review state into an executable contract.
+
+### Changed
+
+- **`synthesis-autopilot` v1.2.0** directly orchestrates adversarial
+  counterparts where the runtime permits it, budgets and counts any genuine
+  principal courier crossings, writes proportionality before round one, and
+  binds completion to the principal's outcome. Control verification stops
+  after one generation unless a requested artifact or enforcing boundary is
+  still defective.
+- **AGENT HEURISTIC — `synthesis-skill-router` v1.3.0** makes the prompt-hidden
+  adversarial-review specialist reachable from outcome-shaped requests.
+
 ## [4.49.0] - 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
 - **AGENT HEURISTIC — `synthesis-skill-router` v1.3.0** makes the prompt-hidden
   adversarial-review specialist reachable from outcome-shaped requests.
 
+### Fixed
+
+- **`synthesis-inbox-cleanup` v1.6.2 — portable atomic runtime-pointer swaps.**
+  The 4.49.0 repair used BSD-only `mv -h`; GNU `mv` rejected the option and
+  left the Linux validation workflow red. The installer now uses Python's
+  atomic `os.replace` on both macOS and Linux. Its repoint fixture models the
+  GNU refusal on every host, and the skill metadata now matches the release
+  line that 4.49.0 intended to advance.
+
 ## [4.49.0] - 2026-08-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Adversarial review now has an outcome and a stop rule (August 2026).**
+Release **4.50.0** adds `synthesis-adversarial-review`: differently shaped
+agents attack a closed artifact universe, record concessions and terminal
+verdicts, and stop when the principal's outcome is established. Its
+fail-closed YAML ledger separates authority from enforcement and blocking
+defects from improvements, while `synthesis-autopilot` directly transports
+review packets and treats human courier crossings as a budgeted delivery
+cost. See the [4.50.0 release notes](CHANGELOG.md).
+
 **The engine that never updated (August 2026).** Release **4.49.0** fixes a
 silent failure in `synthesis-inbox-cleanup`'s runtime installer: it repointed
 `engine/current` with `mv -f`, but that path is a symlink to a directory, so

--- a/skills/synthesis-adversarial-review/SKILL.md
+++ b/skills/synthesis-adversarial-review/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: synthesis-adversarial-review
+description: "Run bounded, differently-shaped-agent adversarial review against the principal's outcome, with artifact-complete rounds, production-topology handoffs, explicit concessions, a fail-closed finding ledger, sufficiency rulings, and independent post-publication acceptance. Use for adversarial review, cross-agent review, red-team collaboration, review rounds, finding-ledger work, or reviewer handoffs."
+license: "Apache-2.0"
+depends_on: ["synthesis-grounding-discipline", "synthesis-anti-shortcuts", "synthesis-project-management"]
+metadata:
+  author: "Rajiv Pant"
+  version: "1.0.0"
+  source_repo: "github.com/synthesisengineering/synthesis-skills"
+  source_type: "public"
+---
+
+# Synthesis Adversarial Review
+
+## Purpose
+
+Adversarial collaboration is useful when differently shaped agents attack the same work
+from different blind spots. It is not an invitation to maximize rounds. The review exists
+to deliver the principal's outcome: the artifacts and enforced boundaries the principal
+asked to ship, at the accepted quality bar. Reviewer satisfaction, control growth, and a
+large finding count are not completion criteria.
+
+This skill governs the review protocol. It does not grant publication, deployment,
+communication, or repair authority. Those approval boundaries survive the review.
+
+## Before Round One: Proportionality Contract
+
+Record this section in the engagement plan before dispatching a reviewer:
+
+1. **Principal outcome.** State the outcome in the principal's terms, including the
+   artifact or system boundary that must ship.
+2. **Closed review universe.** Enumerate the artifacts, surfaces, and decision planes.
+   Each assigned plane receives a per-artifact terminal disposition in the same round.
+3. **Consequence and depth.** Name the harm the review is meant to prevent and the one
+   verifier generation justified by that harm.
+4. **Round-trip budget.** Set a budget for principal courier crossings. Agent-to-agent
+   transport is not a principal crossing; a required human copy/paste is. Declare,
+   batch, and count every such crossing. Exceeding the budget is a blocked-state alert.
+5. **Stop rule.** Define green artifact acceptance, allowed open risks, approval gates,
+   and the sufficiency checkpoint. Fewer rounds must come from complete coverage and
+   stronger fixtures, never from fewer checks or lower quality.
+
+If the universe cannot be enumerated, record why and define the bounded derivation that
+will close it. “Representative samples” do not support a closed-world completion claim.
+
+## Roles and Blind-Spot Rotation
+
+Use at least two roles:
+
+- **Executor:** owns the principal's artifacts, production implementation, and repairs.
+- **Adversarial reviewer:** derives attacks independently, attempts to falsify the
+  executor's claims, and does not inherit the executor's preferred abstraction.
+
+Rotate the blind spot, not merely the agent name. Useful rotations include artifact versus
+control plane, semantic versus structural evidence, producer versus consumer, pre-change
+versus post-change state, and source versus destination representation. The reviewer reads
+the bounded evidence package but independently re-derives the load-bearing facts.
+
+Concession is health. A loop in which neither side ever reverses is two agents defending
+priors. Every round records which claims the executor conceded, which the reviewer
+conceded, and which remain evidence-bearing disagreements.
+
+## Goal-Focused Round
+
+One goal-focused round has five terminal stages:
+
+1. **Contract.** Restate the principal's outcome, immutable decisions, approval gates,
+   assigned artifact universe, and this round's attack plane.
+2. **Attack.** Derive counterexamples from the production path. Start controls at
+   generation zero: encode motivating real defects as failing fixtures before repair.
+3. **Disposition.** Give every artifact and finding one terminal row. Valid labels include
+   accepted, blocked, repaired-prose, repaired-source, repaired-verified, conceded, and
+   awaiting-principal; prose and executable repair are not interchangeable.
+4. **Concept sweep.** Search the whole evidence package for the semantic claim a repair
+   displaced. A corrected row beside stale summaries, receipts, headings, or sidecars is
+   not a correction.
+5. **Sufficiency.** Present established, open, and risk of shipping now. Put the ship-now
+   choice in front of the principal at the named checkpoint. The principal's ruling terminates the loop.
+
+Until artifact acceptance is green, most effort belongs to the principal's artifacts.
+System improvements route separately unless they block delivery. A `ship-improving`
+finding names its follow-up project; it does not extend the current delivery. A
+`ship-blocking` finding remains in the delivery until repaired, conceded by the reviewer,
+or ruled on by the principal.
+
+## Sidecars, Evidence, and Handoff Topology
+
+Sidecars are claims. A manifest, receipt, verifier output, summary, or acceptance matrix
+has no more authority than the production boundary that consumes it. Verify the claimed
+artifact set and state rather than accepting the sidecar because it is structured.
+
+Every review handoff names:
+
+- the **production entry point** whose behavior matters;
+- the **enforcing boundary** that can refuse the state-changing action;
+- the **receipt consumer** that validates the receipt before permitting that action;
+- the exact artifacts, hashes, versions, and declared representations in scope;
+- the command or procedure that reproduces each finding;
+- the concept sweep required after any attribution or provenance correction;
+- what the evidence does not verify.
+
+A diagnostic is not an acceptance test; an acceptance test is not an enforced gate. Only
+a fail-closed caller at the state-changing boundary can issue an authority receipt.
+
+## Finding Ledger
+
+Create one YAML ledger per engagement in the owning project's `resources/` directory:
+
+```bash
+python3 scripts/finding_ledger.py init \
+  --resources-root resources \
+  --file resources/<engagement>-findings.yaml \
+  --engagement <id> \
+  --principal-outcome '<outcome>' \
+  --round-trip-budget <count> \
+  --proportionality 'AGENT HEURISTIC: <bounded rationale>'
+```
+
+Each finding must carry:
+
+- one state: `open | challenged | repaired-prose | repaired-source |
+  repaired-verified | conceded | awaiting-principal`;
+- one classification: `ship-blocking | ship-improving`;
+- an authority label: `principal-rule | agent-heuristic`, plus a provenance id;
+- an enforcement outcome in a separate field;
+- evidence and an append-only transition history;
+- a follow-up project when classified `ship-improving`.
+
+The authority label and enforcement outcome answer different questions. `AGENT HEURISTIC`
+may be the honest provenance label while enforcement is still wrong. Exercise every report
+branch and verify finding, authority, and enforcement outcome independently.
+
+Ledger edits are compare-before-write operations. `transition` requires the recorded prior
+state; missing or duplicate ids, stale expected state, unknown keys, invalid classification,
+and symlink targets refuse without writing. Every command requires the owning project's
+literal `resources/` root, rejects a target outside it or any symlinked path component, and
+holds the resources-directory lock across read, expected-state comparison, replacement,
+and read-back. Use `validate` before handoff.
+
+Acceptance manifests label each case `diagnostic | acceptance-test | enforced-gate`.
+Section-shape and vocabulary checks are diagnostics, not behavioral acceptance. A manifest
+does not issue an authority receipt. Native agent scenarios establish protocol behavior;
+only a fail-closed caller at the state-changing boundary can claim an enforced gate.
+
+## Bounded Control Depth
+
+Verifying a verifier once is legitimate. A finding in generation N+1 of a control the
+principal did not request stops control growth; it does not automatically start generation N+2. If a round's findings are entirely self-inflicted by the newly introduced control,
+record them, state the consequence for the principal's outcome, and refuse another control
+round without an explicit principal decision.
+
+This bound does not waive a defect in the requested artifacts or enforcing boundary. It
+prevents an auxiliary control from becoming the mission.
+
+## Bounded Post-Publication Acceptance
+
+Publication or deployment begins a separate acceptance phase; it is not implied by a
+successful build or publisher-authored receipt.
+
+1. A second agent derives the live artifact universe from destination state, not from the
+   publisher's receipt.
+2. Validate the verifier with a known-good and known-bad positive control before
+   interpreting a uniform result.
+3. Record a per-artifact matrix across source, live origin, discovery surfaces, links,
+   hygiene, and destination-specific deployment terminal state.
+4. Distinguish exact-session readiness from aggregate project hygiene and prove durable
+   artifact, board delivery, lifecycle receipt, remote publication, and receiver
+   acceptance independently.
+5. End when every artifact has a terminal verdict. Generic review does not reopen an
+   approval already exercised. A reproduced concrete correction requires fresh approval
+   before any new publication or deployment.
+
+## Agent-Principal Norms
+
+- An agent has standing to surface a known-false claim once in the principal's own stated
+  terms, especially when the agent is the reason the claim is known false.
+- A proposed constraint loosening nominates the loosener for review.
+- Principal rules and agent heuristics remain explicitly labeled. Approval fatigue is a
+  failure mode: a gate that fires on trivia teaches rubber-stamping.
+
+## Completion Report
+
+Report the principal outcome first, then the artifact matrix, ship-blocking findings,
+ship-improving follow-ups, concessions, courier-crossing count, sufficiency ruling, and
+approval gates. Name the unverified remainder. “The reviewer is satisfied” is never a
+completion signal.

--- a/skills/synthesis-adversarial-review/acceptance-suite.yaml
+++ b/skills/synthesis-adversarial-review/acceptance-suite.yaml
@@ -28,3 +28,15 @@ cases:
   - id: symlink-boundary
     fixture: scripts/test_finding_ledger.py::test_symlink_ledger_is_refused
     motivating_defect: engagement-round-1-symlink-escape
+  - id: principal-outcome-round-semantics
+    fixture: scripts/test_protocol_contract.py::test_review_protocol_is_principal_outcome_focused
+    motivating_defect: catalogue-P0-2-reviewer-satisfaction-replaced-the-principal-outcome
+  - id: production-topology-handoff
+    fixture: scripts/test_protocol_contract.py::test_handoff_contract_names_the_production_topology
+    motivating_defect: engagement-sidecars-and-receipts-were-treated-as-proof
+  - id: bounded-control-depth
+    fixture: scripts/test_protocol_contract.py::test_control_depth_and_sufficiency_are_bounded
+    motivating_defect: catalogue-P0-3-controls-generated-unrequested-controls
+  - id: direct-agent-orchestration
+    fixture: scripts/test_protocol_contract.py::test_autopilot_tracks_direct_dispatch_and_courier_cost
+    motivating_defect: catalogue-P0-1-more-than-twenty-principal-courier-crossings

--- a/skills/synthesis-adversarial-review/acceptance-suite.yaml
+++ b/skills/synthesis-adversarial-review/acceptance-suite.yaml
@@ -6,61 +6,83 @@ membership: closed
 production_entry_point: scripts/finding_ledger.py
 enforcing_boundary: atomic ledger replacement after schema and transition validation
 expected_status: pass
+metadata_class: acceptance-test
+issues_authority_receipt: false
+unverified_remainder: live agent behavior, release state, publication, deployment, and principal approvals
 cases:
   - id: ledger-init
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_init_creates_declared_engagement
     motivating_defect: catalogue-P0-1-principal-courier-cost-was-untracked
   - id: courier-crossing-budget
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_courier_crossings_are_compare_before_write_and_budget_bounded
     motivating_defect: catalogue-P0-1-principal-courier-crossings-had-no-auditable-mutation-path
   - id: completion-signal-coverage
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_every_success_branch_names_the_unverified_remainder
     motivating_defect: context-edit-body-currency-unqualified-success-for-partial-work
   - id: classification-required
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_add_requires_ship_classification_without_mutating
     motivating_defect: catalogue-P0-4-ship-blocking-and-ship-improving-were-conflated
   - id: label-outcome-separation
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_authority_label_and_enforcement_outcome_remain_separate
     motivating_defect: principal-boundary-unlabelled-agent-heuristic-became-a-rule
   - id: executable-repair-state
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_transition_requires_the_recorded_prior_state
     motivating_defect: engagement-round-2-prose-and-source-repair-were-conflated
   - id: follow-up-routing
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_ship_improving_requires_follow_up_project
     motivating_defect: catalogue-P0-4-improvements-extended-the-current-delivery
   - id: duplicate-identity
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_duplicate_finding_id_refuses_without_mutating
     motivating_defect: round-36-duplicate-identities-collapsed-before-validation
   - id: symlink-boundary
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_symlink_ledger_is_refused
     motivating_defect: engagement-round-1-symlink-escape
   - id: principal-outcome-round-semantics
+    control_class: diagnostic
     fixture: scripts/test_protocol_contract.py::test_review_protocol_is_principal_outcome_focused
     motivating_defect: catalogue-P0-2-reviewer-satisfaction-replaced-the-principal-outcome
   - id: production-topology-handoff
+    control_class: diagnostic
     fixture: scripts/test_protocol_contract.py::test_handoff_contract_names_the_production_topology
     motivating_defect: engagement-sidecars-and-receipts-were-treated-as-proof
   - id: bounded-control-depth
+    control_class: diagnostic
     fixture: scripts/test_protocol_contract.py::test_control_depth_and_sufficiency_are_bounded
     motivating_defect: catalogue-P0-3-controls-generated-unrequested-controls
   - id: direct-agent-orchestration
+    control_class: diagnostic
     fixture: scripts/test_protocol_contract.py::test_autopilot_tracks_direct_dispatch_and_courier_cost
     motivating_defect: catalogue-P0-1-more-than-twenty-principal-courier-crossings
   - id: hidden-specialist-routing
+    control_class: diagnostic
     fixture: scripts/test_protocol_contract.py::test_hidden_specialist_is_reachable_through_the_router
     motivating_defect: codex-prompt-budget-hides-specialists-without-a-router-path
   - id: atomic-courier-compare-before-write
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_concurrent_crossing_writers_cannot_both_report_success
     motivating_defect: r1-review-two-stale-writers-both-succeeded-and-lost-one-event
   - id: contiguous-finding-history
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_transition_history_is_contiguous_and_evidence_bound
     motivating_defect: r1-review-validator-certified-a-noncontiguous-evidence-chain
   - id: resources-containment
+    control_class: acceptance-test
     fixture: scripts/test_finding_ledger.py::test_resources_root_rejects_symlinked_parent_and_outside_target
     motivating_defect: r1-review-symlinked-parent-escaped-the-owning-project-resources-boundary
   - id: declared-control-authority
+    control_class: diagnostic
     fixture: scripts/test_protocol_contract.py::test_acceptance_manifest_classifies_control_authority
     motivating_defect: r1-review-diagnostics-were-presented-as-acceptance-authority
   - id: token-soup-refusal
+    control_class: diagnostic
     fixture: scripts/test_protocol_contract.py::test_protocol_acceptance_rejects_token_soup
     motivating_defect: r1-review-five-protocol-checks-passed-against-semantically-inert-token-soup

--- a/skills/synthesis-adversarial-review/acceptance-suite.yaml
+++ b/skills/synthesis-adversarial-review/acceptance-suite.yaml
@@ -13,6 +13,9 @@ cases:
   - id: courier-crossing-budget
     fixture: scripts/test_finding_ledger.py::test_courier_crossings_are_compare_before_write_and_budget_bounded
     motivating_defect: catalogue-P0-1-principal-courier-crossings-had-no-auditable-mutation-path
+  - id: completion-signal-coverage
+    fixture: scripts/test_finding_ledger.py::test_every_success_branch_names_the_unverified_remainder
+    motivating_defect: context-edit-body-currency-unqualified-success-for-partial-work
   - id: classification-required
     fixture: scripts/test_finding_ledger.py::test_add_requires_ship_classification_without_mutating
     motivating_defect: catalogue-P0-4-ship-blocking-and-ship-improving-were-conflated

--- a/skills/synthesis-adversarial-review/acceptance-suite.yaml
+++ b/skills/synthesis-adversarial-review/acceptance-suite.yaml
@@ -40,3 +40,6 @@ cases:
   - id: direct-agent-orchestration
     fixture: scripts/test_protocol_contract.py::test_autopilot_tracks_direct_dispatch_and_courier_cost
     motivating_defect: catalogue-P0-1-more-than-twenty-principal-courier-crossings
+  - id: hidden-specialist-routing
+    fixture: scripts/test_protocol_contract.py::test_hidden_specialist_is_reachable_through_the_router
+    motivating_defect: codex-prompt-budget-hides-specialists-without-a-router-path

--- a/skills/synthesis-adversarial-review/acceptance-suite.yaml
+++ b/skills/synthesis-adversarial-review/acceptance-suite.yaml
@@ -1,0 +1,30 @@
+# AGENT HEURISTIC: this manifest shape is the generation-zero instance that R5 will
+# formalize. The controlling plan requires a manifest now but does not prescribe keys.
+schema: 1
+suite: synthesis-adversarial-review-finding-ledger
+membership: closed
+production_entry_point: scripts/finding_ledger.py
+enforcing_boundary: atomic ledger replacement after schema and transition validation
+expected_status: pass
+cases:
+  - id: ledger-init
+    fixture: scripts/test_finding_ledger.py::test_init_creates_declared_engagement
+    motivating_defect: catalogue-P0-1-principal-courier-cost-was-untracked
+  - id: classification-required
+    fixture: scripts/test_finding_ledger.py::test_add_requires_ship_classification_without_mutating
+    motivating_defect: catalogue-P0-4-ship-blocking-and-ship-improving-were-conflated
+  - id: label-outcome-separation
+    fixture: scripts/test_finding_ledger.py::test_authority_label_and_enforcement_outcome_remain_separate
+    motivating_defect: principal-boundary-unlabelled-agent-heuristic-became-a-rule
+  - id: executable-repair-state
+    fixture: scripts/test_finding_ledger.py::test_transition_requires_the_recorded_prior_state
+    motivating_defect: engagement-round-2-prose-and-source-repair-were-conflated
+  - id: follow-up-routing
+    fixture: scripts/test_finding_ledger.py::test_ship_improving_requires_follow_up_project
+    motivating_defect: catalogue-P0-4-improvements-extended-the-current-delivery
+  - id: duplicate-identity
+    fixture: scripts/test_finding_ledger.py::test_duplicate_finding_id_refuses_without_mutating
+    motivating_defect: round-36-duplicate-identities-collapsed-before-validation
+  - id: symlink-boundary
+    fixture: scripts/test_finding_ledger.py::test_symlink_ledger_is_refused
+    motivating_defect: engagement-round-1-symlink-escape

--- a/skills/synthesis-adversarial-review/acceptance-suite.yaml
+++ b/skills/synthesis-adversarial-review/acceptance-suite.yaml
@@ -49,3 +49,18 @@ cases:
   - id: hidden-specialist-routing
     fixture: scripts/test_protocol_contract.py::test_hidden_specialist_is_reachable_through_the_router
     motivating_defect: codex-prompt-budget-hides-specialists-without-a-router-path
+  - id: atomic-courier-compare-before-write
+    fixture: scripts/test_finding_ledger.py::test_concurrent_crossing_writers_cannot_both_report_success
+    motivating_defect: r1-review-two-stale-writers-both-succeeded-and-lost-one-event
+  - id: contiguous-finding-history
+    fixture: scripts/test_finding_ledger.py::test_transition_history_is_contiguous_and_evidence_bound
+    motivating_defect: r1-review-validator-certified-a-noncontiguous-evidence-chain
+  - id: resources-containment
+    fixture: scripts/test_finding_ledger.py::test_resources_root_rejects_symlinked_parent_and_outside_target
+    motivating_defect: r1-review-symlinked-parent-escaped-the-owning-project-resources-boundary
+  - id: declared-control-authority
+    fixture: scripts/test_protocol_contract.py::test_acceptance_manifest_classifies_control_authority
+    motivating_defect: r1-review-diagnostics-were-presented-as-acceptance-authority
+  - id: token-soup-refusal
+    fixture: scripts/test_protocol_contract.py::test_protocol_acceptance_rejects_token_soup
+    motivating_defect: r1-review-five-protocol-checks-passed-against-semantically-inert-token-soup

--- a/skills/synthesis-adversarial-review/acceptance-suite.yaml
+++ b/skills/synthesis-adversarial-review/acceptance-suite.yaml
@@ -10,6 +10,9 @@ cases:
   - id: ledger-init
     fixture: scripts/test_finding_ledger.py::test_init_creates_declared_engagement
     motivating_defect: catalogue-P0-1-principal-courier-cost-was-untracked
+  - id: courier-crossing-budget
+    fixture: scripts/test_finding_ledger.py::test_courier_crossings_are_compare_before_write_and_budget_bounded
+    motivating_defect: catalogue-P0-1-principal-courier-crossings-had-no-auditable-mutation-path
   - id: classification-required
     fixture: scripts/test_finding_ledger.py::test_add_requires_ship_classification_without_mutating
     motivating_defect: catalogue-P0-4-ship-blocking-and-ship-improving-were-conflated

--- a/skills/synthesis-adversarial-review/agents/openai.yaml
+++ b/skills/synthesis-adversarial-review/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Synthesis Adversarial Review"
+  short_description: "Run bounded, evidence-led cross-agent review"
+  default_prompt: "Use $synthesis-adversarial-review to adversarially review the current work against the principal's outcome."
+policy:
+  allow_implicit_invocation: false

--- a/skills/synthesis-adversarial-review/scripts/finding_ledger.py
+++ b/skills/synthesis-adversarial-review/scripts/finding_ledger.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+"""Create and edit a fail-closed adversarial-review finding ledger.
+
+The ledger is an engagement-owned YAML file. Every mutation validates the complete
+document, requires an explicit expected prior state where one exists, writes atomically,
+and verifies the bytes read back from disk. A missing finding, duplicate identity,
+unrecognised state, or incomplete classification refuses without changing the file.
+
+Commands:
+
+    finding_ledger.py init --resources-root DIR --file FILE --engagement ID
+        --principal-outcome TEXT --round-trip-budget N --proportionality TEXT
+    finding_ledger.py record-crossing --resources-root DIR --file FILE
+        --expected-count N
+        --evidence TEXT
+    finding_ledger.py add --resources-root DIR --file FILE --id ID --title TEXT --state STATE
+        --classification CLASS --authority-label LABEL --provenance-id ID
+        --enforcement-outcome TEXT --evidence TEXT [--follow-up-project ID]
+    finding_ledger.py transition --resources-root DIR --file FILE --id ID --from-state STATE
+        --to-state STATE --evidence TEXT
+    finding_ledger.py validate --resources-root DIR --file FILE
+
+Exit codes: 0 changed or valid, 1 refused, 2 invocation or dependency error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import pathlib
+import stat
+import sys
+import tempfile
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - exercised only on an incomplete runtime
+    yaml = None
+
+
+SCHEMA = 1
+STATES = {
+    "open",
+    "challenged",
+    "repaired-prose",
+    "repaired-source",
+    "repaired-verified",
+    "conceded",
+    "awaiting-principal",
+}
+CLASSIFICATIONS = {"ship-blocking", "ship-improving"}
+AUTHORITY_LABELS = {"principal-rule", "agent-heuristic"}
+
+# AGENT HEURISTIC: strict key sets make an unknown schema addition a refusal instead of
+# letting one producer write a field that another silently ignores. A future extension
+# increments SCHEMA and updates these sets deliberately.
+TOP_KEYS = {"schema", "engagement", "findings"}
+ENGAGEMENT_KEYS = {
+    "id",
+    "principal_outcome",
+    "principal_courier_round_trips",
+    "proportionality",
+    "created_at",
+}
+FINDING_KEYS = {
+    "id",
+    "title",
+    "state",
+    "classification",
+    "authority",
+    "enforcement_outcome",
+    "evidence",
+    "history",
+    "created_at",
+}
+OPTIONAL_FINDING_KEYS = {"follow_up_project"}
+AUTHORITY_KEYS = {"label", "provenance_id"}
+HISTORY_KEYS = {"at", "from", "to", "evidence"}
+TRIP_HISTORY_KEYS = {"at", "evidence"}
+
+# AGENT HEURISTIC: every successful ledger command repeats one common coverage
+# boundary so a schema mutation cannot be mistaken for artifact acceptance.
+UNVERIFIED_REMAINDER = (
+    "not verified: artifact acceptance, review sufficiency, approval status, "
+    "publication, or deployment"
+)
+
+
+class LedgerError(RuntimeError):
+    """The requested ledger operation is unsafe or invalid."""
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def report_success(message: str) -> None:
+    print(f"{message}; {UNVERIFIED_REMAINDER}")
+
+
+def lexical_absolute(path: pathlib.Path) -> pathlib.Path:
+    return pathlib.Path(os.path.abspath(os.path.expanduser(str(path))))
+
+
+def reject_symlink_components(path: pathlib.Path, label: str) -> None:
+    current = pathlib.Path(path.anchor)
+    for part in path.parts[1:]:
+        current = current / part
+        if os.path.lexists(current) and current.is_symlink():
+            raise LedgerError(f"{label} contains a symlink component: {current}")
+
+
+def validated_resources_root(path: pathlib.Path) -> pathlib.Path:
+    root = lexical_absolute(path)
+    reject_symlink_components(root, "resources root")
+    if not root.is_dir():
+        raise LedgerError(f"resources root is not a directory: {root}")
+    return root
+
+
+@contextmanager
+def resources_lock(root: pathlib.Path):
+    """Serialize the complete read/compare/write transaction on a stable inode."""
+
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    try:
+        descriptor = os.open(root, flags)
+    except OSError as exc:
+        raise LedgerError(f"could not open resources root safely: {root}: {exc}") from exc
+    try:
+        if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            raise LedgerError(f"resources root is not a directory: {root}")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        reject_symlink_components(root, "resources root")
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def nonempty(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise LedgerError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def exact_keys(value: dict, required: set[str], optional: set[str], label: str) -> None:
+    missing = sorted(required - set(value))
+    extra = sorted(set(value) - required - optional)
+    if missing or extra:
+        raise LedgerError(f"{label} keys invalid: missing={missing}, extra={extra}")
+
+
+def validate_document(doc: Any) -> dict:
+    if not isinstance(doc, dict):
+        raise LedgerError("ledger root must be a mapping")
+    exact_keys(doc, TOP_KEYS, set(), "ledger")
+    if doc["schema"] != SCHEMA:
+        raise LedgerError(
+            f"ledger schema {doc['schema']!r} is not supported; expected {SCHEMA}"
+        )
+
+    engagement = doc["engagement"]
+    if not isinstance(engagement, dict):
+        raise LedgerError("engagement must be a mapping")
+    exact_keys(engagement, ENGAGEMENT_KEYS, set(), "engagement")
+    nonempty(engagement["id"], "engagement.id")
+    nonempty(engagement["principal_outcome"], "engagement.principal_outcome")
+    nonempty(engagement["proportionality"], "engagement.proportionality")
+    nonempty(engagement["created_at"], "engagement.created_at")
+    trips = engagement["principal_courier_round_trips"]
+    if not isinstance(trips, dict) or set(trips) != {"budget", "count", "history"}:
+        raise LedgerError(
+            "engagement.principal_courier_round_trips must contain budget, count, "
+            "and history"
+        )
+    for key in ("budget", "count"):
+        if isinstance(trips[key], bool) or not isinstance(trips[key], int) or trips[key] < 0:
+            raise LedgerError(f"principal_courier_round_trips.{key} must be >= 0")
+    if trips["count"] > trips["budget"]:
+        raise LedgerError(
+            "principal courier round-trip budget exceeded; the engagement is blocked"
+        )
+    trip_history = trips["history"]
+    if not isinstance(trip_history, list):
+        raise LedgerError("principal_courier_round_trips.history must be a list")
+    if len(trip_history) != trips["count"]:
+        raise LedgerError(
+            "principal_courier_round_trips.count must equal the history length"
+        )
+    for index, event in enumerate(trip_history):
+        label = f"principal_courier_round_trips.history[{index}]"
+        if not isinstance(event, dict):
+            raise LedgerError(f"{label} must be a mapping")
+        exact_keys(event, TRIP_HISTORY_KEYS, set(), label)
+        nonempty(event["at"], f"{label}.at")
+        nonempty(event["evidence"], f"{label}.evidence")
+
+    findings = doc["findings"]
+    if not isinstance(findings, list):
+        raise LedgerError("findings must be a list")
+    seen: set[str] = set()
+    for index, finding in enumerate(findings):
+        label = f"findings[{index}]"
+        if not isinstance(finding, dict):
+            raise LedgerError(f"{label} must be a mapping")
+        exact_keys(finding, FINDING_KEYS, OPTIONAL_FINDING_KEYS, label)
+        finding_id = nonempty(finding["id"], f"{label}.id")
+        if finding_id in seen:
+            raise LedgerError(f"duplicate finding id: {finding_id}")
+        seen.add(finding_id)
+        nonempty(finding["title"], f"{label}.title")
+        if finding["state"] not in STATES:
+            raise LedgerError(f"{label}.state is not recognised: {finding['state']!r}")
+        classification = finding["classification"]
+        if classification not in CLASSIFICATIONS:
+            raise LedgerError(f"{label}.classification is not recognised: {classification!r}")
+        if classification == "ship-improving":
+            nonempty(finding.get("follow_up_project"), f"{label}.follow_up_project")
+        authority = finding["authority"]
+        if not isinstance(authority, dict):
+            raise LedgerError(f"{label}.authority must be a mapping")
+        exact_keys(authority, AUTHORITY_KEYS, set(), f"{label}.authority")
+        if authority["label"] not in AUTHORITY_LABELS:
+            raise LedgerError(
+                f"{label}.authority.label is not recognised: {authority['label']!r}"
+            )
+        nonempty(authority["provenance_id"], f"{label}.authority.provenance_id")
+        nonempty(finding["enforcement_outcome"], f"{label}.enforcement_outcome")
+        nonempty(finding["evidence"], f"{label}.evidence")
+        nonempty(finding["created_at"], f"{label}.created_at")
+        history = finding["history"]
+        if not isinstance(history, list) or not history:
+            raise LedgerError(f"{label}.history must be a non-empty list")
+        previous_state: str | None = None
+        for hindex, event in enumerate(history):
+            hlabel = f"{label}.history[{hindex}]"
+            if not isinstance(event, dict):
+                raise LedgerError(f"{hlabel} must be a mapping")
+            exact_keys(event, HISTORY_KEYS, set(), hlabel)
+            nonempty(event["at"], f"{hlabel}.at")
+            if event["from"] is not None and event["from"] not in STATES:
+                raise LedgerError(f"{hlabel}.from is not recognised")
+            if event["to"] not in STATES:
+                raise LedgerError(f"{hlabel}.to is not recognised")
+            nonempty(event["evidence"], f"{hlabel}.evidence")
+            if hindex == 0:
+                if event["from"] is not None:
+                    raise LedgerError(f"{hlabel}.from must be null for the first event")
+            elif event["from"] != previous_state:
+                raise LedgerError(
+                    f"{hlabel}.from does not match the previous terminal state"
+                )
+            if event["from"] is not None and event["from"] == event["to"]:
+                raise LedgerError(f"{hlabel} must change state")
+            previous_state = event["to"]
+        if history[-1]["to"] != finding["state"]:
+            raise LedgerError(
+                f"{label}.state does not match its terminal history event"
+            )
+        if history[-1]["evidence"] != finding["evidence"]:
+            raise LedgerError(
+                f"{label}.evidence does not match its terminal history event"
+            )
+    return doc
+
+
+def ensure_path(
+    path: pathlib.Path, resources_root: pathlib.Path, *, must_exist: bool
+) -> pathlib.Path:
+    path = lexical_absolute(path)
+    try:
+        relative = path.relative_to(resources_root)
+    except ValueError as exc:
+        raise LedgerError(
+            f"ledger path is outside the declared resources root: {path}"
+        ) from exc
+    if not relative.parts:
+        raise LedgerError("ledger path must name a file beneath the resources root")
+    reject_symlink_components(path, "ledger path")
+    if path.suffix not in {".yaml", ".yml"}:
+        raise LedgerError(f"ledger path must end in .yaml or .yml: {path}")
+    if path.is_symlink():
+        raise LedgerError(f"refusing a symlink ledger path: {path}")
+    if must_exist and not path.is_file():
+        raise LedgerError(f"ledger is not a file: {path}")
+    if not must_exist and path.exists():
+        raise LedgerError(f"ledger already exists: {path}")
+    if not path.parent.is_dir():
+        raise LedgerError(f"ledger parent is not a directory: {path.parent}")
+    return path
+
+
+def load(path: pathlib.Path, resources_root: pathlib.Path) -> dict:
+    path = ensure_path(path, resources_root, must_exist=True)
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise LedgerError(f"could not parse {path}: {exc}") from exc
+    return validate_document(doc)
+
+
+def serialize(doc: dict) -> str:
+    validate_document(doc)
+    return yaml.safe_dump(doc, sort_keys=False, allow_unicode=True)
+
+
+def atomic_write(
+    path: pathlib.Path,
+    doc: dict,
+    resources_root: pathlib.Path,
+    *,
+    create: bool = False,
+) -> None:
+    path = ensure_path(path, resources_root, must_exist=not create)
+    text = serialize(doc)
+    mode = path.stat().st_mode & 0o777 if path.exists() else 0o644
+    handle = tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False
+    )
+    temporary = pathlib.Path(handle.name)
+    try:
+        with handle as stream:
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+        written = path.read_text(encoding="utf-8")
+        if written != text:
+            raise LedgerError(f"post-write byte verification failed: {path}")
+        validate_document(yaml.safe_load(written))
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def command_init(args: argparse.Namespace) -> None:
+    if args.round_trip_budget < 0:
+        raise LedgerError("round-trip-budget must be >= 0")
+    stamp = now()
+    doc = {
+        "schema": SCHEMA,
+        "engagement": {
+            "id": nonempty(args.engagement, "engagement"),
+            "principal_outcome": nonempty(args.principal_outcome, "principal-outcome"),
+            "principal_courier_round_trips": {
+                "budget": args.round_trip_budget,
+                "count": 0,
+                "history": [],
+            },
+            "proportionality": nonempty(args.proportionality, "proportionality"),
+            "created_at": stamp,
+        },
+        "findings": [],
+    }
+    atomic_write(args.file, doc, args.resources_root, create=True)
+    report_success(f"initialized {args.file}")
+
+
+def command_record_crossing(args: argparse.Namespace) -> None:
+    doc = load(args.file, args.resources_root)
+    trips = doc["engagement"]["principal_courier_round_trips"]
+    if args.expected_count != trips["count"]:
+        raise LedgerError(
+            f"principal courier crossing count is {trips['count']}, not expected "
+            f"{args.expected_count}; re-read the ledger before retrying"
+        )
+    if trips["count"] >= trips["budget"]:
+        raise LedgerError(
+            "principal courier round-trip budget would be exceeded; the engagement "
+            "is blocked"
+        )
+    trips["count"] += 1
+    trips["history"].append(
+        {"at": now(), "evidence": nonempty(args.evidence, "evidence")}
+    )
+    atomic_write(args.file, doc, args.resources_root)
+    report_success(
+        "recorded principal courier crossing "
+        f"{trips['count']}/{trips['budget']}"
+    )
+
+
+def command_add(args: argparse.Namespace) -> None:
+    doc = load(args.file, args.resources_root)
+    if any(item["id"] == args.id for item in doc["findings"]):
+        raise LedgerError(f"finding id already exists: {args.id}")
+    if args.classification == "ship-improving" and not args.follow_up_project:
+        raise LedgerError(
+            "ship-improving findings require --follow-up-project; they do not extend "
+            "the current delivery"
+        )
+    stamp = now()
+    finding = {
+        "id": nonempty(args.id, "id"),
+        "title": nonempty(args.title, "title"),
+        "state": args.state,
+        "classification": args.classification,
+        "authority": {
+            "label": args.authority_label,
+            "provenance_id": nonempty(args.provenance_id, "provenance-id"),
+        },
+        "enforcement_outcome": nonempty(
+            args.enforcement_outcome, "enforcement-outcome"
+        ),
+        "evidence": nonempty(args.evidence, "evidence"),
+        "history": [
+            {"at": stamp, "from": None, "to": args.state, "evidence": args.evidence}
+        ],
+        "created_at": stamp,
+    }
+    if args.follow_up_project:
+        finding["follow_up_project"] = nonempty(
+            args.follow_up_project, "follow-up-project"
+        )
+    doc["findings"].append(finding)
+    atomic_write(args.file, doc, args.resources_root)
+    report_success(f"added {args.id} as {args.classification}/{args.state}")
+
+
+def command_transition(args: argparse.Namespace) -> None:
+    doc = load(args.file, args.resources_root)
+    matches = [item for item in doc["findings"] if item["id"] == args.id]
+    if len(matches) != 1:
+        raise LedgerError(f"expected exactly one finding {args.id!r}, found {len(matches)}")
+    finding = matches[0]
+    if finding["state"] != args.from_state:
+        raise LedgerError(
+            f"{args.id} is {finding['state']!r}, not expected {args.from_state!r}; "
+            "re-read the ledger before retrying"
+        )
+    if args.to_state == args.from_state:
+        raise LedgerError("transition must change state")
+    evidence = nonempty(args.evidence, "evidence")
+    finding["state"] = args.to_state
+    finding["evidence"] = evidence
+    finding["history"].append(
+        {
+            "at": now(),
+            "from": args.from_state,
+            "to": args.to_state,
+            "evidence": evidence,
+        }
+    )
+    atomic_write(args.file, doc, args.resources_root)
+    report_success(f"transitioned {args.id}: {args.from_state} -> {args.to_state}")
+
+
+def parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0], allow_abbrev=False)
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    init = sub.add_parser("init", allow_abbrev=False)
+    init.add_argument("--resources-root", required=True, type=pathlib.Path)
+    init.add_argument("--file", required=True, type=pathlib.Path)
+    init.add_argument("--engagement", required=True)
+    init.add_argument("--principal-outcome", required=True)
+    init.add_argument("--round-trip-budget", required=True, type=int)
+    init.add_argument("--proportionality", required=True)
+
+    crossing = sub.add_parser("record-crossing", allow_abbrev=False)
+    crossing.add_argument("--resources-root", required=True, type=pathlib.Path)
+    crossing.add_argument("--file", required=True, type=pathlib.Path)
+    crossing.add_argument("--expected-count", required=True, type=int)
+    crossing.add_argument("--evidence", required=True)
+
+    add = sub.add_parser("add", allow_abbrev=False)
+    add.add_argument("--resources-root", required=True, type=pathlib.Path)
+    add.add_argument("--file", required=True, type=pathlib.Path)
+    add.add_argument("--id", required=True)
+    add.add_argument("--title", required=True)
+    add.add_argument("--state", required=True, choices=sorted(STATES))
+    add.add_argument("--classification", required=True, choices=sorted(CLASSIFICATIONS))
+    add.add_argument("--authority-label", required=True, choices=sorted(AUTHORITY_LABELS))
+    add.add_argument("--provenance-id", required=True)
+    add.add_argument("--enforcement-outcome", required=True)
+    add.add_argument("--evidence", required=True)
+    add.add_argument("--follow-up-project")
+
+    transition = sub.add_parser("transition", allow_abbrev=False)
+    transition.add_argument("--resources-root", required=True, type=pathlib.Path)
+    transition.add_argument("--file", required=True, type=pathlib.Path)
+    transition.add_argument("--id", required=True)
+    transition.add_argument("--from-state", required=True, choices=sorted(STATES))
+    transition.add_argument("--to-state", required=True, choices=sorted(STATES))
+    transition.add_argument("--evidence", required=True)
+
+    validate = sub.add_parser("validate", allow_abbrev=False)
+    validate.add_argument("--resources-root", required=True, type=pathlib.Path)
+    validate.add_argument("--file", required=True, type=pathlib.Path)
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    if yaml is None:
+        print("finding-ledger error: PyYAML is required", file=sys.stderr)
+        return 2
+    ap = parser()
+    args = ap.parse_args(argv)
+    try:
+        args.resources_root = validated_resources_root(args.resources_root)
+        args.file = lexical_absolute(args.file)
+        with resources_lock(args.resources_root):
+            if args.command == "init":
+                command_init(args)
+            elif args.command == "record-crossing":
+                command_record_crossing(args)
+            elif args.command == "add":
+                command_add(args)
+            elif args.command == "transition":
+                command_transition(args)
+            else:
+                doc = load(args.file, args.resources_root)
+                report_success(
+                    f"valid {args.file}: schema {doc['schema']}, "
+                    f"{len(doc['findings'])} finding(s)"
+                )
+    except LedgerError as exc:
+        print(f"finding-ledger refused: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/synthesis-adversarial-review/scripts/protocol_acceptance.py
+++ b/skills/synthesis-adversarial-review/scripts/protocol_acceptance.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Diagnose the structural adversarial-review and orchestration contract.
+
+AGENT HEURISTIC: this is a diagnostic for section-scoped source structure. It
+cannot establish that an agent followed the protocol; native behavioral smoke
+checks remain a separate acceptance surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+HEADING = re.compile(r"^(#{2,3})\s+(.+?)\s*$", re.MULTILINE)
+
+
+def read(path: pathlib.Path) -> str:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"unsafe or missing contract file: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def section_map(text: str) -> tuple[list[str], dict[str, str]]:
+    matches = list(HEADING.finditer(text))
+    order = [match.group(2) for match in matches]
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        sections[match.group(2)] = text[match.end() : end]
+    return order, sections
+
+
+def require_order(order: list[str], expected: list[str], errors: list[str]) -> None:
+    positions: list[int] = []
+    for heading in expected:
+        if heading not in order:
+            errors.append(f"missing section: {heading}")
+        else:
+            positions.append(order.index(heading))
+    if len(positions) == len(expected) and positions != sorted(positions):
+        errors.append("protocol sections are out of order")
+
+
+def require_terms(
+    sections: dict[str, str], heading: str, terms: tuple[str, ...], errors: list[str]
+) -> None:
+    body = re.sub(r"\s+", " ", sections.get(heading, ""))
+    for term in terms:
+        if term not in body:
+            errors.append(f"{heading!r} is missing {term!r}")
+
+
+def review_errors(text: str) -> list[str]:
+    errors: list[str] = []
+    order, sections = section_map(text)
+    expected = [
+        "Purpose",
+        "Before Round One: Proportionality Contract",
+        "Roles and Blind-Spot Rotation",
+        "Goal-Focused Round",
+        "Sidecars, Evidence, and Handoff Topology",
+        "Finding Ledger",
+        "Bounded Control Depth",
+        "Bounded Post-Publication Acceptance",
+        "Agent-Principal Norms",
+        "Completion Report",
+    ]
+    require_order(order, expected, errors)
+    requirements = {
+        "Purpose": ("principal's outcome", "Reviewer satisfaction"),
+        "Before Round One: Proportionality Contract": (
+            "Closed review universe",
+            "Round-trip budget",
+            "principal courier crossings",
+            "Stop rule",
+        ),
+        "Roles and Blind-Spot Rotation": (
+            "Executor",
+            "Adversarial reviewer",
+            "Concession is health",
+        ),
+        "Goal-Focused Round": (
+            "Concept sweep",
+            "Sufficiency",
+            "ship-blocking",
+            "ship-improving",
+            "risk of shipping now",
+            "principal's ruling terminates the loop",
+        ),
+        "Sidecars, Evidence, and Handoff Topology": (
+            "Sidecars are claims",
+            "production entry point",
+            "enforcing boundary",
+            "receipt consumer",
+        ),
+        "Finding Ledger": (
+            "authority label",
+            "enforcement outcome",
+            "follow-up project",
+        ),
+        "Bounded Control Depth": (
+            "generation N+1",
+            "generation N+2",
+            "explicit principal decision",
+        ),
+        "Bounded Post-Publication Acceptance": (
+            "second agent",
+            "per-artifact matrix",
+            "fresh approval",
+        ),
+        "Agent-Principal Norms": ("known-false claim", "loosening", "Approval fatigue"),
+        "Completion Report": ("unverified remainder", "principal outcome"),
+    }
+    for heading, terms in requirements.items():
+        require_terms(sections, heading, terms, errors)
+    goal = sections.get("Goal-Focused Round", "")
+    for stage in ("1. **Contract.**", "2. **Attack.**", "3. **Disposition.**", "4. **Concept sweep.**", "5. **Sufficiency.**"):
+        if stage not in goal:
+            errors.append(f"goal-focused round is missing ordered stage {stage!r}")
+    return errors
+
+
+def autopilot_errors(text: str) -> list[str]:
+    errors: list[str] = []
+    _, sections = section_map(text)
+    require_terms(
+        sections,
+        "Cross-Agent Orchestration",
+        (
+            "direct session-to-session dispatch",
+            "principal courier crossings",
+            "round-trip budget",
+            "principal's outcome",
+            "generation N+1",
+            "generation N+2",
+        ),
+        errors,
+    )
+    return errors
+
+
+def router_errors(text: str) -> list[str]:
+    errors: list[str] = []
+    _, sections = section_map(text)
+    require_terms(
+        sections,
+        "Software engineering and review",
+        ("adversarial review", "../synthesis-adversarial-review/SKILL.md"),
+        errors,
+    )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument("--review", required=True, type=pathlib.Path)
+    parser.add_argument("--autopilot", required=True, type=pathlib.Path)
+    parser.add_argument("--router", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+    try:
+        errors = [
+            *review_errors(read(args.review)),
+            *autopilot_errors(read(args.autopilot)),
+            *router_errors(read(args.router)),
+        ]
+    except (OSError, ValueError) as exc:
+        print(f"protocol diagnostic refused: {exc}", file=sys.stderr)
+        return 1
+    if errors:
+        for error in errors:
+            print(f"protocol diagnostic refused: {error}", file=sys.stderr)
+        return 1
+    print(
+        "PASS protocol source structure; not verified: native agent behavior, "
+        "review sufficiency, release state, or approval status"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/synthesis-adversarial-review/scripts/test_finding_ledger.py
+++ b/skills/synthesis-adversarial-review/scripts/test_finding_ledger.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+
+import yaml
+
+
+SCRIPT = pathlib.Path(__file__).with_name("finding_ledger.py")
+
+
+def run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def initialize(path: pathlib.Path) -> None:
+    result = run(
+        "init",
+        "--file",
+        str(path),
+        "--engagement",
+        "fixture-engagement",
+        "--principal-outcome",
+        "Ship the accepted controls without using the principal as courier.",
+        "--round-trip-budget",
+        "0",
+        "--proportionality",
+        "One bounded adversarial exchange; stop control growth at generation one.",
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def add_args(path: pathlib.Path, finding_id: str = "R1-F001") -> list[str]:
+    return [
+        "add",
+        "--file",
+        str(path),
+        "--id",
+        finding_id,
+        "--title",
+        "A fixture finding",
+        "--state",
+        "challenged",
+        "--classification",
+        "ship-blocking",
+        "--authority-label",
+        "agent-heuristic",
+        "--provenance-id",
+        "agent-heuristic:fixture",
+        "--enforcement-outcome",
+        "reported-without-enforcement",
+        "--evidence",
+        "fixture evidence",
+    ]
+
+
+def test_init_creates_declared_engagement(tmp_path: pathlib.Path) -> None:
+    ledger = tmp_path / "findings.yaml"
+    initialize(ledger)
+    doc = yaml.safe_load(ledger.read_text(encoding="utf-8"))
+    assert doc["schema"] == 1
+    assert doc["engagement"]["id"] == "fixture-engagement"
+    assert doc["engagement"]["principal_outcome"].startswith("Ship the accepted")
+    assert doc["engagement"]["principal_courier_round_trips"] == {
+        "budget": 0,
+        "count": 0,
+    }
+    assert doc["findings"] == []
+
+
+def test_add_requires_ship_classification_without_mutating(
+    tmp_path: pathlib.Path,
+) -> None:
+    ledger = tmp_path / "findings.yaml"
+    initialize(ledger)
+    before = ledger.read_bytes()
+    args = add_args(ledger)
+    at = args.index("--classification")
+    del args[at : at + 2]
+    result = run(*args)
+    assert result.returncode != 0
+    assert ledger.read_bytes() == before
+
+
+def test_authority_label_and_enforcement_outcome_remain_separate(
+    tmp_path: pathlib.Path,
+) -> None:
+    ledger = tmp_path / "findings.yaml"
+    initialize(ledger)
+    result = run(*add_args(ledger))
+    assert result.returncode == 0, result.stderr
+    finding = yaml.safe_load(ledger.read_text(encoding="utf-8"))["findings"][0]
+    assert finding["authority"] == {
+        "label": "agent-heuristic",
+        "provenance_id": "agent-heuristic:fixture",
+    }
+    assert finding["enforcement_outcome"] == "reported-without-enforcement"
+    assert finding["authority"]["label"] not in finding["enforcement_outcome"]
+
+
+def test_transition_requires_the_recorded_prior_state(tmp_path: pathlib.Path) -> None:
+    ledger = tmp_path / "findings.yaml"
+    initialize(ledger)
+    assert run(*add_args(ledger)).returncode == 0
+    before = ledger.read_bytes()
+    stale = run(
+        "transition",
+        "--file",
+        str(ledger),
+        "--id",
+        "R1-F001",
+        "--from-state",
+        "open",
+        "--to-state",
+        "repaired-source",
+        "--evidence",
+        "source repair",
+    )
+    assert stale.returncode != 0
+    assert ledger.read_bytes() == before
+    changed = run(
+        "transition",
+        "--file",
+        str(ledger),
+        "--id",
+        "R1-F001",
+        "--from-state",
+        "challenged",
+        "--to-state",
+        "repaired-source",
+        "--evidence",
+        "source repair",
+    )
+    assert changed.returncode == 0, changed.stderr
+    finding = yaml.safe_load(ledger.read_text(encoding="utf-8"))["findings"][0]
+    assert finding["state"] == "repaired-source"
+    assert finding["history"][-1]["from"] == "challenged"
+
+
+def test_ship_improving_requires_follow_up_project(tmp_path: pathlib.Path) -> None:
+    ledger = tmp_path / "findings.yaml"
+    initialize(ledger)
+    args = add_args(ledger)
+    at = args.index("ship-blocking")
+    args[at] = "ship-improving"
+    refused = run(*args)
+    assert refused.returncode != 0
+    assert yaml.safe_load(ledger.read_text(encoding="utf-8"))["findings"] == []
+    accepted = run(*args, "--follow-up-project", "fixture-follow-up")
+    assert accepted.returncode == 0, accepted.stderr
+    finding = yaml.safe_load(ledger.read_text(encoding="utf-8"))["findings"][0]
+    assert finding["follow_up_project"] == "fixture-follow-up"
+
+
+def test_duplicate_finding_id_refuses_without_mutating(tmp_path: pathlib.Path) -> None:
+    ledger = tmp_path / "findings.yaml"
+    initialize(ledger)
+    assert run(*add_args(ledger)).returncode == 0
+    before = ledger.read_bytes()
+    duplicate = run(*add_args(ledger))
+    assert duplicate.returncode != 0
+    assert ledger.read_bytes() == before
+
+
+def test_symlink_ledger_is_refused(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / "target.yaml"
+    initialize(target)
+    link = tmp_path / "link.yaml"
+    os.symlink(target, link)
+    before = target.read_bytes()
+    result = run("validate", "--file", str(link))
+    assert result.returncode != 0
+    assert target.read_bytes() == before

--- a/skills/synthesis-adversarial-review/scripts/test_finding_ledger.py
+++ b/skills/synthesis-adversarial-review/scripts/test_finding_ledger.py
@@ -20,7 +20,7 @@ def run(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def initialize(path: pathlib.Path) -> None:
+def initialize(path: pathlib.Path, *, budget: int = 0) -> None:
     result = run(
         "init",
         "--file",
@@ -30,7 +30,7 @@ def initialize(path: pathlib.Path) -> None:
         "--principal-outcome",
         "Ship the accepted controls without using the principal as courier.",
         "--round-trip-budget",
-        "0",
+        str(budget),
         "--proportionality",
         "One bounded adversarial exchange; stop control growth at generation one.",
     )
@@ -71,6 +71,7 @@ def test_init_creates_declared_engagement(tmp_path: pathlib.Path) -> None:
     assert doc["engagement"]["principal_courier_round_trips"] == {
         "budget": 0,
         "count": 0,
+        "history": [],
     }
     assert doc["findings"] == []
 
@@ -178,3 +179,51 @@ def test_symlink_ledger_is_refused(tmp_path: pathlib.Path) -> None:
     result = run("validate", "--file", str(link))
     assert result.returncode != 0
     assert target.read_bytes() == before
+
+
+def test_courier_crossings_are_compare_before_write_and_budget_bounded(
+    tmp_path: pathlib.Path,
+) -> None:
+    ledger = tmp_path / "findings.yaml"
+    initialize(ledger, budget=1)
+    recorded = run(
+        "record-crossing",
+        "--file",
+        str(ledger),
+        "--expected-count",
+        "0",
+        "--evidence",
+        "Human copied one provider-boundary payload.",
+    )
+    assert recorded.returncode == 0, recorded.stderr
+    trips = yaml.safe_load(ledger.read_text(encoding="utf-8"))["engagement"][
+        "principal_courier_round_trips"
+    ]
+    assert trips["count"] == 1
+    assert trips["history"][0]["evidence"].startswith("Human copied")
+
+    before = ledger.read_bytes()
+    stale = run(
+        "record-crossing",
+        "--file",
+        str(ledger),
+        "--expected-count",
+        "0",
+        "--evidence",
+        "A stale writer must refuse.",
+    )
+    assert stale.returncode != 0
+    assert ledger.read_bytes() == before
+
+    exceeded = run(
+        "record-crossing",
+        "--file",
+        str(ledger),
+        "--expected-count",
+        "1",
+        "--evidence",
+        "This would exceed the declared budget.",
+    )
+    assert exceeded.returncode != 0
+    assert "blocked" in exceeded.stderr
+    assert ledger.read_bytes() == before

--- a/skills/synthesis-adversarial-review/scripts/test_finding_ledger.py
+++ b/skills/synthesis-adversarial-review/scripts/test_finding_ledger.py
@@ -227,3 +227,49 @@ def test_courier_crossings_are_compare_before_write_and_budget_bounded(
     assert exceeded.returncode != 0
     assert "blocked" in exceeded.stderr
     assert ledger.read_bytes() == before
+
+
+def test_every_success_branch_names_the_unverified_remainder(
+    tmp_path: pathlib.Path,
+) -> None:
+    ledger = tmp_path / "findings.yaml"
+    initialized = run(
+        "init",
+        "--file",
+        str(ledger),
+        "--engagement",
+        "coverage-fixture",
+        "--principal-outcome",
+        "Ship the requested artifact.",
+        "--round-trip-budget",
+        "1",
+        "--proportionality",
+        "One bounded exchange.",
+    )
+    crossed = run(
+        "record-crossing",
+        "--file",
+        str(ledger),
+        "--expected-count",
+        "0",
+        "--evidence",
+        "One declared provider-boundary crossing.",
+    )
+    added = run(*add_args(ledger))
+    transitioned = run(
+        "transition",
+        "--file",
+        str(ledger),
+        "--id",
+        "R1-F001",
+        "--from-state",
+        "challenged",
+        "--to-state",
+        "repaired-verified",
+        "--evidence",
+        "The requested artifact passed its acceptance boundary.",
+    )
+    validated = run("validate", "--file", str(ledger))
+    for result in (initialized, crossed, added, transitioned, validated):
+        assert result.returncode == 0, result.stderr
+        assert "not verified:" in result.stdout.lower()

--- a/skills/synthesis-adversarial-review/scripts/test_finding_ledger.py
+++ b/skills/synthesis-adversarial-review/scripts/test_finding_ledger.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import time
 
 import yaml
 
@@ -11,9 +12,17 @@ import yaml
 SCRIPT = pathlib.Path(__file__).with_name("finding_ledger.py")
 
 
-def run(*args: str) -> subprocess.CompletedProcess[str]:
+def run(
+    *args: str, resources_root: pathlib.Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    command, *rest = args
+    if command in {"init", "record-crossing", "add", "transition", "validate"}:
+        file_index = rest.index("--file") + 1
+        ledger = pathlib.Path(rest[file_index])
+        root = resources_root or ledger.parent
+        rest = ["--resources-root", str(root), *rest]
     return subprocess.run(
-        [sys.executable, str(SCRIPT), *args],
+        [sys.executable, str(SCRIPT), command, *rest],
         capture_output=True,
         text=True,
         check=False,
@@ -273,3 +282,137 @@ def test_every_success_branch_names_the_unverified_remainder(
     for result in (initialized, crossed, added, transitioned, validated):
         assert result.returncode == 0, result.stderr
         assert "not verified:" in result.stdout.lower()
+
+
+def test_transition_history_is_contiguous_and_evidence_bound(
+    tmp_path: pathlib.Path,
+) -> None:
+    mutations = ("first-from", "broken-chain", "evidence-mismatch")
+    for mutation in mutations:
+        root = tmp_path / mutation
+        root.mkdir()
+        ledger = root / "findings.yaml"
+        initialize(ledger)
+        assert run(*add_args(ledger)).returncode == 0
+        doc = yaml.safe_load(ledger.read_text(encoding="utf-8"))
+        finding = doc["findings"][0]
+        if mutation == "first-from":
+            finding["history"][0]["from"] = "open"
+        elif mutation == "broken-chain":
+            finding["history"].append(
+                {
+                    "at": "2026-08-26T00:00:00+00:00",
+                    "from": "open",
+                    "to": "repaired-verified",
+                    "evidence": "terminal evidence",
+                }
+            )
+            finding["state"] = "repaired-verified"
+            finding["evidence"] = "terminal evidence"
+        else:
+            finding["evidence"] = "top-level evidence disagrees"
+        ledger.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
+        refused = run("validate", "--file", str(ledger))
+        assert refused.returncode != 0, mutation
+
+
+def test_resources_root_rejects_symlinked_parent_and_outside_target(
+    tmp_path: pathlib.Path,
+) -> None:
+    resources = tmp_path / "resources"
+    resources.mkdir()
+    safe = resources / "safe.yaml"
+    initialize(safe)
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    linked = resources / "linked"
+    os.symlink(outside, linked)
+    escaped = linked / "escaped.yaml"
+    result = run(
+        "init",
+        "--file",
+        str(escaped),
+        "--engagement",
+        "escape-fixture",
+        "--principal-outcome",
+        "Keep the ledger inside resources.",
+        "--round-trip-budget",
+        "0",
+        "--proportionality",
+        "One resources boundary.",
+        resources_root=resources,
+    )
+    assert result.returncode != 0
+    assert not (outside / "escaped.yaml").exists()
+
+    external = outside / "external.yaml"
+    result = run(
+        "init",
+        "--file",
+        str(external),
+        "--engagement",
+        "outside-fixture",
+        "--principal-outcome",
+        "Keep the ledger inside resources.",
+        "--round-trip-budget",
+        "0",
+        "--proportionality",
+        "One resources boundary.",
+        resources_root=resources,
+    )
+    assert result.returncode != 0
+    assert not external.exists()
+
+
+def test_concurrent_crossing_writers_cannot_both_report_success(
+    tmp_path: pathlib.Path,
+) -> None:
+    ledger = tmp_path / "findings.yaml"
+    initialize(ledger, budget=1)
+    start = tmp_path / "start"
+    workers: list[subprocess.Popen[str]] = []
+    wrapper = (
+        "import os,pathlib,sys,time;"
+        "ready=pathlib.Path(sys.argv[1]);start=pathlib.Path(sys.argv[2]);"
+        "ready.write_text('ready');"
+        "deadline=time.monotonic()+10;"
+        "\nwhile not start.exists():\n"
+        "  assert time.monotonic()<deadline\n"
+        "  time.sleep(0.001)\n"
+        "os.execv(sys.executable,[sys.executable,*sys.argv[3:]])"
+    )
+    command = [
+        str(SCRIPT),
+        "record-crossing",
+        "--resources-root",
+        str(tmp_path),
+        "--file",
+        str(ledger),
+        "--expected-count",
+        "0",
+        "--evidence",
+        "One synchronized provider-boundary crossing.",
+    ]
+    for index in range(8):
+        ready = tmp_path / f"ready-{index}"
+        workers.append(
+            subprocess.Popen(
+                [sys.executable, "-c", wrapper, str(ready), str(start), *command],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        )
+    deadline = time.monotonic() + 10
+    while len(list(tmp_path.glob("ready-*"))) != len(workers):
+        assert time.monotonic() < deadline
+        time.sleep(0.005)
+    start.write_text("start", encoding="utf-8")
+    results = [worker.communicate(timeout=15) + (worker.returncode,) for worker in workers]
+    assert [result[2] for result in results].count(0) == 1, results
+    trips = yaml.safe_load(ledger.read_text(encoding="utf-8"))["engagement"][
+        "principal_courier_round_trips"
+    ]
+    assert trips["count"] == 1
+    assert len(trips["history"]) == 1

--- a/skills/synthesis-adversarial-review/scripts/test_protocol_contract.py
+++ b/skills/synthesis-adversarial-review/scripts/test_protocol_contract.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pathlib
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+REVIEW = SKILL_ROOT / "SKILL.md"
+AUTOPILOT = SKILL_ROOT.parent / "synthesis-autopilot" / "SKILL.md"
+
+
+def review_text() -> str:
+    return REVIEW.read_text(encoding="utf-8")
+
+
+def autopilot_text() -> str:
+    return AUTOPILOT.read_text(encoding="utf-8")
+
+
+def test_review_protocol_is_principal_outcome_focused() -> None:
+    text = review_text()
+    for required in (
+        "principal's outcome",
+        "goal-focused round",
+        "ship-blocking",
+        "ship-improving",
+        "Concession is health",
+        "per-artifact matrix",
+    ):
+        assert required in text
+
+
+def test_handoff_contract_names_the_production_topology() -> None:
+    text = review_text()
+    for required in (
+        "production entry point",
+        "enforcing boundary",
+        "receipt consumer",
+        "Sidecars are claims",
+        "concept sweep",
+    ):
+        assert required in text
+
+
+def test_control_depth_and_sufficiency_are_bounded() -> None:
+    text = review_text()
+    for required in (
+        "established",
+        "open",
+        "risk of shipping now",
+        "principal's ruling terminates the loop",
+        "generation N+1",
+        "generation N+2",
+    ):
+        assert required in text
+
+
+def test_autopilot_tracks_direct_dispatch_and_courier_cost() -> None:
+    text = autopilot_text()
+    for required in (
+        "direct session-to-session dispatch",
+        "principal courier crossings",
+        "round-trip budget",
+        "proportionality",
+        "reviewer satisfaction",
+    ):
+        assert required in text

--- a/skills/synthesis-adversarial-review/scripts/test_protocol_contract.py
+++ b/skills/synthesis-adversarial-review/scripts/test_protocol_contract.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import pathlib
+import subprocess
+import sys
+
+import yaml
 
 
 SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
 REVIEW = SKILL_ROOT / "SKILL.md"
 AUTOPILOT = SKILL_ROOT.parent / "synthesis-autopilot" / "SKILL.md"
 ROUTER = SKILL_ROOT.parent / "synthesis-skill-router" / "SKILL.md"
+CONTRACT = pathlib.Path(__file__).with_name("protocol_acceptance.py")
+MANIFEST = SKILL_ROOT / "acceptance-suite.yaml"
 
 
 def review_text() -> str:
@@ -75,3 +81,64 @@ def test_hidden_specialist_is_reachable_through_the_router() -> None:
     text = router_text()
     assert "../synthesis-adversarial-review/SKILL.md" in text
     assert "adversarial review" in text.lower()
+
+
+def test_acceptance_manifest_classifies_control_authority() -> None:
+    manifest = yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+    assert manifest["metadata_class"] == "acceptance-test"
+    assert manifest["issues_authority_receipt"] is False
+    allowed = {"diagnostic", "acceptance-test", "enforced-gate"}
+    for case in manifest["cases"]:
+        assert case["control_class"] in allowed
+    assert all(
+        case["control_class"] == "diagnostic"
+        for case in manifest["cases"]
+        if "test_protocol_contract.py" in case["fixture"]
+    )
+
+
+def test_protocol_acceptance_rejects_token_soup(tmp_path: pathlib.Path) -> None:
+    valid = subprocess.run(
+        [
+            sys.executable,
+            str(CONTRACT),
+            "--review",
+            str(REVIEW),
+            "--autopilot",
+            str(AUTOPILOT),
+            "--router",
+            str(ROUTER),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert valid.returncode == 0, valid.stderr
+
+    token_soup = tmp_path / "tokens.md"
+    token_soup.write_text(
+        "principal's outcome goal-focused round ship-blocking ship-improving "
+        "Concession is health per-artifact matrix production entry point "
+        "enforcing boundary receipt consumer Sidecars are claims concept sweep "
+        "established open risk of shipping now principal's ruling terminates "
+        "the loop generation N+1 generation N+2 direct session-to-session "
+        "dispatch principal courier crossings round-trip budget proportionality "
+        "reviewer satisfaction ../synthesis-adversarial-review/SKILL.md",
+        encoding="utf-8",
+    )
+    refused = subprocess.run(
+        [
+            sys.executable,
+            str(CONTRACT),
+            "--review",
+            str(token_soup),
+            "--autopilot",
+            str(token_soup),
+            "--router",
+            str(token_soup),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert refused.returncode != 0

--- a/skills/synthesis-adversarial-review/scripts/test_protocol_contract.py
+++ b/skills/synthesis-adversarial-review/scripts/test_protocol_contract.py
@@ -6,6 +6,7 @@ import pathlib
 SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
 REVIEW = SKILL_ROOT / "SKILL.md"
 AUTOPILOT = SKILL_ROOT.parent / "synthesis-autopilot" / "SKILL.md"
+ROUTER = SKILL_ROOT.parent / "synthesis-skill-router" / "SKILL.md"
 
 
 def review_text() -> str:
@@ -14,6 +15,10 @@ def review_text() -> str:
 
 def autopilot_text() -> str:
     return AUTOPILOT.read_text(encoding="utf-8")
+
+
+def router_text() -> str:
+    return ROUTER.read_text(encoding="utf-8")
 
 
 def test_review_protocol_is_principal_outcome_focused() -> None:
@@ -64,3 +69,9 @@ def test_autopilot_tracks_direct_dispatch_and_courier_cost() -> None:
         "reviewer satisfaction",
     ):
         assert required in text
+
+
+def test_hidden_specialist_is_reachable_through_the_router() -> None:
+    text = router_text()
+    assert "../synthesis-adversarial-review/SKILL.md" in text
+    assert "adversarial review" in text.lower()

--- a/skills/synthesis-autopilot/SKILL.md
+++ b/skills/synthesis-autopilot/SKILL.md
@@ -2,10 +2,10 @@
 name: synthesis-autopilot
 description: "Execute an explicitly delegated whole task autonomously using the thinking framework, durable plan and context, checkpoints, anti-shortcut discipline, and implementation-integrity gate. Activate only for clear end-to-end delegation such as 'autopilot this,' 'take care of this for me,' 'handle this end to end,' or 'complete all phases autonomously'; never infer it from a single-step approval, discussion of autonomy, or ambiguous wording."
 license: "Apache-2.0"
-depends_on: ["synthesis-thinking-framework", "synthesis-context-lifecycle", "synthesis-checkpoint", "synthesis-anti-shortcuts", "synthesis-grounding-discipline", "synthesis-implementation-integrity", "synthesis-project-management"]
+depends_on: ["synthesis-thinking-framework", "synthesis-context-lifecycle", "synthesis-checkpoint", "synthesis-anti-shortcuts", "synthesis-grounding-discipline", "synthesis-implementation-integrity", "synthesis-project-management", "synthesis-adversarial-review"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.1.0"
+  version: "1.2.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -76,6 +76,10 @@ Engaged: <date> · Requested by: <user> · Status: <phase N of M>
 ## Mission
 What "done" means, in the user's terms.
 
+## Principal outcome
+The artifact or system outcome the principal asked to ship. Reviewer
+satisfaction and control construction are not substitutes.
+
 ## Standing instructions
 The delegation contract above, restated — so a post-compaction
 re-read restores the mode, not just the task.
@@ -86,6 +90,15 @@ Everything the user has decided; never re-litigate these.
 ## Coordination claims
 Session id, active source-area globs, overlaps checked, and messages pending.
 
+## Proportionality
+Consequence being prevented, bounded review universe, justified control
+depth, and why the planned review effort is proportionate.
+
+## Cross-agent orchestration and round-trip budget
+Counterpart sessions, direct dispatch path, provider-boundary exception if
+one exists, allowed principal courier crossings, current count, and the
+blocked-state alert threshold.
+
 ## Phases
 - [x] Phase 1 — ...
 - [ ] Phase 2 — ...
@@ -95,6 +108,9 @@ Dated entries: decision, thinking-framework mode used, rationale.
 
 ## Batched questions for the user
 Only questions the user alone can answer. Presented at checkpoints.
+
+## Sufficiency checkpoint
+Established, open, risk of shipping now, and the principal's ruling.
 
 ## Completion criteria and verification plan
 ```
@@ -110,6 +126,36 @@ Every decision in an autonomous run falls into one of three classes:
 3. **User-only → batch.** Facts only the user knows, genuine value trade-offs between goals the user holds, scope changes beyond the delegation. Add to the plan file's batched-questions section and continue with every piece of work that does not depend on the answer. Present the batch at a natural checkpoint — a phase boundary or the completion report.
 
 **Never block the whole run on one question.** Re-sequence around it. Halt early only when *every* remaining path depends on an unanswered user-only question — that is a blocked state, reported per the alerts section.
+
+## Cross-Agent Orchestration
+
+When an autonomous plan calls for adversarial or independent review, autopilot owns the
+transport. Use direct session-to-session dispatch where the runtime provides it. Give the
+counterpart the bounded evidence package, production entry point, enforcing boundary,
+receipt consumer, principal outcome, and terminal return contract. Apply the sub-agent
+acceptance audit to its return before adopting any finding.
+
+If a provider boundary genuinely has no direct transport, declare that before round one.
+Batch the payload, identify who must paste it, and count it as one of the plan's principal
+courier crossings. Never hide a manual crossing inside “send this to the reviewer.” The
+round-trip budget is a tracked delivery cost; exceeding it triggers the blocked-state alert
+rather than silently recruiting the principal as orchestration middleware.
+
+Write the proportionality section before the first review round: principal outcome,
+closed artifact universe, consequence being prevented, justified control depth, and stop
+rule. Fewer rounds come from complete per-artifact coverage and stronger fixtures, never
+from reducing quality.
+
+At each named checkpoint, record a sufficiency ruling with exactly three evidence fields:
+established, open, and risk of shipping now. Put the ship-now choice in front of the
+principal when the plan names that gate; the principal's ruling terminates the review loop.
+Completion remains the principal's outcome, never reviewer satisfaction.
+
+Control depth is bounded. Verifying a requested verifier once is legitimate. A finding in
+generation N+1 of a control the principal did not request does not start generation N+2.
+If a round's findings are entirely self-inflicted by the new control, record the findings
+and stop control growth until the principal explicitly decides otherwise. Use
+synthesis-adversarial-review for the complete round and ledger protocol.
 
 ## Standing Gates Survive Autonomy
 
@@ -130,7 +176,7 @@ When a phase reaches a gated action, prepare everything up to the gate (the draf
 3. **Coordinate** — read the shared active-sessions board and claim every
    source area this run may write before editing.
 4. **Register** — attach to or create the synthesis project (synthesis-project-management); create the plan file.
-5. **Phase loop** — for each phase: re-read the plan file and coordination board; execute with anti-shortcut discipline; classify each decision per the protocol above; dispatch sub-agents per the hygiene rules below; then update the plan file, and at natural checkpoints run the synthesis-context-lifecycle session protocol so CONTEXT.md and the session log stay current.
+5. **Phase loop** — for each phase: re-read the plan file and coordination board; execute with anti-shortcut discipline; classify each decision per the protocol above; dispatch sub-agents per the hygiene rules below; directly orchestrate any adversarial counterpart and count principal courier crossings; record the sufficiency checkpoint; then update the plan file, and at natural checkpoints run the synthesis-context-lifecycle session protocol so CONTEXT.md and the session log stay current.
 6. **Verify** — before declaring the mission complete, run synthesis-implementation-integrity (or the domain analog). Fix what it finds; verification that only reports is not verification.
 7. **Close** — session-end per synthesis-context-lifecycle (context files updated, work committed where applicable); release the coordination claims; completion report in plain language: what shipped, what was decided and why, the batched questions; then the completion alert.
 
@@ -166,5 +212,6 @@ Nothing above is specific to software. The mode runs the same for engineering, r
 | synthesis-anti-shortcuts | Solution quality; dispatch and acceptance hygiene | Every draft, plan, brief, and sub-agent return |
 | synthesis-grounding-discipline | Claim quality: provenance, cache re-verification, absence proof | Every recorded fact and status claim; before any write or deletion |
 | synthesis-implementation-integrity | Verification before completion claims | Before "done"; per-phase for high-stakes phases |
+| synthesis-adversarial-review | Bounded cross-agent attack, findings, sufficiency, and acceptance | When a plan calls for adversarial or independent review |
 
 Each dependency works standalone. This mode is the sequencing that makes them one behavior: delegate once, and the stack runs itself.

--- a/skills/synthesis-inbox-cleanup/SKILL.md
+++ b/skills/synthesis-inbox-cleanup/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.6.0"
+  version: "1.6.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
   platform: "macOS (Apple Silicon and Intel)"
@@ -16,6 +16,14 @@ metadata:
 A manifest-driven email cleanup engine that scales the same human-curated rules across three account tool stacks on macOS: iCloud / generic IMAP, Microsoft 365 / outlook.com via Mail.app AppleScript, and Gmail via the workspace-mcp Gmail API (with optional native server-side filters).
 
 The engine is deterministic. Email content does not change rules at runtime. When an LLM is invoked — for new-sender categorization or for higher-risk paths like body-reading digests — sanitization defenses run first. The skill ships adversarial test fixtures so prompt-injection regressions surface in CI rather than in production.
+
+## v1.6.2 — Cross-platform runtime pointer replacement
+
+The runtime installer replaces its staged `engine/current` symlink with
+Python's atomic `os.replace`. The previous repair used BSD `mv -h`, which works
+on macOS but fails under GNU `mv` before the pointer can move. The regression
+fixture now models that GNU refusal on every host while preserving the original
+two-install, differing-digest acceptance path.
 
 ## v1.6.0 — Impersonation scanning: the taxonomy had no cell for *hostile*
 

--- a/skills/synthesis-inbox-cleanup/scripts/install.sh
+++ b/skills/synthesis-inbox-cleanup/scripts/install.sh
@@ -106,12 +106,15 @@ install_engine_runtime() {
         return 1
     fi
     ln -s "releases/$source_digest" "$link_stage"
-    # -h is load-bearing: engine/current is a symlink TO A DIRECTORY, and without
-    # it mv follows the link and deposits the staged link INSIDE the old release
-    # instead of replacing the pointer. The install then "succeeds" at every step
-    # while the runtime stays pinned to whatever release it already had. Caught
-    # 2026-08-24 with a stray .current.<pid>.tmp found inside the old release dir.
-    mv -fh "$link_stage" "$ENGINE_CURRENT"
+    # AGENT HEURISTIC: os.replace supplies the same atomic pointer swap on macOS
+    # and Linux. BSD mv needs -h to replace a symlink to a directory, while GNU
+    # mv rejects that option.
+    python3 - "$link_stage" "$ENGINE_CURRENT" <<'PY'
+import os
+import sys
+
+os.replace(sys.argv[1], sys.argv[2])
+PY
 
     resolved_current="$(cd "$ENGINE_CURRENT" && pwd -P)"
     resolved_release="$(cd "$release_dir" && pwd -P)"

--- a/skills/synthesis-inbox-cleanup/tests/fixtures/mv-no-h
+++ b/skills/synthesis-inbox-cleanup/tests/fixtures/mv-no-h
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+# Model GNU mv's refusal of the BSD-only -h option while delegating every
+# portable invocation to the host implementation.
+for argument in "$@"; do
+    case "$argument" in
+        -?*h*)
+            echo "mv fixture: option h is unsupported" >&2
+            exit 64
+            ;;
+    esac
+done
+
+exec "$SYNTHESIS_TEST_REAL_MV" "$@"

--- a/skills/synthesis-inbox-cleanup/tests/test_runtime_installer.sh
+++ b/skills/synthesis-inbox-cleanup/tests/test_runtime_installer.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SKILL_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+FIXTURE_ROOT="$SKILL_ROOT/tests/fixtures"
 TEST_ROOT=$(mktemp -d)
 SOURCE_SENTINEL="$SKILL_ROOT/.runtime-installer-source-sentinel"
 CWD_SENTINEL="$TEST_ROOT/cwd-sentinel"
@@ -83,7 +84,14 @@ test -d "$OLD_RELEASE"
 STAGED_SOURCE="$TEST_ROOT/altered-skill"
 cp -R "$SKILL_ROOT" "$STAGED_SOURCE"
 printf '\n# regression-marker\n' >> "$STAGED_SOURCE/scripts/_lib.py"
-SYNTHESIS_INBOX_HOME="$REPOINT_ROOT" "$STAGED_SOURCE/scripts/install.sh" >/dev/null 2>&1 || {
+PORTABLE_BIN="$TEST_ROOT/portable-bin"
+mkdir -p "$PORTABLE_BIN"
+cp "$FIXTURE_ROOT/mv-no-h" "$PORTABLE_BIN/mv"
+chmod 700 "$PORTABLE_BIN/mv"
+SYNTHESIS_TEST_REAL_MV=$(command -v mv) \
+    PATH="$PORTABLE_BIN:$PATH" \
+    SYNTHESIS_INBOX_HOME="$REPOINT_ROOT" \
+    "$STAGED_SOURCE/scripts/install.sh" >/dev/null 2>&1 || {
     echo "installer failed while repointing an existing engine/current" >&2
     exit 1
 }

--- a/skills/synthesis-skill-router/SKILL.md
+++ b/skills/synthesis-skill-router/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.2.0"
+  version: "1.3.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -30,6 +30,8 @@ Choose the narrowest matching workflow, then read its sibling `SKILL.md` complet
 
 ### Software engineering and review
 
+- AGENT HEURISTIC — Conduct a bounded adversarial review, rotate differently shaped
+  reviewers, or maintain a finding ledger: `../synthesis-adversarial-review/SKILL.md`
 - Plan implementation: `../synthesis-code-planning/SKILL.md`; for unresolved architecture choices also load `../synthesis-preplan/SKILL.md`
 - Audit code or a codebase: `../synthesis-code-audit/SKILL.md`, `../synthesis-codebase-review/SKILL.md`
 - Integrate multi-contributor work: `../synthesis-code-integration/SKILL.md`


### PR DESCRIPTION
## What changed

- Add the synthesis-adversarial-review protocol and fail-closed finding ledger.
- Extend synthesis-autopilot with direct counterpart orchestration, courier budgets, proportionality, sufficiency rulings, and bounded control depth.
- Make the prompt-hidden specialist reachable through the synthesis skill router.
- Preserve generation-zero fixtures before implementation and add the independent reviewer-derived defects before their repairs.
- Repair the Linux CI failure caused by BSD-only mv -h, with a host-independent failing fixture committed before the os.replace implementation; align synthesis-inbox-cleanup metadata at v1.6.2.

## Verification before CI

- R1 suite: 19 passed
- Source conformance: 198 passed
- Instructions: 2 passed
- Full repository verification: 144 conformance, 39 project-management, 8 knowledge-base/OKF, 38 daily/message/hooks, 22 onboarding, 42 transcript tests, inbox suites, runtime installer, shell syntax, and installer tests all passed
- Cross-platform runtime-pointer fixture, diff check, and Python compilation passed

AGENT HEURISTIC: the section-structure checker remains a diagnostic. Native behavior, release state, and approval status require their separate acceptance surfaces.