### PR TITLE
Make Git-backed acceptance fixtures hermetic

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.53.0",
+  "version": "4.53.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.53.0",
+  "version": "4.53.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
 
 ### Fixed
 
-- **Project-management acceptance fixtures remain isolated from user-level Git hooks.**
+- **Git-backed acceptance fixtures remain isolated from user-level Git hooks.**
   Synthetic Git operations now disable inherited hooks, so an active global
   coordination gate cannot block fixture setup before the behavior under test
   runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.53.1] - 2026-08-26
+
+### Fixed
+
+- **Project-management acceptance fixtures remain isolated from user-level Git hooks.**
+  Synthetic Git operations now disable inherited hooks, so an active global
+  coordination gate cannot block fixture setup before the behavior under test
+  runs.
+
 ## [4.53.0] - 2026-08-26
 
 ### Added

--- a/skills/synthesis-agent-conformance/scripts/test_active_project.py
+++ b/skills/synthesis-agent-conformance/scripts/test_active_project.py
@@ -52,6 +52,7 @@ def fixture(tmp_path: Path) -> tuple[dict[str, object], Path]:
     git(worktree, "init", "--initial-branch", "feature/test")
     git(worktree, "config", "user.email", "test@example.com")
     git(worktree, "config", "user.name", "Test")
+    git(worktree, "config", "core.hooksPath", "/dev/null")
     project = worktree / "projects" / "test"
     project.mkdir(parents=True)
     plan = project / "plan.md"

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -412,6 +412,10 @@ def test_activate_and_handoff(tmp_path: Path, monkeypatch) -> None:
     subprocess.run(
         ["git", "-C", str(project), "config", "user.name", "Test"], check=True
     )
+    subprocess.run(
+        ["git", "-C", str(project), "config", "core.hooksPath", "/dev/null"],
+        check=True,
+    )
     subprocess.run(["git", "-C", str(project), "add", "."], check=True)
     subprocess.run(
         ["git", "-C", str(project), "commit", "-m", "test"],
@@ -505,6 +509,7 @@ def clone_pair_with_project(tmp_path: Path) -> tuple[Path, Path]:
         )
         git(clone, "config", "user.email", "test@example.com")
         git(clone, "config", "user.name", "Test")
+        git(clone, "config", "core.hooksPath", "/dev/null")
         clones.append(clone)
     writer, reader = clones
     project = writer / "projects" / "demo"
@@ -598,6 +603,10 @@ def write_stopped_project(tmp_path: Path) -> Path:
     subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
     subprocess.run(
         ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "core.hooksPath", "/dev/null"],
         check=True,
     )
     subprocess.run(["git", "-C", str(repo), "add", "."], check=True)

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -65,7 +65,7 @@ def staged_repository(tmp_path: Path) -> Path:
 
 def git(root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["git", *arguments],
+        ["git", "-c", "core.hooksPath=/dev/null", *arguments],
         cwd=root,
         capture_output=True,
         text=True,

--- a/skills/synthesis-project-management/scripts/test_retire_worktree.py
+++ b/skills/synthesis-project-management/scripts/test_retire_worktree.py
@@ -22,7 +22,7 @@ SPEC.loader.exec_module(MODULE)
 
 def git(cwd: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["git", "-C", str(cwd), *arguments],
+        ["git", "-c", "core.hooksPath=/dev/null", "-C", str(cwd), *arguments],
         capture_output=True,
         text=True,
         check=True,


### PR DESCRIPTION
## Summary

- isolate synthetic Git operations from inherited user-level hooks
- preserve live coordination enforcement while allowing fixture repositories to initialize
- publish the repair as version 4.53.1

## Evidence

- red: installed global coordination enforcement caused 17 project-management fixture failures and 27 conformance fixture failures
- green: 108 project-management and Git-hook tests pass
- green: 144 conformance tests pass
- green: 103 remaining required-suite tests pass
- green: the complete gated release check passes for 4.53.1
