### PR TITLE
Add publication promotion gate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.50.0",
+  "version": "4.51.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.50.0",
+  "version": "4.51.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
       - run: python skills/synthesis-agent-conformance/scripts/conformance.py instructions --repo-root .
       - run: python -m pytest skills/synthesis-agent-conformance/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-project-management/scripts/test_coordination.py -q
-      - run: python -m pytest skills/synthesis-promotion-gate/scripts/test_*.py -q
+      - run: python -m pytest skills/synthesis-promotion-gate/scripts/ -q
       - run: python -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-onboarding/scripts/test_onboard.py -q

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,7 @@ jobs:
       - run: python skills/synthesis-agent-conformance/scripts/conformance.py instructions --repo-root .
       - run: python -m pytest skills/synthesis-agent-conformance/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-project-management/scripts/test_coordination.py -q
+      - run: python -m pytest skills/synthesis-promotion-gate/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-onboarding/scripts/test_onboard.py -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   DOM text, heading text, HTML comments, and raw page source under one
   canonical marker policy. A versioned surface manifest must agree exactly
   with configured renderer inspections; missing outputs and inputs consumed
-  by no renderer refuse the run.
+  by no renderer refuse the run. Symlinked config and rendered-output paths
+  are refused before their targets can be inspected.
 - **Executable authority topology.** `check` emits a non-authoritative
   acceptance receipt. `enforce` revalidates config, policy, inputs, sidecars,
   renderer outputs, and hashes immediately before a supplied promotion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   canonical marker policy. A versioned surface manifest must agree exactly
   with configured renderer inspections; missing outputs and inputs consumed
   by no renderer refuse the run. Symlinked config and rendered-output paths
-  are refused before their targets can be inspected.
+  are refused before their targets can be inspected. The output universe is
+  closed, policy examples execute against every projection, malformed
+  monitored HTML refuses permissive parser divergence, and the shipped
+  acceptance schema is consumed by the production loader.
 - **Executable authority topology.** `check` emits a non-authoritative
-  acceptance receipt. `enforce` revalidates config, policy, inputs, sidecars,
-  renderer outputs, and hashes immediately before a supplied promotion
-  command, then issues an enforced-gate receipt only after that command
-  succeeds. The generation-zero suite carries the five successful-build
-  defects, comment leakage, inline-tag adjacency, frontmatter route mismatch,
-  and the staged page the old selector never inspected.
+  acceptance receipt. `enforce` captures each inspected output exactly once,
+  passes a separate content snapshot to the supplied promotion command, and
+  revalidates config, policy, inputs, sidecars, and snapshot hashes at that
+  boundary. It issues an enforced-gate receipt only after that command
+  succeeds. Engine-owned limits remain present in every receipt and cannot be
+  erased by repository configuration.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   with configured renderer inspections; missing outputs and inputs consumed
   by no renderer refuse the run. Symlinked config and rendered-output paths
   are refused before their targets can be inspected. The output universe is
-  closed, policy examples execute against every projection, malformed
-  monitored HTML refuses permissive parser divergence, and the shipped
-  acceptance schema is consumed by the production loader.
+  closed, policy examples execute against every projection, and the shipped
+  acceptance schema is consumed by the production loader. The engine does not
+  approximate HTML grammar: a strict command protocol consumes identity-bound
+  representations from the repository's destination parser or renderer. A
+  parse5-derived corpus executes the Round-15 inline, entity, comment,
+  attribute, code, hidden-container, and malformed-input matrix.
 - **Executable authority topology.** `check` emits a non-authoritative
   acceptance receipt. `enforce` captures each inspected output exactly once,
   passes a separate content snapshot to the supplied promotion command, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.51.0] - 2026-08-26
+
+### Added
+
+- **`synthesis-promotion-gate` v1.0.0 — rendered publication boundaries.**
+  The new gate extracts a declared publishable range, builds into an isolated
+  output root, derives every expected route from frontmatter, and inspects
+  DOM text, heading text, HTML comments, and raw page source under one
+  canonical marker policy. A versioned surface manifest must agree exactly
+  with configured renderer inspections; missing outputs and inputs consumed
+  by no renderer refuse the run.
+- **Executable authority topology.** `check` emits a non-authoritative
+  acceptance receipt. `enforce` revalidates config, policy, inputs, sidecars,
+  renderer outputs, and hashes immediately before a supplied promotion
+  command, then issues an enforced-gate receipt only after that command
+  succeeds. The generation-zero suite carries the five successful-build
+  defects, comment leakage, inline-tag adjacency, frontmatter route mismatch,
+  and the staged page the old selector never inspected.
+
+### Changed
+
+- **The gated release and repository CI run the promotion acceptance suite.**
+  A release cannot install a promotion-gate change on either client unless
+  its fail-closed behavioral cases pass.
+- **AGENT HEURISTIC — `synthesis-skill-router` v1.4.0** routes publication
+  boundary, publishable-range, and promotion-receipt work to the new
+  prompt-hidden specialist.
+
 ## [4.50.0] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Release **4.51.0** adds `synthesis-promotion-gate`: an isolated build and
 rendered-output boundary that computes routes from frontmatter, checks DOM
 text, headings, comments, and raw source under one marker policy, and refuses
 missing or undeclared renderer outputs. Its ordinary `check` receipt carries
-no authority; only the fail-closed `enforce` caller can pass a captured content
-snapshot to a supplied promotion command after immediate contract and snapshot
-revalidation. See the
+no authority. Declared DOM channels come from an identity-bound destination
+parser or renderer rather than a hand-written HTML approximation; only the
+fail-closed `enforce` caller can pass a captured content snapshot to a supplied
+promotion command after immediate contract and snapshot revalidation. See the
 [4.51.0 release notes](CHANGELOG.md).
 
 **Adversarial review now has an outcome and a stop rule (August 2026).**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A successful build is not a publication-safety signal (August 2026).**
+Release **4.51.0** adds `synthesis-promotion-gate`: an isolated build and
+rendered-output boundary that computes routes from frontmatter, checks DOM
+text, headings, comments, and raw source under one marker policy, and refuses
+missing renderer outputs. Its ordinary `check` receipt carries no authority;
+only the fail-closed `enforce` caller can run a supplied promotion command,
+after immediate hash revalidation. See the
+[4.51.0 release notes](CHANGELOG.md).
+
 **Adversarial review now has an outcome and a stop rule (August 2026).**
 Release **4.50.0** adds `synthesis-adversarial-review`: differently shaped
 agents attack a closed artifact universe, record concessions and terminal

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 Release **4.51.0** adds `synthesis-promotion-gate`: an isolated build and
 rendered-output boundary that computes routes from frontmatter, checks DOM
 text, headings, comments, and raw source under one marker policy, and refuses
-missing renderer outputs. Its ordinary `check` receipt carries no authority;
-only the fail-closed `enforce` caller can run a supplied promotion command,
-after immediate hash revalidation. See the
+missing or undeclared renderer outputs. Its ordinary `check` receipt carries
+no authority; only the fail-closed `enforce` caller can pass a captured content
+snapshot to a supplied promotion command after immediate contract and snapshot
+revalidation. See the
 [4.51.0 release notes](CHANGELOG.md).
 
 **Adversarial review now has an outcome and a stop rule (August 2026).**

--- a/skills/synthesis-promotion-gate/SKILL.md
+++ b/skills/synthesis-promotion-gate/SKILL.md
@@ -111,7 +111,9 @@ The surface manifest is the canonical declared renderer set. For each input cons
 each renderer, the gate computes the output route from frontmatter and the renderer's
 route template. Directory-name substring selection is forbidden. Duplicate routes,
 inputs consumed by no renderer, and expected outputs absent after the build are
-refusals. Every renderer in the manifest must have one matching `inspected_surfaces`
+refusals. Expected output paths cannot traverse symlinks; the gate never inspects bytes
+outside its isolated build root. Every renderer in the manifest must have one matching
+`inspected_surfaces`
 entry; neither side may silently contain an extra renderer.
 
 A build can contain unrelated pages. The receipt lists those as `unscoped_outputs`; it

--- a/skills/synthesis-promotion-gate/SKILL.md
+++ b/skills/synthesis-promotion-gate/SKILL.md
@@ -37,10 +37,12 @@ python3 skills/synthesis-promotion-gate/scripts/promotion_gate.py check \
 Its receipt is an `acceptance-test`, with `authority_receipt: false`.
 
 `enforce` is the production entry point. It builds into an isolated temporary root,
-inspects every frontmatter-derived route, writes a candidate receipt, re-hashes the
-contract and artifacts immediately before the boundary, then invokes the supplied
-promotion command. The command must carry both `{candidate_receipt}` and
-`{output_root}` as literal arguments; the gate substitutes their exact temporary paths.
+captures each expected output exactly once, inspects those captured bytes, closes the
+output universe, materializes a separate content snapshot, writes a candidate receipt,
+and re-hashes the contract and snapshot immediately before the boundary. It then
+invokes the supplied promotion command. The command must carry both
+`{candidate_receipt}` and `{output_root}` as literal arguments; the gate substitutes
+the exact receipt and captured-snapshot paths.
 
 ```bash
 python3 skills/synthesis-promotion-gate/scripts/promotion_gate.py enforce \
@@ -56,11 +58,13 @@ transition. The receipt withholds matched content and records a digest instead.
 
 ## Configure the Contract
 
-Start from the three files under `templates/`:
+Start from the four files under `templates/`:
 
 - `promotion-gate.example.yaml` becomes `.agents/promotion-gate.yaml`.
 - `marker-policy.example.yaml` is the one canonical marker identity and projection file.
 - `surface-manifest.example.yaml` enumerates every consuming renderer and its version.
+- `acceptance-suite.example.yaml` declares the closed, production-consumable cases for
+  the repository instance.
 
 The gate refuses unknown configuration keys. Paths are project-relative, cannot escape
 the project, and cannot traverse symlink components. The build command is an argument
@@ -89,6 +93,9 @@ Name the representation actually judged. The engine supports:
 
 Do not label `dom-text` as browser-visible text. This implementation uses Python's
 `html.parser`, records its runtime version in the receipt, and declares its exclusions.
+Malformed monitored structures such as unclosed or mismatched headings and raw-text
+elements refuse the run because permissive destination repair can otherwise produce a
+different projection.
 When a destination needs another semantic channel—accessible attributes, feed fields,
 search documents, or a renderer-specific DOM—extend the engine and add a motivating
 fixture before adding that representation to a live configuration.
@@ -100,6 +107,10 @@ negative examples, and representation-specific regex projections. Surface predic
 may differ; identity and rationale may not be copied into separate lists. This allows a
 heading-only projection to reject an internal section while ordinary prose containing
 the same words remains valid.
+
+The loader executes the canonical examples against every projection: each projection
+must match at least one positive example and must reject every negative example. A
+schema-valid but behaviorally empty projection is an invalid policy.
 
 The policy is a bounded vocabulary, not a semantic disclosure model. Keep patterns tied
 to observed pipeline scaffolding. If a proposed pattern matches ordinary language,
@@ -116,9 +127,10 @@ outside its isolated build root. Every renderer in the manifest must have one ma
 `inspected_surfaces`
 entry; neither side may silently contain an extra renderer.
 
-A build can contain unrelated pages. The receipt lists those as `unscoped_outputs`; it
-does not claim to have inspected them. If they consume the promotion inputs, add the
-renderer and routes to the surface manifest.
+The build output universe is closed: it must equal the frontmatter-derived route set.
+An additional file is `unscoped-rendered-output` and refuses the run before the output
+root can reach a promotion command. If another page belongs in the transaction, add
+its input, renderer, and route to the declared contract.
 
 ## Receipt Contract and Unverified Remainder
 
@@ -131,6 +143,11 @@ A receipt binds:
 - production entry point, enforcing boundary, receipt consumer, and explicit unverified
   remainder.
 
+The unverified remainder is structured. `engine_owned` always names limits the
+repository cannot erase; `repository_declared` adds non-empty instance-specific limits.
+Configuration can add to this remainder but cannot replace it with `none` or an
+equivalent claim.
+
 A static renderer version is a declared fact, not independently discovered runtime
 identity. Keep it current in the same change as renderer updates. The gate cannot prove
 that an unknown consumer is absent or that remote destination bytes still match after
@@ -138,10 +155,13 @@ the supplied command returns; verify those at their own boundary.
 
 ## Acceptance Discipline
 
-The shipped `acceptance-suite.yaml` is closed and executable. Its generation-zero cases
+The shipped `acceptance-suite.yaml` is closed, accepted by the production loader, and
+executable. Its generation-zero cases
 come from real promotion defects: a sensitive comment in page source, five rendered
 scaffolding defects behind a successful build, inline-tag adjacency, frontmatter route
-mismatch, and a staged page the old selector never inspected. Run it with:
+mismatch, a staged page the old selector never inspected, an undeclared output crossing
+the boundary, a post-build mutation, an inert policy example, parser divergence, and
+acceptance-schema drift. Run it with:
 
 ```bash
 python3 -m pytest skills/synthesis-promotion-gate/scripts/test_*.py -q

--- a/skills/synthesis-promotion-gate/SKILL.md
+++ b/skills/synthesis-promotion-gate/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: synthesis-promotion-gate
+description: "Configure and run a fail-closed publication promotion gate that builds in isolation, derives output routes from frontmatter, inspects declared destination representations, binds receipts to exact inputs and renderer surfaces, and permits a state-changing promotion command only after immediate revalidation. Use for publication gates, outward-surface cleanliness, rendered-output inspection, publishable-range contracts, or promotion receipts."
+license: "Apache-2.0"
+depends_on: ["synthesis-grounding-discipline", "synthesis-implementation-integrity"]
+metadata:
+  author: "Rajiv Pant"
+  version: "1.0.0"
+  source_repo: "github.com/synthesisengineering/synthesis-skills"
+  source_type: "public"
+---
+
+# Synthesis Promotion Gate
+
+## Doctrine
+
+A successful build is not a publication-safety signal. A build establishes that a
+renderer accepted its inputs. Promotion requires a second judgment over the outgoing
+artifacts, in the representations the destination exposes.
+
+This skill supplies that boundary for configured promotion scaffolding. It does not
+decide whether ordinary prose is appropriate to disclose, prove that an undeclared
+consumer does not exist, or grant publication or deployment permission. Those approval
+gates remain in force. A clean receipt is evidence only for the exact policy, inputs,
+renderers, routes, representations, and command recorded in it.
+
+## Two Commands, Two Authority Classes
+
+`check` builds and inspects but cannot change publication state:
+
+```bash
+python3 skills/synthesis-promotion-gate/scripts/promotion_gate.py check \
+  --config .agents/promotion-gate.yaml \
+  --receipt .agents/receipts/promotion-check.json
+```
+
+Its receipt is an `acceptance-test`, with `authority_receipt: false`.
+
+`enforce` is the production entry point. It builds into an isolated temporary root,
+inspects every frontmatter-derived route, writes a candidate receipt, re-hashes the
+contract and artifacts immediately before the boundary, then invokes the supplied
+promotion command. The command must carry both `{candidate_receipt}` and
+`{output_root}` as literal arguments; the gate substitutes their exact temporary paths.
+
+```bash
+python3 skills/synthesis-promotion-gate/scripts/promotion_gate.py enforce \
+  --config .agents/promotion-gate.yaml \
+  --receipt .agents/receipts/promotion-enforced.json \
+  -- python3 tools/promote.py {candidate_receipt} {output_root}
+```
+
+Only a clean `enforce` run whose supplied command returns zero issues an
+`enforced-gate` receipt with `authority_receipt: true`. A dirty artifact, missing route,
+changed input, changed policy, failed build, or failed promotion command refuses the
+transition. The receipt withholds matched content and records a digest instead.
+
+## Configure the Contract
+
+Start from the three files under `templates/`:
+
+- `promotion-gate.example.yaml` becomes `.agents/promotion-gate.yaml`.
+- `marker-policy.example.yaml` is the one canonical marker identity and projection file.
+- `surface-manifest.example.yaml` enumerates every consuming renderer and its version.
+
+The gate refuses unknown configuration keys. Paths are project-relative, cannot escape
+the project, and cannot traverse symlink components. The build command is an argument
+list, never a shell string, and must receive `{output_root}` so the inspected build is
+isolated from a repository's ordinary output directory.
+
+Every input must contain exactly one configured publishable-range start marker and one
+end marker. The receipt binds both the whole-source hash and the extracted-range hash.
+Draft material may exist outside that range; it earns no path into a rendered output.
+
+Sidecar globs close a second input channel. A marker projected to `sidecar-flags` refuses
+promotion when an attestation, review record, or other declared sidecar remains
+unresolved even if the page itself is clean.
+
+## Declared Representations
+
+Name the representation actually judged. The engine supports:
+
+- `publishable-source`: the exact source bytes between the range markers;
+- `dom-text`: non-comment DOM text nodes in document order, with inline adjacency
+  preserved and no invented separators; raw-text elements are excluded explicitly;
+- `dom-heading-text`: each heading's DOM text with inline adjacency preserved;
+- `html-comments`: comment nodes, separate from displayed text;
+- `raw-page-source`: the generated HTML bytes decoded as UTF-8;
+- `sidecar-flags`: the complete text of each file matched by a configured sidecar glob.
+
+Do not label `dom-text` as browser-visible text. This implementation uses Python's
+`html.parser`, records its runtime version in the receipt, and declares its exclusions.
+When a destination needs another semantic channel—accessible attributes, feed fields,
+search documents, or a renderer-specific DOM—extend the engine and add a motivating
+fixture before adding that representation to a live configuration.
+
+## Canonical Marker Policy
+
+Each marker identity appears once with a threat rationale, provenance, positive and
+negative examples, and representation-specific regex projections. Surface predicates
+may differ; identity and rationale may not be copied into separate lists. This allows a
+heading-only projection to reject an internal section while ordinary prose containing
+the same words remains valid.
+
+The policy is a bounded vocabulary, not a semantic disclosure model. Keep patterns tied
+to observed pipeline scaffolding. If a proposed pattern matches ordinary language,
+repair its structural projection or remove it; approval fatigue is not safety.
+
+## Route and Surface Completeness
+
+The surface manifest is the canonical declared renderer set. For each input consumed by
+each renderer, the gate computes the output route from frontmatter and the renderer's
+route template. Directory-name substring selection is forbidden. Duplicate routes,
+inputs consumed by no renderer, and expected outputs absent after the build are
+refusals. Every renderer in the manifest must have one matching `inspected_surfaces`
+entry; neither side may silently contain an extra renderer.
+
+A build can contain unrelated pages. The receipt lists those as `unscoped_outputs`; it
+does not claim to have inspected them. If they consume the promotion inputs, add the
+renderer and routes to the surface manifest.
+
+## Receipt Contract and Unverified Remainder
+
+A receipt binds:
+
+- config, marker-policy, surface-manifest, and acceptance-suite hashes;
+- whole-source, publishable-range, sidecar, build-command-file, and rendered-output hashes;
+- renderer ids and versions, exact input-to-output routes, inspected representations,
+  parser identity, build result, and promotion-command result;
+- production entry point, enforcing boundary, receipt consumer, and explicit unverified
+  remainder.
+
+A static renderer version is a declared fact, not independently discovered runtime
+identity. Keep it current in the same change as renderer updates. The gate cannot prove
+that an unknown consumer is absent or that remote destination bytes still match after
+the supplied command returns; verify those at their own boundary.
+
+## Acceptance Discipline
+
+The shipped `acceptance-suite.yaml` is closed and executable. Its generation-zero cases
+come from real promotion defects: a sensitive comment in page source, five rendered
+scaffolding defects behind a successful build, inline-tag adjacency, frontmatter route
+mismatch, and a staged page the old selector never inspected. Run it with:
+
+```bash
+python3 -m pytest skills/synthesis-promotion-gate/scripts/test_*.py -q
+```
+
+A changed enforcing boundary or new representation gets its failing fixture before the
+repair. Tests that inspect prose or manifest shape remain diagnostics. Only the
+fail-closed `enforce` topology is an enforced gate.

--- a/skills/synthesis-promotion-gate/SKILL.md
+++ b/skills/synthesis-promotion-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: synthesis-promotion-gate
-description: "Configure and run a fail-closed publication promotion gate that builds in isolation, derives output routes from frontmatter, inspects declared destination representations, binds receipts to exact inputs and renderer surfaces, and permits a state-changing promotion command only after immediate revalidation. Use for publication gates, outward-surface cleanliness, rendered-output inspection, publishable-range contracts, or promotion receipts."
+description: "Configure and run a fail-closed publication promotion gate that builds in isolation, derives output routes from frontmatter, consumes identity-bound representations from the destination parser or renderer, binds receipts to exact inputs and renderer surfaces, and permits a state-changing promotion command only after immediate revalidation. Use for publication gates, outward-surface cleanliness, rendered-output inspection, publishable-range contracts, or promotion receipts."
 license: "Apache-2.0"
 depends_on: ["synthesis-grounding-discipline", "synthesis-implementation-integrity"]
 metadata:
@@ -71,6 +71,16 @@ the project, and cannot traverse symlink components. The build command is an arg
 list, never a shell string, and must receive `{output_root}` so the inspected build is
 isolated from a repository's ordinary output directory.
 
+`destination_projection` is a second argument-list command. It receives one JSON batch on
+standard input containing the exact captured HTML for every route and returns the strict
+schema-1 representation batch. It must call the repository's destination parser or
+renderer; substituting a hand parser is a contract violation. Its reported parser,
+parser-version, and renderer identity must exactly match `expected_identity`. The gate
+binds the adapter command-file hashes, executes it once over the closed route universe,
+and refuses missing, duplicate, additional, malformed, or identity-mismatched projection
+rows. **AGENT HEURISTIC:** this strict adapter protocol is the generic public seam chosen
+for D2; the repository-owned adapter is the per-repository instance.
+
 Every input must contain exactly one configured publishable-range start marker and one
 end marker. The receipt binds both the whole-source hash and the extracted-range hash.
 Draft material may exist outside that range; it earns no path into a rendered output.
@@ -84,18 +94,20 @@ unresolved even if the page itself is clean.
 Name the representation actually judged. The engine supports:
 
 - `publishable-source`: the exact source bytes between the range markers;
-- `dom-text`: non-comment DOM text nodes in document order, with inline adjacency
-  preserved and no invented separators; raw-text elements are excluded explicitly;
-- `dom-heading-text`: each heading's DOM text with inline adjacency preserved;
+- `dom-text`: the destination projector's displayed-prose text regions, with inline
+  adjacency preserved and no matching invented across structural regions;
+- `dom-heading-text`: each destination-projected heading's text with inline adjacency
+  preserved;
 - `html-comments`: comment nodes, separate from displayed text;
 - `raw-page-source`: the generated HTML bytes decoded as UTF-8;
 - `sidecar-flags`: the complete text of each file matched by a configured sidecar glob.
 
-Do not label `dom-text` as browser-visible text. This implementation uses Python's
-`html.parser`, records its runtime version in the receipt, and declares its exclusions.
-Malformed monitored structures such as unclosed or mismatched headings and raw-text
-elements refuse the run because permissive destination repair can otherwise produce a
-different projection.
+Do not label `dom-text` as all browser-visible or accessible text. The projector's declared
+representation excludes accessible attributes, code, non-displayed containers, CSS
+layout, accessibility-tree computation, and client-side mutation unless a repository
+explicitly extends the protocol and acceptance corpus for those channels. The engine does
+not carry a fallback HTML parser: if the destination projection is unavailable or its
+identity differs, the run refuses.
 When a destination needs another semantic channel—accessible attributes, feed fields,
 search documents, or a renderer-specific DOM—extend the engine and add a motivating
 fixture before adding that representation to a live configuration.
@@ -139,7 +151,8 @@ A receipt binds:
 - config, marker-policy, surface-manifest, and acceptance-suite hashes;
 - whole-source, publishable-range, sidecar, build-command-file, and rendered-output hashes;
 - renderer ids and versions, exact input-to-output routes, inspected representations,
-  parser identity, build result, and promotion-command result;
+  destination projection identity and representation digests, build result, and
+  promotion-command result;
 - production entry point, enforcing boundary, receipt consumer, and explicit unverified
   remainder.
 
@@ -160,8 +173,10 @@ executable. Its generation-zero cases
 come from real promotion defects: a sensitive comment in page source, five rendered
 scaffolding defects behind a successful build, inline-tag adjacency, frontmatter route
 mismatch, a staged page the old selector never inspected, an undeclared output crossing
