### PR TITLE
Enforce coordination claims at the commit boundary

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.52.0",
+  "version": "4.53.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.52.0",
+  "version": "4.53.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.53.0] - 2026-08-26
+
+### Added
+
+- **`synthesis-project-management` v2.5.0 — staged-path claim enforcement.**
+  `coordination.py check-staged` takes a lock/CAS-fenced snapshot of the
+  lease-backed board, resolves the committing session through an explicit
+  selector, environment, or owned active-project pointer, and requires an
+  exact registered worktree and branch.
+  Every staged path is compared with that session's source-area claims using a
+  rename-disabled index view, so a rename's source and destination both enter
+  the closed path universe. Missing board, lease, selector, session, worktree,
+  branch, or index evidence refuses. Workspace-conflict errors now name the
+  isolated-worktree, distinct-branch, and exact-claim remedy. Claim globs use
+  path-segment semantics: `*` cannot silently authorize a deeper directory,
+  while `**` remains the explicit recursive form. Claims and staged paths are
+  resolved to the same filesystem identity before matching, including macOS
+  path aliases.
+- **Recorded outside-claim overrides.** An exception can proceed only after
+  the reason, repository, branch, staged tree, and outside paths are appended
+  atomically to the board's existing Messages section and the unchanged index
+  is revalidated. No board schema changes were introduced.
+- **AGENT HEURISTIC — hash-bound receipt serialization.** Successful checks
+  expose a compact JSON receipt bound to the board content, canonical session
+  UUID, exact worktree and branch, staged tree, staged path list, enforcement
+  outcome, and outside-path list. Every result separates authority label from
+  enforcement outcome and names the state changes that invalidate the receipt
+  plus the semantic work it does not verify.
+
+### Changed
+
+- **`synthesis-git-hooks` v2.4.0 — config-gated claim checks at pre-commit.**
+  A configured `coordination_board` makes `check-staged` a fail-closed boundary
+  before content scanning and repository-local hooks. The installer and doctor
+  copy, monitor, and drift-check the project-management runtime and its
+  versioned session-word asset. The hook consumes the checker's JSON, requires
+  an authorizing outcome and the receipt's boundary fields, recomputes its
+  binding digest, and revalidates the board hash, worktree, branch, staged tree,
+  outside-path set, and rename-closed path universe before continuing. A
+  coordination refusal is reported as an authority refusal, distinct from a
+  broken content-policy engine. Without that setting, commits are not blocked by
+  coordination, and the hook reports the control's absence before running its
+  established credential and exposure checks.
+
+### Fixed
+
+- **Fresh git-hook installs now produce a parseable v2 policy.** The template
+  previously declared `config_version: 1` even though the engine refused
+  versions below 2, and represented empty groups with flow-style lists that
+  the strict parser also refuses. A clean installer could therefore copy its
+  own template and immediately fail its doctor. The generation-zero installer
+  fixture now executes that path end to end.
+- **Fresh git-hook installs retain their drift baseline.** The installer writes
+  the absolute source directory into the installed runtime. Both the installer
+  doctor and later direct doctor runs compare all installed engine files and
+  the coordination asset with that source. A present pointer that is malformed
+  or no longer resolves a complete source fails the doctor closed.
+- **Coordination authority cannot be resurrected by a stale refresh.** The
+  check's lease snapshot now passes through the existing compare-and-swap
+  mutation boundary. A concurrent release advances the lease, forces a retry,
+  and is read before any authority receipt can be issued.
+
 ## [4.52.0] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A coordination claim now reaches the Git index (August 2026).** Release
+**4.53.0** adds `coordination.py check-staged`: before a configured commit can
+proceed, the active board session must name the exact worktree and branch, and
+its source-area claims must cover every staged path, including both sides of a
+rename. Outside paths refuse unless an explicit reason is recorded atomically
+on the lease-backed board. The lease read is CAS-fenced against concurrent
+release, path aliases resolve before claim matching, and the hook consumes only
+a receipt whose bound outcome authorizes the staged tree. Repositories that do
+not configure coordination remain usable, while the hook states that this
+control is absent and still runs its credential and exposure checks. Every
+result names what remains unverified. See the [4.53.0 release notes](CHANGELOG.md).
+
 **A heading cannot make a summary a primary transcript (August 2026).**
 Release **4.52.0** adds an executable source-grade boundary to
 `synthesis-meeting-transcripts`. Complete raw provider-message records pair an

--- a/skills/synthesis-git-hooks/SKILL.md
+++ b/skills/synthesis-git-hooks/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: synthesis-git-hooks
-description: "Deterministic pre-commit policy for the synthesis-engineering workflow. Classifies each repo by publication surface (personal / public-surface / strict) from its push remotes, applies a tiered pattern set: Tier 0 credentials always; Tier 1 financial / HR / confidentiality / client names in strict and public-surface repos — public-surface minus only the disclosure ledger's published-precedent names. YAML-driven policy lives in ~/.synthesis/git-hook-config.yaml. Use when asked to: install git hooks, configure pre-commit policy, prevent credential leaks, prevent confidential-name leaks, allow published bio names on my own sites, disclosure ledger enforcement, set up the synthesis-engineering enforcement layer."
+description: "Deterministic pre-commit policy for the synthesis-engineering workflow. Enforces staged paths against an active session's lease-backed coordination claim when a board is configured. Classifies each repo by publication surface (personal / public-surface / strict) from its push remotes, applies a tiered pattern set: Tier 0 credentials always; Tier 1 financial / HR / confidentiality / client names in strict and public-surface repos — public-surface minus only the disclosure ledger's published-precedent names. YAML-driven policy lives in ~/.synthesis/git-hook-config.yaml. Use when asked to: install git hooks, configure pre-commit policy, enforce coordination claims, prevent credential leaks, prevent confidential-name leaks, allow published bio names on my own sites, disclosure ledger enforcement, set up the synthesis-engineering enforcement layer."
 license: "Apache-2.0"
-depends_on: []
+depends_on: ["synthesis-project-management"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.3.0"
+  version: "2.4.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -14,7 +14,30 @@ metadata:
 
 A YAML-driven pre-commit policy engine. Part of the synthesis-engineering operational layer — deterministic enforcement that catches credential leaks and exposure-sensitive content at the commit boundary, before the diff persists.
 
-The engine is small (one bash script + one Python sidecar). The policy is data — a YAML file at `~/.synthesis/git-hook-config.yaml` that anyone adopting synthesis engineering fills in with their own personal-remote patterns, client names, and internal URLs.
+The engine is a Bash boundary plus standard-library Python sidecars. The policy
+is data — a YAML file at `~/.synthesis/git-hook-config.yaml` that anyone
+adopting synthesis engineering fills in with personal-remote patterns, client
+names, internal URLs, and optionally a coordination-board path.
+
+## v2.4.0 — Coordination claims at the commit boundary
+
+When `coordination_board` is configured, pre-commit invokes
+`synthesis-project-management`'s `check-staged` before content scanning or a
+repo-local hook. It refuses unless the selected active session owns the exact
+worktree and branch and every staged source/destination path is covered by the
+session's claims. `SYNTHESIS_COORDINATION_SESSION` supplies the committing
+session when the active-project pointer does not. A deliberate outside-claim
+exception requires `SYNTHESIS_COORDINATION_OVERRIDE_REASON`; the checker
+atomically records it on the board before the commit proceeds. Missing runtime,
+board, lease refresh, selector, or index evidence fails closed.
+The hook accepts only `passed-inside-claim` and `recorded-override`, requires the
+outcome and outside-path list to match their hash-bound receipt fields, and
+revalidates the board and index before continuing. A coordination refusal is
+reported separately from content-policy-engine unavailability.
+
+Repositories remain usable when coordination is not adopted: omitting
+`coordination_board` does not block, and each hook invocation explicitly says
+that this control is absent. The credential and exposure scanners still run.
 
 ## v2.3.0 — Portable drift-source resolution
 
@@ -27,6 +50,9 @@ checkouts, worktrees, client plugin caches), else the documented locations
 the ecosystem's own installers create (direct-copy skill installs, the
 shared installer's cached clone). A source must carry all three engine
 files to qualify, and the doctor names the resolved source in its output.
+The v2.4.0 installer also persists its absolute source directory beside the
+installed engine. Later direct doctor runs use that pointer before documented
+fallback locations; an invalid or missing pointed source is a doctor failure.
 
 ## v2.1.2 — Exact-copy migration calibration
 
@@ -111,6 +137,11 @@ claude plugin install synthesis-skills@synthesis-engineering
 
 # 3. Edit ~/.synthesis/git-hook-config.yaml with YOUR personal-remote patterns
 #    (your GitHub user/org), confidential names, internal URLs.
+
+# 4. To enforce lease-backed source-area claims, enable the optional boundary:
+# coordination_board: '~/.synthesis/coordination/active-sessions.md'
+# Then export SYNTHESIS_COORDINATION_SESSION=<your board selector> in commit
+# processes that do not own the active-project pointer.
 ```
 
 After install, every `git commit` on the workstation runs the policy. No per-repo configuration needed; classification is automatic from each repo's push remotes.
@@ -165,7 +196,7 @@ This skill is one of four deterministic-enforcement layers. Each runs at a diffe
 |---|---|---|
 | `synthesis-anti-shortcuts` | Costume-vocabulary detection in agent outputs | Stop hook + PreToolUse hook |
 | (agent-rules sync) | Single source of truth for CLAUDE.md / AGENTS.md / ~/.codex/AGENTS.md | PostToolUse hook on edits |
-| **`synthesis-git-hooks` (this skill)** | **Credential + exposure-sensitive pattern check at commit boundary** | **pre-commit** |
+| **`synthesis-git-hooks` (this skill)** | **Coordination-claim enforcement plus credential and exposure-sensitive checks at the commit boundary** | **pre-commit** |
 | `synthesis-repo-guard` | Uncommitted changes + unpushed commits | Session-end skill |
 
 The discipline isn't a prompt the agent has to remember — it's a runtime check the agent can't route around. This is the differentiator from vibe coding / agentic coding / spec-driven development: methodology becomes runtime infrastructure, not a Markdown file the agent may or may not consult.
@@ -185,6 +216,14 @@ synthesis-git-hooks/
     ├── tier-classification.md        # how `git remote -v` becomes the class
     └── per-repo-overrides.md         # delegation to repo-local .githooks
 ```
+
+The installer also copies `coordination.py`, `coordination_schema.py`,
+`pointer_lock.py`, and the versioned session-word asset from the declared
+`synthesis-project-management` dependency into the shared runtime. Their
+canonical source remains in that owning skill; the git-hooks doctor compares
+the installed copies with those source paths and reports drift. `source-path`
+records the install-time source directory so direct installed-doctor runs can
+repeat that comparison without an environment override.
 
 ## Companion artifacts
 

--- a/skills/synthesis-git-hooks/agents/openai.yaml
+++ b/skills/synthesis-git-hooks/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Synthesis Git Hooks"
-  short_description: "Apply the git hooks synthesis workflow"
+  short_description: "Enforce commit policy and coordination claims"
   default_prompt: "Use $synthesis-git-hooks to apply this workflow to the current task."
 
 policy:

--- a/skills/synthesis-git-hooks/scripts/_load_config.py
+++ b/skills/synthesis-git-hooks/scripts/_load_config.py
@@ -55,17 +55,26 @@ import warnings
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
-SIDECAR_VERSION = "2.3.0"
+SIDECAR_VERSION = "2.4.0"
 REQUIRED_CONFIG_VERSION = 2
 
 DEFAULT_CONFIG = Path.home() / ".synthesis" / "git-hook-config.yaml"
 
-# The three files that constitute the engine. A directory qualifies as a
-# drift-comparison source only when it carries all of them — a partial copy
-# would let missing files pass the byte-compare loop as "no drift".
-ENGINE_FILES = ("pre-commit", "commit-msg", "_load_config.py")
+# The installed engine includes the coordination runtime because a configured
+# board turns check-staged into a fail-closed commit boundary. The source files
+# remain canonical in synthesis-project-management; source_engine_path maps the
+# dependency instead of duplicating it in this skill.
+CORE_ENGINE_FILES = ("pre-commit", "commit-msg", "_load_config.py")
+COORDINATION_ENGINE_FILES = (
+    "coordination.py",
+    "coordination_schema.py",
+    "pointer_lock.py",
+)
+ENGINE_FILES = CORE_ENGINE_FILES + COORDINATION_ENGINE_FILES
+COORDINATION_ASSET = "session-words-v1.txt.zlib.b85"
 
 SOURCE_ENV = "SYNTHESIS_GIT_HOOKS_SOURCE"