-the boundary, a post-build mutation, an inert policy example, parser divergence, and
-acceptance-schema drift. Run it with:
+the boundary, a post-build mutation, an inert policy example, destination-parser
+divergence, and acceptance-schema drift. The parse5-derived Round-15 fixture corpus
+compares inline, entity, comment, attribute, code, hidden-container, and malformed-input
+planes through the production projection protocol. Run it with:
 
 ```bash
 python3 -m pytest skills/synthesis-promotion-gate/scripts/test_*.py -q

--- a/skills/synthesis-promotion-gate/acceptance-suite.yaml
+++ b/skills/synthesis-promotion-gate/acceptance-suite.yaml
@@ -61,3 +61,31 @@ cases:
     control_class: acceptance-test
     fixture: scripts/test_promotion_gate.py::test_symlinked_rendered_output_is_refused_instead_of_inspecting_outside_bytes
     motivating_defect: implementation-self-review-rendered-output-could-follow-an-outside-symlink
+  - id: closed-output-universe
+    control_class: enforced-gate
+    fixture: scripts/test_promotion_gate.py::test_unscoped_output_refuses_before_the_whole_root_reaches_promotion
+    motivating_defect: r2-review-unscoped-dirty-output-crossed-the-whole-root-promotion-boundary
+  - id: captured-content-handoff
+    control_class: enforced-gate
+    fixture: scripts/test_promotion_gate.py::test_promotion_consumes_a_captured_snapshot_not_a_build_childs_later_mutation
+    motivating_defect: r2-review-build-child-mutated-output-after-revalidation
+  - id: executable-policy-examples
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_each_policy_projection_must_match_a_positive_and_reject_negatives
+    motivating_defect: r2-review-marker-examples-were-schema-only
+  - id: malformed-destination-representation
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_malformed_heading_that_destination_repairs_is_refused
+    motivating_defect: r2-review-unclosed-heading-diverged-from-destination-parsing
+  - id: engine-owned-unverified-remainder
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_engine_owned_unverified_remainder_cannot_be_erased_by_config
+    motivating_defect: r2-review-config-could-claim-no-unverified-remainder
+  - id: acceptance-schema-self-consumption
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_shipped_acceptance_manifest_is_consumable_by_the_engine
+    motivating_defect: r2-review-shipped-acceptance-manifest-failed-its-own-loader
+  - id: acceptance-instance-template
+    control_class: diagnostic
+    fixture: scripts/test_promotion_gate.py::test_repository_acceptance_template_is_shipped_and_consumable
+    motivating_defect: r2-review-required-repository-acceptance-template-was-absent

--- a/skills/synthesis-promotion-gate/acceptance-suite.yaml
+++ b/skills/synthesis-promotion-gate/acceptance-suite.yaml
@@ -73,6 +73,10 @@ cases:
     control_class: acceptance-test
     fixture: scripts/test_promotion_gate.py::test_each_policy_projection_must_match_a_positive_and_reject_negatives
     motivating_defect: r2-review-marker-examples-were-schema-only
+  - id: executable-policy-negative-examples
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_policy_projection_that_matches_a_negative_example_is_refused
+    motivating_defect: r2-review-marker-negative-examples-were-schema-only
   - id: malformed-destination-representation
     control_class: acceptance-test
     fixture: scripts/test_promotion_gate.py::test_malformed_heading_that_destination_repairs_is_refused
@@ -81,6 +85,10 @@ cases:
     control_class: acceptance-test
     fixture: scripts/test_promotion_gate.py::test_engine_owned_unverified_remainder_cannot_be_erased_by_config
     motivating_defect: r2-review-config-could-claim-no-unverified-remainder
+  - id: none-like-additional-remainder
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_additional_remainder_cannot_claim_that_nothing_is_unverified
+    motivating_defect: r2-review-config-could-deny-the-unverified-remainder
   - id: acceptance-schema-self-consumption
     control_class: acceptance-test
     fixture: scripts/test_promotion_gate.py::test_shipped_acceptance_manifest_is_consumable_by_the_engine

--- a/skills/synthesis-promotion-gate/acceptance-suite.yaml
+++ b/skills/synthesis-promotion-gate/acceptance-suite.yaml
@@ -1,0 +1,55 @@
+# AGENT HEURISTIC: the plan requires an executable, closed acceptance manifest but
+# does not prescribe its schema. R5 will generalize this instance across skills.
+schema: 1
+suite: synthesis-promotion-gate
+membership: closed
+production_entry_point: scripts/promotion_gate.py enforce
+enforcing_boundary: before the supplied promotion command
+receipt_consumer: built-in candidate revalidation plus supplied command
+expected_status: pass
+unverified_remainder: consumers omitted from a repository's surface manifest, disclosure semantics outside the configured marker policy, and destination bytes after the supplied command returns
+cases:
+  - id: round2-five-rendered-defects
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_successful_build_refuses_all_five_round2_rendered_defects
+    motivating_defect: engagement-round-2-build-succeeded-with-five-outward-surface-defects
+  - id: sensitive-comment-page-source
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_sensitive_html_comment_is_inspected_as_comment_and_raw_source
+    motivating_defect: engagement-round-2-sensitive-comment-survived-in-generated-page-source
+  - id: tag-adjacency
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_dom_heading_preserves_tag_adjacency_instead_of_inventing_spaces
+    motivating_defect: engagement-round-15-tag-to-space-projection-missed-visible-adjacency
+  - id: frontmatter-route-bijection
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_route_bijection_uses_frontmatter_slug_not_source_directory
+    motivating_defect: engagement-round-15-directory-substring-routing-ignored-frontmatter
+  - id: staged-page-inspection-completeness
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_every_staged_input_must_have_an_inspected_output
+    motivating_defect: engagement-round-15-one-of-two-staged-pages-was-never-inspected
+  - id: publishable-range
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_publishable_range_excludes_internal_draft_material_but_binds_both_hashes
+    motivating_defect: engagement-round-2-byte-identity-certified-the-wrong-source-range
+  - id: unresolved-sidecar
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_unresolved_sidecar_flag_refuses_promotion_even_when_rendered_page_is_clean
+    motivating_defect: engagement-unresolved-sidecar-flags-were-not-promotion-blockers
+  - id: refusal-precedes-state-change
+    control_class: enforced-gate
+    fixture: scripts/test_promotion_gate.py::test_dirty_enforced_gate_never_invokes_the_promotion_command
+    motivating_defect: engagement-round-15-standalone-successful-command-had-no-enforcing-boundary
+  - id: receipt-consumer-topology
+    control_class: enforced-gate
+    fixture: scripts/test_promotion_gate.py::test_clean_enforced_gate_revalidates_receipt_then_invokes_the_consumer
+    motivating_defect: engagement-round-15-authority-had-no-required-caller-or-receipt-consumer
+  - id: changed-input-revalidation
+    control_class: enforced-gate
+    fixture: scripts/test_promotion_gate.py::test_input_changed_during_build_refuses_before_the_promotion_command
+    motivating_defect: engagement-round-15-receipt-was-not-bound-to-later-promoted-bytes
+  - id: surface-manifest-agreement
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_surface_manifest_and_inspection_config_must_name_the_same_renderers
+    motivating_defect: engagement-round-15-canonical-mirror-was-absent-from-the-inspected-surface-list

--- a/skills/synthesis-promotion-gate/acceptance-suite.yaml
+++ b/skills/synthesis-promotion-gate/acceptance-suite.yaml
@@ -53,3 +53,11 @@ cases:
     control_class: acceptance-test
     fixture: scripts/test_promotion_gate.py::test_surface_manifest_and_inspection_config_must_name_the_same_renderers
     motivating_defect: engagement-round-15-canonical-mirror-was-absent-from-the-inspected-surface-list
+  - id: config-symlink-boundary
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_symlinked_config_is_refused_without_following_it
+    motivating_defect: implementation-self-review-resolved-a-config-symlink-before-validating-it
+  - id: rendered-output-symlink-boundary
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_symlinked_rendered_output_is_refused_instead_of_inspecting_outside_bytes
+    motivating_defect: implementation-self-review-rendered-output-could-follow-an-outside-symlink

--- a/skills/synthesis-promotion-gate/acceptance-suite.yaml
+++ b/skills/synthesis-promotion-gate/acceptance-suite.yaml
@@ -81,6 +81,18 @@ cases:
     control_class: acceptance-test
     fixture: scripts/test_promotion_gate.py::test_malformed_heading_that_destination_repairs_is_refused
     motivating_defect: r2-review-unclosed-heading-diverged-from-destination-parsing
+  - id: renderer-derived-representation-matrix
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_renderer_derived_destination_fixture_matrix_is_consumed
+    motivating_defect: engagement-round-15-inline-entity-comment-attribute-code-hidden-container-matrix
+  - id: destination-projection-identity-binding
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_destination_projection_identity_mismatch_refuses
+    motivating_defect: r2-review-parser-identity-was-not-bound-to-the-consumed-projection
+  - id: destination-projection-route-closure
+    control_class: acceptance-test
+    fixture: scripts/test_promotion_gate.py::test_destination_projection_must_return_the_closed_route_universe
+    motivating_defect: engagement-round-15-staged-page-never-entered-the-inspected-universe
   - id: engine-owned-unverified-remainder
     control_class: acceptance-test
     fixture: scripts/test_promotion_gate.py::test_engine_owned_unverified_remainder_cannot_be_erased_by_config

--- a/skills/synthesis-promotion-gate/agents/openai.yaml
+++ b/skills/synthesis-promotion-gate/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Synthesis Promotion Gate"
+  short_description: "Inspect rendered publication surfaces before promotion"
+  default_prompt: "Use $synthesis-promotion-gate to configure or run the fail-closed promotion boundary for this repository."
+policy:
+  allow_implicit_invocation: false

--- a/skills/synthesis-promotion-gate/fixtures/destination-representations.yaml
+++ b/skills/synthesis-promotion-gate/fixtures/destination-representations.yaml
@@ -1,0 +1,107 @@
+# Renderer-derived generation-zero corpus. These projections were generated with the
+# destination Astro dependency's parse5 7.3.0 through the engagement's
+# render_channels.mjs adapter, then reduced to the three representations R2 declares.
+# AGENT HEURISTIC: this fixture schema is local to the public skill.
+schema: 1
+provenance:
+  motivating_contract: engagement-round-15-destination-grammar-matrix
+  generator: SYNTH_PARSE5=<destination-parse5-entry> node render_channels.mjs
+  parser_entry_sha256: b825162aced2e79be8d68d45efb1f89ec34ed4189467195a071a0d7b694a19d4
+  parser_package_sha256: 8196284780fe95c3245a40e3c17b45fc85ef709f1211775987d037e5e873fe95
+  generator_sha256: 84f5e878ee2798397d788b753a5fa19887ef26cd668aae474abb13744b9ea2a5
+identity:
+  parser: parse5
+  parser_version: "7.3.0"
+  renderer: fixture-renderer-1
+cases:
+  - id: clean-paragraph
+    plane: control
+    html: "<p>Clean.</p>"
+    representations:
+      dom-text: ["clean."]
+      dom-heading-text: []
+      html-comments: []
+  - id: clean-heading
+    plane: control
+    html: "<h1>Clean public page</h1>"
+    representations:
+      dom-text: ["clean public page"]
+      dom-heading-text: ["clean public page"]
+      html-comments: []
+  - id: sensitive-comment
+    plane: comment
+    html: "<!-- ORIGINAL OPENER private holdings REDACTED --><p>Clean.</p>"
+    representations:
+      dom-text: ["clean."]
+      dom-heading-text: []
+      html-comments: ["original opener private holdings redacted"]
+  - id: sensitive-comment-colon
+    plane: comment
+    html: "<!-- ORIGINAL OPENER: private holdings REDACTED --><p>Public.</p>"
+    representations:
+      dom-text: ["public."]
+      dom-heading-text: []
+      html-comments: ["original opener: private holdings redacted"]
+  - id: entity-decoded-date
+    plane: entity
+    html: "<p>&lt;DATE&gt;</p>"
+    representations:
+      dom-text: ["<date>"]
+      dom-heading-text: []
+      html-comments: []
+  - id: publication-heading
+    plane: heading
+    html: "<h2>Publication Notes</h2>"
+    representations:
+      dom-text: ["publication notes"]
+      dom-heading-text: ["publication notes"]
+      html-comments: []
+  - id: inline-adjacency
+    plane: inline
+    html: "<h2>Public<a href='/x'>ation</a> Notes</h2>"
+    representations:
+      dom-text: ["publication notes"]
+      dom-heading-text: ["publication notes"]
+      html-comments: []
+  - id: unclosed-heading-repair
+    plane: malformed
+    html: "<h2>Publication Notes"
+    representations:
+      dom-text: ["publication notes"]
+      dom-heading-text: ["publication notes"]
+      html-comments: []
+  - id: table-foster-parenting-repair
+    plane: malformed
+    html: "<tr><h2><p>Publication Notes"
+    representations:
+      dom-text: ["publication notes"]
+      dom-heading-text: ["publication notes"]
+      html-comments: []
+  - id: entity-adjacency
+    plane: entity
+    html: "<h2>Public&#x61;tion&nbsp;Notes</h2>"
+    representations:
+      dom-text: ["publication notes"]
+      dom-heading-text: ["publication notes"]
+      html-comments: []
+  - id: attribute-exclusion
+    plane: attribute
+    html: '<img alt="Publication Notes"><p>Clean.</p>'
+    representations:
+      dom-text: ["clean."]
+      dom-heading-text: []
+      html-comments: []
+  - id: code-channel-exclusion
+    plane: code
+    html: "<pre><code>Publication Notes</code></pre><p>Clean.</p>"
+    representations:
+      dom-text: ["clean."]
+      dom-heading-text: []
+      html-comments: []
+  - id: hidden-container-exclusion
+    plane: hidden-container
+    html: "<script>Publication Notes</script><p>Clean.</p>"
+    representations:
+      dom-text: ["clean."]
+      dom-heading-text: []
+      html-comments: []

--- a/skills/synthesis-promotion-gate/scripts/promotion_gate.py
+++ b/skills/synthesis-promotion-gate/scripts/promotion_gate.py
@@ -3,10 +3,10 @@
 
 A successful build is not a publication-safety signal. ``check`` produces an
 acceptance-test receipt and never authorizes a state change. ``enforce`` keeps the
-isolated rendered outputs alive, revalidates the exact inputs and receipt immediately
-before the supplied promotion command, and invokes that command only after every
-declared representation is clean. Only that fail-closed caller can issue an
-``enforced-gate`` receipt.
+captured rendered bytes alive in a separate content snapshot, revalidates the exact
+inputs and snapshot immediately before the supplied promotion command, and invokes
+that command only after every declared representation is clean. Only that fail-closed
+caller can issue an ``enforced-gate`` receipt.
 
 This engine detects configured promotion scaffolding. It does not decide whether
 ordinary prose is appropriate to disclose, prove that a surface manifest names an
@@ -59,7 +59,7 @@ CONFIG_KEYS = {
     "acceptance_suite",
     "inspected_surfaces",
     "sidecar_flag_globs",
-    "unverified_remainder",
+    "additional_unverified_remainder",
 }
 BUILD_KEYS = {"command", "working_directory", "output_root"}
 INPUT_KEYS = {"root", "globs"}
@@ -71,6 +71,32 @@ RENDERER_KEYS = {
     "input_globs",
     "route_template",
     "output_prefix",
+}
+ACCEPTANCE_KEYS = {
+    "schema",
+    "suite",
+    "membership",
+    "production_entry_point",
+    "enforcing_boundary",
+    "receipt_consumer",
+    "expected_status",
+    "unverified_remainder",
+    "cases",
+}
+ACCEPTANCE_CASE_KEYS = {"id", "control_class", "fixture", "motivating_defect"}
+ENGINE_UNVERIFIED_REMAINDER = [
+    "consumers absent from the declared surface manifest",
+    "semantic disclosures outside the canonical marker policy",
+    "destination bytes after the supplied promotion command returns",
+    "destination parser equivalence beyond the declared representations",
+]
+EMPTY_REMAINDER_CLAIMS = {
+    "none",
+    "n/a",
+    "na",
+    "nothing",
+    "fully verified",
+    "no remainder",
 }
 
 
@@ -113,7 +139,7 @@ def require_string(value: Any, label: str) -> str:
 
 def require_string_list(value: Any, label: str) -> list[str]:
     if not isinstance(value, list) or not value or not all(
-        isinstance(item, str) and item for item in value
+        isinstance(item, str) and item.strip() for item in value
     ):
         raise GateError("invalid-config", f"{label} must be a non-empty list of strings")
     return value
@@ -205,7 +231,15 @@ def load_config(path: pathlib.Path) -> tuple[pathlib.Path, dict[str, Any]]:
 
     for key in ("marker_policy", "surface_manifest", "acceptance_suite"):
         project_path(project_root, config.get(key), key, file_only=True)
-    require_string(config.get("unverified_remainder"), "unverified_remainder")
+    remainder = require_string_list(
+        config.get("additional_unverified_remainder"),
+        "additional_unverified_remainder",
+    )
+    if any(item.strip().casefold() in EMPTY_REMAINDER_CLAIMS for item in remainder):
+        raise GateError(
+            "invalid-config",
+            "additional_unverified_remainder cannot erase or deny the engine-owned remainder",
+        )
     if not isinstance(config.get("sidecar_flag_globs"), list) or not all(
         isinstance(item, str) and item for item in config["sidecar_flag_globs"]
     ):
@@ -252,8 +286,12 @@ def load_policy(project_root: pathlib.Path, config: dict[str, Any]) -> tuple[pat
         seen.add(marker_id)
         require_string(item["threat_rationale"], f"marker {marker_id}.threat_rationale")
         require_string(item["provenance"], f"marker {marker_id}.provenance")
-        require_string_list(item["positive_examples"], f"marker {marker_id}.positive_examples")
-        require_string_list(item["negative_examples"], f"marker {marker_id}.negative_examples")
+        positive_examples = require_string_list(
+            item["positive_examples"], f"marker {marker_id}.positive_examples"
+        )
+        negative_examples = require_string_list(
+            item["negative_examples"], f"marker {marker_id}.negative_examples"
+        )
         raw_projections = require_mapping(item["projections"], f"marker {marker_id}.projections")
         if not raw_projections:
             raise GateError("invalid-marker-policy", f"marker {marker_id} has no projections")
@@ -276,12 +314,23 @@ def load_policy(project_root: pathlib.Path, config: dict[str, Any]) -> tuple[pat
                 projection["pattern"], f"marker {marker_id}.{representation}.pattern"
             )
             try:
-                projections[representation] = re.compile(pattern, re.IGNORECASE | re.DOTALL)
+                compiled = re.compile(pattern, re.IGNORECASE | re.DOTALL)
             except re.error as exc:
                 raise GateError(
                     "invalid-marker-policy",
                     f"marker {marker_id}.{representation} has invalid regex: {exc}",
                 ) from exc
+            if not any(compiled.search(example) for example in positive_examples):
+                raise GateError(
+                    "invalid-marker-policy",
+                    f"marker {marker_id}.{representation} matches no canonical positive example",
+                )
+            if any(compiled.search(example) for example in negative_examples):
+                raise GateError(
+                    "invalid-marker-policy",
+                    f"marker {marker_id}.{representation} matches a canonical negative example",
+                )
+            projections[representation] = compiled
         markers.append(Marker(marker_id, projections))
     return path, markers
 
@@ -289,16 +338,48 @@ def load_policy(project_root: pathlib.Path, config: dict[str, Any]) -> tuple[pat
 def load_acceptance(project_root: pathlib.Path, config: dict[str, Any]) -> pathlib.Path:
     path = project_path(project_root, config["acceptance_suite"], "acceptance_suite", file_only=True)
     manifest = yaml_document(path, "acceptance suite")
+    if set(manifest) != ACCEPTANCE_KEYS:
+        missing = sorted(ACCEPTANCE_KEYS - set(manifest))
+        extra = sorted(set(manifest) - ACCEPTANCE_KEYS)
+        raise GateError(
+            "invalid-acceptance-suite",
+            f"acceptance suite schema mismatch; missing={missing}, extra={extra}",
+        )
     if manifest.get("schema") != SCHEMA or manifest.get("membership") != "closed":
-        raise GateError("invalid-acceptance-suite", "acceptance suite must declare schema 1 and closed membership")
-    require_string(manifest.get("boundary"), "acceptance suite boundary")
+        raise GateError(
+            "invalid-acceptance-suite",
+            "acceptance suite must declare schema 1 and closed membership",
+        )
+    for key in (
+        "suite",
+        "production_entry_point",
+        "enforcing_boundary",
+        "receipt_consumer",
+        "unverified_remainder",
+    ):
+        require_string(manifest.get(key), f"acceptance suite {key}")
     if manifest.get("expected_status") != "pass":
         raise GateError("invalid-acceptance-suite", "acceptance suite expected_status must be pass")
     cases = manifest.get("cases")
     if not isinstance(cases, list) or not cases:
         raise GateError("invalid-acceptance-suite", "acceptance suite must contain cases")
+    case_ids: set[str] = set()
     for case in cases:
         value = require_mapping(case, "acceptance case")
+        if set(value) != ACCEPTANCE_CASE_KEYS:
+            raise GateError(
+                "invalid-acceptance-suite",
+                "each acceptance case must declare id, control_class, fixture, and motivating_defect",
+            )
+        case_id = require_string(value.get("id"), "acceptance case id")
+        if case_id in case_ids:
+            raise GateError("invalid-acceptance-suite", f"duplicate acceptance case id: {case_id}")
+        case_ids.add(case_id)
+        require_string(value.get("fixture"), f"acceptance case {case_id} fixture")
+        require_string(
+            value.get("motivating_defect"),
+            f"acceptance case {case_id} motivating_defect",
+        )
         if value.get("control_class") not in CONTROL_CLASSES:
             raise GateError("invalid-acceptance-suite", "acceptance case has unknown control_class")
     return path
@@ -531,35 +612,65 @@ class DeclaredHtmlProjection(HTMLParser):
         self.dom_parts: list[str] = []
         self.comments: list[str] = []
         self.headings: list[str] = []
-        self._heading_parts: list[list[str]] = []
-        self._raw_depth = 0
+        self.structural_errors: list[str] = []
+        self._heading_stack: list[tuple[str, list[str]]] = []
+        self._raw_stack: list[str] = []
+        self._finished = False
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         tag = tag.lower()
         if tag in RAW_TEXT_ELEMENTS:
-            self._raw_depth += 1
+            if self._raw_stack:
+                self.structural_errors.append("nested raw-text element")
+            self._raw_stack.append(tag)
         if tag in HEADING_ELEMENTS:
-            self._heading_parts.append([])
+            if self._heading_stack:
+                self.structural_errors.append("nested heading element")
+            self._heading_stack.append((tag, []))
 
     def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        return
+        tag = tag.lower()
+        if tag in RAW_TEXT_ELEMENTS or tag in HEADING_ELEMENTS:
+            self.structural_errors.append("self-closing monitored element")
 
     def handle_endtag(self, tag: str) -> None:
         tag = tag.lower()
-        if tag in HEADING_ELEMENTS and self._heading_parts:
-            self.headings.append("".join(self._heading_parts.pop()))
-        if tag in RAW_TEXT_ELEMENTS and self._raw_depth:
-            self._raw_depth -= 1
+        if tag in HEADING_ELEMENTS:
+            if not self._heading_stack:
+                self.structural_errors.append("unmatched heading end tag")
+            else:
+                opened, parts = self._heading_stack.pop()
+                if opened != tag:
+                    self.structural_errors.append("mismatched heading end tag")
+                else:
+                    self.headings.append("".join(parts))
+        if tag in RAW_TEXT_ELEMENTS:
+            if not self._raw_stack:
+                self.structural_errors.append("unmatched raw-text end tag")
+            else:
+                opened = self._raw_stack.pop()
+                if opened != tag:
+                    self.structural_errors.append("mismatched raw-text end tag")
 
     def handle_data(self, data: str) -> None:
-        if self._raw_depth:
+        if self._raw_stack:
             return
         self.dom_parts.append(data)
-        for heading in self._heading_parts:
-            heading.append(data)
+        if self._heading_stack:
+            self._heading_stack[-1][1].append(data)
 
     def handle_comment(self, data: str) -> None:
         self.comments.append(data)
+
+    def finish(self) -> None:
+        if self._finished:
+            return
+        self.close()
+        if self._heading_stack:
+            self.structural_errors.append("unclosed heading element")
+        if self._raw_stack:
+            self.structural_errors.append("unclosed raw-text element")
+        self._finished = True
 
     def representations(self, raw: str) -> dict[str, list[str]]:
         return {
@@ -685,7 +796,10 @@ def base_receipt(mode: str, config_path: pathlib.Path) -> dict[str, Any]:
                 "receipt_consumer": "none",
             }
         ),
-        "unverified_remainder": "Configuration could not be loaded; no safety claim is available.",
+        "unverified_remainder": {
+            "engine_owned": list(ENGINE_UNVERIFIED_REMAINDER),
+            "repository_declared": [],
+        },
     }
 
 
@@ -713,22 +827,36 @@ def output_identities(output_root: pathlib.Path, expected: list[dict[str, Any]])
     ]
 
 
-def current_core_identities(
+def captured_output_identities(captured: dict[str, bytes]) -> list[dict[str, str]]:
+    return [
+        {"route": route, "sha256": sha256_bytes(payload)}
+        for route, payload in sorted(captured.items())
+    ]
+
+
+def current_contract_identities(
     project_root: pathlib.Path,
     config_path: pathlib.Path,
     linked: list[pathlib.Path],
     inputs: list[InputArtifact],
     sidecars: list[pathlib.Path],
-    output_root: pathlib.Path,
-    expected: list[dict[str, Any]],
 ) -> dict[str, Any]:
     return {
         "config_sha256": sha256_file(config_path),
         "linked": file_identities(project_root, linked),
         "inputs": file_identities(project_root, [item.path for item in inputs]),
         "sidecars": file_identities(project_root, sidecars),
-        "outputs": output_identities(output_root, expected),
     }
+
+
+def materialize_snapshot(root: pathlib.Path, captured: dict[str, bytes]) -> None:
+    root.mkdir()
+    for route, payload in sorted(captured.items()):
+        target = root / route
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+        if target.read_bytes() != payload:
+            raise GateError("snapshot-write", f"captured output read-back failed: {route}")
 
 
 def run_gate(
@@ -745,7 +873,10 @@ def run_gate(
             "sha256": sha256_file(config_path),
             "logical_output_root": config["build"]["output_root"],
         }
-        receipt["unverified_remainder"] = config["unverified_remainder"]
+        receipt["unverified_remainder"] = {
+            "engine_owned": list(ENGINE_UNVERIFIED_REMAINDER),
+            "repository_declared": list(config["additional_unverified_remainder"]),
+        }
         policy_path, markers = load_policy(project_root, config)
         acceptance_path = load_acceptance(project_root, config)
         manifest_path, renderers, inspections = load_surfaces(project_root, config)
@@ -811,14 +942,12 @@ def run_gate(
         with tempfile.TemporaryDirectory(prefix="synthesis-promotion-gate-") as temporary:
             output_root = pathlib.Path(temporary) / "rendered"
             output_root.mkdir()
-            baseline = current_core_identities(
+            baseline = current_contract_identities(
                 project_root,
                 config_path,
                 linked,
                 inputs,
                 sidecars,
-                output_root,
-                [],
             )
             build_command = substitute(
                 raw_build_command,
@@ -870,6 +999,7 @@ def run_gate(
 
             inspected: list[dict[str, Any]] = []
             missing: list[str] = []
+            captured_outputs: dict[str, bytes] = {}
             expected_by_route = {item["route"]: item for item in expected}
             for route, item in expected_by_route.items():
                 output = output_root / route
@@ -886,19 +1016,47 @@ def run_gate(
                         }
                     )
                     continue
-                raw = output.read_text(encoding="utf-8")
+                try:
+                    payload = output.read_bytes()
+                    raw = payload.decode("utf-8")
+                except (OSError, UnicodeError) as exc:
+                    receipt["findings"].append(
+                        {
+                            "kind": "rendered-representation-invalid",
+                            "path": item["input"],
+                            "renderer": item["renderer"],
+                            "route": route,
+                            "message": f"rendered output cannot be captured as UTF-8: {type(exc).__name__}",
+                        }
+                    )
+                    continue
+                captured_outputs[route] = payload
                 parser = DeclaredHtmlProjection()
                 parser.feed(raw)
+                parser.finish()
                 projected = parser.representations(raw)
                 representations = inspections[item["renderer"]]
                 inspected.append(
                     {
                         **item,
-                        "sha256": sha256_file(output),
+                        "sha256": sha256_bytes(payload),
                         "representations": representations,
                         "parser": f"python-html.parser:{sys.version_info.major}.{sys.version_info.minor}",
                     }
                 )
+                if parser.structural_errors:
+                    receipt["findings"].append(
+                        {
+                            "kind": "rendered-representation-invalid",
+                            "path": item["input"],
+                            "renderer": item["renderer"],
+                            "route": route,
+                            "message": (
+                                "declared projection found malformed monitored HTML "
+                                f"({len(parser.structural_errors)} structural error(s))"
+                            ),
+                        }
+                    )
                 for representation in representations:
                     if representation not in DESTINATION_REPRESENTATIONS:
                         continue
@@ -914,26 +1072,33 @@ def run_gate(
                     )
             receipt["route_bijection"]["inspected"] = inspected
             receipt["route_bijection"]["missing"] = missing
-            actual_outputs = sorted(
-                path.relative_to(output_root).as_posix()
-                for path in output_root.rglob("*")
-                if path.is_file()
-            )
-            receipt["route_bijection"]["unscoped_outputs"] = sorted(
-                set(actual_outputs) - set(expected_by_route)
-            )
+            actual_outputs: list[str] = []
+            for path in output_root.rglob("*"):
+                if path.is_symlink():
+                    no_symlink_components(path, output_root)
+                if path.is_file():
+                    actual_outputs.append(path.relative_to(output_root).as_posix())
+            unscoped_outputs = sorted(set(actual_outputs) - set(expected_by_route))
+            receipt["route_bijection"]["unscoped_outputs"] = unscoped_outputs
+            for route in unscoped_outputs:
+                receipt["findings"].append(
+                    {
+                        "kind": "unscoped-rendered-output",
+                        "path": route,
+                        "route": route,
+                        "message": "rendered output is outside the closed frontmatter-derived route universe",
+                    }
+                )
 
-            post_build = current_core_identities(
+            post_contract = current_contract_identities(
                 project_root,
                 config_path,
                 linked,
                 inputs,
                 sidecars,
-                output_root,
-                expected,
             )
             for key in ("config_sha256", "linked", "inputs", "sidecars"):
-                if baseline[key] != post_build[key]:
+                if baseline[key] != post_contract[key]:
                     kind = "input-changed-during-build" if key == "inputs" else "contract-changed-during-build"
                     if not any(f["kind"] == kind for f in receipt["findings"]):
                         receipt["findings"].append(
@@ -943,6 +1108,10 @@ def run_gate(
                                 "message": f"{key} identity changed during the build",
                             }
                         )
+            post_build = {
+                **post_contract,
+                "outputs": captured_output_identities(captured_outputs),
+            }
             receipt["identity_binding"] = post_build
 
             if receipt["findings"]:
@@ -984,21 +1153,29 @@ def run_gate(
                 atomic_json(receipt_path, receipt)
                 return 1
 
+            snapshot_root = pathlib.Path(temporary) / f"captured-{uuid.uuid4().hex}"
+            materialize_snapshot(snapshot_root, captured_outputs)
+            snapshot_outputs = output_identities(snapshot_root, expected)
+            receipt["handoff"] = {
+                "mode": "captured-content-snapshot",
+                "outputs": snapshot_outputs,
+            }
             candidate_receipt = pathlib.Path(temporary) / "candidate-receipt.json"
             candidate = copy.deepcopy(receipt)
             candidate["metadata_class"] = "acceptance-test"
             candidate["authority_receipt"] = False
             atomic_json(candidate_receipt, candidate)
 
-            immediately_before = current_core_identities(
-                project_root,
-                config_path,
-                linked,
-                inputs,
-                sidecars,
-                output_root,
-                expected,
-            )
+            immediately_before = {
+                **current_contract_identities(
+                    project_root,
+                    config_path,
+                    linked,
+                    inputs,
+                    sidecars,
+                ),
+                "outputs": output_identities(snapshot_root, expected),
+            }
             if immediately_before != post_build:
                 receipt["status"] = "refused"
                 receipt["findings"].append(
@@ -1015,7 +1192,7 @@ def run_gate(
                 promotion_command,
                 {
                     "candidate_receipt": str(candidate_receipt),
-                    "output_root": str(output_root),
+                    "output_root": str(snapshot_root),
                     "project_root": str(project_root),
                     "config_dir": str(config_path.parent),
                 },
@@ -1051,6 +1228,17 @@ def run_gate(
                         "kind": "promotion-command-failed",
                         "path": str(project_root),
                         "message": f"promotion command exited {promoted.returncode}",
+                    }
+                )
+                atomic_json(receipt_path, receipt)
+                return 1
+            if output_identities(snapshot_root, expected) != snapshot_outputs:
+                receipt["status"] = "refused"
+                receipt["findings"].append(
+                    {
+                        "kind": "snapshot-changed-during-promotion",
+                        "path": str(config_path),
+                        "message": "the supplied promotion command changed the captured output snapshot",
                     }
                 )
                 atomic_json(receipt_path, receipt)

--- a/skills/synthesis-promotion-gate/scripts/promotion_gate.py
+++ b/skills/synthesis-promotion-gate/scripts/promotion_gate.py
@@ -21,7 +21,6 @@ import copy
 import datetime as dt
 import fnmatch
 import hashlib
-from html.parser import HTMLParser
 import json
 import os
 import pathlib
@@ -46,8 +45,6 @@ DESTINATION_REPRESENTATIONS = {
 }
 AUXILIARY_REPRESENTATIONS = {"publishable-source", "sidecar-flags"}
 REPRESENTATIONS = DESTINATION_REPRESENTATIONS | AUXILIARY_REPRESENTATIONS
-RAW_TEXT_ELEMENTS = {"script", "style", "template", "noscript"}
-HEADING_ELEMENTS = {f"h{level}" for level in range(1, 7)}
 
 CONFIG_KEYS = {
     "schema",
@@ -60,11 +57,14 @@ CONFIG_KEYS = {
     "inspected_surfaces",
     "sidecar_flag_globs",
     "additional_unverified_remainder",
+    "destination_projection",
 }
 BUILD_KEYS = {"command", "working_directory", "output_root"}
 INPUT_KEYS = {"root", "globs"}
 RANGE_KEYS = {"start", "end", "required"}
 SURFACE_KEYS = {"renderer", "representations"}
+DESTINATION_PROJECTION_KEYS = {"command", "working_directory", "expected_identity"}
+DESTINATION_IDENTITY_KEYS = {"parser", "parser_version", "renderer"}
 RENDERER_KEYS = {
     "id",
     "version",
@@ -145,6 +145,14 @@ def require_string_list(value: Any, label: str) -> list[str]:
     return value
 
 
+def require_optional_string_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or not all(
+        isinstance(item, str) for item in value
+    ):
+        raise GateError("destination-projection-invalid", f"{label} must be a list of strings")
+    return value
+
+
 def yaml_document(path: pathlib.Path, label: str) -> dict[str, Any]:
     try:
         value = yaml.safe_load(path.read_text(encoding="utf-8"))
@@ -219,6 +227,37 @@ def load_config(path: pathlib.Path) -> tuple[pathlib.Path, dict[str, Any]]:
     require_keys(inputs, INPUT_KEYS, "inputs")
     project_path(project_root, inputs.get("root"), "inputs.root")
     require_string_list(inputs.get("globs"), "inputs.globs")
+
+    projection = require_mapping(
+        config.get("destination_projection"), "destination_projection"
+    )
+    require_keys(projection, DESTINATION_PROJECTION_KEYS, "destination_projection")
+    if set(projection) != DESTINATION_PROJECTION_KEYS:
+        raise GateError("invalid-config", "every destination_projection field is required")
+    projection_command = require_string_list(
+        projection.get("command"), "destination_projection.command"
+    )
+    if any("{" in argument or "}" in argument for argument in projection_command):
+        raise GateError(
+            "invalid-config",
+            "destination_projection.command receives JSON on stdin and cannot contain substitutions",
+        )
+    project_path(
+        project_root,
+        projection.get("working_directory"),
+        "destination_projection.working_directory",
+    )
+    identity = require_mapping(
+        projection.get("expected_identity"),
+        "destination_projection.expected_identity",
+    )
+    if set(identity) != DESTINATION_IDENTITY_KEYS:
+        raise GateError(
+            "invalid-config",
+            "destination_projection.expected_identity must declare parser, parser_version, and renderer",
+        )
+    for key in sorted(DESTINATION_IDENTITY_KEYS):
+        require_string(identity.get(key), f"destination_projection.expected_identity.{key}")
 
     range_config = require_mapping(config.get("publishable_range"), "publishable_range")
     require_keys(range_config, RANGE_KEYS, "publishable_range")
@@ -604,81 +643,118 @@ def expected_routes(
     return expected, findings
 
 
-class DeclaredHtmlProjection(HTMLParser):
-    """Exact declared projections; this is not called browser-visible text."""
+def representation_digest(values: list[str]) -> str:
+    payload = json.dumps(values, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return sha256_bytes(payload)
 
-    def __init__(self) -> None:
-        super().__init__(convert_charrefs=True)
-        self.dom_parts: list[str] = []
-        self.comments: list[str] = []
-        self.headings: list[str] = []
-        self.structural_errors: list[str] = []
-        self._heading_stack: list[tuple[str, list[str]]] = []
-        self._raw_stack: list[str] = []
-        self._finished = False
 
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        tag = tag.lower()
-        if tag in RAW_TEXT_ELEMENTS:
-            if self._raw_stack:
-                self.structural_errors.append("nested raw-text element")
-            self._raw_stack.append(tag)
-        if tag in HEADING_ELEMENTS:
-            if self._heading_stack:
-                self.structural_errors.append("nested heading element")
-            self._heading_stack.append((tag, []))
-
-    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        tag = tag.lower()
-        if tag in RAW_TEXT_ELEMENTS or tag in HEADING_ELEMENTS:
-            self.structural_errors.append("self-closing monitored element")
-
-    def handle_endtag(self, tag: str) -> None:
-        tag = tag.lower()
-        if tag in HEADING_ELEMENTS:
-            if not self._heading_stack:
-                self.structural_errors.append("unmatched heading end tag")
-            else:
-                opened, parts = self._heading_stack.pop()
-                if opened != tag:
-                    self.structural_errors.append("mismatched heading end tag")
-                else:
-                    self.headings.append("".join(parts))
-        if tag in RAW_TEXT_ELEMENTS:
-            if not self._raw_stack:
-                self.structural_errors.append("unmatched raw-text end tag")
-            else:
-                opened = self._raw_stack.pop()
-                if opened != tag:
-                    self.structural_errors.append("mismatched raw-text end tag")
-
-    def handle_data(self, data: str) -> None:
-        if self._raw_stack:
-            return
-        self.dom_parts.append(data)
-        if self._heading_stack:
-            self._heading_stack[-1][1].append(data)
-
-    def handle_comment(self, data: str) -> None:
-        self.comments.append(data)
-
-    def finish(self) -> None:
-        if self._finished:
-            return
-        self.close()
-        if self._heading_stack:
-            self.structural_errors.append("unclosed heading element")
-        if self._raw_stack:
-            self.structural_errors.append("unclosed raw-text element")
-        self._finished = True
-
-    def representations(self, raw: str) -> dict[str, list[str]]:
-        return {
-            "dom-text": ["".join(self.dom_parts)],
-            "dom-heading-text": self.headings,
-            "html-comments": self.comments,
-            "raw-page-source": [raw],
+def project_destinations(
+    command: list[str],
+    working_directory: pathlib.Path,
+    expected_identity: dict[str, str],
+    documents: dict[str, str],
+) -> tuple[dict[str, dict[str, list[str]]], dict[str, Any]]:
+    """Consume destination-produced representations through the strict JSON protocol."""
+    request = {
+        "schema": SCHEMA,
+        "documents": [
+            {"route": route, "html": html}
+            for route, html in sorted(documents.items())
+        ],
+    }
+    try:
+        projected = subprocess.run(
+            command,
+            cwd=working_directory,
+            input=json.dumps(request, ensure_ascii=False),
+            capture_output=True,
+            text=True,
+            timeout=900,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise GateError(
+            "destination-projection-failed",
+            f"destination projection command could not complete: {type(exc).__name__}",
+        ) from exc
+    telemetry = {
+        "exit_code": projected.returncode,
+        "stdout_sha256": sha256_bytes(projected.stdout.encode("utf-8")),
+        "stderr_sha256": sha256_bytes(projected.stderr.encode("utf-8")),
+    }
+    if projected.returncode != 0:
+        raise GateError(
+            "destination-projection-failed",
+            f"destination projection command exited {projected.returncode}",
+        )
+    try:
+        response = json.loads(projected.stdout)
+    except (json.JSONDecodeError, UnicodeError) as exc:
+        raise GateError(
+            "destination-projection-invalid",
+            "destination projection command returned invalid JSON",
+        ) from exc
+    response = require_mapping(response, "destination projection response")
+    if set(response) != {"schema", "identity", "documents"} or response.get("schema") != SCHEMA:
+        raise GateError(
+            "destination-projection-invalid",
+            "destination projection response must contain schema 1, identity, and documents",
+        )
+    identity = require_mapping(response.get("identity"), "destination projection identity")
+    if set(identity) != DESTINATION_IDENTITY_KEYS or not all(
+        isinstance(identity.get(key), str) and identity[key].strip()
+        for key in DESTINATION_IDENTITY_KEYS
+    ):
+        raise GateError(
+            "destination-projection-invalid",
+            "destination projection identity has an invalid shape",
+        )
+    if identity != expected_identity:
+        raise GateError(
+            "destination-projection-identity-mismatch",
+            "destination projection identity differs from the configured identity",
+        )
+    raw_documents = response.get("documents")
+    if not isinstance(raw_documents, list):
+        raise GateError(
+            "destination-projection-invalid",
+            "destination projection documents must be a list",
+        )
+    by_route: dict[str, dict[str, list[str]]] = {}
+    projected_representations = DESTINATION_REPRESENTATIONS - {"raw-page-source"}
+    for index, raw_document in enumerate(raw_documents):
+        document = require_mapping(raw_document, f"destination projection document {index}")
+        if set(document) != {"route", "representations"}:
+            raise GateError(
+                "destination-projection-invalid",
+                "each projected document must contain route and representations",
+            )
+        route = require_string(document.get("route"), "projected document route")
+        if route in by_route:
+            raise GateError(
+                "destination-projection-invalid",
+                f"destination projection duplicated route {route}",
+            )
+        representations = require_mapping(
+            document.get("representations"),
+            f"destination projection representations for {route}",
+        )
+        if set(representations) != projected_representations:
+            raise GateError(
+                "destination-projection-invalid",
+                f"destination projection for {route} has an incomplete representation set",
+            )
+        by_route[route] = {
+            name: require_optional_string_list(values, f"{route}.{name}")
+            for name, values in representations.items()
         }
+    if set(by_route) != set(documents):
+        raise GateError(
+            "destination-projection-invalid",
+            "destination projection route universe differs from the captured output universe",
+        )
+    telemetry["identity"] = identity
+    return by_route, telemetry
 
 
 def marker_findings(
@@ -777,6 +853,7 @@ def base_receipt(mode: str, config_path: pathlib.Path) -> dict[str, Any]:
         "policy": {},
         "surface_manifest": {},
         "acceptance_suite": {},
+        "destination_projection": {},
         "build": {"exit_code": None},
         "inputs": [],
         "sidecars": [],
@@ -840,12 +917,17 @@ def current_contract_identities(
     linked: list[pathlib.Path],
     inputs: list[InputArtifact],
     sidecars: list[pathlib.Path],
+    commands: dict[str, tuple[pathlib.Path, list[str]]],
 ) -> dict[str, Any]:
     return {
         "config_sha256": sha256_file(config_path),
         "linked": file_identities(project_root, linked),
         "inputs": file_identities(project_root, [item.path for item in inputs]),
         "sidecars": file_identities(project_root, sidecars),
+        "commands": {
+            name: command_identity(working_directory, command)
+            for name, (working_directory, command) in sorted(commands.items())
+        },
     }
 
 
@@ -880,6 +962,20 @@ def run_gate(
         policy_path, markers = load_policy(project_root, config)
         acceptance_path = load_acceptance(project_root, config)
         manifest_path, renderers, inspections = load_surfaces(project_root, config)
+        projection_config = config["destination_projection"]
+        projection_working_directory = project_path(
+            project_root,
+            projection_config["working_directory"],
+            "destination_projection.working_directory",
+        )
+        projection_command = list(projection_config["command"])
+        projection_identity = dict(projection_config["expected_identity"])
+        renderer_versions = {renderer["version"] for renderer in renderers}
+        if renderer_versions != {projection_identity["renderer"]}:
+            raise GateError(
+                "invalid-config",
+                "destination projection renderer identity must equal every declared renderer version",
+            )
         receipt["policy"] = {
             "path": policy_path.relative_to(project_root).as_posix(),
             "sha256": sha256_file(policy_path),
@@ -896,6 +992,13 @@ def run_gate(
         receipt["acceptance_suite"] = {
             "path": acceptance_path.relative_to(project_root).as_posix(),
             "sha256": sha256_file(acceptance_path),
+        }
+        receipt["destination_projection"] = {
+            "declared_command": projection_command,
+            "expected_identity": projection_identity,
+            "command_file_identities": command_identity(
+                projection_working_directory, projection_command
+            ),
         }
         inputs = discover_inputs(project_root, config)
         receipt["inputs"] = [item.receipt() for item in inputs]
@@ -938,6 +1041,13 @@ def run_gate(
         receipt["build"]["command_file_identities"] = command_identity(
             working_directory, raw_build_command
         )
+        command_contracts = {
+            "build": (working_directory, raw_build_command),
+            "destination_projection": (
+                projection_working_directory,
+                projection_command,
+            ),
+        }
 
         with tempfile.TemporaryDirectory(prefix="synthesis-promotion-gate-") as temporary:
             output_root = pathlib.Path(temporary) / "rendered"
@@ -948,6 +1058,7 @@ def run_gate(
                 linked,
                 inputs,
                 sidecars,
+                command_contracts,
             )
             build_command = substitute(
                 raw_build_command,
@@ -1000,6 +1111,7 @@ def run_gate(
             inspected: list[dict[str, Any]] = []
             missing: list[str] = []
             captured_outputs: dict[str, bytes] = {}
+            captured_text: dict[str, str] = {}
             expected_by_route = {item["route"]: item for item in expected}
             for route, item in expected_by_route.items():
                 output = output_root / route
@@ -1031,45 +1143,7 @@ def run_gate(
                     )
                     continue
                 captured_outputs[route] = payload
-                parser = DeclaredHtmlProjection()
-                parser.feed(raw)
-                parser.finish()
-                projected = parser.representations(raw)
-                representations = inspections[item["renderer"]]
-                inspected.append(
-                    {
-                        **item,
-                        "sha256": sha256_bytes(payload),
-                        "representations": representations,
-                        "parser": f"python-html.parser:{sys.version_info.major}.{sys.version_info.minor}",
-                    }
-                )
-                if parser.structural_errors:
-                    receipt["findings"].append(
-                        {
-                            "kind": "rendered-representation-invalid",
-                            "path": item["input"],
-                            "renderer": item["renderer"],
-                            "route": route,
-                            "message": (
-                                "declared projection found malformed monitored HTML "
-                                f"({len(parser.structural_errors)} structural error(s))"
-                            ),
-                        }
-                    )
-                for representation in representations:
-                    if representation not in DESTINATION_REPRESENTATIONS:
-                        continue
-                    receipt["findings"].extend(
-                        marker_findings(
-                            markers,
-                            representation,
-                            projected[representation],
-                            path=item["input"],
-                            renderer=item["renderer"],
-                            route=route,
-                        )
-                    )
+                captured_text[route] = raw
             receipt["route_bijection"]["inspected"] = inspected
             receipt["route_bijection"]["missing"] = missing
             actual_outputs: list[str] = []
@@ -1090,14 +1164,56 @@ def run_gate(
                     }
                 )
 
+            if set(captured_text) == set(expected_by_route):
+                projected_by_route, projection_telemetry = project_destinations(
+                    projection_command,
+                    projection_working_directory,
+                    projection_identity,
+                    captured_text,
+                )
+                receipt["destination_projection"].update(projection_telemetry)
+                for route, item in expected_by_route.items():
+                    projected = {
+                        **projected_by_route[route],
+                        "raw-page-source": [captured_text[route]],
+                    }
+                    representations = inspections[item["renderer"]]
+                    inspected.append(
+                        {
+                            **item,
+                            "sha256": sha256_bytes(captured_outputs[route]),
+                            "representations": representations,
+                            "projection_identity": projection_identity,
+                            "representation_sha256": {
+                                name: representation_digest(projected[name])
+                                for name in sorted(DESTINATION_REPRESENTATIONS)
+                            },
+                        }
+                    )
+                    for representation in representations:
+                        if representation not in DESTINATION_REPRESENTATIONS:
+                            continue
+                        receipt["findings"].extend(
+                            marker_findings(
+                                markers,
+                                representation,
+                                projected[representation],
+                                path=item["input"],
+                                renderer=item["renderer"],
+                                route=route,
+                            )
+                        )
+                receipt["route_bijection"]["inspected"] = inspected
+
             post_contract = current_contract_identities(
                 project_root,
                 config_path,
                 linked,
                 inputs,
                 sidecars,
+                command_contracts,
             )
-            for key in ("config_sha256", "linked", "inputs", "sidecars"):
+            for key in ("config_sha256", "linked", "inputs", "sidecars", "commands"):
                 if baseline[key] != post_contract[key]:
                     kind = "input-changed-during-build" if key == "inputs" else "contract-changed-during-build"
                     if not any(f["kind"] == kind for f in receipt["findings"]):
@@ -1173,6 +1289,7 @@ def run_gate(
                     linked,
                     inputs,
                     sidecars,
+                    command_contracts,
                 ),
                 "outputs": output_identities(snapshot_root, expected),
             }

--- a/skills/synthesis-promotion-gate/scripts/promotion_gate.py
+++ b/skills/synthesis-promotion-gate/scripts/promotion_gate.py
@@ -1,0 +1,1101 @@
+#!/usr/bin/env python3
+"""Render, inspect, and enforce a publication promotion boundary.
+
+A successful build is not a publication-safety signal. ``check`` produces an
+acceptance-test receipt and never authorizes a state change. ``enforce`` keeps the
+isolated rendered outputs alive, revalidates the exact inputs and receipt immediately
+before the supplied promotion command, and invokes that command only after every
+declared representation is clean. Only that fail-closed caller can issue an
+``enforced-gate`` receipt.
+
+This engine detects configured promotion scaffolding. It does not decide whether
+ordinary prose is appropriate to disclose, prove that a surface manifest names an
+unknown consumer, or establish the bytes at a remote destination after the supplied
+command returns. Each receipt names that remainder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import datetime as dt
+import fnmatch
+import hashlib
+from html.parser import HTMLParser
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import uuid
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+import yaml
+
+
+SCHEMA = 1
+CONTROL_CLASSES = {"diagnostic", "acceptance-test", "enforced-gate"}
+DESTINATION_REPRESENTATIONS = {
+    "dom-text",
+    "dom-heading-text",
+    "html-comments",
+    "raw-page-source",
+}
+AUXILIARY_REPRESENTATIONS = {"publishable-source", "sidecar-flags"}
+REPRESENTATIONS = DESTINATION_REPRESENTATIONS | AUXILIARY_REPRESENTATIONS
+RAW_TEXT_ELEMENTS = {"script", "style", "template", "noscript"}
+HEADING_ELEMENTS = {f"h{level}" for level in range(1, 7)}
+
+CONFIG_KEYS = {
+    "schema",
+    "build",
+    "inputs",
+    "publishable_range",
+    "marker_policy",
+    "surface_manifest",
+    "acceptance_suite",
+    "inspected_surfaces",
+    "sidecar_flag_globs",
+    "unverified_remainder",
+}
+BUILD_KEYS = {"command", "working_directory", "output_root"}
+INPUT_KEYS = {"root", "globs"}
+RANGE_KEYS = {"start", "end", "required"}
+SURFACE_KEYS = {"renderer", "representations"}
+RENDERER_KEYS = {
+    "id",
+    "version",
+    "input_globs",
+    "route_template",
+    "output_prefix",
+}
+
+
+class GateError(RuntimeError):
+    def __init__(self, kind: str, message: str):
+        super().__init__(message)
+        self.kind = kind
+        self.message = message
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GateError("invalid-config", f"{label} must be a mapping")
+    return value
+
+
+def require_keys(value: dict[str, Any], allowed: set[str], label: str) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise GateError("invalid-config", f"{label} has unknown keys: {', '.join(unknown)}")
+
+
+def require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise GateError("invalid-config", f"{label} must be a non-empty string")
+    return value
+
+
+def require_string_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or not value or not all(
+        isinstance(item, str) and item for item in value
+    ):
+        raise GateError("invalid-config", f"{label} must be a non-empty list of strings")
+    return value
+
+
+def yaml_document(path: pathlib.Path, label: str) -> dict[str, Any]:
+    try:
+        value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise GateError("unreadable-config", f"cannot read {label} {path}: {exc}") from exc
+    return require_mapping(value, label)
+
+
+def no_symlink_components(path: pathlib.Path, stop: pathlib.Path) -> None:
+    current = path
+    stop = stop.resolve()
+    while True:
+        if current.is_symlink():
+            raise GateError("symlink-path", f"symlinked path component is refused: {current}")
+        if current.resolve(strict=False) == stop:
+            return
+        if current.parent == current:
+            raise GateError("path-outside-project", f"path is outside project root: {path}")
+        current = current.parent
+
+
+def project_path(
+    project_root: pathlib.Path,
+    value: Any,
+    label: str,
+    *,
+    must_exist: bool = True,
+    file_only: bool = False,
+) -> pathlib.Path:
+    raw = pathlib.Path(require_string(value, label))
+    if raw.is_absolute():
+        raise GateError("path-outside-project", f"{label} must be relative to the project root")
+    candidate = project_root / raw
+    resolved_root = project_root.resolve()
+    resolved = candidate.resolve(strict=False)
+    try:
+        resolved.relative_to(resolved_root)
+    except ValueError as exc:
+        raise GateError("path-outside-project", f"{label} escapes the project root: {raw}") from exc
+    no_symlink_components(candidate, project_root)
+    if must_exist and not candidate.exists():
+        raise GateError("missing-path", f"{label} does not exist: {candidate}")
+    if file_only and not candidate.is_file():
+        raise GateError("missing-path", f"{label} is not a regular file: {candidate}")
+    return candidate
+
+
+def load_config(path: pathlib.Path) -> tuple[pathlib.Path, dict[str, Any]]:
+    if path.is_symlink() or not path.is_file():
+        raise GateError("unreadable-config", f"config is not a regular non-symlink file: {path}")
+    config = yaml_document(path, "promotion gate config")
+    require_keys(config, CONFIG_KEYS, "promotion gate config")
+    if config.get("schema") != SCHEMA:
+        raise GateError("invalid-config", f"config schema must be {SCHEMA}")
+    project_root = path.parent.parent if path.parent.name == ".agents" else path.parent
+    project_root = project_root.resolve()
+
+    build = require_mapping(config.get("build"), "build")
+    require_keys(build, BUILD_KEYS, "build")
+    command = require_string_list(build.get("command"), "build.command")
+    if "{output_root}" not in command:
+        raise GateError(
+            "invalid-config",
+            "build.command must carry the literal {output_root} argument so isolated output is explicit",
+        )
+    project_path(project_root, build.get("working_directory"), "build.working_directory")
+    logical_output = pathlib.PurePosixPath(require_string(build.get("output_root"), "build.output_root"))
+    if logical_output.is_absolute() or ".." in logical_output.parts:
+        raise GateError("invalid-config", "build.output_root must be a safe relative path")
+
+    inputs = require_mapping(config.get("inputs"), "inputs")
+    require_keys(inputs, INPUT_KEYS, "inputs")
+    project_path(project_root, inputs.get("root"), "inputs.root")
+    require_string_list(inputs.get("globs"), "inputs.globs")
+
+    range_config = require_mapping(config.get("publishable_range"), "publishable_range")
+    require_keys(range_config, RANGE_KEYS, "publishable_range")
+    start = require_string(range_config.get("start"), "publishable_range.start")
+    end = require_string(range_config.get("end"), "publishable_range.end")
+    if start == end:
+        raise GateError("invalid-config", "publishable range start and end must differ")
+    if range_config.get("required") is not True:
+        raise GateError("invalid-config", "publishable_range.required must be true")
+
+    for key in ("marker_policy", "surface_manifest", "acceptance_suite"):
+        project_path(project_root, config.get(key), key, file_only=True)
+    require_string(config.get("unverified_remainder"), "unverified_remainder")
+    if not isinstance(config.get("sidecar_flag_globs"), list) or not all(
+        isinstance(item, str) and item for item in config["sidecar_flag_globs"]
+    ):
+        raise GateError("invalid-config", "sidecar_flag_globs must be a list of strings")
+    return project_root, config
+
+
+@dataclass(frozen=True)
+class Marker:
+    marker_id: str
+    projections: dict[str, re.Pattern[str]]
+
+
+def load_policy(project_root: pathlib.Path, config: dict[str, Any]) -> tuple[pathlib.Path, list[Marker]]:
+    path = project_path(project_root, config["marker_policy"], "marker_policy", file_only=True)
+    policy = yaml_document(path, "marker policy")
+    if set(policy) != {"schema", "markers"} or policy.get("schema") != SCHEMA:
+        raise GateError("invalid-marker-policy", "marker policy must contain schema 1 and markers")
+    entries = policy.get("markers")
+    if not isinstance(entries, list) or not entries:
+        raise GateError("invalid-marker-policy", "marker policy markers must be a non-empty list")
+    seen: set[str] = set()
+    markers: list[Marker] = []
+    required = {
+        "id",
+        "threat_rationale",
+        "provenance",
+        "positive_examples",
+        "negative_examples",
+        "projections",
+    }
+    for index, raw in enumerate(entries):
+        item = require_mapping(raw, f"marker {index}")
+        if set(item) != required:
+            missing = sorted(required - set(item))
+            extra = sorted(set(item) - required)
+            raise GateError(
+                "invalid-marker-policy",
+                f"marker {index} schema mismatch; missing={missing}, extra={extra}",
+            )
+        marker_id = require_string(item["id"], f"marker {index}.id")
+        if marker_id in seen:
+            raise GateError("invalid-marker-policy", f"duplicate marker id: {marker_id}")
+        seen.add(marker_id)
+        require_string(item["threat_rationale"], f"marker {marker_id}.threat_rationale")
+        require_string(item["provenance"], f"marker {marker_id}.provenance")
+        require_string_list(item["positive_examples"], f"marker {marker_id}.positive_examples")
+        require_string_list(item["negative_examples"], f"marker {marker_id}.negative_examples")
+        raw_projections = require_mapping(item["projections"], f"marker {marker_id}.projections")
+        if not raw_projections:
+            raise GateError("invalid-marker-policy", f"marker {marker_id} has no projections")
+        projections: dict[str, re.Pattern[str]] = {}
+        for representation, raw_projection in raw_projections.items():
+            if representation not in REPRESENTATIONS:
+                raise GateError(
+                    "invalid-marker-policy",
+                    f"marker {marker_id} names unknown representation {representation}",
+                )
+            projection = require_mapping(
+                raw_projection, f"marker {marker_id}.{representation}"
+            )
+            if set(projection) != {"pattern"}:
+                raise GateError(
+                    "invalid-marker-policy",
+                    f"marker {marker_id}.{representation} must contain only pattern",
+                )
+            pattern = require_string(
+                projection["pattern"], f"marker {marker_id}.{representation}.pattern"
+            )
+            try:
+                projections[representation] = re.compile(pattern, re.IGNORECASE | re.DOTALL)
+            except re.error as exc:
+                raise GateError(
+                    "invalid-marker-policy",
+                    f"marker {marker_id}.{representation} has invalid regex: {exc}",
+                ) from exc
+        markers.append(Marker(marker_id, projections))
+    return path, markers
+
+
+def load_acceptance(project_root: pathlib.Path, config: dict[str, Any]) -> pathlib.Path:
+    path = project_path(project_root, config["acceptance_suite"], "acceptance_suite", file_only=True)
+    manifest = yaml_document(path, "acceptance suite")
+    if manifest.get("schema") != SCHEMA or manifest.get("membership") != "closed":
+        raise GateError("invalid-acceptance-suite", "acceptance suite must declare schema 1 and closed membership")
+    require_string(manifest.get("boundary"), "acceptance suite boundary")
+    if manifest.get("expected_status") != "pass":
+        raise GateError("invalid-acceptance-suite", "acceptance suite expected_status must be pass")
+    cases = manifest.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise GateError("invalid-acceptance-suite", "acceptance suite must contain cases")
+    for case in cases:
+        value = require_mapping(case, "acceptance case")
+        if value.get("control_class") not in CONTROL_CLASSES:
+            raise GateError("invalid-acceptance-suite", "acceptance case has unknown control_class")
+    return path
+
+
+def load_surfaces(
+    project_root: pathlib.Path, config: dict[str, Any]
+) -> tuple[pathlib.Path, list[dict[str, Any]], dict[str, list[str]]]:
+    path = project_path(project_root, config["surface_manifest"], "surface_manifest", file_only=True)
+    manifest = yaml_document(path, "surface manifest")
+    if set(manifest) != {"schema", "renderers"} or manifest.get("schema") != SCHEMA:
+        raise GateError("invalid-surface-manifest", "surface manifest must contain schema 1 and renderers")
+    raw_renderers = manifest.get("renderers")
+    if not isinstance(raw_renderers, list) or not raw_renderers:
+        raise GateError("invalid-surface-manifest", "surface manifest renderers must be non-empty")
+    renderers: list[dict[str, Any]] = []
+    ids: set[str] = set()
+    for raw in raw_renderers:
+        renderer = require_mapping(raw, "renderer")
+        require_keys(renderer, RENDERER_KEYS, "renderer")
+        if set(renderer) != RENDERER_KEYS:
+            raise GateError("invalid-surface-manifest", "every renderer field is required")
+        renderer_id = require_string(renderer["id"], "renderer.id")
+        if renderer_id in ids:
+            raise GateError("invalid-surface-manifest", f"duplicate renderer id: {renderer_id}")
+        ids.add(renderer_id)
+        require_string(renderer["version"], f"renderer {renderer_id}.version")
+        require_string_list(renderer["input_globs"], f"renderer {renderer_id}.input_globs")
+        require_string(renderer["route_template"], f"renderer {renderer_id}.route_template")
+        output_prefix = pathlib.PurePosixPath(str(renderer["output_prefix"]))
+        if output_prefix.is_absolute() or ".." in output_prefix.parts:
+            raise GateError("invalid-surface-manifest", f"renderer {renderer_id} output_prefix is unsafe")
+        renderers.append(renderer)
+
+    raw_inspections = config.get("inspected_surfaces")
+    if not isinstance(raw_inspections, list) or not raw_inspections:
+        raise GateError("invalid-config", "inspected_surfaces must be a non-empty list")
+    inspections: dict[str, list[str]] = {}
+    for raw in raw_inspections:
+        inspection = require_mapping(raw, "inspected surface")
+        require_keys(inspection, SURFACE_KEYS, "inspected surface")
+        if set(inspection) != SURFACE_KEYS:
+            raise GateError("invalid-config", "every inspected surface field is required")
+        renderer_id = require_string(inspection["renderer"], "inspected surface renderer")
+        if renderer_id in inspections:
+            raise GateError("invalid-config", f"duplicate inspected renderer: {renderer_id}")
+        representations = require_string_list(
+            inspection["representations"], f"inspected surface {renderer_id}.representations"
+        )
+        unknown = sorted(set(representations) - (DESTINATION_REPRESENTATIONS | {"publishable-source"}))
+        if unknown:
+            raise GateError("invalid-config", f"unknown inspected representations: {', '.join(unknown)}")
+        if not set(representations) & DESTINATION_REPRESENTATIONS:
+            raise GateError("invalid-config", f"renderer {renderer_id} has no destination representation")
+        inspections[renderer_id] = representations
+    if set(inspections) != ids:
+        missing = sorted(ids - set(inspections))
+        extra = sorted(set(inspections) - ids)
+        raise GateError(
+            "surface-manifest-mismatch",
+            f"surface manifest and inspected surfaces disagree; missing={missing}, extra={extra}",
+        )
+    return path, renderers, inspections
+
+
+@dataclass
+class InputArtifact:
+    path: pathlib.Path
+    relative_path: str
+    source_sha256: str
+    publishable_sha256: str
+    publishable: str
+    frontmatter: dict[str, Any]
+
+    def receipt(self) -> dict[str, Any]:
+        return {
+            "path": self.relative_path,
+            "source_sha256": self.source_sha256,
+            "publishable_sha256": self.publishable_sha256,
+            "frontmatter": self.frontmatter,
+        }
+
+
+def split_frontmatter(text: str, relative: str) -> tuple[dict[str, Any], str]:
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise GateError("invalid-input", f"{relative} has no YAML frontmatter")
+    closing = next((index for index, line in enumerate(lines[1:], 1) if line.strip() == "---"), None)
+    if closing is None:
+        raise GateError("invalid-input", f"{relative} has unterminated YAML frontmatter")
+    try:
+        frontmatter = yaml.safe_load("".join(lines[1:closing])) or {}
+    except yaml.YAMLError as exc:
+        raise GateError("invalid-input", f"{relative} frontmatter is invalid YAML: {exc}") from exc
+    if not isinstance(frontmatter, dict):
+        raise GateError("invalid-input", f"{relative} frontmatter must be a mapping")
+    return frontmatter, "".join(lines[closing + 1 :])
+
+
+def extract_publishable(body: str, relative: str, range_config: dict[str, Any]) -> str:
+    start, end = range_config["start"], range_config["end"]
+    if body.count(start) != 1 or body.count(end) != 1:
+        raise GateError(
+            "publishable-range",
+            f"{relative} must contain exactly one publishable start and end marker",
+        )
+    start_at = body.index(start) + len(start)
+    end_at = body.index(end)
+    if end_at <= start_at:
+        raise GateError("publishable-range", f"{relative} publishable markers are reversed")
+    return body[start_at:end_at]
+
+
+def discover_inputs(project_root: pathlib.Path, config: dict[str, Any]) -> list[InputArtifact]:
+    inputs = config["inputs"]
+    input_root = project_path(project_root, inputs["root"], "inputs.root")
+    found: set[pathlib.Path] = set()
+    for pattern in inputs["globs"]:
+        for path in input_root.glob(pattern):
+            if path.is_file():
+                no_symlink_components(path, project_root)
+                found.add(path)
+    if not found:
+        raise GateError("empty-input-universe", "input globs matched no files")
+    artifacts: list[InputArtifact] = []
+    for path in sorted(found):
+        raw = path.read_bytes()
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise GateError("invalid-input", f"input is not UTF-8: {path}") from exc
+        relative = path.relative_to(project_root).as_posix()
+        frontmatter, body = split_frontmatter(text, relative)
+        slug = frontmatter.get("slug")
+        if not isinstance(slug, str) or not slug.strip():
+            raise GateError("invalid-input", f"{relative} has no non-empty frontmatter slug")
+        publishable = extract_publishable(body, relative, config["publishable_range"])
+        artifacts.append(
+            InputArtifact(
+                path,
+                relative,
+                sha256_bytes(raw),
+                sha256_bytes(publishable.encode("utf-8")),
+                publishable,
+                frontmatter,
+            )
+        )
+    return artifacts
+
+
+def matches_any(path: str, patterns: Iterable[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def route_fields(frontmatter: dict[str, Any]) -> dict[str, str]:
+    fields = {key: str(value) for key, value in frontmatter.items() if value is not None}
+    raw_date = fields.get("date", "")
+    match = re.match(r"^(\d{4})-(\d{2})-(\d{2})", raw_date)
+    if match:
+        fields.update(year=match.group(1), month=match.group(2), day=match.group(3))
+    return fields
+
+
+def safe_route(value: str, renderer_id: str) -> str:
+    route = pathlib.PurePosixPath(value)
+    if route.is_absolute() or ".." in route.parts or not route.parts:
+        raise GateError("invalid-route", f"renderer {renderer_id} produced unsafe route {value!r}")
+    return route.as_posix()
+
+
+def expected_routes(
+    inputs: list[InputArtifact], renderers: list[dict[str, Any]]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    expected: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+    used_outputs: dict[str, str] = {}
+    for artifact in inputs:
+        consumers = [
+            renderer
+            for renderer in renderers
+            if matches_any(artifact.relative_path, renderer["input_globs"])
+        ]
+        if not consumers:
+            findings.append(
+                {
+                    "kind": "unconsumed-input",
+                    "path": artifact.relative_path,
+                    "message": "input is not named by any consuming renderer",
+                }
+            )
+            continue
+        for renderer in consumers:
+            renderer_id = renderer["id"]
+            try:
+                rendered = renderer["route_template"].format_map(route_fields(artifact.frontmatter))
+            except KeyError as exc:
+                raise GateError(
+                    "invalid-route",
+                    f"renderer {renderer_id} route requires absent frontmatter field {exc.args[0]}",
+                ) from exc
+            prefix = str(renderer["output_prefix"]).strip("/")
+            route = safe_route("/".join(part for part in (prefix, rendered.strip("/")) if part), renderer_id)
+            if route in used_outputs:
+                findings.append(
+                    {
+                        "kind": "route-not-bijective",
+                        "path": artifact.relative_path,
+                        "route": route,
+                        "message": f"route is already assigned to {used_outputs[route]}",
+                    }
+                )
+                continue
+            used_outputs[route] = artifact.relative_path
+            expected.append(
+                {
+                    "renderer": renderer_id,
+                    "renderer_version": renderer["version"],
+                    "input": artifact.relative_path,
+                    "route": route,
+                }
+            )
+    return expected, findings
+
+
+class DeclaredHtmlProjection(HTMLParser):
+    """Exact declared projections; this is not called browser-visible text."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.dom_parts: list[str] = []
+        self.comments: list[str] = []
+        self.headings: list[str] = []
+        self._heading_parts: list[list[str]] = []
+        self._raw_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
+        if tag in RAW_TEXT_ELEMENTS:
+            self._raw_depth += 1
+        if tag in HEADING_ELEMENTS:
+            self._heading_parts.append([])
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        return
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in HEADING_ELEMENTS and self._heading_parts:
+            self.headings.append("".join(self._heading_parts.pop()))
+        if tag in RAW_TEXT_ELEMENTS and self._raw_depth:
+            self._raw_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._raw_depth:
+            return
+        self.dom_parts.append(data)
+        for heading in self._heading_parts:
+            heading.append(data)
+
+    def handle_comment(self, data: str) -> None:
+        self.comments.append(data)
+
+    def representations(self, raw: str) -> dict[str, list[str]]:
+        return {
+            "dom-text": ["".join(self.dom_parts)],
+            "dom-heading-text": self.headings,
+            "html-comments": self.comments,
+            "raw-page-source": [raw],
+        }
+
+
+def marker_findings(
+    markers: list[Marker],
+    representation: str,
+    values: Iterable[str],
+    *,
+    path: str,
+    renderer: str | None = None,
+    route: str | None = None,
+) -> list[dict[str, Any]]:
+    values = list(values)
+    findings: list[dict[str, Any]] = []
+    for marker in markers:
+        pattern = marker.projections.get(representation)
+        if pattern is None:
+            continue
+        match = next((pattern.search(value) for value in values if pattern.search(value)), None)
+        if match is None:
+            continue
+        finding: dict[str, Any] = {
+            "kind": "marker-hit",
+            "marker_id": marker.marker_id,
+            "representation": representation,
+            "path": path,
+            "evidence_sha256": sha256_bytes(match.group(0).encode("utf-8")),
+            "message": "configured marker matched; content is withheld from the receipt",
+        }
+        if renderer is not None:
+            finding["renderer"] = renderer
+        if route is not None:
+            finding["route"] = route
+        findings.append(finding)
+    return findings
+
+
+def sidecar_paths(project_root: pathlib.Path, config: dict[str, Any]) -> list[pathlib.Path]:
+    found: set[pathlib.Path] = set()
+    for pattern in config["sidecar_flag_globs"]:
+        for path in project_root.glob(pattern):
+            if path.is_file():
+                no_symlink_components(path, project_root)
+                found.add(path)
+    return sorted(found)
+
+
+def file_identities(project_root: pathlib.Path, paths: Iterable[pathlib.Path]) -> list[dict[str, str]]:
+    return [
+        {"path": path.relative_to(project_root).as_posix(), "sha256": sha256_file(path)}
+        for path in sorted(set(paths))
+    ]
+
+
+def command_identity(working_directory: pathlib.Path, command: list[str]) -> list[dict[str, str]]:
+    identities: list[dict[str, str]] = []
+    for argument in command:
+        if "{" in argument:
+            continue
+        candidate = pathlib.Path(argument)
+        if not candidate.is_absolute():
+            candidate = working_directory / candidate
+        if candidate.is_file():
+            identities.append({"argument": argument, "sha256": sha256_file(candidate)})
+    return identities
+
+
+def atomic_json(path: pathlib.Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise GateError("symlink-path", f"receipt target is a symlink: {path}")
+    payload = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        if path.read_bytes() != payload:
+            raise GateError("receipt-write", f"receipt read-back failed: {path}")
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def base_receipt(mode: str, config_path: pathlib.Path) -> dict[str, Any]:
+    enforce = mode == "enforce"
+    return {
+        "schema": SCHEMA,
+        "invocation_id": str(uuid.uuid4()),
+        "created_at": utc_now(),
+        "status": "refused",
+        "metadata_class": "enforced-gate" if enforce else "acceptance-test",
+        "authority_receipt": False,
+        "config": {"path": str(config_path)},
+        "policy": {},
+        "surface_manifest": {},
+        "acceptance_suite": {},
+        "build": {"exit_code": None},
+        "inputs": [],
+        "sidecars": [],
+        "route_bijection": {"expected": [], "inspected": [], "missing": []},
+        "findings": [],
+        "promotion": {"attempted": False, "exit_code": None},
+        "topology": (
+            {
+                "production_entry_point": "promotion_gate.py enforce",
+                "enforcing_boundary": "before the supplied promotion command",
+                "receipt_consumer": "built-in candidate revalidation plus supplied command",
+            }
+            if enforce
+            else {
+                "production_entry_point": "promotion_gate.py check",
+                "enforcing_boundary": "none; check cannot invoke a promotion command",
+                "receipt_consumer": "none",
+            }
+        ),
+        "unverified_remainder": "Configuration could not be loaded; no safety claim is available.",
+    }
+
+
+def add_fatal(receipt: dict[str, Any], error: GateError) -> None:
+    receipt["findings"].append(
+        {"kind": error.kind, "path": receipt["config"]["path"], "message": error.message}
+    )
+
+
+def substitute(command: list[str], values: dict[str, str]) -> list[str]:
+    result: list[str] = []
+    for argument in command:
+        rendered = argument
+        for name, value in values.items():
+            rendered = rendered.replace("{" + name + "}", value)
+        result.append(rendered)
+    return result
+
+
+def output_identities(output_root: pathlib.Path, expected: list[dict[str, Any]]) -> list[dict[str, str]]:
+    return [
+        {"route": item["route"], "sha256": sha256_file(output_root / item["route"])}
+        for item in expected
+        if (output_root / item["route"]).is_file()
+    ]
+
+
+def current_core_identities(
+    project_root: pathlib.Path,
+    config_path: pathlib.Path,
+    linked: list[pathlib.Path],
+    inputs: list[InputArtifact],
+    sidecars: list[pathlib.Path],
+    output_root: pathlib.Path,
+    expected: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "config_sha256": sha256_file(config_path),
+        "linked": file_identities(project_root, linked),
+        "inputs": file_identities(project_root, [item.path for item in inputs]),
+        "sidecars": file_identities(project_root, sidecars),
+        "outputs": output_identities(output_root, expected),
+    }
+
+
+def run_gate(
+    mode: str,
+    config_path: pathlib.Path,
+    receipt_path: pathlib.Path,
+    promotion_command: list[str],
+) -> int:
+    receipt = base_receipt(mode, config_path)
+    try:
+        project_root, config = load_config(config_path)
+        receipt["config"] = {
+            "path": str(config_path),
+            "sha256": sha256_file(config_path),
+            "logical_output_root": config["build"]["output_root"],
+        }
+        receipt["unverified_remainder"] = config["unverified_remainder"]
+        policy_path, markers = load_policy(project_root, config)
+        acceptance_path = load_acceptance(project_root, config)
+        manifest_path, renderers, inspections = load_surfaces(project_root, config)
+        receipt["policy"] = {
+            "path": policy_path.relative_to(project_root).as_posix(),
+            "sha256": sha256_file(policy_path),
+            "marker_ids": [marker.marker_id for marker in markers],
+        }
+        receipt["surface_manifest"] = {
+            "path": manifest_path.relative_to(project_root).as_posix(),
+            "sha256": sha256_file(manifest_path),
+            "renderers": [
+                {"id": renderer["id"], "version": renderer["version"]}
+                for renderer in renderers
+            ],
+        }
+        receipt["acceptance_suite"] = {
+            "path": acceptance_path.relative_to(project_root).as_posix(),
+            "sha256": sha256_file(acceptance_path),
+        }
+        inputs = discover_inputs(project_root, config)
+        receipt["inputs"] = [item.receipt() for item in inputs]
+        sidecars = sidecar_paths(project_root, config)
+        receipt["sidecars"] = file_identities(project_root, sidecars)
+        expected, route_findings = expected_routes(inputs, renderers)
+        receipt["route_bijection"]["expected"] = expected
+        receipt["findings"].extend(route_findings)
+
+        for artifact in inputs:
+            if any(
+                "publishable-source" in inspections[renderer["id"]]
+                and matches_any(artifact.relative_path, renderer["input_globs"])
+                for renderer in renderers
+            ):
+                receipt["findings"].extend(
+                    marker_findings(
+                        markers,
+                        "publishable-source",
+                        [artifact.publishable],
+                        path=artifact.relative_path,
+                    )
+                )
+        for sidecar in sidecars:
+            receipt["findings"].extend(
+                marker_findings(
+                    markers,
+                    "sidecar-flags",
+                    [sidecar.read_text(encoding="utf-8")],
+                    path=sidecar.relative_to(project_root).as_posix(),
+                )
+            )
+
+        linked = [policy_path, manifest_path, acceptance_path]
+        working_directory = project_path(
+            project_root, config["build"]["working_directory"], "build.working_directory"
+        )
+        raw_build_command = config["build"]["command"]
+        receipt["build"]["declared_command"] = raw_build_command
+        receipt["build"]["command_file_identities"] = command_identity(
+            working_directory, raw_build_command
+        )
+
+        with tempfile.TemporaryDirectory(prefix="synthesis-promotion-gate-") as temporary:
+            output_root = pathlib.Path(temporary) / "rendered"
+            output_root.mkdir()
+            baseline = current_core_identities(
+                project_root,
+                config_path,
+                linked,
+                inputs,
+                sidecars,
+                output_root,
+                [],
+            )
+            build_command = substitute(
+                raw_build_command,
+                {
+                    "output_root": str(output_root),
+                    "project_root": str(project_root),
+                    "config_dir": str(config_path.parent),
+                },
+            )
+            try:
+                built = subprocess.run(
+                    build_command,
+                    cwd=working_directory,
+                    capture_output=True,
+                    text=True,
+                    timeout=900,
+                    check=False,
+                )
+                receipt["build"].update(
+                    exit_code=built.returncode,
+                    stdout_sha256=sha256_bytes(built.stdout.encode("utf-8")),
+                    stderr_sha256=sha256_bytes(built.stderr.encode("utf-8")),
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                receipt["build"].update(exit_code=None, error=type(exc).__name__)
+                receipt["findings"].append(
+                    {"kind": "build-failed", "path": str(working_directory), "message": str(exc)}
+                )
+                built = None
+            if built is not None and built.returncode != 0:
+                receipt["findings"].append(
+                    {
+                        "kind": "build-failed",
+                        "path": str(working_directory),
+                        "message": f"declared build exited {built.returncode}",
+                    }
+                )
+
+            for artifact in inputs:
+                actual = sha256_file(artifact.path)
+                if actual != artifact.source_sha256:
+                    receipt["findings"].append(
+                        {
+                            "kind": "input-changed-during-build",
+                            "path": artifact.relative_path,
+                            "message": "input hash changed after discovery and before promotion",
+                        }
+                    )
+
+            inspected: list[dict[str, Any]] = []
+            missing: list[str] = []
+            expected_by_route = {item["route"]: item for item in expected}
+            for route, item in expected_by_route.items():
+                output = output_root / route
+                no_symlink_components(output, output_root)
+                if not output.is_file():
+                    missing.append(route)
+                    receipt["findings"].append(
+                        {
+                            "kind": "missing-rendered-output",
+                            "path": item["input"],
+                            "renderer": item["renderer"],
+                            "route": route,
+                            "message": "frontmatter-derived output is absent and therefore uninspected",
+                        }
+                    )
+                    continue
+                raw = output.read_text(encoding="utf-8")
+                parser = DeclaredHtmlProjection()
+                parser.feed(raw)
+                projected = parser.representations(raw)
+                representations = inspections[item["renderer"]]
+                inspected.append(
+                    {
+                        **item,
+                        "sha256": sha256_file(output),
+                        "representations": representations,
+                        "parser": f"python-html.parser:{sys.version_info.major}.{sys.version_info.minor}",
+                    }
+                )
+                for representation in representations:
+                    if representation not in DESTINATION_REPRESENTATIONS:
+                        continue
+                    receipt["findings"].extend(
+                        marker_findings(
+                            markers,
+                            representation,
+                            projected[representation],
+                            path=item["input"],
+                            renderer=item["renderer"],
+                            route=route,
+                        )
+                    )
+            receipt["route_bijection"]["inspected"] = inspected
+            receipt["route_bijection"]["missing"] = missing
+            actual_outputs = sorted(
+                path.relative_to(output_root).as_posix()
+                for path in output_root.rglob("*")
+                if path.is_file()
+            )
+            receipt["route_bijection"]["unscoped_outputs"] = sorted(
+                set(actual_outputs) - set(expected_by_route)
+            )
+
+            post_build = current_core_identities(
+                project_root,
+                config_path,
+                linked,
+                inputs,
+                sidecars,
+                output_root,
+                expected,
+            )
+            for key in ("config_sha256", "linked", "inputs", "sidecars"):
+                if baseline[key] != post_build[key]:
+                    kind = "input-changed-during-build" if key == "inputs" else "contract-changed-during-build"
+                    if not any(f["kind"] == kind for f in receipt["findings"]):
+                        receipt["findings"].append(
+                            {
+                                "kind": kind,
+                                "path": str(config_path),
+                                "message": f"{key} identity changed during the build",
+                            }
+                        )
+            receipt["identity_binding"] = post_build
+
+            if receipt["findings"]:
+                atomic_json(receipt_path, receipt)
+                print(
+                    f"REFUSED {len(receipt['findings'])} finding(s); "
+                    "a successful build is not a publication-safety signal."
+                )
+                return 1
+
+            receipt["status"] = "pass"
+            if mode == "check":
+                atomic_json(receipt_path, receipt)
+                print("PASS acceptance-test receipt written; no promotion authority issued.")
+                return 0
+
+            if not promotion_command:
+                receipt["status"] = "refused"
+                receipt["findings"].append(
+                    {
+                        "kind": "missing-promotion-command",
+                        "path": str(config_path),
+                        "message": "enforce requires a supplied promotion command",
+                    }
+                )
+                atomic_json(receipt_path, receipt)
+                return 1
+            required_tokens = {"{candidate_receipt}", "{output_root}"}
+            present = {token for token in required_tokens if token in promotion_command}
+            if present != required_tokens:
+                receipt["status"] = "refused"
+                receipt["findings"].append(
+                    {
+                        "kind": "unbound-promotion-command",
+                        "path": str(config_path),
+                        "message": "promotion command must carry {candidate_receipt} and {output_root}",
+                    }
+                )
+                atomic_json(receipt_path, receipt)
+                return 1
+
+            candidate_receipt = pathlib.Path(temporary) / "candidate-receipt.json"
+            candidate = copy.deepcopy(receipt)
+            candidate["metadata_class"] = "acceptance-test"
+            candidate["authority_receipt"] = False
+            atomic_json(candidate_receipt, candidate)
+
+            immediately_before = current_core_identities(
+                project_root,
+                config_path,
+                linked,
+                inputs,
+                sidecars,
+                output_root,
+                expected,
+            )
+            if immediately_before != post_build:
+                receipt["status"] = "refused"
+                receipt["findings"].append(
+                    {
+                        "kind": "receipt-revalidation-failed",
+                        "path": str(config_path),
+                        "message": "bound inputs or outputs changed before the state-changing command",
+                    }
+                )
+                atomic_json(receipt_path, receipt)
+                return 1
+
+            command = substitute(
+                promotion_command,
+                {
+                    "candidate_receipt": str(candidate_receipt),
+                    "output_root": str(output_root),
+                    "project_root": str(project_root),
+                    "config_dir": str(config_path.parent),
+                },
+            )
+            receipt["promotion"]["attempted"] = True
+            try:
+                promoted = subprocess.run(
+                    command,
+                    cwd=project_root,
+                    capture_output=True,
+                    text=True,
+                    timeout=900,
+                    check=False,
+                )
+                receipt["promotion"].update(
+                    exit_code=promoted.returncode,
+                    command=promotion_command,
+                    stdout_sha256=sha256_bytes(promoted.stdout.encode("utf-8")),
+                    stderr_sha256=sha256_bytes(promoted.stderr.encode("utf-8")),
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                receipt["promotion"].update(exit_code=None, command=promotion_command)
+                receipt["status"] = "refused"
+                receipt["findings"].append(
+                    {"kind": "promotion-command-failed", "path": str(project_root), "message": str(exc)}
+                )
+                atomic_json(receipt_path, receipt)
+                return 1
+            if promoted.returncode != 0:
+                receipt["status"] = "refused"
+                receipt["findings"].append(
+                    {
+                        "kind": "promotion-command-failed",
+                        "path": str(project_root),
+                        "message": f"promotion command exited {promoted.returncode}",
+                    }
+                )
+                atomic_json(receipt_path, receipt)
+                return 1
+            receipt["metadata_class"] = "enforced-gate"
+            receipt["authority_receipt"] = True
+            receipt["status"] = "pass"
+            atomic_json(receipt_path, receipt)
+            print("PASS enforced-gate receipt written after the promotion command returned cleanly.")
+            return 0
+    except GateError as exc:
+        add_fatal(receipt, exc)
+        try:
+            atomic_json(receipt_path, receipt)
+        except GateError as write_error:
+            print(f"REFUSED {exc.message}; receipt also failed: {write_error.message}", file=sys.stderr)
+            return 1
+        print(f"REFUSED {exc.message}", file=sys.stderr)
+        return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    for mode in ("check", "enforce"):
+        command = subparsers.add_parser(mode)
+        command.add_argument("--config", required=True, type=pathlib.Path)
+        command.add_argument("--receipt", required=True, type=pathlib.Path)
+        if mode == "enforce":
+            command.add_argument("promotion_command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    promotion = getattr(args, "promotion_command", [])
+    if promotion and promotion[0] == "--":
+        promotion = promotion[1:]
+    # os.path.abspath is intentionally lexical. pathlib.resolve() would follow a
+    # symlink before load_config() or atomic_json() could refuse it.
+    config_path = pathlib.Path(os.path.abspath(os.fspath(args.config)))
+    receipt_path = pathlib.Path(os.path.abspath(os.fspath(args.receipt)))
+    return run_gate(
+        args.mode,
+        config_path,
+        receipt_path,
+        promotion,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/synthesis-promotion-gate/scripts/test_promotion_gate.py
+++ b/skills/synthesis-promotion-gate/scripts/test_promotion_gate.py
@@ -498,3 +498,43 @@ def test_surface_manifest_and_inspection_config_must_name_the_same_renderers(
     receipt = read_receipt(receipt_path)
     assert any(f["kind"] == "surface-manifest-mismatch" for f in receipt["findings"])
 
+
+def test_symlinked_config_is_refused_without_following_it(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+    )
+    linked_config = config.with_name("linked-promotion-gate.yaml")
+    linked_config.symlink_to(config.name)
+    result, receipt_path = run_gate(linked_config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(f["kind"] in {"symlink-path", "unreadable-config"} for f in receipt["findings"])
+
+
+def test_symlinked_rendered_output_is_refused_instead_of_inspecting_outside_bytes(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={},
+    )
+    outside = tmp_path / "outside.html"
+    outside.write_text("<p>Clean.</p>", encoding="utf-8")
+    (root / "fixture_build.py").write_text(
+        "import pathlib, sys\n"
+        "target = pathlib.Path(sys.argv[1]) / 'articles/clean/index.html'\n"
+        "target.parent.mkdir(parents=True, exist_ok=True)\n"
+        f"target.symlink_to({str(outside)!r})\n",
+        encoding="utf-8",
+    )
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(f["kind"] == "symlink-path" for f in receipt["findings"])

--- a/skills/synthesis-promotion-gate/scripts/test_promotion_gate.py
+++ b/skills/synthesis-promotion-gate/scripts/test_promotion_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from html.parser import HTMLParser
 import pathlib
 import subprocess
 import sys
@@ -51,7 +52,7 @@ def marker_policy() -> dict[str, Any]:
                 "id": "unresolved-date",
                 "threat_rationale": "A publication date placeholder rendered to a reader surface.",
                 "provenance": "engagement-round-2-two-date-blocks",
-                "positive_examples": ["<DATE>"],
+                "positive_examples": ["<DATE>", "&lt;DATE&gt;"],
                 "negative_examples": ["2026-08-26"],
                 "projections": {
                     "publishable-source": {"pattern": r"<\s*date\s*>"},
@@ -538,3 +539,195 @@ def test_symlinked_rendered_output_is_refused_instead_of_inspecting_outside_byte
     assert result.returncode == 1
     receipt = read_receipt(receipt_path)
     assert any(f["kind"] == "symlink-path" for f in receipt["findings"])
+
+
+def test_unscoped_output_refuses_before_the_whole_root_reaches_promotion(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={
+            "articles/clean/index.html": "<p>Clean.</p>",
+            "unscoped/internal/index.html": "<h2>Publication Notes</h2>",
+        },
+    )
+    sentinel = root / "promoted.txt"
+    command = [
+        sys.executable,
+        "fixture_promote.py",
+        "{candidate_receipt}",
+        "{output_root}",
+        str(sentinel),
+    ]
+    result, receipt_path = run_gate(config, mode="enforce", promotion_command=command)
+    assert result.returncode == 1
+    assert not sentinel.exists()
+    receipt = read_receipt(receipt_path)
+    assert any(f["kind"] == "unscoped-rendered-output" for f in receipt["findings"])
+
+
+def test_promotion_consumes_a_captured_snapshot_not_a_build_childs_later_mutation(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={},
+    )
+    (root / "fixture_build.py").write_text(
+        "import pathlib, subprocess, sys\n"
+        "target = pathlib.Path(sys.argv[1]) / 'articles/clean/index.html'\n"
+        "target.parent.mkdir(parents=True, exist_ok=True)\n"
+        "target.write_text('<p>Clean.</p>', encoding='utf-8')\n"
+        "code = \"import pathlib,time; time.sleep(0.20); pathlib.Path(%r).write_text('<h2>Publication Notes</h2>', encoding='utf-8')\" % str(target)\n"
+        "subprocess.Popen([sys.executable, '-c', code], stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, close_fds=True, start_new_session=True)\n",
+        encoding="utf-8",
+    )
+    (root / "consume_after_delay.py").write_text(
+        "import json, pathlib, sys, time\n"
+        "candidate = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))\n"
+        "time.sleep(0.45)\n"
+        "source = pathlib.Path(sys.argv[2]) / 'articles/clean/index.html'\n"
+        "pathlib.Path(sys.argv[3]).write_text(source.read_text(encoding='utf-8'), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    consumed = root / "consumed.html"
+    command = [
+        sys.executable,
+        "consume_after_delay.py",
+        "{candidate_receipt}",
+        "{output_root}",
+        str(consumed),
+    ]
+    result, receipt_path = run_gate(config, mode="enforce", promotion_command=command)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert consumed.read_text(encoding="utf-8") == "<p>Clean.</p>"
+    receipt = read_receipt(receipt_path)
+    assert receipt["authority_receipt"] is True
+    assert receipt["handoff"]["mode"] == "captured-content-snapshot"
+
+
+def test_each_policy_projection_must_match_a_positive_and_reject_negatives(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "dirty", "slug": "dirty"}],
+        outputs={"articles/dirty/index.html": "<h2>Publication Notes</h2>"},
+    )
+    policy_path = root / "marker-policy.yaml"
+    policy = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    policy["markers"][2]["projections"]["dom-heading-text"]["pattern"] = "^NEVER_MATCH$"
+    write_yaml(policy_path, policy)
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(f["kind"] == "invalid-marker-policy" for f in receipt["findings"])
+
+
+class DestinationHeadingOracle(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.current: list[str] | None = None
+        self.headings: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() in {f"h{level}" for level in range(1, 7)}:
+            self.current = []
+
+    def handle_data(self, data: str) -> None:
+        if self.current is not None:
+            self.current.append(data)
+
+    def finish(self) -> list[str]:
+        if self.current is not None:
+            self.headings.append("".join(self.current))
+            self.current = None
+        return self.headings
+
+
+def test_malformed_heading_that_destination_repairs_is_refused(
+    tmp_path: pathlib.Path,
+) -> None:
+    html = "<h2>Publication Notes"
+    oracle = DestinationHeadingOracle()
+    oracle.feed(html)
+    assert oracle.finish() == ["Publication Notes"]
+    config = make_project(
+        tmp_path / "project",
+        articles=[{"directory": "malformed", "slug": "malformed"}],
+        outputs={"articles/malformed/index.html": html},
+    )
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(f["kind"] == "rendered-representation-invalid" for f in receipt["findings"])
+
+
+def test_engine_owned_unverified_remainder_cannot_be_erased_by_config(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+    )
+    doc = yaml.safe_load(config.read_text(encoding="utf-8"))
+    doc["unverified_remainder"] = "none"
+    write_yaml(config, doc)
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert isinstance(receipt["unverified_remainder"], dict)
+    assert receipt["unverified_remainder"]["engine_owned"]
+    assert any(f["kind"] == "invalid-config" for f in receipt["findings"])
+
+
+def test_clean_receipt_always_carries_structured_engine_owned_remainder(
+    tmp_path: pathlib.Path,
+) -> None:
+    config = make_project(
+        tmp_path / "project",
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+    )
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 0
+    remainder = read_receipt(receipt_path)["unverified_remainder"]
+    assert remainder["engine_owned"]
+    assert remainder["repository_declared"]
+
+
+def test_shipped_acceptance_manifest_is_consumable_by_the_engine(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+    )
+    (root / "acceptance.yaml").write_bytes((SKILL_ROOT / "acceptance-suite.yaml").read_bytes())
+    result, _receipt_path = run_gate(config)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_repository_acceptance_template_is_shipped_and_consumable(
+    tmp_path: pathlib.Path,
+) -> None:
+    template = SKILL_ROOT / "templates/acceptance-suite.example.yaml"
+    assert template.is_file()
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+    )
+    (root / "acceptance.yaml").write_bytes(template.read_bytes())
+    result, _receipt_path = run_gate(config)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/skills/synthesis-promotion-gate/scripts/test_promotion_gate.py
+++ b/skills/synthesis-promotion-gate/scripts/test_promotion_gate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from html.parser import HTMLParser
+import hashlib
 import pathlib
 import subprocess
 import sys
@@ -12,6 +12,7 @@ import yaml
 
 SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = pathlib.Path(__file__).with_name("promotion_gate.py")
+DESTINATION_FIXTURES = SKILL_ROOT / "fixtures/destination-representations.yaml"
 
 START = "<!-- SYNTHESIS:PUBLISHABLE:START -->"
 END = "<!-- SYNTHESIS:PUBLISHABLE:END -->"
@@ -115,6 +116,38 @@ sentinel.write_text("promoted", encoding="utf-8")
 '''
 
 
+FIXTURE_PROJECTION_SCRIPT = r'''#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+corpus = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+request = json.load(sys.stdin)
+by_html = {case["html"]: case["representations"] for case in corpus["cases"]}
+documents = []
+for document in request.get("documents", []):
+    html = document.get("html")
+    if html not in by_html:
+        print("captured HTML is absent from the closed renderer-derived fixture corpus", file=sys.stderr)
+        raise SystemExit(7)
+    documents.append({"route": document["route"], "representations": by_html[html]})
+sys.stdout.write(json.dumps({
+    "schema": 1,
+    "identity": corpus["identity"],
+    "documents": documents,
+}, sort_keys=True))
+'''
+
+
+def destination_fixture_corpus() -> dict[str, Any]:
+    return yaml.safe_load(DESTINATION_FIXTURES.read_text(encoding="utf-8"))
+
+
+def representation_digest(values: list[str]) -> str:
+    payload = json.dumps(values, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
 def make_project(
     root: pathlib.Path,
     *,
@@ -139,6 +172,13 @@ def make_project(
 
     (root / "fixture_build.py").write_text(BUILD_SCRIPT, encoding="utf-8")
     (root / "fixture_promote.py").write_text(PROMOTE_SCRIPT, encoding="utf-8")
+    (root / "fixture_projection.py").write_text(
+        FIXTURE_PROJECTION_SCRIPT, encoding="utf-8"
+    )
+    corpus = destination_fixture_corpus()
+    (root / "destination-fixtures.json").write_text(
+        json.dumps(corpus, sort_keys=True), encoding="utf-8"
+    )
     build_spec: dict[str, Any] = {"outputs": outputs}
     if mutate_source:
         build_spec["mutate_path"] = str(root / mutate_source)
@@ -210,6 +250,15 @@ def make_project(
                 "output_root": "dist",
             },
             "inputs": {"root": "drafts", "globs": ["**/index.md"]},
+            "destination_projection": {
+                "command": [
+                    sys.executable,
+                    "fixture_projection.py",
+                    "destination-fixtures.json",
+                ],
+                "working_directory": ".",
+                "expected_identity": corpus["identity"],
+            },
             "publishable_range": {"start": START, "end": END, "required": True},
             "marker_policy": "marker-policy.yaml",
             "surface_manifest": "surface-manifest.yaml",
@@ -657,34 +706,10 @@ def test_policy_projection_that_matches_a_negative_example_is_refused(
     assert any(f["kind"] == "invalid-marker-policy" for f in receipt["findings"])
 
 
-class DestinationHeadingOracle(HTMLParser):
-    def __init__(self) -> None:
-        super().__init__(convert_charrefs=True)
-        self.current: list[str] | None = None
-        self.headings: list[str] = []
-
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        if tag.lower() in {f"h{level}" for level in range(1, 7)}:
-            self.current = []
-
-    def handle_data(self, data: str) -> None:
-        if self.current is not None:
-            self.current.append(data)
-
-    def finish(self) -> list[str]:
-        if self.current is not None:
-            self.headings.append("".join(self.current))
-            self.current = None
-        return self.headings
-
-
 def test_malformed_heading_that_destination_repairs_is_refused(
     tmp_path: pathlib.Path,
 ) -> None:
     html = "<h2>Publication Notes"
-    oracle = DestinationHeadingOracle()
-    oracle.feed(html)
-    assert oracle.finish() == ["Publication Notes"]
     config = make_project(
         tmp_path / "project",
         articles=[{"directory": "malformed", "slug": "malformed"}],
@@ -693,7 +718,98 @@ def test_malformed_heading_that_destination_repairs_is_refused(
     result, receipt_path = run_gate(config)
     assert result.returncode == 1
     receipt = read_receipt(receipt_path)
-    assert any(f["kind"] == "rendered-representation-invalid" for f in receipt["findings"])
+    assert any(
+        finding.get("marker_id") == "publication-notes"
+        and finding.get("representation") == "dom-heading-text"
+        for finding in receipt["findings"]
+    )
+
+
+def test_renderer_derived_destination_fixture_matrix_is_consumed(
+    tmp_path: pathlib.Path,
+) -> None:
+    corpus = destination_fixture_corpus()
+    required_planes = {
+        "inline",
+        "entity",
+        "comment",
+        "attribute",
+        "code",
+        "hidden-container",
+        "malformed",
+    }
+    cases = {
+        case["plane"]: case
+        for case in corpus["cases"]
+        if case["plane"] in required_planes
+    }
+    assert set(cases) == required_planes
+    for plane, case in sorted(cases.items()):
+        slug = plane.replace("-", "")
+        config = make_project(
+            tmp_path / plane,
+            articles=[{"directory": slug, "slug": slug}],
+            outputs={f"articles/{slug}/index.html": case["html"]},
+        )
+        _result, receipt_path = run_gate(config)
+        receipt = read_receipt(receipt_path)
+        assert receipt["destination_projection"]["identity"] == corpus["identity"]
+        inspected = receipt["route_bijection"]["inspected"]
+        assert len(inspected) == 1
+        expected = {
+            **case["representations"],
+            "raw-page-source": [case["html"]],
+        }
+        assert inspected[0]["representation_sha256"] == {
+            name: representation_digest(values)
+            for name, values in sorted(expected.items())
+        }
+
+
+def test_destination_projection_identity_mismatch_refuses(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+    )
+    doc = yaml.safe_load(config.read_text(encoding="utf-8"))
+    doc["destination_projection"]["expected_identity"]["parser_version"] = "wrong"
+    write_yaml(config, doc)
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(
+        finding["kind"] == "destination-projection-identity-mismatch"
+        for finding in receipt["findings"]
+    )
+
+
+def test_destination_projection_must_return_the_closed_route_universe(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+    )
+    identity = destination_fixture_corpus()["identity"]
+    (root / "fixture_projection.py").write_text(
+        "import json, sys\n"
+        "json.load(sys.stdin)\n"
+        f"print(json.dumps({{'schema': 1, 'identity': {identity!r}, 'documents': []}}))\n",
+        encoding="utf-8",
+    )
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(
+        finding["kind"] == "destination-projection-invalid"
+        for finding in receipt["findings"]
+    )
 
 
 def test_engine_owned_unverified_remainder_cannot_be_erased_by_config(

--- a/skills/synthesis-promotion-gate/scripts/test_promotion_gate.py
+++ b/skills/synthesis-promotion-gate/scripts/test_promotion_gate.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+import yaml
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = pathlib.Path(__file__).with_name("promotion_gate.py")
+
+START = "<!-- SYNTHESIS:PUBLISHABLE:START -->"
+END = "<!-- SYNTHESIS:PUBLISHABLE:END -->"
+
+
+def write_yaml(path: pathlib.Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(value, sort_keys=False), encoding="utf-8")
+
+
+def source_text(slug: str, body: str, *, outside: str = "") -> str:
+    return (
+        "---\n"
+        f'title: "Fixture {slug}"\n'
+        f'slug: "{slug}"\n'
+        'date: "2026-08-26"\n'
+        "---\n\n"
+        f"{outside}\n{START}\n{body}\n{END}\n"
+    )
+
+
+def marker_policy() -> dict[str, Any]:
+    return {
+        "schema": 1,
+        "markers": [
+            {
+                "id": "private-original-opener",
+                "threat_rationale": "A rejected private opener survived in page source.",
+                "provenance": "engagement-round-2-sensitive-html-comment",
+                "positive_examples": ["ORIGINAL OPENER private holdings"],
+                "negative_examples": ["An ordinary public introduction."],
+                "projections": {
+                    "html-comments": {"pattern": r"original\s+opener.*private\s+holdings"},
+                    "raw-page-source": {"pattern": r"original\s+opener.*private\s+holdings"},
+                },
+            },
+            {
+                "id": "unresolved-date",
+                "threat_rationale": "A publication date placeholder rendered to a reader surface.",
+                "provenance": "engagement-round-2-two-date-blocks",
+                "positive_examples": ["<DATE>"],
+                "negative_examples": ["2026-08-26"],
+                "projections": {
+                    "publishable-source": {"pattern": r"<\s*date\s*>"},
+                    "dom-text": {"pattern": r"<\s*date\s*>"},
+                    "raw-page-source": {"pattern": r"&lt;\s*date\s*&gt;"},
+                },
+            },
+            {
+                "id": "publication-notes",
+                "threat_rationale": "Internal publication notes rendered as a reader-facing section.",
+                "provenance": "engagement-round-2-two-publication-notes-sections",
+                "positive_examples": ["Publication Notes"],
+                "negative_examples": ["I keep publication notes beside a draft."],
+                "projections": {
+                    "dom-heading-text": {"pattern": r"^\s*publication\s+notes\s*$"},
+                    "html-comments": {"pattern": r"publication\s+notes"},
+                },
+            },
+            {
+                "id": "unresolved-sidecar",
+                "threat_rationale": "An unresolved sidecar attestation cannot authorize promotion.",
+                "provenance": "engagement-sidecar-flags",
+                "positive_examples": ["status: unresolved"],
+                "negative_examples": ["status: resolved"],
+                "projections": {
+                    "sidecar-flags": {"pattern": r"status\s*:\s*unresolved"},
+                },
+            },
+        ],
+    }
+
+
+BUILD_SCRIPT = r'''#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+output_root = pathlib.Path(sys.argv[1])
+spec = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+for relative, html in spec["outputs"].items():
+    target = output_root / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(html, encoding="utf-8")
+if spec.get("mutate_path"):
+    target = pathlib.Path(spec["mutate_path"])
+    target.write_text(target.read_text(encoding="utf-8") + "\nchanged during build\n", encoding="utf-8")
+'''
+
+
+PROMOTE_SCRIPT = r'''#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+candidate = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+output_root = pathlib.Path(sys.argv[2])
+sentinel = pathlib.Path(sys.argv[3])
+if candidate.get("status") != "pass" or not list(output_root.rglob("*.html")):
+    raise SystemExit(9)
+sentinel.write_text("promoted", encoding="utf-8")
+'''
+
+
+def make_project(
+    root: pathlib.Path,
+    *,
+    articles: list[dict[str, str]],
+    outputs: dict[str, str],
+    sidecar: str | None = None,
+    mutate_source: str | None = None,
+    representations: list[str] | None = None,
+) -> pathlib.Path:
+    root.mkdir(parents=True, exist_ok=True)
+    for article in articles:
+        path = root / "drafts" / article["directory"] / "index.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            source_text(
+                article["slug"],
+                article.get("body", "Public body."),
+                outside=article.get("outside", ""),
+            ),
+            encoding="utf-8",
+        )
+
+    (root / "fixture_build.py").write_text(BUILD_SCRIPT, encoding="utf-8")
+    (root / "fixture_promote.py").write_text(PROMOTE_SCRIPT, encoding="utf-8")
+    build_spec: dict[str, Any] = {"outputs": outputs}
+    if mutate_source:
+        build_spec["mutate_path"] = str(root / mutate_source)
+    (root / "build-map.json").write_text(
+        json.dumps(build_spec, sort_keys=True), encoding="utf-8"
+    )
+
+    write_yaml(root / "marker-policy.yaml", marker_policy())
+    write_yaml(
+        root / "surface-manifest.yaml",
+        {
+            "schema": 1,
+            "renderers": [
+                {
+                    "id": "fixture-html",
+                    "version": "fixture-renderer-1",
+                    "input_globs": ["drafts/**/index.md"],
+                    "route_template": "articles/{slug}/index.html",
+                    "output_prefix": "",
+                }
+            ],
+        },
+    )
+    write_yaml(
+        root / "acceptance.yaml",
+        {
+            "schema": 1,
+            "membership": "closed",
+            "boundary": "fixture promotion command",
+            "expected_status": "pass",
+            "cases": [{"id": "fixture", "control_class": "enforced-gate"}],
+        },
+    )
+    if sidecar is not None:
+        path = root / "sidecars" / "attestation.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(sidecar, encoding="utf-8")
+
+    reps = representations or [
+        "publishable-source",
+        "dom-text",
+        "dom-heading-text",
+        "html-comments",
+        "raw-page-source",
+    ]
+    write_yaml(
+        root / ".agents" / "promotion-gate.yaml",
+        {
+            "schema": 1,
+            "build": {
+                "command": [
+                    sys.executable,
+                    "fixture_build.py",
+                    "{output_root}",
+                    "build-map.json",
+                ],
+                "working_directory": ".",
+                "output_root": "dist",
+            },
+            "inputs": {"root": "drafts", "globs": ["**/index.md"]},
+            "publishable_range": {"start": START, "end": END, "required": True},
+            "marker_policy": "marker-policy.yaml",
+            "surface_manifest": "surface-manifest.yaml",
+            "acceptance_suite": "acceptance.yaml",
+            "inspected_surfaces": [
+                {"renderer": "fixture-html", "representations": reps}
+            ],
+            "sidecar_flag_globs": ["sidecars/**/*.yaml"],
+            "unverified_remainder": (
+                "Consumers omitted from the surface manifest and destination bytes "
+                "after the promotion command returns."
+            ),
+        },
+    )
+    return root / ".agents" / "promotion-gate.yaml"
+
+
+def run_gate(
+    config: pathlib.Path,
+    *,
+    mode: str = "check",
+    promotion_command: list[str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], pathlib.Path]:
+    receipt = config.parent.parent / f"{mode}-receipt.json"
+    command = [
+        sys.executable,
+        str(SCRIPT),
+        mode,
+        "--config",
+        str(config),
+        "--receipt",
+        str(receipt),
+    ]
+    if promotion_command:
+        command.extend(["--", *promotion_command])
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    return result, receipt
+
+
+def read_receipt(path: pathlib.Path) -> dict[str, Any]:
+    assert path.is_file(), f"receipt missing: {path}"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_successful_build_refuses_all_five_round2_rendered_defects(
+    tmp_path: pathlib.Path,
+) -> None:
+    articles = [
+        {"directory": "leak", "slug": "leak"},
+        {"directory": "date-a", "slug": "date-a"},
+        {"directory": "date-b", "slug": "date-b"},
+        {"directory": "notes-a", "slug": "notes-a"},
+        {"directory": "notes-b", "slug": "notes-b"},
+    ]
+    outputs = {
+        "articles/leak/index.html": "<!-- ORIGINAL OPENER: private holdings REDACTED --><p>Public.</p>",
+        "articles/date-a/index.html": "<p>&lt;DATE&gt;</p>",
+        "articles/date-b/index.html": "<p>&lt;DATE&gt;</p>",
+        "articles/notes-a/index.html": "<h2>Publication Notes</h2>",
+        "articles/notes-b/index.html": "<h2>Publication Notes</h2>",
+    }
+    config = make_project(tmp_path / "project", articles=articles, outputs=outputs)
+
+    result, receipt_path = run_gate(config)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    receipt = read_receipt(receipt_path)
+    assert receipt["build"]["exit_code"] == 0
+    assert receipt["status"] == "refused"
+    assert receipt["authority_receipt"] is False
+    dirty_routes = {
+        finding["route"] for finding in receipt["findings"] if finding.get("route")
+    }
+    assert dirty_routes == set(outputs)
+    assert {"private-original-opener", "unresolved-date", "publication-notes"} <= {
+        finding.get("marker_id") for finding in receipt["findings"]
+    }
+
+
+def test_sensitive_html_comment_is_inspected_as_comment_and_raw_source(
+    tmp_path: pathlib.Path,
+) -> None:
+    config = make_project(
+        tmp_path / "project",
+        articles=[{"directory": "leak", "slug": "leak"}],
+        outputs={
+            "articles/leak/index.html": "<!-- ORIGINAL OPENER private holdings REDACTED --><p>Clean.</p>"
+        },
+    )
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    representations = {
+        f["representation"]
+        for f in receipt["findings"]
+        if f.get("marker_id") == "private-original-opener"
+    }
+    assert representations == {"html-comments", "raw-page-source"}
+
+
+def test_dom_heading_preserves_tag_adjacency_instead_of_inventing_spaces(
+    tmp_path: pathlib.Path,
+) -> None:
+    config = make_project(
+        tmp_path / "project",
+        articles=[{"directory": "adjacency", "slug": "adjacency"}],
+        outputs={
+            "articles/adjacency/index.html": "<h2>Public<a href='/x'>ation</a> Notes</h2>"
+        },
+    )
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(
+        f.get("marker_id") == "publication-notes"
+        and f.get("representation") == "dom-heading-text"
+        for f in receipt["findings"]
+    )
+
+
+def test_route_bijection_uses_frontmatter_slug_not_source_directory(
+    tmp_path: pathlib.Path,
+) -> None:
+    config = make_project(
+        tmp_path / "project",
+        articles=[{"directory": "wrong-directory", "slug": "actual-route"}],
+        outputs={"articles/wrong-directory/index.html": "<p>Clean.</p>"},
+    )
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(
+        f["kind"] == "missing-rendered-output"
+        and f["route"] == "articles/actual-route/index.html"
+        for f in receipt["findings"]
+    )
+
+
+def test_every_staged_input_must_have_an_inspected_output(
+    tmp_path: pathlib.Path,
+) -> None:
+    config = make_project(
+        tmp_path / "project",
+        articles=[
+            {"directory": "seen", "slug": "seen"},
+            {"directory": "never-inspected", "slug": "never-inspected"},
+        ],
+        outputs={"articles/seen/index.html": "<p>Clean.</p>"},
+    )
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    expected = receipt["route_bijection"]["expected"]
+    assert len(expected) == 2
+    assert any(f["route"].endswith("never-inspected/index.html") for f in receipt["findings"])
+
+
+def test_publishable_range_excludes_internal_draft_material_but_binds_both_hashes(
+    tmp_path: pathlib.Path,
+) -> None:
+    config = make_project(
+        tmp_path / "project",
+        articles=[
+            {
+                "directory": "clean",
+                "slug": "clean",
+                "outside": "<!-- ORIGINAL OPENER private holdings REDACTED -->",
+            }
+        ],
+        outputs={"articles/clean/index.html": "<h1>Clean public page</h1>"},
+    )
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 0, result.stdout + result.stderr
+    receipt = read_receipt(receipt_path)
+    assert receipt["status"] == "pass"
+    assert receipt["metadata_class"] == "acceptance-test"
+    assert receipt["authority_receipt"] is False
+    identity = receipt["inputs"][0]
+    assert identity["source_sha256"] != identity["publishable_sha256"]
+    assert receipt["unverified_remainder"]
+
+
+def test_unresolved_sidecar_flag_refuses_promotion_even_when_rendered_page_is_clean(
+    tmp_path: pathlib.Path,
+) -> None:
+    config = make_project(
+        tmp_path / "project",
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+        sidecar="status: unresolved\n",
+    )
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(
+        f.get("marker_id") == "unresolved-sidecar"
+        and f.get("representation") == "sidecar-flags"
+        for f in receipt["findings"]
+    )
+
+
+def test_dirty_enforced_gate_never_invokes_the_promotion_command(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "dirty", "slug": "dirty"}],
+        outputs={"articles/dirty/index.html": "<h2>Publication Notes</h2>"},
+    )
+    sentinel = root / "promoted.txt"
+    command = [
+        sys.executable,
+        "fixture_promote.py",
+        "{candidate_receipt}",
+        "{output_root}",
+        str(sentinel),
+    ]
+    result, receipt_path = run_gate(config, mode="enforce", promotion_command=command)
+    assert result.returncode == 1
+    assert not sentinel.exists()
+    assert read_receipt(receipt_path)["authority_receipt"] is False
+
+
+def test_clean_enforced_gate_revalidates_receipt_then_invokes_the_consumer(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+    )
+    sentinel = root / "promoted.txt"
+    command = [
+        sys.executable,
+        "fixture_promote.py",
+        "{candidate_receipt}",
+        "{output_root}",
+        str(sentinel),
+    ]
+    result, receipt_path = run_gate(config, mode="enforce", promotion_command=command)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert sentinel.read_text(encoding="utf-8") == "promoted"
+    receipt = read_receipt(receipt_path)
+    assert receipt["status"] == "pass"
+    assert receipt["metadata_class"] == "enforced-gate"
+    assert receipt["authority_receipt"] is True
+    assert receipt["topology"] == {
+        "production_entry_point": "promotion_gate.py enforce",
+        "enforcing_boundary": "before the supplied promotion command",
+        "receipt_consumer": "built-in candidate revalidation plus supplied command",
+    }
+    assert receipt["promotion"]["exit_code"] == 0
+
+
+def test_input_changed_during_build_refuses_before_the_promotion_command(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    relative = "drafts/race/index.md"
+    config = make_project(
+        root,
+        articles=[{"directory": "race", "slug": "race"}],
+        outputs={"articles/race/index.html": "<p>Clean.</p>"},
+        mutate_source=relative,
+    )
+    sentinel = root / "promoted.txt"
+    command = [
+        sys.executable,
+        "fixture_promote.py",
+        "{candidate_receipt}",
+        "{output_root}",
+        str(sentinel),
+    ]
+    result, receipt_path = run_gate(config, mode="enforce", promotion_command=command)
+    assert result.returncode == 1
+    assert not sentinel.exists()
+    receipt = read_receipt(receipt_path)
+    assert any(f["kind"] == "input-changed-during-build" for f in receipt["findings"])
+
+
+def test_surface_manifest_and_inspection_config_must_name_the_same_renderers(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+    )
+    doc = yaml.safe_load(config.read_text(encoding="utf-8"))
+    doc["inspected_surfaces"][0]["renderer"] = "undeclared-renderer"
+    write_yaml(config, doc)
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(f["kind"] == "surface-manifest-mismatch" for f in receipt["findings"])
+

--- a/skills/synthesis-promotion-gate/scripts/test_promotion_gate.py
+++ b/skills/synthesis-promotion-gate/scripts/test_promotion_gate.py
@@ -68,7 +68,6 @@ def marker_policy() -> dict[str, Any]:
                 "negative_examples": ["I keep publication notes beside a draft."],
                 "projections": {
                     "dom-heading-text": {"pattern": r"^\s*publication\s+notes\s*$"},
-                    "html-comments": {"pattern": r"publication\s+notes"},
                 },
             },
             {
@@ -167,10 +166,21 @@ def make_project(
         root / "acceptance.yaml",
         {
             "schema": 1,
+            "suite": "fixture-promotion-gate",
             "membership": "closed",
-            "boundary": "fixture promotion command",
+            "production_entry_point": "promotion_gate.py enforce",
+            "enforcing_boundary": "before the fixture promotion command",
+            "receipt_consumer": "fixture promotion command",
             "expected_status": "pass",
-            "cases": [{"id": "fixture", "control_class": "enforced-gate"}],
+            "unverified_remainder": "destination bytes after the fixture command returns",
+            "cases": [
+                {
+                    "id": "fixture",
+                    "control_class": "enforced-gate",
+                    "fixture": "test_promotion_gate.py::fixture",
+                    "motivating_defect": "fixture-boundary",
+                }
+            ],
         },
     )
     if sidecar is not None:
@@ -208,10 +218,9 @@ def make_project(
                 {"renderer": "fixture-html", "representations": reps}
             ],
             "sidecar_flag_globs": ["sidecars/**/*.yaml"],
-            "unverified_remainder": (
-                "Consumers omitted from the surface manifest and destination bytes "
-                "after the promotion command returns."
-            ),
+            "additional_unverified_remainder": [
+                "repository-specific consumers not yet declared by this fixture"
+            ],
         },
     )
     return root / ".agents" / "promotion-gate.yaml"
@@ -629,6 +638,25 @@ def test_each_policy_projection_must_match_a_positive_and_reject_negatives(
     assert any(f["kind"] == "invalid-marker-policy" for f in receipt["findings"])
 
 
+def test_policy_projection_that_matches_a_negative_example_is_refused(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "dirty", "slug": "dirty"}],
+        outputs={"articles/dirty/index.html": "<h2>Publication Notes</h2>"},
+    )
+    policy_path = root / "marker-policy.yaml"
+    policy = yaml.safe_load(policy_path.read_text(encoding="utf-8"))
+    policy["markers"][2]["projections"]["dom-heading-text"]["pattern"] = "publication"
+    write_yaml(policy_path, policy)
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert any(f["kind"] == "invalid-marker-policy" for f in receipt["findings"])
+
+
 class DestinationHeadingOracle(HTMLParser):
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
@@ -701,6 +729,25 @@ def test_clean_receipt_always_carries_structured_engine_owned_remainder(
     remainder = read_receipt(receipt_path)["unverified_remainder"]
     assert remainder["engine_owned"]
     assert remainder["repository_declared"]
+
+
+def test_additional_remainder_cannot_claim_that_nothing_is_unverified(
+    tmp_path: pathlib.Path,
+) -> None:
+    root = tmp_path / "project"
+    config = make_project(
+        root,
+        articles=[{"directory": "clean", "slug": "clean"}],
+        outputs={"articles/clean/index.html": "<p>Clean.</p>"},
+    )
+    doc = yaml.safe_load(config.read_text(encoding="utf-8"))
+    doc["additional_unverified_remainder"] = ["none"]
+    write_yaml(config, doc)
+    result, receipt_path = run_gate(config)
+    assert result.returncode == 1
+    receipt = read_receipt(receipt_path)
+    assert receipt["unverified_remainder"]["engine_owned"]
+    assert any(f["kind"] == "invalid-config" for f in receipt["findings"])
 
 
 def test_shipped_acceptance_manifest_is_consumable_by_the_engine(

--- a/skills/synthesis-promotion-gate/scripts/test_skill_contract.py
+++ b/skills/synthesis-promotion-gate/scripts/test_skill_contract.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+
+SKILL_ROOT = pathlib.Path(__file__).resolve().parents[1]
+REPO_ROOT = SKILL_ROOT.parents[1]
+
+
+def test_skill_distinguishes_acceptance_from_enforcement_and_names_remainder() -> None:
+    text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+    normalized = " ".join(text.split()).lower()
+    for phrase in (
+        "A successful build is not a publication-safety signal",
+        "acceptance-test",
+        "enforced-gate",
+        "authority_receipt: false",
+        "unverified remainder",
+        "does not decide whether ordinary prose is appropriate to disclose",
+    ):
+        assert phrase.lower() in normalized
+
+
+def test_skill_names_destination_representations_and_frontmatter_routes() -> None:
+    text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+    for phrase in (
+        "dom-text",
+        "dom-heading-text",
+        "html-comments",
+        "raw-page-source",
+        "frontmatter",
+        "Directory-name substring selection is forbidden",
+    ):
+        assert phrase in text
+
+
+def test_templates_use_one_policy_and_a_complete_renderer_mapping() -> None:
+    config = yaml.safe_load(
+        (SKILL_ROOT / "templates/promotion-gate.example.yaml").read_text(encoding="utf-8")
+    )
+    policy = yaml.safe_load(
+        (SKILL_ROOT / "templates/marker-policy.example.yaml").read_text(encoding="utf-8")
+    )
+    surfaces = yaml.safe_load(
+        (SKILL_ROOT / "templates/surface-manifest.example.yaml").read_text(encoding="utf-8")
+    )
+    assert config["marker_policy"] == ".agents/promotion-marker-policy.yaml"
+    assert len({marker["id"] for marker in policy["markers"]}) == len(policy["markers"])
+    assert {surface["renderer"] for surface in config["inspected_surfaces"]} == {
+        renderer["id"] for renderer in surfaces["renderers"]
+    }
+    assert all("projections" in marker for marker in policy["markers"])
+
+
+def test_acceptance_manifest_classifies_only_boundary_cases_as_enforced() -> None:
+    manifest = yaml.safe_load((SKILL_ROOT / "acceptance-suite.yaml").read_text(encoding="utf-8"))
+    enforced = {
+        case["id"] for case in manifest["cases"] if case["control_class"] == "enforced-gate"
+    }
+    assert enforced == {
+        "refusal-precedes-state-change",
+        "receipt-consumer-topology",
+        "changed-input-revalidation",
+    }
+
+
+def test_prompt_hidden_skill_is_reachable_through_router() -> None:
+    router = (REPO_ROOT / "skills/synthesis-skill-router/SKILL.md").read_text(encoding="utf-8")
+    assert "../synthesis-promotion-gate/SKILL.md" in router
+    adapter = yaml.safe_load((SKILL_ROOT / "agents/openai.yaml").read_text(encoding="utf-8"))
+    assert adapter["policy"]["allow_implicit_invocation"] is False

--- a/skills/synthesis-promotion-gate/scripts/test_skill_contract.py
+++ b/skills/synthesis-promotion-gate/scripts/test_skill_contract.py
@@ -49,6 +49,11 @@ def test_templates_use_one_policy_and_a_complete_renderer_mapping() -> None:
     assert config["marker_policy"] == ".agents/promotion-marker-policy.yaml"
     assert config["acceptance_suite"] == ".agents/promotion-acceptance-suite.yaml"
     assert config["additional_unverified_remainder"]
+    assert config["destination_projection"]["expected_identity"] == {
+        "parser": "parse5",
+        "parser_version": "7.3.0",
+        "renderer": "astro@5.0.0",
+    }
     assert len({marker["id"] for marker in policy["markers"]}) == len(policy["markers"])
     assert {surface["renderer"] for surface in config["inspected_surfaces"]} == {
         renderer["id"] for renderer in surfaces["renderers"]
@@ -78,6 +83,26 @@ def test_all_four_repository_contract_templates_are_shipped() -> None:
         "marker-policy.example.yaml",
         "promotion-gate.example.yaml",
         "surface-manifest.example.yaml",
+    }
+
+
+def test_renderer_derived_fixture_matrix_covers_round15_grammar_planes() -> None:
+    corpus = yaml.safe_load(
+        (SKILL_ROOT / "fixtures/destination-representations.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert corpus["identity"]["parser"] == "parse5"
+    assert {
+        case["plane"] for case in corpus["cases"]
+    } >= {
+        "inline",
+        "entity",
+        "comment",
+        "attribute",
+        "code",
+        "hidden-container",
+        "malformed",
     }
 
 

--- a/skills/synthesis-promotion-gate/scripts/test_skill_contract.py
+++ b/skills/synthesis-promotion-gate/scripts/test_skill_contract.py
@@ -47,6 +47,8 @@ def test_templates_use_one_policy_and_a_complete_renderer_mapping() -> None:
         (SKILL_ROOT / "templates/surface-manifest.example.yaml").read_text(encoding="utf-8")
     )
     assert config["marker_policy"] == ".agents/promotion-marker-policy.yaml"
+    assert config["acceptance_suite"] == ".agents/promotion-acceptance-suite.yaml"
+    assert config["additional_unverified_remainder"]
     assert len({marker["id"] for marker in policy["markers"]}) == len(policy["markers"])
     assert {surface["renderer"] for surface in config["inspected_surfaces"]} == {
         renderer["id"] for renderer in surfaces["renderers"]
@@ -63,6 +65,19 @@ def test_acceptance_manifest_classifies_only_boundary_cases_as_enforced() -> Non
         "refusal-precedes-state-change",
         "receipt-consumer-topology",
         "changed-input-revalidation",
+        "closed-output-universe",
+        "captured-content-handoff",
+    }
+
+
+def test_all_four_repository_contract_templates_are_shipped() -> None:
+    assert {
+        path.name for path in (SKILL_ROOT / "templates").glob("*.example.yaml")
+    } == {
+        "acceptance-suite.example.yaml",
+        "marker-policy.example.yaml",
+        "promotion-gate.example.yaml",
+        "surface-manifest.example.yaml",
     }
 
 

--- a/skills/synthesis-promotion-gate/templates/acceptance-suite.example.yaml
+++ b/skills/synthesis-promotion-gate/templates/acceptance-suite.example.yaml
@@ -1,0 +1,15 @@
+# AGENT HEURISTIC: repository instances use the same closed schema as the
+# shipped suite so the production loader validates its own contract.
+schema: 1
+suite: repository-promotion-gate
+membership: closed
+production_entry_point: scripts/promotion_gate.py enforce
+enforcing_boundary: before the supplied promotion command
+receipt_consumer: built-in candidate revalidation plus supplied command
+expected_status: pass
+unverified_remainder: repository-specific cases outside this closed suite
+cases:
+  - id: repository-clean-promotion
+    control_class: enforced-gate
+    fixture: tests/test_promotion.py::test_clean_promotion_crosses_the_gate
+    motivating_defect: repository-publication-boundary

--- a/skills/synthesis-promotion-gate/templates/marker-policy.example.yaml
+++ b/skills/synthesis-promotion-gate/templates/marker-policy.example.yaml
@@ -13,7 +13,7 @@ markers:
   - id: unresolved-date
     threat_rationale: A date placeholder must not cross into the publishable range or rendered page.
     provenance: engagement-round-2-unresolved-date-blocks
-    positive_examples: ["<DATE>"]
+    positive_examples: ["<DATE>", "&lt;DATE&gt;"]
     negative_examples: ["2026-08-26"]
     projections:
       publishable-source:

--- a/skills/synthesis-promotion-gate/templates/marker-policy.example.yaml
+++ b/skills/synthesis-promotion-gate/templates/marker-policy.example.yaml
@@ -1,0 +1,40 @@
+schema: 1
+markers:
+  - id: private-original-opener
+    threat_rationale: A rejected private opener must not survive in generated page source.
+    provenance: engagement-round-2-sensitive-html-comment
+    positive_examples: ["ORIGINAL OPENER private holdings"]
+    negative_examples: ["An ordinary public introduction."]
+    projections:
+      html-comments:
+        pattern: 'original\s+opener.*private\s+holdings'
+      raw-page-source:
+        pattern: 'original\s+opener.*private\s+holdings'
+  - id: unresolved-date
+    threat_rationale: A date placeholder must not cross into the publishable range or rendered page.
+    provenance: engagement-round-2-unresolved-date-blocks
+    positive_examples: ["<DATE>"]
+    negative_examples: ["2026-08-26"]
+    projections:
+      publishable-source:
+        pattern: '<\s*date\s*>'
+      dom-text:
+        pattern: '<\s*date\s*>'
+      raw-page-source:
+        pattern: '&lt;\s*date\s*&gt;'
+  - id: publication-notes-section
+    threat_rationale: Internal publication notes must not render as a reader-facing section.
+    provenance: engagement-round-2-publication-notes-sections
+    positive_examples: ["Publication Notes"]
+    negative_examples: ["I keep publication notes beside the draft."]
+    projections:
+      dom-heading-text:
+        pattern: '^\s*publication\s+notes\s*$'
+  - id: unresolved-sidecar
+    threat_rationale: An unresolved sidecar attestation cannot authorize promotion.
+    provenance: engagement-sidecar-flag-contract
+    positive_examples: ["status: unresolved"]
+    negative_examples: ["status: resolved"]
+    projections:
+      sidecar-flags:
+        pattern: 'status\s*:\s*unresolved'

--- a/skills/synthesis-promotion-gate/templates/promotion-gate.example.yaml
+++ b/skills/synthesis-promotion-gate/templates/promotion-gate.example.yaml
@@ -7,6 +7,16 @@ build:
 inputs:
   root: content/drafts
   globs: ["**/index.md"]
+# AGENT HEURISTIC: the plan requires destination-grammar consumption but does not
+# prescribe the JSON adapter protocol. This command receives the strict document batch
+# on stdin and must project it with this repository's actual renderer/parser.
+destination_projection:
+  command: [node, tools/render-promotion-channels.mjs]
+  working_directory: .
+  expected_identity:
+    parser: parse5
+    parser_version: "7.3.0"
+    renderer: astro@5.0.0
 publishable_range:
   start: "<!-- SYNTHESIS:PUBLISHABLE:START -->"
   end: "<!-- SYNTHESIS:PUBLISHABLE:END -->"

--- a/skills/synthesis-promotion-gate/templates/promotion-gate.example.yaml
+++ b/skills/synthesis-promotion-gate/templates/promotion-gate.example.yaml
@@ -24,4 +24,5 @@ inspected_surfaces:
       - raw-page-source
 sidecar_flag_globs:
   - sidecars/**/*.yaml
-unverified_remainder: Consumers omitted from this manifest, semantic disclosures outside this marker policy, and destination bytes after the supplied promotion command returns.
+additional_unverified_remainder:
+  - Repository-specific consumers not yet represented in this example manifest.

--- a/skills/synthesis-promotion-gate/templates/promotion-gate.example.yaml
+++ b/skills/synthesis-promotion-gate/templates/promotion-gate.example.yaml
@@ -1,0 +1,27 @@
+schema: 1
+build:
+  # Argument list only. The build must write to this substituted isolated root.
+  command: [python3, tools/build_for_promotion.py, --output, "{output_root}"]
+  working_directory: .
+  output_root: dist
+inputs:
+  root: content/drafts
+  globs: ["**/index.md"]
+publishable_range:
+  start: "<!-- SYNTHESIS:PUBLISHABLE:START -->"
+  end: "<!-- SYNTHESIS:PUBLISHABLE:END -->"
+  required: true
+marker_policy: .agents/promotion-marker-policy.yaml
+surface_manifest: .agents/promotion-surface-manifest.yaml
+acceptance_suite: .agents/promotion-acceptance-suite.yaml
+inspected_surfaces:
+  - renderer: primary-html
+    representations:
+      - publishable-source
+      - dom-text
+      - dom-heading-text
+      - html-comments
+      - raw-page-source
+sidecar_flag_globs:
+  - sidecars/**/*.yaml
+unverified_remainder: Consumers omitted from this manifest, semantic disclosures outside this marker policy, and destination bytes after the supplied promotion command returns.

--- a/skills/synthesis-promotion-gate/templates/surface-manifest.example.yaml
+++ b/skills/synthesis-promotion-gate/templates/surface-manifest.example.yaml
@@ -1,0 +1,8 @@
+schema: 1
+renderers:
+  - id: primary-html
+    # Record the exact renderer version used by the configured build command.
+    version: astro@5.0.0
+    input_globs: ["content/drafts/**/index.md"]
+    route_template: "articles/{slug}/index.html"
+    output_prefix: ""

--- a/skills/synthesis-skill-router/SKILL.md
+++ b/skills/synthesis-skill-router/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.3.0"
+  version: "1.4.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -41,6 +41,8 @@ Choose the narrowest matching workflow, then read its sibling `SKILL.md` complet
 
 ### Writing, research, and publishing
 
+- AGENT HEURISTIC — Configure or run a rendered-output publication boundary,
+  publishable-range contract, or promotion receipt: `../synthesis-promotion-gate/SKILL.md`
 - Write or refresh an article: `../synthesis-article-writing/SKILL.md`, `../synthesis-article-refresh/SKILL.md`
 - Frame a topic or brief its readers: `../synthesis-content-framing/SKILL.md`, `../synthesis-reader-briefing/SKILL.md`
 - Check quality and revise prose: `../synthesis-content-quality/SKILL.md`, `../synthesis-writing-pitfalls/SKILL.md`, `../synthesis-writing-craft/SKILL.md`

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -73,7 +73,7 @@ REQUIRED_CHECKS: tuple[tuple[str, list[str]], ...] = (
     ("conformance.instructions", ["python3", "skills/synthesis-agent-conformance/scripts/conformance.py", "instructions", "--repo-root", "."]),
     ("pytest.conformance", ["python3", "-m", "pytest", "skills/synthesis-agent-conformance/scripts/", "-q"]),
     ("pytest.coordination", ["python3", "-m", "pytest", "skills/synthesis-project-management/scripts/test_coordination.py", "-q"]),
-    ("pytest.promotion-gate", ["python3", "-m", "pytest", "skills/synthesis-promotion-gate/scripts/test_*.py", "-q"]),
+    ("pytest.promotion-gate", ["python3", "-m", "pytest", "skills/synthesis-promotion-gate/scripts/", "-q"]),
     ("pytest.rituals-guard-hooks", ["python3", "-m", "pytest", "skills/synthesis-daily-rituals/scripts/", "skills/synthesis-message-guard/scripts/", "skills/synthesis-git-hooks/scripts/", "-q"]),
     ("compileall", ["python3", "-m", "compileall", "-q", "skills"]),
 )

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -73,6 +73,7 @@ REQUIRED_CHECKS: tuple[tuple[str, list[str]], ...] = (
     ("conformance.instructions", ["python3", "skills/synthesis-agent-conformance/scripts/conformance.py", "instructions", "--repo-root", "."]),
     ("pytest.conformance", ["python3", "-m", "pytest", "skills/synthesis-agent-conformance/scripts/", "-q"]),
     ("pytest.coordination", ["python3", "-m", "pytest", "skills/synthesis-project-management/scripts/test_coordination.py", "-q"]),
+    ("pytest.promotion-gate", ["python3", "-m", "pytest", "skills/synthesis-promotion-gate/scripts/test_*.py", "-q"]),
     ("pytest.rituals-guard-hooks", ["python3", "-m", "pytest", "skills/synthesis-daily-rituals/scripts/", "skills/synthesis-message-guard/scripts/", "skills/synthesis-git-hooks/scripts/", "-q"]),
     ("compileall", ["python3", "-m", "compileall", "-q", "skills"]),
 )

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -95,6 +95,17 @@ def test_first_json_returns_empty_when_absent() -> None:
     assert release._first_json("no json here") == ""
 
 
+def test_required_checks_do_not_depend_on_shell_glob_expansion() -> None:
+    """subprocess receives argv directly; wildcard tokens therefore run zero tests."""
+    wildcard_arguments = [
+        argument
+        for _name, command in release.REQUIRED_CHECKS
+        for argument in command
+        if "*" in argument or "?" in argument or "[" in argument
+    ]
+    assert wildcard_arguments == []
+
+
 # --- client reporting, fail-closed -----------------------------------------
 
 


### PR DESCRIPTION
Adds a fail-closed promotion boundary with destination-derived representations, closed route and output universes, captured-content handoff, executable marker policy examples, and structured receipts.

Verification:
- 564 repository tests pass
- gated 4.51.0 check-only preflight passes
- adversarial acceptance passes all six repair findings