+SOURCE_POINTER_NAME = "source-path"
 
 
 class ConfigError(Exception):
@@ -566,6 +575,16 @@ def load_config(path: Path) -> dict:
             file=sys.stderr,
         )
         sys.exit(2)
+    coordination_board = config.get("coordination_board")
+    if coordination_board is not None and (
+        not isinstance(coordination_board, str) or not coordination_board.strip()
+    ):
+        print(
+            "synthesis-git-hooks: coordination_board must be a non-empty "
+            "path string when configured (fail closed)",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     problems = validate_all_patterns(config)
     if problems:
         print(
@@ -621,6 +640,14 @@ def emit_shell_vars(config: dict) -> None:
     print(f"ALLOWLIST_REGEX={shlex.quote(allowlist)}")
     print(f"DIFF_EXCLUDE_REGEX={shlex.quote(diff_excludes)}")
     print(f"CHECK_COMMIT_MSG={check_msg}")
+    coordination_board = config.get("coordination_board")
+    if coordination_board is None:
+        print("COORDINATION_CHECK_STAGED=0")
+        print("COORDINATION_BOARD=''")
+    else:
+        expanded_board = str(Path(coordination_board).expanduser())
+        print("COORDINATION_CHECK_STAGED=1")
+        print(f"COORDINATION_BOARD={shlex.quote(expanded_board)}")
     # MUST be last: the engine treats its absence as sidecar failure.
     print("SYNTHESIS_SIDECAR_OK=1")
 
@@ -643,9 +670,48 @@ def _grep_validates(pattern: str) -> Optional[str]:
     return None
 
 
+def source_engine_path(path: Path, name: str) -> Path:
+    """Map an installed filename to its canonical source path.
+
+    Direct engine bundles may carry the dependency beside the core files. In
+    the plugin/source tree, coordination stays canonical in its owning skill.
+    """
+    local = path / name
+    if name in CORE_ENGINE_FILES or local.is_file():
+        return local
+    if len(path.parents) < 2:
+        return local
+    return (
+        path.parents[1]
+        / "synthesis-project-management"
+        / "scripts"
+        / name
+    )
+
+
+def source_coordination_asset(path: Path) -> Path:
+    local = path.parent / "references" / COORDINATION_ASSET
+    if local.is_file():
+        return local
+    if len(path.parents) < 2:
+        return local
+    return (
+        path.parents[1]
+        / "synthesis-project-management"
+        / "references"
+        / COORDINATION_ASSET
+    )
+
+
+def installed_coordination_asset(hooks_path: Path) -> Path:
+    return hooks_path.parent / "references" / COORDINATION_ASSET
+
+
 def _is_engine_source(path: Path) -> bool:
-    """True when ``path`` carries every engine file (a usable drift source)."""
-    return all((path / name).is_file() for name in ENGINE_FILES)
+    """True when ``path`` resolves every engine file and required asset."""
+    return all(source_engine_path(path, name).is_file() for name in ENGINE_FILES) and (
+        source_coordination_asset(path).is_file()
+    )
 
 
 def _installed_engine_dirs(hooks_path: Optional[Path]) -> set:
@@ -682,6 +748,36 @@ def _documented_source_dirs() -> List[Path]:
     ]
 
 
+def _persisted_source_dir(
+    hooks_path: Optional[Path],
+) -> Tuple[Optional[Path], Optional[str]]:
+    """Resolve the source pointer written by the generation-zero installer."""
+    if hooks_path is None:
+        return None, None
+    pointer = hooks_path / SOURCE_POINTER_NAME
+    if not pointer.exists() and not pointer.is_symlink():
+        return None, None
+    if pointer.is_symlink() or not pointer.is_file():
+        return None, f"persisted source pointer is not a regular file: {pointer}"
+    try:
+        raw = pointer.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        return None, f"persisted source pointer is unreadable: {pointer}: {exc}"
+    lines = raw.splitlines()
+    if len(lines) != 1 or not lines[0].strip():
+        return None, f"persisted source pointer must contain one path: {pointer}"
+    candidate = Path(lines[0]).expanduser()
+    if not candidate.is_absolute():
+        return None, f"persisted source pointer must be absolute: {pointer}"
+    candidate = candidate.resolve()
+    if not _is_engine_source(candidate):
+        return None, (
+            f"persisted source pointer does not resolve an engine source: "
+            f"{pointer} -> {candidate} (fail closed)"
+        )
+    return candidate, None
+
+
 def resolve_source_dir(
     hooks_path: Optional[Path],
 ) -> Tuple[Optional[Path], Optional[str]]:
@@ -697,7 +793,9 @@ def resolve_source_dir(
     2. This script's own directory, unless it is itself an installed engine
        copy — running the doctor from a repo checkout, a worktree, or a
        client plugin cache compares the installation against that copy.
-    3. Documented locations the ecosystem's own installers create, first
+    3. The source path persisted by ``install.sh``. A present but invalid
+       pointer is a doctor problem, never a reason to fall through.
+    4. Documented locations the ecosystem's own installers create, first
        complete candidate wins.
 
     Returns ``(source_dir, problem)``. Both ``None`` means no source is
@@ -719,6 +817,11 @@ def resolve_source_dir(
     own_dir = Path(__file__).resolve().parent
     if own_dir not in installed and _is_engine_source(own_dir):
         return own_dir, None
+    persisted, persisted_problem = _persisted_source_dir(hooks_path)
+    if persisted_problem:
+        return None, persisted_problem
+    if persisted is not None:
+        return persisted, None
     for candidate in _documented_source_dirs():
         if candidate.resolve() not in installed and _is_engine_source(candidate):
             return candidate, None
@@ -766,6 +869,23 @@ def run_doctor(config_path: Path) -> int:
                     "disclosure_ledger — public-surface repos get zero "
                     "allowances, which blocks published-precedent content"
                 )
+            coordination_board = config.get("coordination_board")
+            if coordination_board is None:
+                infos.append(
+                    "coordination check-staged control absent: no "
+                    "coordination_board configured"
+                )
+            elif not isinstance(coordination_board, str) or not coordination_board.strip():
+                problems.append(
+                    "coordination_board must be a non-empty path string"
+                )
+            else:
+                board_path = Path(coordination_board).expanduser()
+                infos.append(f"coordination check-staged configured: {board_path}")
+                if not board_path.is_file():
+                    problems.append(
+                        f"configured coordination board is unavailable: {board_path}"
+                    )
         except ConfigError as exc:
             problems.append(f"config unparsable: {exc}")
 
@@ -790,6 +910,9 @@ def run_doctor(config_path: Path) -> int:
                 problems.append(f"hooksPath missing {name}: {f}")
             elif name in ("pre-commit", "commit-msg") and not os.access(f, os.X_OK):
                 problems.append(f"{f} is not executable")
+        asset = installed_coordination_asset(hp_dir)
+        if not asset.is_file():
+            problems.append(f"coordination runtime missing asset: {asset}")
     else:
         problems.append(
             "core.hooksPath is not set globally — the engine is not wired in"
@@ -809,13 +932,24 @@ def run_doctor(config_path: Path) -> int:
     elif hp_dir is not None:
         drift_found = False
         for name in ENGINE_FILES:
-            src, inst = src_dir / name, hp_dir / name
+            src, inst = source_engine_path(src_dir, name), hp_dir / name
             if inst.exists() and src.read_bytes() != inst.read_bytes():
                 drift_found = True
                 problems.append(
                     f"DRIFT: installed {name} differs from skill source "
                     f"({inst} vs {src}) — reinstall or sync back"
                 )
+        source_asset = source_coordination_asset(src_dir)
+        installed_asset = installed_coordination_asset(hp_dir)
+        if (
+            installed_asset.exists()
+            and source_asset.read_bytes() != installed_asset.read_bytes()
+        ):
+            drift_found = True
+            problems.append(
+                "DRIFT: installed coordination asset differs from skill source "
+                f"({installed_asset} vs {source_asset}) — reinstall or sync back"
+            )
         if not drift_found:
             infos.append(
                 f"installed engine matches skill source (no drift): {src_dir}"

--- a/skills/synthesis-git-hooks/scripts/git-hook-config.example.yaml
+++ b/skills/synthesis-git-hooks/scripts/git-hook-config.example.yaml
@@ -8,7 +8,14 @@
 # Schema reference: ~/.synthesis/git-hooks/README.md
 # Distributable form: github.com/synthesisengineering/synthesis-skills/skills/synthesis-git-hooks
 
-config_version: 1
+config_version: 2
+
+# Optional commit-boundary coordination control. When configured, pre-commit
+# fails closed unless the committing session's exact worktree, branch, and
+# staged paths are covered by an active lease-backed board claim. Without this
+# field, the hook reports that the coordination control is absent and continues
+# with the credential/exposure scan.
+# coordination_board: '~/.synthesis/coordination/active-sessions.md'
 
 # A repo classifies as `personal` when EVERY push remote URL matches at least
 # one of these regex patterns (case-insensitive). Otherwise it classifies as
@@ -89,20 +96,20 @@ tier_1_strict_only:
   # Confidential client / company names. Add your own. Examples:
   #   - 'acme-corp'
   #   - 'example-client'
-  confidential_names: []
+  confidential_names:
 
   # Private/shared skill names. Add the names of skills from your private
   # synthesis-skills repos that should not appear in public docs. Examples:
   #   - 'YOUR-PERSONAL-ORG-private-some-skill'
   #   - 'YOUR-CLIENT-NAME-internal-skill'
-  private_skill_names: []
+  private_skill_names:
 
   # Internal URLs / repo references that must not leak into public docs.
   # Examples:
   #   - 'github\.com/YOUR-CLIENT-ORG'
   #   - 'internal\.YOUR-CLIENT-DOMAIN'
   #   - 'ai-knowledge-YOUR-CLIENT-NAME'
-  internal_urls: []
+  internal_urls:
 
 # ─── Allowlist — lines that legitimately match a pattern above. ──────────
 # SPDX-style license declarations in package manifests look like

--- a/skills/synthesis-git-hooks/scripts/install.sh
+++ b/skills/synthesis-git-hooks/scripts/install.sh
@@ -16,18 +16,47 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+SKILLS_DIR="$(cd -- "$SCRIPT_DIR/../.." &> /dev/null && pwd)"
+COORDINATION_SOURCE="$SKILLS_DIR/synthesis-project-management/scripts"
+COORDINATION_REFERENCES="$SKILLS_DIR/synthesis-project-management/references"
 
 TARGET_DIR="$HOME/.synthesis/git-hooks"
+TARGET_REFERENCES="$HOME/.synthesis/references"
 CONFIG_PATH="$HOME/.synthesis/git-hook-config.yaml"
 
+for source in \
+    "$COORDINATION_SOURCE/coordination.py" \
+    "$COORDINATION_SOURCE/coordination_schema.py" \
+    "$COORDINATION_SOURCE/pointer_lock.py" \
+    "$COORDINATION_REFERENCES/session-words-v1.txt.zlib.b85"; do
+    [ -f "$source" ] || {
+        echo "✖ Required synthesis-project-management dependency missing: $source" >&2
+        exit 1
+    }
+done
+
 mkdir -p "$TARGET_DIR"
+mkdir -p "$TARGET_REFERENCES"
 mkdir -p "$(dirname "$CONFIG_PATH")"
 
 echo "→ Copying engine to $TARGET_DIR/"
 cp -f "$SCRIPT_DIR/pre-commit" "$TARGET_DIR/pre-commit"
 cp -f "$SCRIPT_DIR/commit-msg" "$TARGET_DIR/commit-msg"
 cp -f "$SCRIPT_DIR/_load_config.py" "$TARGET_DIR/_load_config.py"
-chmod +x "$TARGET_DIR/pre-commit" "$TARGET_DIR/commit-msg" "$TARGET_DIR/_load_config.py"
+cp -f "$COORDINATION_SOURCE/coordination.py" "$TARGET_DIR/coordination.py"
+cp -f "$COORDINATION_SOURCE/coordination_schema.py" "$TARGET_DIR/coordination_schema.py"
+cp -f "$COORDINATION_SOURCE/pointer_lock.py" "$TARGET_DIR/pointer_lock.py"
+printf '%s\n' "$SCRIPT_DIR" > "$TARGET_DIR/source-path"
+cp -f "$COORDINATION_REFERENCES/session-words-v1.txt.zlib.b85" \
+    "$TARGET_REFERENCES/session-words-v1.txt.zlib.b85"
+chmod +x \
+    "$TARGET_DIR/pre-commit" \
+    "$TARGET_DIR/commit-msg" \
+    "$TARGET_DIR/_load_config.py" \
+    "$TARGET_DIR/coordination.py" \
+    "$TARGET_DIR/coordination_schema.py" \
+    "$TARGET_DIR/pointer_lock.py"
+chmod 644 "$TARGET_DIR/source-path"
 
 if [ -f "$CONFIG_PATH" ]; then
     echo "→ Config already exists at $CONFIG_PATH — not overwriting."

--- a/skills/synthesis-git-hooks/scripts/pre-commit
+++ b/skills/synthesis-git-hooks/scripts/pre-commit
@@ -67,6 +67,24 @@ EOF
     exit 1
 }
 
+coordination_refused() {
+    cat >&2 <<EOF
+
+==================================================================
+  X  COMMIT BLOCKED — coordination authority refused
+==================================================================
+
+$1
+
+The configured coordination gate did not issue valid authority for
+this staged tree. Its finding and remediation appear above.
+
+Diagnose:   python3 $SIDECAR --doctor
+Board:      ${COORDINATION_BOARD:-not configured}
+EOF
+    exit 1
+}
+
 [ -f "$CONFIG" ]  || fail_closed "Config not found at $CONFIG. Run the skill's install.sh to set it up."
 [ -f "$SIDECAR" ] || fail_closed "Sidecar not found at $SIDECAR."
 
@@ -83,6 +101,179 @@ set -e
 eval "$SIDECAR_OUT"
 [ "${SYNTHESIS_SIDECAR_OK:-0}" = "1" ] || fail_closed "Sidecar output incomplete (missing OK sentinel)."
 [ -n "${ACTIVE_REGEX:-}" ] || fail_closed "Active pattern set is empty — Tier 0 must never be empty in a valid config."
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || fail_closed "Cannot resolve the Git worktree root."
+
+# A configured board promotes the advisory source-area claim to a commit
+# boundary. Without a configured board the content scanner still runs, but D6
+# requires the absent coordination control to be stated on every invocation.
+case "${COORDINATION_CHECK_STAGED:-}" in
+    1)
+        COORDINATION_RUNTIME="$HOOK_DIR/coordination.py"
+        COORDINATION_ASSET="$HOOK_DIR/../references/session-words-v1.txt.zlib.b85"
+        for dependency in coordination.py coordination_schema.py pointer_lock.py; do
+            [ -f "$HOOK_DIR/$dependency" ] || fail_closed "coordination runtime incomplete: missing $HOOK_DIR/$dependency."
+        done
+        [ -f "$COORDINATION_ASSET" ] || fail_closed "coordination runtime incomplete: missing $COORDINATION_ASSET."
+        [ -n "${COORDINATION_BOARD:-}" ] || fail_closed "Coordination control enabled without a board path."
+        COORDINATION_ARGS=(
+            --board "$COORDINATION_BOARD"
+            check-staged
+            --repository "$REPO_ROOT"
+            --json
+        )
+        if [ -n "${SYNTHESIS_COORDINATION_SESSION:-}" ]; then
+            COORDINATION_ARGS+=(--session "$SYNTHESIS_COORDINATION_SESSION")
+        fi
+        if [ -n "${SYNTHESIS_COORDINATION_OVERRIDE_REASON:-}" ]; then
+            COORDINATION_ARGS+=(--override-reason "$SYNTHESIS_COORDINATION_OVERRIDE_REASON")
+        fi
+        # AGENT HEURISTIC: the plan requires a receipt consumer but does not
+        # prescribe its transport. Parse the JSON in-process, require its
+        # boundary fields, and recompute the binding digest before continuing.
+        set +e
+        COORDINATION_OUT=$("$PYBIN" "$COORDINATION_RUNTIME" "${COORDINATION_ARGS[@]}" 2>&1)
+        COORDINATION_STATUS=$?
+        set -e
+        if [ "$COORDINATION_STATUS" -ne 0 ]; then
+            printf '%s\n' "$COORDINATION_OUT"
+            coordination_refused "coordination check-staged exited $COORDINATION_STATUS; no commit authority receipt was issued."
+        fi
+        set +e
+        COORDINATION_SUMMARY=$(printf '%s' "$COORDINATION_OUT" | \
+            COORDINATION_EXPECTED_REPOSITORY="$REPO_ROOT" \
+            COORDINATION_EXPECTED_BOARD="$COORDINATION_BOARD" \
+            "$PYBIN" -c '
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+payload = json.load(sys.stdin)
+outcome = payload.get("enforcement_outcome")
+remainder = payload.get("unverified_remainder")
+if not isinstance(remainder, list) or not remainder:
+    raise SystemExit("missing unverified remainder")
+if outcome == "no-staged-paths":
+    if payload.get("issues_authority_receipt") or "receipt" in payload:
+        raise SystemExit("no-staged-paths result unexpectedly issued a receipt")
+    print(
+        "coordination check-staged: no-staged-paths; no authority receipt "
+        "required; unverified remainder: " + "; ".join(remainder)
+    )
+    raise SystemExit(0)
+authorizing_outcomes = {"passed-inside-claim", "recorded-override"}
+if outcome not in authorizing_outcomes:
+    raise SystemExit(f"non-authorizing enforcement outcome: {outcome!r}")
+if payload.get("issues_authority_receipt") is not True:
+    raise SystemExit("successful staged-path result issued no authority receipt")
+receipt = payload.get("receipt")
+if not isinstance(receipt, dict):
+    raise SystemExit("authority receipt is not a mapping")
+required = {
+    "binding_sha256",
+    "board_sha256",
+    "branch",
+    "enforcement_outcome",
+    "outside_paths",
+    "repository",
+    "session_uuid",
+    "staged_paths",
+    "staged_tree",
+}
+missing = sorted(required - receipt.keys())
+if missing:
+    raise SystemExit("authority receipt missing: " + ", ".join(missing))
+if not receipt["staged_paths"]:
+    raise SystemExit("authority receipt covers no staged paths")
+if receipt.get("receipt_consumer") != "synthesis-git-hooks pre-commit":
+    raise SystemExit("authority receipt names a different consumer")
+outside_paths = payload.get("outside_paths")
+if not isinstance(outside_paths, list):
+    raise SystemExit("top-level outside paths are not a list")
+if receipt["enforcement_outcome"] != outcome:
+    raise SystemExit("authority receipt enforcement outcome mismatch")
+if receipt["outside_paths"] != outside_paths:
+    raise SystemExit("authority receipt outside paths mismatch")
+if outcome == "passed-inside-claim" and outside_paths:
+    raise SystemExit("inside-claim outcome names outside paths")
+if outcome == "recorded-override":
+    if not outside_paths:
+        raise SystemExit("recorded override names no outside paths")
+    if not receipt.get("override_reason"):
+        raise SystemExit("recorded override has no bound reason")
+try:
+    session_uuid = uuid.UUID(receipt["session_uuid"])
+except (ValueError, AttributeError) as exc:
+    raise SystemExit("authority receipt has an invalid session UUID") from exc
+if session_uuid.version != 7:
+    raise SystemExit("authority receipt session identity is not UUIDv7")
+binding = receipt["binding_sha256"]
+unsigned = dict(receipt)
+del unsigned["binding_sha256"]
+canonical = json.dumps(unsigned, sort_keys=True, separators=(",", ":"))
+expected = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+if binding != expected:
+    raise SystemExit("authority receipt binding digest mismatch")
+repository = Path(os.environ["COORDINATION_EXPECTED_REPOSITORY"]).resolve()
+if Path(receipt["repository"]).resolve() != repository:
+    raise SystemExit("authority receipt repository no longer matches")
+board = Path(os.environ["COORDINATION_EXPECTED_BOARD"]).expanduser().resolve()
+if Path(receipt.get("board", "")).expanduser().resolve() != board:
+    raise SystemExit("authority receipt board no longer matches")
+if hashlib.sha256(board.read_bytes()).hexdigest() != receipt["board_sha256"]:
+    raise SystemExit("coordination board changed after receipt issuance")
+branch = subprocess.run(
+    ["git", "branch", "--show-current"],
+    cwd=repository,
+    capture_output=True,
+    text=True,
+    check=True,
+).stdout.strip()
+if branch != receipt["branch"]:
+    raise SystemExit("Git branch changed after receipt issuance")
+tree = subprocess.run(
+    ["git", "write-tree"],
+    cwd=repository,
+    capture_output=True,
+    text=True,
+    check=True,
+).stdout.strip()
+if tree != receipt["staged_tree"]:
+    raise SystemExit("Git index tree changed after receipt issuance")
+names = subprocess.run(
+    ["git", "diff", "--cached", "--name-only", "-z", "--no-renames"],
+    cwd=repository,
+    capture_output=True,
+    check=True,
+).stdout
+paths = sorted(
+    value.decode("utf-8", errors="surrogateescape")
+    for value in names.split(b"\0")
+    if value
+)
+if paths != receipt["staged_paths"]:
+    raise SystemExit("staged path universe changed after receipt issuance")
+print(
+    f"coordination check-staged: {outcome}; authority receipt consumed; "
+    "unverified remainder: " + "; ".join(remainder)
+)
+')
+        COORDINATION_RECEIPT_STATUS=$?
+        set -e
+        [ "$COORDINATION_RECEIPT_STATUS" -eq 0 ] || coordination_refused "coordination authority receipt validation failed."
+        printf '%s\n' "$COORDINATION_SUMMARY"
+        ;;
+    0)
+        echo "coordination check-staged: control absent — no coordination_board configured; commit not blocked by this control" >&2
+        ;;
+    *)
+        fail_closed "Sidecar output incomplete (invalid COORDINATION_CHECK_STAGED value)."
+        ;;
+esac
 
 # Determine which files to scan. Always exclude files that contain pattern
 # definitions by design — adding a name to the policy is the opposite of
@@ -208,7 +399,6 @@ fi
 
 # Export class for any delegated per-repo hook, then chain.
 export SYNTHESIS_REPO_CLASS="$REPO_CLASS"
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || true
 if [ -n "$REPO_ROOT" ]; then
     REPO_HOOK="$REPO_ROOT/.githooks/pre-commit"
     if [ -f "$REPO_HOOK" ] && [ -x "$REPO_HOOK" ]; then

--- a/skills/synthesis-git-hooks/scripts/test_pre_commit.py
+++ b/skills/synthesis-git-hooks/scripts/test_pre_commit.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os
+import shutil
+import shlex
 import subprocess
 from pathlib import Path
 
@@ -602,6 +604,57 @@ def engine_copy(target: Path) -> None:
         destination.chmod(0o755)
 
 
+def r4_policy(path: Path, board: Path | None = None) -> None:
+    policy(path)
+    if board is not None:
+        path.write_text(
+            path.read_text(encoding="utf-8")
+            + f"coordination_board: '{board}'\n",
+            encoding="utf-8",
+        )
+
+
+def r4_engine_bundle(target: Path, *, coordination: bool = True) -> None:
+    engine_copy(target)
+    if not coordination:
+        return
+    coordination_source = SCRIPT_DIR.parents[1] / "synthesis-project-management" / "scripts"
+    for name in ("coordination.py", "coordination_schema.py", "pointer_lock.py"):
+        destination = target / name
+        shutil.copy2(coordination_source / name, destination)
+        destination.chmod(0o755)
+
+
+def r4_board_claim(board: Path, root: Path, engine: Path) -> str:
+    branch = run(root, "git", "branch", "--show-current").stdout.strip()
+    completed = run(
+        root,
+        sys.executable,
+        str(engine / "coordination.py"),
+        "--board",
+        str(board),
+        "claim",
+        "--session",
+        "A",
+        "--agent",
+        "test",
+        "--project",
+        "project-a",
+        "--mode",
+        "autonomous",
+        "--goal",
+        "test hook",
+        "--workspace",
+        f"{root} @ {branch}",
+        "--area",
+        f"{root}/claimed/**",
+        "--context-role",
+        "owner",
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    return "A"
+
+
 def test_source_env_override_is_authoritative(tmp_path, monkeypatch) -> None:
     source = tmp_path / "anywhere" / "scripts"
     engine_copy(source)
@@ -719,3 +772,112 @@ def test_doctor_detects_drift_end_to_end(tmp_path: Path) -> None:
     drifted = doctor()
     assert drifted.returncode == 1, drifted.stdout + drifted.stderr
     assert "DRIFT: installed pre-commit" in drifted.stdout
+
+
+def test_r4_configured_hook_blocks_outside_claim(tmp_path: Path) -> None:
+    root, environment = repository(tmp_path)
+    engine = tmp_path / "engine"
+    r4_engine_bundle(engine)
+    board = tmp_path / "coordination" / "active-sessions.md"
+    r4_board_claim(board, root, engine)
+    r4_policy(Path(environment["SYNTHESIS_GIT_HOOK_CONFIG"]), board)
+    environment["SYNTHESIS_COORDINATION_SESSION"] = "A"
+    (root / "outside.md").write_text("ordinary content\n", encoding="utf-8")
+    assert run(root, "git", "add", "outside.md").returncode == 0
+
+    completed = run(root, str(engine / "pre-commit"), env=environment)
+
+    assert completed.returncode == 1
+    assert "refused-outside-claim" in completed.stdout + completed.stderr
+    assert "COMMIT BLOCKED" in completed.stderr
+
+
+def test_r4_unconfigured_hook_reports_control_absence(tmp_path: Path) -> None:
+    root, environment = repository(tmp_path)
+    engine = tmp_path / "engine"
+    r4_engine_bundle(engine)
+    r4_policy(Path(environment["SYNTHESIS_GIT_HOOK_CONFIG"]))
+    (root / "ordinary.md").write_text("ordinary content\n", encoding="utf-8")
+    assert run(root, "git", "add", "ordinary.md").returncode == 0
+
+    completed = run(root, str(engine / "pre-commit"), env=environment)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    output = completed.stdout + completed.stderr
+    assert "coordination check-staged" in output
+    assert "control absent" in output
+    assert "commit not blocked by this control" in output
+
+
+def test_r4_configured_hook_missing_runtime_fails_closed(tmp_path: Path) -> None:
+    root, environment = repository(tmp_path)
+    engine = tmp_path / "engine"
+    r4_engine_bundle(engine, coordination=False)
+    board = tmp_path / "coordination" / "active-sessions.md"
+    r4_policy(Path(environment["SYNTHESIS_GIT_HOOK_CONFIG"]), board)
+    environment["SYNTHESIS_COORDINATION_SESSION"] = "A"
+    (root / "ordinary.md").write_text("ordinary content\n", encoding="utf-8")
+    assert run(root, "git", "add", "ordinary.md").returncode == 0
+
+    completed = run(root, str(engine / "pre-commit"), env=environment)
+
+    assert completed.returncode == 1
+    assert "coordination runtime" in completed.stderr
+    assert "COMMIT BLOCKED" in completed.stderr
+
+
+def test_r4_installer_copies_coordination_runtime(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    environment = dict(os.environ)
+    environment["HOME"] = str(home)
+    environment["GIT_CONFIG_GLOBAL"] = str(tmp_path / "gitconfig")
+    environment["SYNTHESIS_GIT_HOOKS_SOURCE"] = str(SCRIPT_DIR)
+
+    completed = subprocess.run(
+        ["bash", str(SCRIPT_DIR / "install.sh")],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    installed = home / ".synthesis" / "git-hooks"
+    assert {path.name for path in installed.iterdir()} == {
+        "pre-commit",
+        "commit-msg",
+        "_load_config.py",
+        "coordination.py",
+        "coordination_schema.py",
+        "pointer_lock.py",
+    }
+    seeded = home / ".synthesis" / "git-hook-config.yaml"
+    assert SIDECAR.parse_simple_yaml(seeded.read_text(encoding="utf-8"))[
+        "config_version"
+    ] == 2
+
+
+def test_r4_config_sidecar_emits_board_gate(tmp_path: Path) -> None:
+    board = tmp_path / "coordination" / "active-sessions.md"
+    config = tmp_path / "policy.yaml"
+    r4_policy(config, board)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SIDECAR_PATH),
+            "--config",
+            str(config),
+            "--emit-shell-vars",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "COORDINATION_CHECK_STAGED=1" in completed.stdout
+    assert f"COORDINATION_BOARD={shlex.quote(str(board))}" in completed.stdout

--- a/skills/synthesis-git-hooks/scripts/test_pre_commit.py
+++ b/skills/synthesis-git-hooks/scripts/test_pre_commit.py
@@ -596,12 +596,19 @@ def test_double_quoted_pattern_keeps_its_escapes(tmp_path: Path) -> None:
 
 
 def engine_copy(target: Path) -> None:
-    """Copy the three engine files into `target`, executable bits included."""
+    """Copy the complete installed engine shape into `target`."""
     target.mkdir(parents=True, exist_ok=True)
     for name in SIDECAR.ENGINE_FILES:
         destination = target / name
-        destination.write_bytes((SCRIPT_DIR / name).read_bytes())
+        destination.write_bytes(
+            SIDECAR.source_engine_path(SCRIPT_DIR, name).read_bytes()
+        )
         destination.chmod(0o755)
+    references = target.parent / "references"
+    references.mkdir(exist_ok=True)
+    (references / SIDECAR.COORDINATION_ASSET).write_bytes(
+        SIDECAR.source_coordination_asset(SCRIPT_DIR).read_bytes()
+    )
 
 
 def r4_policy(path: Path, board: Path | None = None) -> None:
@@ -615,14 +622,14 @@ def r4_policy(path: Path, board: Path | None = None) -> None:
 
 
 def r4_engine_bundle(target: Path, *, coordination: bool = True) -> None:
-    engine_copy(target)
     if not coordination:
+        target.mkdir(parents=True, exist_ok=True)
+        for name in SIDECAR.CORE_ENGINE_FILES:
+            destination = target / name
+            shutil.copy2(SCRIPT_DIR / name, destination)
+            destination.chmod(0o755)
         return
-    coordination_source = SCRIPT_DIR.parents[1] / "synthesis-project-management" / "scripts"
-    for name in ("coordination.py", "coordination_schema.py", "pointer_lock.py"):
-        destination = target / name
-        shutil.copy2(coordination_source / name, destination)
-        destination.chmod(0o755)
+    engine_copy(target)
 
 
 def r4_board_claim(board: Path, root: Path, engine: Path) -> str:
@@ -790,6 +797,123 @@ def test_r4_configured_hook_blocks_outside_claim(tmp_path: Path) -> None:
     assert completed.returncode == 1
     assert "refused-outside-claim" in completed.stdout + completed.stderr
     assert "COMMIT BLOCKED" in completed.stderr
+    assert "coordination authority refused" in completed.stderr
+    assert "policy engine unavailable" not in completed.stderr
+
+
+def test_r4_configured_hook_consumes_bound_receipt(tmp_path: Path) -> None:
+    root, environment = repository(tmp_path)
+    engine = tmp_path / "engine"
+    r4_engine_bundle(engine)
+    board = tmp_path / "coordination" / "active-sessions.md"
+    r4_board_claim(board, root, engine)
+    r4_policy(Path(environment["SYNTHESIS_GIT_HOOK_CONFIG"]), board)
+    environment["SYNTHESIS_COORDINATION_SESSION"] = "A"
+    claimed = root / "claimed"
+    claimed.mkdir()
+    (claimed / "inside.md").write_text("ordinary content\n", encoding="utf-8")
+    assert run(root, "git", "add", "claimed/inside.md").returncode == 0
+
+    completed = run(root, str(engine / "pre-commit"), env=environment)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "passed-inside-claim" in completed.stdout
+    assert "authority receipt consumed" in completed.stdout
+    assert "unverified remainder" in completed.stdout
+
+
+def test_r4_hook_rejects_index_changed_after_receipt(tmp_path: Path) -> None:
+    root, environment = repository(tmp_path)
+    engine = tmp_path / "engine"
+    r4_engine_bundle(engine)
+    board = tmp_path / "coordination" / "active-sessions.md"
+    r4_board_claim(board, root, engine)
+    r4_policy(Path(environment["SYNTHESIS_GIT_HOOK_CONFIG"]), board)
+    environment["SYNTHESIS_COORDINATION_SESSION"] = "A"
+    claimed = root / "claimed"
+    claimed.mkdir()
+    (claimed / "inside.md").write_text("ordinary content\n", encoding="utf-8")
+    assert run(root, "git", "add", "claimed/inside.md").returncode == 0
+
+    real_checker = engine / "coordination-real.py"
+    (engine / "coordination.py").replace(real_checker)
+    (engine / "coordination.py").write_text(
+        """\
+import subprocess
+import sys
+from pathlib import Path
+
+completed = subprocess.run(
+    [sys.executable, str(Path(__file__).with_name("coordination-real.py")), *sys.argv[1:]],
+    capture_output=True,
+    text=True,
+    check=False,
+)
+if completed.returncode == 0:
+    repository = Path(sys.argv[sys.argv.index("--repository") + 1])
+    late = repository / "claimed" / "late.md"
+    late.write_text("late index mutation\\n", encoding="utf-8")
+    subprocess.run(["git", "add", str(late)], cwd=repository, check=True)
+sys.stdout.write(completed.stdout)
+sys.stderr.write(completed.stderr)
+raise SystemExit(completed.returncode)
+""",
+        encoding="utf-8",
+    )
+
+    completed = run(root, str(engine / "pre-commit"), env=environment)
+
+    assert completed.returncode == 1
+    assert "receipt validation failed" in completed.stderr
+
+
+def test_r4_hook_rejects_refusing_outcome_with_valid_receipt(
+    tmp_path: Path,
+) -> None:
+    root, environment = repository(tmp_path)
+    engine = tmp_path / "engine"
+    r4_engine_bundle(engine)
+    board = tmp_path / "coordination" / "active-sessions.md"
+    r4_board_claim(board, root, engine)
+    r4_policy(Path(environment["SYNTHESIS_GIT_HOOK_CONFIG"]), board)
+    environment["SYNTHESIS_COORDINATION_SESSION"] = "A"
+    claimed = root / "claimed"
+    claimed.mkdir()
+    (claimed / "inside.md").write_text("ordinary content\n", encoding="utf-8")
+    assert run(root, "git", "add", "claimed/inside.md").returncode == 0
+
+    real_checker = engine / "coordination-real.py"
+    (engine / "coordination.py").replace(real_checker)
+    (engine / "coordination.py").write_text(
+        """\
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+completed = subprocess.run(
+    [sys.executable, str(Path(__file__).with_name("coordination-real.py")), *sys.argv[1:]],
+    capture_output=True,
+    text=True,
+    check=False,
+)
+if completed.returncode == 0:
+    payload = json.loads(completed.stdout)
+    payload["enforcement_outcome"] = "refused-outside-claim"
+    payload["outside_paths"] = ["claimed/inside.md"]
+    sys.stdout.write(json.dumps(payload))
+else:
+    sys.stdout.write(completed.stdout)
+sys.stderr.write(completed.stderr)
+raise SystemExit(completed.returncode)
+""",
+        encoding="utf-8",
+    )
+
+    completed = run(root, str(engine / "pre-commit"), env=environment)
+
+    assert completed.returncode == 1
+    assert "receipt validation failed" in completed.stderr
 
 
 def test_r4_unconfigured_hook_reports_control_absence(tmp_path: Path) -> None:
@@ -832,7 +956,7 @@ def test_r4_installer_copies_coordination_runtime(tmp_path: Path) -> None:
     environment = dict(os.environ)
     environment["HOME"] = str(home)
     environment["GIT_CONFIG_GLOBAL"] = str(tmp_path / "gitconfig")
-    environment["SYNTHESIS_GIT_HOOKS_SOURCE"] = str(SCRIPT_DIR)
+    environment.pop("SYNTHESIS_GIT_HOOKS_SOURCE", None)
 
     completed = subprocess.run(
         ["bash", str(SCRIPT_DIR / "install.sh")],
@@ -852,11 +976,69 @@ def test_r4_installer_copies_coordination_runtime(tmp_path: Path) -> None:
         "coordination.py",
         "coordination_schema.py",
         "pointer_lock.py",
+        "source-path",
     }
+    assert (
+        home / ".synthesis" / "references" / "session-words-v1.txt.zlib.b85"
+    ).is_file()
     seeded = home / ".synthesis" / "git-hook-config.yaml"
     assert SIDECAR.parse_simple_yaml(seeded.read_text(encoding="utf-8"))[
         "config_version"
     ] == 2
+    output = completed.stdout + completed.stderr
+    assert "installed engine matches skill source (no drift)" in output
+    assert "skill source not found" not in output
+
+    direct_doctor = subprocess.run(
+        [sys.executable, str(installed / "_load_config.py"), "--doctor"],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert direct_doctor.returncode == 0, direct_doctor.stdout + direct_doctor.stderr
+    assert "installed engine matches skill source (no drift)" in direct_doctor.stdout
+    assert "skill source not found" not in direct_doctor.stdout
+
+
+def test_r4_invalid_persisted_source_pointer_fails_doctor_closed(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    installed = home / ".synthesis" / "git-hooks"
+    engine_copy(installed)
+    (installed / "source-path").write_text(
+        str(tmp_path / "missing-source") + "\n", encoding="utf-8"
+    )
+    config = tmp_path / "policy.yaml"
+    policy(config)
+    (home / ".gitconfig").write_text(
+        f"[core]\n\thooksPath = {installed}\n", encoding="utf-8"
+    )
+    environment = dict(os.environ)
+    environment["HOME"] = str(home)
+    environment["SYNTHESIS_GIT_HOOK_CONFIG"] = str(config)
+    for variable in (
+        "SYNTHESIS_GIT_HOOKS_SOURCE",
+        "XDG_CACHE_HOME",
+        "XDG_CONFIG_HOME",
+        "GIT_CONFIG_GLOBAL",
+    ):
+        environment.pop(variable, None)
+
+    completed = subprocess.run(
+        [sys.executable, str(installed / "_load_config.py"), "--doctor"],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    assert "persisted source pointer" in completed.stdout
+    assert "UNHEALTHY" in completed.stdout
 
 
 def test_r4_config_sidecar_emits_board_gate(tmp_path: Path) -> None:

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.4.0"
+  version: "2.5.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -13,6 +13,22 @@ metadata:
 # Synthesis Project Management System
 
 A lightweight project management system designed for human-agent collaboration. Optimized for context preservation across conversation sessions and context compaction events.
+
+## v2.5.0 — Staged paths enforced against coordination claims
+
+`coordination.py check-staged` compares both sides of every staged rename and
+all other staged paths with the selected active session's source-area claims.
+The exact Git worktree and branch must also appear on that session's board row.
+The authority snapshot is taken under the board lock; a lease-backed board
+passes through a compare-and-swap fence so a concurrent release is read before
+the check can issue a receipt. Equivalent filesystem spellings resolve before
+claim matching.
+An outside path refuses by default; an explicit override succeeds only after
+its reason, staged tree, repository, branch, and outside paths are appended
+atomically to `## Messages`. Every result separates its authority label from
+its enforcement outcome and names the unverified remainder. The receipt binds
+that outcome and its outside-path list alongside the staged tree. The board
+remains schema v3; this release adds no columns or sidecar state.
 
 ## Configuration
 
@@ -319,6 +335,10 @@ python3 <synthesis-project-management-root>/scripts/coordination.py claim \
 python3 <synthesis-project-management-root>/scripts/coordination.py heartbeat \
   --session s-6adk-06yc-yqb2
 
+# Verify the current index against this session's exact board claim
+python3 <synthesis-project-management-root>/scripts/coordination.py \
+  check-staged --session s-6adk-06yc-yqb2 --repository /path/to/worktree
+
 # Leave an asynchronous handoff
 printf '%s\n' "Source checks pass; live install awaits authorization." |
   python3 <synthesis-project-management-root>/scripts/coordination.py message \
@@ -328,6 +348,17 @@ printf '%s\n' "Source checks pass; live install awaits authorization." |
 python3 <synthesis-project-management-root>/scripts/coordination.py release \
   --session s-6adk-06yc-yqb2
 ```
+
+**AGENT HEURISTIC — selector precedence.** `check-staged` uses an explicit
+`--session`, then
+`SYNTHESIS_COORDINATION_SESSION`, then `owner_session` in the active-project
+pointer. The board is refreshed from its configured lease before evaluation.
+A missing/unreadable board, inactive session, detached branch, unregistered
+worktree, or unreadable index refuses. To make a deliberately exceptional
+commit, pass `--override-reason` (or set
+`SYNTHESIS_COORDINATION_OVERRIDE_REASON` when the git-hook boundary invokes
+the check); the override is not authority until its board write completes and
+the index revalidates unchanged.
 
 The claim command normally allocates the identity. It prints the canonical
 UUIDv7, compact `s-xxxx-xxxx-xxxx` form, and speakable

--- a/skills/synthesis-project-management/acceptance-suite.yaml
+++ b/skills/synthesis-project-management/acceptance-suite.yaml
@@ -34,6 +34,10 @@ cases:
     control_class: enforced-gate
     fixture: scripts/test_coordination.py::test_r4_inactive_session_is_refused
     motivating_defect: engagement-released-claim-could-be-mistaken-for-current-authority
+  - id: lease-fence
+    control_class: enforced-gate
+    fixture: scripts/test_coordination.py::test_r4_lease_fence_cannot_resurrect_released_session
+    motivating_defect: agent-heuristic-stale-unlocked-refresh-resurrected-released-authority
   - id: registered-worktree
     control_class: enforced-gate
     fixture: scripts/test_coordination.py::test_r4_unregistered_worktree_is_refused
@@ -46,6 +50,14 @@ cases:
     control_class: enforced-gate
     fixture: scripts/test_coordination.py::test_r4_missing_board_is_unverifiable
     motivating_defect: engagement-unreachable-board-could-be-treated-as-no-conflict
+  - id: glob-boundary
+    control_class: acceptance-test
+    fixture: scripts/test_coordination.py::test_r4_glob_claim_does_not_authorize_deeper_sibling_path
+    motivating_defect: agent-self-review-wildcard-prefix-could-authorize-an-unmatched-deeper-path
+  - id: path-alias-canonicalization
+    control_class: acceptance-test
+    fixture: scripts/test_coordination.py::test_r4_symlink_alias_claim_matches_resolved_worktree
+    motivating_defect: agent-heuristic-equivalent-macos-path-spellings-falsely-refused-authority
   - id: manifest-closure
     control_class: diagnostic
     fixture: scripts/test_coordination.py::test_r4_acceptance_manifest_is_closed_and_resolvable
@@ -54,6 +66,18 @@ cases:
     control_class: enforced-gate
     fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_configured_hook_blocks_outside_claim
     motivating_defect: engagement-standalone-check-had-no-required-commit-boundary-consumer
+  - id: receipt-consumption
+    control_class: enforced-gate
+    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_configured_hook_consumes_bound_receipt
+    motivating_defect: agent-self-review-hook-trusted-exit-status-without-consuming-the-hash-bound-receipt
+  - id: changed-index-invalidates-receipt
+    control_class: enforced-gate
+    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_hook_rejects_index_changed_after_receipt
+    motivating_defect: design-constraint-d4-receipt-did-not-expire-when-its-staged-input-changed
+  - id: refusing-outcome-invalidates-receipt
+    control_class: enforced-gate
+    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_hook_rejects_refusing_outcome_with_valid_receipt
+    motivating_defect: design-constraint-d4-d8-hook-consumed-a-valid-receipt-under-a-refusing-outcome
   - id: absent-control-reporting
     control_class: diagnostic
     fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_unconfigured_hook_reports_control_absence
@@ -66,6 +90,10 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_installer_copies_coordination_runtime
     motivating_defect: agent-self-review-default-template-version-one-was-refused-by-the-version-two-engine
+  - id: persisted-source-pointer
+    control_class: enforced-gate
+    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_invalid_persisted_source_pointer_fails_doctor_closed
+    motivating_defect: agent-heuristic-doctor-declared-health-while-source-drift-proof-was-skipped
   - id: config-gate-emission
     control_class: acceptance-test
     fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_config_sidecar_emits_board_gate

--- a/skills/synthesis-project-management/acceptance-suite.yaml
+++ b/skills/synthesis-project-management/acceptance-suite.yaml
@@ -1,0 +1,72 @@
+# AGENT HEURISTIC: the controlling plan requires a closed, executable R4
+# acceptance universe but does not prescribe the manifest schema. R5 will
+# generalize and validate this generation-zero instance.
+schema: 1
+suite: synthesis-project-management-coordination-check-staged
+membership: closed
+production_entry_point: scripts/coordination.py check-staged
+enforcing_boundary: synthesis-git-hooks pre-commit before the repository hook and commit
+receipt_consumer: synthesis-git-hooks pre-commit
+expected_status: pass
+unverified_remainder: committing-process identity before selector resolution, claim legitimacy, semantic correctness of staged bytes, and index mutation after the check returns
+cases:
+  - id: staged-paths-inside-claim
+    control_class: enforced-gate
+    fixture: scripts/test_coordination.py::test_r4_staged_paths_inside_claim_issue_bound_receipt
+    motivating_defect: engagement-staged-commit-authority-was-not-compared-with-the-board-claim
+  - id: staged-path-outside-claim
+    control_class: enforced-gate
+    fixture: scripts/test_coordination.py::test_r4_staged_path_outside_claim_is_refused
+    motivating_defect: engagement-advisory-claim-did-not-stop-an-outside-path-commit
+  - id: rename-source-closure
+    control_class: acceptance-test
+    fixture: scripts/test_coordination.py::test_r4_rename_from_unclaimed_path_is_refused
+    motivating_defect: agent-heuristic-rename-source-could-escape-a-destination-only-path-check
+  - id: active-pointer-selector
+    control_class: acceptance-test
+    fixture: scripts/test_coordination.py::test_r4_active_pointer_resolves_committing_session
+    motivating_defect: engagement-hook-process-had-no-explicit-session-selector
+  - id: recorded-override
+    control_class: enforced-gate
+    fixture: scripts/test_coordination.py::test_r4_recorded_override_binds_reason_and_paths
+    motivating_defect: engagement-outside-claim-override-had-no-durable-accountability-record
+  - id: inactive-session
+    control_class: enforced-gate
+    fixture: scripts/test_coordination.py::test_r4_inactive_session_is_refused
+    motivating_defect: engagement-released-claim-could-be-mistaken-for-current-authority
+  - id: registered-worktree
+    control_class: enforced-gate
+    fixture: scripts/test_coordination.py::test_r4_unregistered_worktree_is_refused
+    motivating_defect: engagement-session-claim-did-not-bind-the-committing-worktree-and-branch
+  - id: conflict-remedy
+    control_class: diagnostic
+    fixture: scripts/test_coordination.py::test_r4_workspace_conflict_names_isolated_worktree_remedy
+    motivating_defect: engagement-workspace-conflict-refusal-omitted-the-required-remedy
+  - id: missing-board
+    control_class: enforced-gate
+    fixture: scripts/test_coordination.py::test_r4_missing_board_is_unverifiable
+    motivating_defect: engagement-unreachable-board-could-be-treated-as-no-conflict
+  - id: manifest-closure
+    control_class: diagnostic
+    fixture: scripts/test_coordination.py::test_r4_acceptance_manifest_is_closed_and_resolvable
+    motivating_defect: catalogue-acceptance-manifest-membership-was-not-executable
+  - id: configured-hook-boundary
+    control_class: enforced-gate
+    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_configured_hook_blocks_outside_claim
+    motivating_defect: engagement-standalone-check-had-no-required-commit-boundary-consumer
+  - id: absent-control-reporting
+    control_class: diagnostic
+    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_unconfigured_hook_reports_control_absence
+    motivating_defect: design-constraint-d6-non-adopter-repositories-must-remain-usable-without-silent-control-claims
+  - id: missing-runtime-fail-closed
+    control_class: enforced-gate
+    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_configured_hook_missing_runtime_fails_closed
+    motivating_defect: catalogue-protective-layer-could-warn-and-pass-when-runtime-was-missing
+  - id: generation-zero-installer
+    control_class: acceptance-test
+    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_installer_copies_coordination_runtime
+    motivating_defect: agent-self-review-default-template-version-one-was-refused-by-the-version-two-engine
+  - id: config-gate-emission
+    control_class: acceptance-test
+    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_config_sidecar_emits_board_gate
+    motivating_defect: engagement-hook-had-no-machine-readable-coordination-control-configuration

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import hashlib
 import fcntl
 import json
@@ -229,6 +230,314 @@ def workspace_conflict(left: str, right: str) -> bool:
         and left_branch not in ignored
         and left_branch == right_branch
     )
+
+
+# AGENT HEURISTIC: the controlling plan fixes the enforcement behavior but not
+# the receipt serialization. Keep the schema small, explicit, and hash-bound so
+# R5 can generalize it without treating prose success as authority.
+CHECK_STAGED_UNVERIFIED_REMAINDER = (
+    "committing-process identity before selector resolution",
+    "claim legitimacy and semantic correctness of staged bytes",
+    "state mutation after the caller's final receipt revalidation",
+)
+CHECK_STAGED_REMEDIATION = (
+    "Use an isolated worktree with a distinct branch, claim that exact "
+    "worktree and every staged source area on the lease-backed coordination "
+    "board, then stage only paths covered by that claim."
+)
+
+
+def _check_staged_payload(
+    args,
+    outcome: str,
+    *,
+    selector_source: str | None = None,
+    outside_paths: list[str] | None = None,
+    detail: str | None = None,
+    remediation: str | None = None,
+    receipt: dict | None = None,
+) -> dict:
+    payload = {
+        "control_class": "enforced-gate",
+        "authority_label": "DESIGN CONSTRAINT (Fable, controlling plan)",
+        "enforcement_outcome": outcome,
+        "issues_authority_receipt": receipt is not None,
+        "board": str(args.board),
+        "selector_source": selector_source,
+        "outside_paths": outside_paths or [],
+        "unverified_remainder": list(CHECK_STAGED_UNVERIFIED_REMAINDER),
+    }
+    if detail:
+        payload["detail"] = detail
+    if remediation:
+        payload["remediation"] = remediation
+    if receipt is not None:
+        payload["receipt"] = receipt
+    return payload
+
+
+def _emit_check_staged(args, payload: dict) -> None:
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(
+        "coordination check-staged: "
+        f"{payload['enforcement_outcome']} "
+        f"(authority-receipt={'yes' if payload['issues_authority_receipt'] else 'no'})"
+    )
+    if payload.get("detail"):
+        print(f"detail: {payload['detail']}")
+    if payload.get("outside_paths"):
+        print("outside claim: " + ", ".join(payload["outside_paths"]))
+    if payload.get("remediation"):
+        print("remediation: " + payload["remediation"])
+    print(
+        "unverified remainder: "
+        + "; ".join(payload["unverified_remainder"])
+    )
+
+
+def _git_bytes(repository: Path, *arguments: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _repository_state(repository: Path) -> tuple[Path, str]:
+    requested = repository.expanduser()
+    if not requested.is_dir():
+        raise RuntimeError(f"repository is not a directory: {requested}")
+    top = _git_bytes(requested, "rev-parse", "--show-toplevel")
+    if top.returncode != 0:
+        detail = top.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(detail or f"not a Git worktree: {requested}")
+    root = Path(top.stdout.decode("utf-8", errors="strict").strip()).resolve()
+    branch_result = _git_bytes(root, "branch", "--show-current")
+    if branch_result.returncode != 0:
+        detail = branch_result.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(detail or f"cannot read branch for {root}")
+    branch = branch_result.stdout.decode("utf-8", errors="strict").strip()
+    if not branch:
+        raise RuntimeError(
+            "detached HEAD has no exact branch identity for a board workspace claim"
+        )
+    return root, branch
+
+
+def _staged_inventory(repository: Path) -> tuple[list[str], str]:
+    names = _git_bytes(
+        repository,
+        "diff",
+        "--cached",
+        "--name-only",
+        "-z",
+        "--no-renames",
+    )
+    if names.returncode != 0:
+        detail = names.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(detail or "cannot enumerate staged paths")
+    paths = [
+        value.decode("utf-8", errors="surrogateescape")
+        for value in names.stdout.split(b"\0")
+        if value
+    ]
+    for path in paths:
+        components = Path(path).parts
+        if Path(path).is_absolute() or ".." in components:
+            raise RuntimeError(f"Git returned an unsafe staged path: {path!r}")
+    tree = _git_bytes(repository, "write-tree")
+    if tree.returncode != 0:
+        detail = tree.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(detail or "cannot materialize the staged tree")
+    return sorted(paths), tree.stdout.decode("ascii", errors="strict").strip()
+
+
+def _workspace_registered(session: Session, repository: Path, branch: str) -> bool:
+    repository_real = Path(os.path.realpath(repository))
+    for workspace in session.workspaces:
+        path, claimed_branch = workspace_parts(workspace)
+        if claimed_branch != branch:
+            continue
+        if Path(os.path.realpath(os.path.expanduser(path))) == repository_real:
+            return True
+    return False
+
+
+def _absolute_claim_pattern(claim: str, repository: Path) -> str | None:
+    raw = plain(claim)
+    if not raw:
+        return None
+    expanded = os.path.expanduser(raw)
+    candidate = Path(expanded)
+    if not candidate.is_absolute():
+        parts = candidate.parts
+        base = (
+            repository.parent
+            if parts and parts[0] == repository.name
+            else repository
+        )
+        candidate = base / candidate
+    # AGENT HEURISTIC: board claims can be recorded through a symlinked macOS
+    # path spelling (for example /tmp while Git resolves /private/tmp). Resolve
+    # the existing prefix of a glob so claim and staged candidates share one
+    # filesystem identity before segment matching.
+    return os.path.realpath(candidate)
+
+
+# AGENT HEURISTIC: claim globs need segment semantics; Python fnmatch lets `*`
+# cross separators, while pathlib's `**` behavior does not cover the board's
+# common trailing-`/**` subtree form. This small matcher makes both explicit.
+def _glob_matches_path(pattern: str, candidate: str) -> bool:
+    """Match path-segment globs without allowing ``*`` to cross ``/``."""
+    pattern_parts = Path(pattern).parts
+    candidate_parts = Path(candidate).parts
+    cache: dict[tuple[int, int], bool] = {}
+
+    def matches(pattern_index: int, candidate_index: int) -> bool:
+        key = (pattern_index, candidate_index)
+        if key in cache:
+            return cache[key]
+        if pattern_index == len(pattern_parts):
+            result = candidate_index == len(candidate_parts)
+        elif pattern_parts[pattern_index] == "**":
+            result = matches(pattern_index + 1, candidate_index) or (
+                candidate_index < len(candidate_parts)
+                and matches(pattern_index, candidate_index + 1)
+            )
+        else:
+            result = (
+                candidate_index < len(candidate_parts)
+                and fnmatch.fnmatchcase(
+                    candidate_parts[candidate_index], pattern_parts[pattern_index]
+                )
+                and matches(pattern_index + 1, candidate_index + 1)
+            )
+        cache[key] = result
+        return result
+
+    return matches(0, 0)
+
+
+def _claim_authorizes_path(
+    claim: str, repository: Path, staged_path: str
+) -> bool:
+    pattern = _absolute_claim_pattern(claim, repository)
+    if pattern is None:
+        return False
+    candidate = os.path.realpath(repository / staged_path)
+    if any(token in pattern for token in ("*", "?", "[")):
+        return _glob_matches_path(pattern, candidate)
+    boundary = Path(pattern)
+    candidate_path = Path(candidate)
+    if plain(claim).endswith("/") or boundary.is_dir():
+        return candidate_path == boundary or boundary in candidate_path.parents
+    return candidate_path == boundary
+
+
+def _outside_claim(
+    session: Session, repository: Path, staged_paths: list[str]
+) -> list[str]:
+    return [
+        path
+        for path in staged_paths
+        if not any(
+            _claim_authorizes_path(claim, repository, path)
+            for claim in session.claims
+        )
+    ]
+
+
+def _resolve_check_selector(args) -> tuple[str | None, str | None]:
+    explicit = getattr(args, "id", None)
+    if explicit:
+        return explicit, "command-line"
+    environment = os.environ.get("SYNTHESIS_COORDINATION_SESSION", "").strip()
+    if environment:
+        return environment, "environment"
+    pointer = Path(args.active_project_file).expanduser()
+    if not pointer.exists():
+        return None, None
+    if pointer.is_symlink():
+        raise RuntimeError(f"active-project pointer must not be a symlink: {pointer}")
+    try:
+        payload = json.loads(pointer.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"active-project pointer is unreadable: {exc}") from exc
+    owner = str(payload.get("owner_session") or "").strip()
+    if not owner:
+        raise RuntimeError("active-project pointer has no owner_session selector")
+    return owner, "active-project"
+
+
+def _append_override_message(
+    content: str,
+    session: Session,
+    repository: Path,
+    branch: str,
+    staged_tree: str,
+    staged_paths: list[str],
+    reason: str,
+) -> str:
+    marker = re.search(
+        r"(?m)^---[ \t]*\n\n## Protocol(?:[^\n]*)?$",
+        content,
+    )
+    if marker is None:
+        raise RuntimeError("board lacks Protocol boundary")
+    body = (
+        f"### recorded-staged-claim-override — {timestamp()}\n\n"
+        f"Session: {session.session_uuid}\n\n"
+        f"Repository: {repository} @ {sanitize(branch)}\n\n"
+        f"Staged tree: {staged_tree}\n\n"
+        f"Outside-claim paths: {', '.join(sanitize(path) for path in staged_paths)}\n\n"
+        f"Reason: {sanitize(reason)}\n\n"
+    )
+    return content[: marker.start()] + body + content[marker.start() :]
+
+
+def _check_staged_receipt(
+    *,
+    board: Path,
+    board_text: str,
+    session: Session,
+    repository: Path,
+    branch: str,
+    staged_tree: str,
+    staged_paths: list[str],
+    enforcement_outcome: str,
+    outside_paths: list[str],
+    override_reason: str | None = None,
+) -> dict:
+    receipt = {
+        "schema": "coordination-check-staged-v1",
+        "schema_provenance": "AGENT HEURISTIC",
+        "authority_label": "DESIGN CONSTRAINT (Fable, controlling plan)",
+        "receipt_consumer": "synthesis-git-hooks pre-commit",
+        "board": str(board),
+        "board_sha256": hashlib.sha256(board_text.encode("utf-8")).hexdigest(),
+        "session_uuid": session.session_uuid,
+        "repository": str(repository),
+        "branch": branch,
+        "claims": session.claims,
+        "enforcement_outcome": enforcement_outcome,
+        "outside_paths": list(outside_paths),
+        "staged_tree": staged_tree,
+        "staged_paths": staged_paths,
+        "issued_at": timestamp(),
+        "invalidated_by": [
+            "board content change",
+            "session, worktree, or branch change",
+            "Git index change",
+        ],
+    }
+    if override_reason is not None:
+        receipt["override_reason"] = override_reason
+    canonical = json.dumps(receipt, sort_keys=True, separators=(",", ":"))
+    receipt["binding_sha256"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return receipt
 
 
 def claims_context(claim: str) -> bool:
@@ -694,6 +1003,38 @@ def locked_update(board: Path, operation) -> None:
         write_board(board, operation(content))
 
 
+def _check_staged_board_snapshot(board: Path) -> str | None:
+    """Return one lock/CAS-fenced authority snapshot for check-staged.
+
+    AGENT HEURISTIC: a read followed by an unlocked mirror write can restore
+    stale active bytes after another process releases the session. A leased
+    board therefore publishes an identity mutation through the existing CAS
+    path. The successful CAS is the read fence: on a concurrent advance it
+    retries from the newer board before exposing local bytes. An unleased
+    board is read under the same filesystem lock used by every mutation.
+    """
+    board.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = board.parent / ".active-sessions.lock"
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        config = lease_configuration(board)
+        if config is not None:
+            lease_update(board, config, lambda content: content)
+            return board.read_text(encoding="utf-8")
+        if not board.exists():
+            return None
+        content = board.read_text(encoding="utf-8")
+        declared = declared_lease(content)
+        if declared is not None:
+            raise RuntimeError(
+                f"board declares a coordination lease ({declared}) but "
+                f"{board.parent / LEASE_CONFIG_NAME} is missing on this "
+                "machine; restore the lease configuration before checking "
+                "commit authority"
+            )
+        return content
+
+
 def validate_sessions(sessions: list[Session]) -> list[str]:
     problems: list[str] = []
     seen_selectors: dict[tuple[str, object], str] = {}
@@ -736,7 +1077,9 @@ def validate_sessions(sessions: list[Session]) -> list[str]:
                     if workspace_conflict(left_workspace, right_workspace):
                         problems.append(
                             f"{left.label} and {right.label} share workspace or branch: "
-                            f"{left_workspace} / {right_workspace}"
+                            f"{left_workspace} / {right_workspace}. Use an isolated "
+                            "worktree with a distinct branch and claim that exact "
+                            "workspace before writing"
                         )
             if (
                 left.project not in {"", "unknown", "none"}
@@ -796,6 +1139,247 @@ def command_status(args) -> int:
     return 10 if args.strict and (payload["problems"] or any(
         item["stale"] for item in payload["sessions"]
     )) else 0
+
+
+def command_check_staged(args) -> int:
+    selector_source: str | None = None
+    try:
+        repository, branch = _repository_state(Path(args.repository))
+        staged_paths, staged_tree = _staged_inventory(repository)
+    except (OSError, UnicodeError, RuntimeError) as exc:
+        payload = _check_staged_payload(
+            args,
+            "unverifiable-repository-or-index",
+            detail=str(exc),
+            remediation=CHECK_STAGED_REMEDIATION,
+        )
+        _emit_check_staged(args, payload)
+        return 10
+
+    try:
+        board_text = _check_staged_board_snapshot(args.board)
+    except (OSError, UnicodeError, ValueError, RuntimeError) as exc:
+        payload = _check_staged_payload(
+            args,
+            "unverifiable-lease-refresh",
+            detail=str(exc),
+            remediation=CHECK_STAGED_REMEDIATION,
+        )
+        _emit_check_staged(args, payload)
+        return 10
+    if board_text is None:
+        payload = _check_staged_payload(
+            args,
+            "unverifiable-missing-board",
+            detail=f"coordination board is unavailable: {args.board}",
+            remediation=CHECK_STAGED_REMEDIATION,
+        )
+        _emit_check_staged(args, payload)
+        return 10
+
+    try:
+        required = ("## Active sessions", "## Messages", "## Protocol")
+        missing = [heading for heading in required if heading not in board_text]
+        if missing:
+            raise RuntimeError("board missing " + ", ".join(missing))
+        sessions = rows(board_text)
+        problems = validate_sessions(sessions)
+        if problems:
+            raise RuntimeError("; ".join(problems))
+        selector, selector_source = _resolve_check_selector(args)
+        if selector is None:
+            raise RuntimeError(
+                "no committing session selector; pass --session, set "
+                "SYNTHESIS_COORDINATION_SESSION, or provide an owned "
+                "active-project pointer"
+            )
+        session = find_session(sessions, selector)
+    except (OSError, UnicodeError, ValueError, RuntimeError) as exc:
+        payload = _check_staged_payload(
+            args,
+            "unverifiable-board-or-session",
+            selector_source=selector_source,
+            detail=str(exc),
+            remediation=CHECK_STAGED_REMEDIATION,
+        )
+        _emit_check_staged(args, payload)
+        return 10
+
+    if session is None:
+        payload = _check_staged_payload(
+            args,
+            "refused-session-not-found",
+            selector_source=selector_source,
+            detail=f"session selector is not present on the board: {selector}",
+            remediation=CHECK_STAGED_REMEDIATION,
+        )
+        _emit_check_staged(args, payload)
+        return 10
+    if not active(session):
+        payload = _check_staged_payload(
+            args,
+            "refused-inactive-session",
+            selector_source=selector_source,
+            detail=f"session {session.label} has status {session.status}",
+            remediation=CHECK_STAGED_REMEDIATION,
+        )
+        _emit_check_staged(args, payload)
+        return 10
+    if not session.session_uuid:
+        payload = _check_staged_payload(
+            args,
+            "unverifiable-session-identity",
+            selector_source=selector_source,
+            detail="the selected legacy board row has no UUID identity",
+            remediation=CHECK_STAGED_REMEDIATION,
+        )
+        _emit_check_staged(args, payload)
+        return 10
+    if not _workspace_registered(session, repository, branch):
+        payload = _check_staged_payload(
+            args,
+            "refused-unregistered-worktree",
+            selector_source=selector_source,
+            detail=f"{repository} @ {branch} is not an exact workspace claim",
+            remediation=CHECK_STAGED_REMEDIATION,
+        )
+        _emit_check_staged(args, payload)
+        return 10
+
+    if not staged_paths:
+        payload = _check_staged_payload(
+            args,
+            "no-staged-paths",
+            selector_source=selector_source,
+            detail="the Git index names no staged paths; no authority receipt issued",
+        )
+        _emit_check_staged(args, payload)
+        return 0
+
+    outside_paths = _outside_claim(session, repository, staged_paths)
+    override_reason = sanitize(str(args.override_reason or ""))
+    if outside_paths and not override_reason:
+        payload = _check_staged_payload(
+            args,
+            "refused-outside-claim",
+            selector_source=selector_source,
+            outside_paths=outside_paths,
+            detail=(
+                f"{len(outside_paths)} of {len(staged_paths)} staged paths "
+                "fall outside the selected session's claim"
+            ),
+            remediation=CHECK_STAGED_REMEDIATION,
+        )
+        _emit_check_staged(args, payload)
+        return 10
+
+    if outside_paths:
+        override_state: dict[str, object] = {}
+
+        def record_override(content: str) -> str:
+            current = rows(content)
+            problems = validate_sessions(current)
+            if problems:
+                raise RuntimeError("; ".join(problems))
+            current_session = find_session(current, selector)
+            if current_session is None or not active(current_session):
+                raise RuntimeError("selected session is missing or inactive")
+            if not current_session.session_uuid:
+                raise RuntimeError("selected session has no UUID identity")
+            if not _workspace_registered(current_session, repository, branch):
+                raise RuntimeError("worktree or branch is no longer registered")
+            current_paths, current_tree = _staged_inventory(repository)
+            if current_paths != staged_paths or current_tree != staged_tree:
+                raise RuntimeError(
+                    "Git index changed before the override could be recorded"
+                )
+            current_outside = _outside_claim(
+                current_session, repository, current_paths
+            )
+            override_state["session"] = current_session
+            override_state["outside"] = current_outside
+            if not current_outside:
+                override_state["recorded"] = False
+                return content
+            override_state["recorded"] = True
+            return _append_override_message(
+                content,
+                current_session,
+                repository,
+                branch,
+                current_tree,
+                current_outside,
+                override_reason,
+            )
+
+        try:
+            locked_update(args.board, record_override)
+            board_text = args.board.read_text(encoding="utf-8")
+        except (OSError, UnicodeError, ValueError, RuntimeError) as exc:
+            payload = _check_staged_payload(
+                args,
+                "refused-override-revalidation",
+                selector_source=selector_source,
+                outside_paths=outside_paths,
+                detail=str(exc),
+                remediation=CHECK_STAGED_REMEDIATION,
+            )
+            _emit_check_staged(args, payload)
+            return 10
+        session = override_state["session"]  # type: ignore[assignment]
+        recorded = bool(override_state["recorded"])
+        outside_paths = list(override_state["outside"])  # type: ignore[arg-type]
+        outcome = "recorded-override" if recorded else "passed-inside-claim"
+        receipt = _check_staged_receipt(
+            board=args.board,
+            board_text=board_text,
+            session=session,  # type: ignore[arg-type]
+            repository=repository,
+            branch=branch,
+            staged_tree=staged_tree,
+            staged_paths=staged_paths,
+            enforcement_outcome=outcome,
+            outside_paths=outside_paths if recorded else [],
+            override_reason=override_reason if recorded else None,
+        )
+        payload = _check_staged_payload(
+            args,
+            outcome,
+            selector_source=selector_source,
+            outside_paths=outside_paths if recorded else [],
+            detail=(
+                "outside-claim authority was recorded on the board"
+                if recorded
+                else "a concurrent board update brought every staged path inside claim"
+            ),
+            receipt=receipt,
+        )
+        _emit_check_staged(args, payload)
+        return 0
+
+    receipt = _check_staged_receipt(
+        board=args.board,
+        board_text=board_text,
+        session=session,
+        repository=repository,
+        branch=branch,
+        staged_tree=staged_tree,
+        staged_paths=staged_paths,
+        enforcement_outcome="passed-inside-claim",
+        outside_paths=[],
+    )
+    payload = _check_staged_payload(
+        args,
+        "passed-inside-claim",
+        selector_source=selector_source,
+        detail=(
+            f"all {len(staged_paths)} staged paths are covered by session "
+            f"{session.label}"
+        ),
+        receipt=receipt,
+    )
+    _emit_check_staged(args, payload)
+    return 0
 
 
 def command_claim(args) -> int:
@@ -1153,6 +1737,31 @@ def parser() -> argparse.ArgumentParser:
     status.add_argument("--json", action="store_true")
     status.add_argument("--strict", action="store_true")
     status.add_argument("--stale-after-minutes", type=int, default=240)
+    check_staged = commands.add_parser(
+        "check-staged",
+        help=(
+            "Fail closed unless every staged path is covered by the selected "
+            "active session's exact worktree and source-area claims."
+        ),
+    )
+    check_staged.add_argument("--id", "--session", dest="id")
+    check_staged.add_argument(
+        "--repository",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository or subdirectory whose Git index is being committed.",
+    )
+    check_staged.add_argument(
+        "--active-project-file", type=Path, default=DEFAULT_ACTIVE_PROJECT
+    )
+    check_staged.add_argument(
+        "--override-reason",
+        help=(
+            "Explicit accountability reason to record on the board before "
+            "allowing staged paths outside the claim."
+        ),
+    )
+    check_staged.add_argument("--json", action="store_true")
     claim = commands.add_parser("claim")
     claim.add_argument(
         "--id",
@@ -1209,6 +1818,8 @@ def main() -> int:
     args.board = args.board.expanduser()
     if args.command == "status":
         return command_status(args)
+    if args.command == "check-staged":
+        return command_check_staged(args)
     if args.command == "claim":
         return command_claim(args)
     if args.command == "heartbeat":

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -1032,6 +1032,8 @@ def test_r4_staged_paths_inside_claim_issue_bound_receipt(
     assert payload["receipt"]["session_uuid"] == session.session_uuid
     assert payload["receipt"]["repository"] == str(root)
     assert payload["receipt"]["branch"] == "main"
+    assert payload["receipt"]["enforcement_outcome"] == "passed-inside-claim"
+    assert payload["receipt"]["outside_paths"] == []
     assert payload["receipt"]["staged_paths"] == ["claimed/inside.md"]
     assert payload["receipt"]["staged_tree"] == git(root, "write-tree").stdout.strip()
     assert payload["unverified_remainder"]
@@ -1121,6 +1123,8 @@ def test_r4_recorded_override_binds_reason_and_paths(
 
     assert payload["enforcement_outcome"] == "recorded-override"
     assert payload["issues_authority_receipt"] is True
+    assert payload["receipt"]["enforcement_outcome"] == "recorded-override"
+    assert payload["receipt"]["outside_paths"] == ["outside.md"]
     assert payload["receipt"]["override_reason"].startswith("Urgent repair")
     assert payload["receipt"]["staged_paths"] == ["outside.md"]
     board_text = board.read_text(encoding="utf-8")
@@ -1146,6 +1150,45 @@ def test_r4_inactive_session_is_refused(
 
     assert payload["enforcement_outcome"] == "refused-inactive-session"
     assert payload["issues_authority_receipt"] is False
+
+
+def test_r4_lease_fence_cannot_resurrect_released_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = staged_repository(tmp_path)
+    claimed = root / "claimed"
+    claimed.mkdir()
+    (claimed / "inside.md").write_text("inside\n", encoding="utf-8")
+    assert git(root, "add", "claimed/inside.md").returncode == 0
+    machine1, machine2 = lease_machines(tmp_path)
+    claim_staged_repository(machine1, root)
+    capsys.readouterr()
+
+    original_fetch = MODULE.lease_fetch
+    raced = False
+
+    def release_after_stale_fetch(config):
+        nonlocal raced
+        sha, content = original_fetch(config)
+        if not raced:
+            raced = True
+            assert MODULE.command_release(args(machine2, id="A")) == 0
+        return sha, content
+
+    monkeypatch.setattr(MODULE, "lease_fetch", release_after_stale_fetch)
+
+    exit_code = MODULE.command_check_staged(
+        check_staged_args(machine1, root)
+    )
+    output = capsys.readouterr().out
+    payload = json.loads(output[output.index("{") :])
+
+    assert raced is True
+    assert exit_code == 10
+    assert payload["enforcement_outcome"] == "refused-inactive-session"
+    assert MODULE.rows(machine1.read_text(encoding="utf-8"))[0].status == "released"
 
 
 def test_r4_unregistered_worktree_is_refused(
@@ -1215,6 +1258,55 @@ def test_r4_missing_board_is_unverifiable(
     assert payload["enforcement_outcome"] == "unverifiable-missing-board"
     assert payload["issues_authority_receipt"] is False
     assert payload["unverified_remainder"]
+
+
+def test_r4_glob_claim_does_not_authorize_deeper_sibling_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = staged_repository(tmp_path)
+    nested = root / "claimed" / "nested"
+    nested.mkdir(parents=True)
+    (nested / "outside.txt").write_text("outside\n", encoding="utf-8")
+    assert git(root, "add", "claimed/nested/outside.txt").returncode == 0
+    board = tmp_path / "active-sessions.md"
+    claim_staged_repository(
+        board,
+        root,
+        area=f"{root}/claimed/*.md",
+    )
+    capsys.readouterr()
+
+    assert MODULE.command_check_staged(check_staged_args(board, root)) == 10
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["enforcement_outcome"] == "refused-outside-claim"
+    assert payload["outside_paths"] == ["claimed/nested/outside.txt"]
+
+
+def test_r4_symlink_alias_claim_matches_resolved_worktree(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = staged_repository(tmp_path)
+    claimed = root / "claimed"
+    claimed.mkdir()
+    (claimed / "inside.md").write_text("inside\n", encoding="utf-8")
+    assert git(root, "add", "claimed/inside.md").returncode == 0
+    alias = tmp_path / "repo-alias"
+    alias.symlink_to(root, target_is_directory=True)
+    board = tmp_path / "active-sessions.md"
+    claim_staged_repository(
+        board,
+        root,
+        workspace=f"{alias} @ main",
+        area=f"{alias}/claimed/**",
+    )
+    capsys.readouterr()
+
+    assert MODULE.command_check_staged(check_staged_args(board, alias)) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["enforcement_outcome"] == "passed-inside-claim"
+    assert payload["outside_paths"] == []
 
 
 def test_r4_acceptance_manifest_is_closed_and_resolvable() -> None:

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import importlib.util
+import ast
 import json
+import subprocess
 import sys
 import threading
 import uuid
 from pathlib import Path
 
 import pytest
+import yaml
 
 
 MODULE_PATH = Path(__file__).with_name("coordination.py")
@@ -42,6 +45,68 @@ def claim_args(
         workspace=[workspace],
         area=[area],
         context_role=context_role,
+    )
+
+
+def staged_repository(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    subprocess.run(
+        ["git", "init", "-b", "main"], cwd=root, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=root, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=root, check=True
+    )
+    return root
+
+
+def git(root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def claim_staged_repository(
+    board: Path,
+    root: Path,
+    *,
+    session_id: str = "A",
+    workspace: str | None = None,
+    area: str | None = None,
+):
+    request = claim_args(
+        board,
+        session_id=session_id,
+        project="project-a",
+        workspace=workspace or f"{root} @ main",
+        area=area or f"{root}/claimed/**",
+    )
+    assert MODULE.command_claim(request) == 0
+    return MODULE.rows(board.read_text(encoding="utf-8"))[0]
+
+
+def check_staged_args(
+    board: Path,
+    root: Path,
+    *,
+    session_id: str | None = "A",
+    active_project_file: Path | None = None,
+    override_reason: str | None = None,
+):
+    return args(
+        board,
+        id=session_id,
+        repository=root,
+        active_project_file=(active_project_file or root / "active-project.json"),
+        override_reason=override_reason,
+        json=True,
     )
 
 
@@ -944,3 +1009,239 @@ def test_semicolon_separated_claims_still_conflict(tmp_path: Path) -> None:
         area="/home/user/workspaces/demo/repo-two/daily/plan.md",
     )
     assert MODULE.command_claim(overlapping) == 10
+
+
+def test_r4_staged_paths_inside_claim_issue_bound_receipt(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = staged_repository(tmp_path)
+    claimed = root / "claimed"
+    claimed.mkdir()
+    (claimed / "inside.md").write_text("inside\n", encoding="utf-8")
+    assert git(root, "add", "claimed/inside.md").returncode == 0
+    board = tmp_path / "coordination" / "active-sessions.md"
+    session = claim_staged_repository(board, root)
+    capsys.readouterr()
+
+    assert MODULE.command_check_staged(check_staged_args(board, root)) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["control_class"] == "enforced-gate"
+    assert payload["enforcement_outcome"] == "passed-inside-claim"
+    assert payload["issues_authority_receipt"] is True
+    assert payload["receipt"]["session_uuid"] == session.session_uuid
+    assert payload["receipt"]["repository"] == str(root)
+    assert payload["receipt"]["branch"] == "main"
+    assert payload["receipt"]["staged_paths"] == ["claimed/inside.md"]
+    assert payload["receipt"]["staged_tree"] == git(root, "write-tree").stdout.strip()
+    assert payload["unverified_remainder"]
+
+
+def test_r4_staged_path_outside_claim_is_refused(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = staged_repository(tmp_path)
+    (root / "outside.md").write_text("outside\n", encoding="utf-8")
+    assert git(root, "add", "outside.md").returncode == 0
+    board = tmp_path / "active-sessions.md"
+    claim_staged_repository(board, root)
+    capsys.readouterr()
+
+    assert MODULE.command_check_staged(check_staged_args(board, root)) == 10
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["enforcement_outcome"] == "refused-outside-claim"
+    assert payload["issues_authority_receipt"] is False
+    assert payload["outside_paths"] == ["outside.md"]
+    assert "isolated worktree" in payload["remediation"]
+
+
+def test_r4_rename_from_unclaimed_path_is_refused(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = staged_repository(tmp_path)
+    (root / "unclaimed.md").write_text("baseline\n", encoding="utf-8")
+    assert git(root, "add", "unclaimed.md").returncode == 0
+    assert git(root, "commit", "-m", "Baseline").returncode == 0
+    (root / "claimed").mkdir()
+    assert git(root, "mv", "unclaimed.md", "claimed/renamed.md").returncode == 0
+    board = tmp_path / "active-sessions.md"
+    claim_staged_repository(board, root)
+    capsys.readouterr()
+
+    assert MODULE.command_check_staged(check_staged_args(board, root)) == 10
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["enforcement_outcome"] == "refused-outside-claim"
+    assert payload["outside_paths"] == ["unclaimed.md"]
+
+
+def test_r4_active_pointer_resolves_committing_session(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = staged_repository(tmp_path)
+    (root / "claimed").mkdir()
+    (root / "claimed" / "inside.md").write_text("inside\n", encoding="utf-8")
+    assert git(root, "add", "claimed/inside.md").returncode == 0
+    board = tmp_path / "active-sessions.md"
+    session = claim_staged_repository(board, root)
+    pointer = tmp_path / "active-project.json"
+    pointer.write_text(
+        json.dumps({"owner_session": session.session_uuid}), encoding="utf-8"
+    )
+    capsys.readouterr()
+
+    request = check_staged_args(
+        board, root, session_id=None, active_project_file=pointer
+    )
+    assert MODULE.command_check_staged(request) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["selector_source"] == "active-project"
+    assert payload["receipt"]["session_uuid"] == session.session_uuid
+
+
+def test_r4_recorded_override_binds_reason_and_paths(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = staged_repository(tmp_path)
+    (root / "outside.md").write_text("outside\n", encoding="utf-8")
+    assert git(root, "add", "outside.md").returncode == 0
+    board = tmp_path / "active-sessions.md"
+    claim_staged_repository(board, root)
+    capsys.readouterr()
+
+    request = check_staged_args(
+        board,
+        root,
+        override_reason="Urgent repair with explicit operator accountability",
+    )
+    assert MODULE.command_check_staged(request) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["enforcement_outcome"] == "recorded-override"
+    assert payload["issues_authority_receipt"] is True
+    assert payload["receipt"]["override_reason"].startswith("Urgent repair")
+    assert payload["receipt"]["staged_paths"] == ["outside.md"]
+    board_text = board.read_text(encoding="utf-8")
+    assert "recorded-staged-claim-override" in board_text
+    assert "Urgent repair with explicit operator accountability" in board_text
+    assert "outside.md" in board_text
+
+
+def test_r4_inactive_session_is_refused(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = staged_repository(tmp_path)
+    (root / "claimed").mkdir()
+    (root / "claimed" / "inside.md").write_text("inside\n", encoding="utf-8")
+    assert git(root, "add", "claimed/inside.md").returncode == 0
+    board = tmp_path / "active-sessions.md"
+    claim_staged_repository(board, root)
+    assert MODULE.command_release(args(board, id="A", active_project_file=None)) == 0
+    capsys.readouterr()
+
+    assert MODULE.command_check_staged(check_staged_args(board, root)) == 10
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["enforcement_outcome"] == "refused-inactive-session"
+    assert payload["issues_authority_receipt"] is False
+
+
+def test_r4_unregistered_worktree_is_refused(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = staged_repository(tmp_path)
+    (root / "inside.md").write_text("inside\n", encoding="utf-8")
+    assert git(root, "add", "inside.md").returncode == 0
+    board = tmp_path / "active-sessions.md"
+    claim_staged_repository(
+        board,
+        root,
+        workspace=f"{tmp_path / 'different-worktree'} @ main",
+        area=f"{root}/**",
+    )
+    capsys.readouterr()
+
+    assert MODULE.command_check_staged(check_staged_args(board, root)) == 10
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["enforcement_outcome"] == "refused-unregistered-worktree"
+    assert "isolated worktree" in payload["remediation"]
+    assert "claim" in payload["remediation"]
+
+
+def test_r4_workspace_conflict_names_isolated_worktree_remedy(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    board = tmp_path / "active-sessions.md"
+    first = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/shared-worktree @ feature/shared",
+        area="/tmp/one/**",
+    )
+    second = claim_args(
+        board,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/shared-worktree @ feature/shared",
+        area="/tmp/two/**",
+    )
+    assert MODULE.command_claim(first) == 0
+    capsys.readouterr()
+
+    assert MODULE.command_claim(second) == 10
+    error = capsys.readouterr().err
+
+    assert "isolated worktree" in error
+    assert "distinct branch" in error
+    assert "claim" in error
+
+
+def test_r4_missing_board_is_unverifiable(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = staged_repository(tmp_path)
+    (root / "inside.md").write_text("inside\n", encoding="utf-8")
+    assert git(root, "add", "inside.md").returncode == 0
+    board = tmp_path / "missing-board.md"
+
+    assert MODULE.command_check_staged(check_staged_args(board, root)) == 10
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["control_class"] == "enforced-gate"
+    assert payload["enforcement_outcome"] == "unverifiable-missing-board"
+    assert payload["issues_authority_receipt"] is False
+    assert payload["unverified_remainder"]
+
+
+def test_r4_acceptance_manifest_is_closed_and_resolvable() -> None:
+    skill_root = Path(__file__).resolve().parents[1]
+    manifest = yaml.safe_load(
+        (skill_root / "acceptance-suite.yaml").read_text(encoding="utf-8")
+    )
+
+    assert manifest["schema"] == 1
+    assert manifest["membership"] == "closed"
+    declared = {case["fixture"] for case in manifest["cases"]}
+    discovered: set[str] = set()
+    for relative in (
+        "scripts/test_coordination.py",
+        "../synthesis-git-hooks/scripts/test_pre_commit.py",
+    ):
+        path = (skill_root / relative).resolve()
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith(
+                "test_r4_"
+            ):
+                discovered.add(f"{relative}::{node.name}")
+
+    assert declared == discovered
+    assert {case["control_class"] for case in manifest["cases"]} <= {
+        "enforced-gate",
+        "acceptance-test",
+        "diagnostic",
+    }


### PR DESCRIPTION
## What changed

- Add `coordination.py check-staged` with exact worktree, branch, staged-path, lease-fence, override, and receipt checks.
- Wire the optional coordination boundary into `synthesis-git-hooks`, including installer and doctor coverage.
- Make workspace-conflict refusals name the isolated-worktree, distinct-branch, and exact-claim remedy.

## Evidence

- D1 history: fixture commits `d8efad0` and `70e5dde` precede production `ca82eb8`; the final fixture boundary is red and the exact head is green.
- Closed acceptance manifest: 22 declared and discovered R4 controls.
- Relevant suites: 131 passed.
- Full gated `release.py --check-only`: passed for 4.53.0.
- Direct adversarial N+2 review: accepted exact head `ca82eb8` after independently replaying all five initial ship blockers.

## Boundary

This PR contains R4 only. It performs no deployment or content publication.