### PR TITLE
Add interoperability integrity controls

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.53.1",
+  "version": "4.54.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.53.1",
+  "version": "4.54.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,6 +20,8 @@ jobs:
       - run: python -m pytest skills/synthesis-agent-conformance/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-project-management/scripts/test_coordination.py -q
       - run: python -m pytest skills/synthesis-promotion-gate/scripts/ -q
+      - run: python -m pytest skills/synthesis-context-lifecycle/scripts/ skills/synthesis-implementation-integrity/scripts/ -q
+      - run: python skills/synthesis-implementation-integrity/scripts/acceptance_suite.py run --manifest skills/synthesis-implementation-integrity/acceptance-suite.yaml --repo-root .
       - run: python -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-onboarding/scripts/test_onboard.py -q

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,10 @@ jobs:
       - run: python -m pytest skills/synthesis-project-management/scripts/test_coordination.py -q
       - run: python -m pytest skills/synthesis-promotion-gate/scripts/ -q
       - run: python -m pytest skills/synthesis-context-lifecycle/scripts/ skills/synthesis-implementation-integrity/scripts/ -q
-      - run: python skills/synthesis-implementation-integrity/scripts/acceptance_suite.py run --manifest skills/synthesis-implementation-integrity/acceptance-suite.yaml --repo-root .
+      - name: Consume transaction-bound R5 acceptance
+        env:
+          SYNTHESIS_ACCEPTANCE_CHANGE_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: python skills/synthesis-skills-manager/scripts/release.py --repo-root . --acceptance-only
       - run: python -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py -q
       - run: python -m pytest skills/synthesis-onboarding/scripts/test_onboard.py -q

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,11 @@ jobs:
   conformance:
     runs-on: ubuntu-latest
     steps:
+      # PRINCIPAL RULE (controlling plan D4): the event base must exist in the
+      # runner repository before the receipt consumer can derive its universe.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   rather than a mutable branch name. CI checks out the history required to
   resolve the event-supplied base commit before deriving the change universe.
 
+### Fixed
+
+- **AGENT HEURISTIC — pointer-fallback tests remain hermetic in coordinated
+  shells.** The pointer-resolution fixture now removes the caller's real
+  coordination selector before exercising fallback identity, so the release
+  gate tests fixture state rather than the executor's ambient session.
+
 ## [4.53.1] - 2026-08-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   parses the fresh result, recomputes every Git and content binding, verifies
   closed terminal coverage, carries the accepted state through the release,
   expires it on any source change, and pushes the immutable accepted commit
-  rather than a mutable branch name.
+  rather than a mutable branch name. CI checks out the history required to
+  resolve the event-supplied base commit before deriving the change universe.
 
 ## [4.53.1] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.54.0] - 2026-08-26
+
+### Added
+
+- **Executable working state has a durable project tier.**
+  `synthesis-context-lifecycle` v1.12.0 defines `resources/scripts/` for
+  portable computation and required inputs cited by durable records. The
+  context doctor warns when an artifact cites a missing, escaped, non-regular,
+  or symlink-traversing script target while explicitly leaving correctness to
+  acceptance evidence.
+- **Closed acceptance manifests are executable release evidence.**
+  `synthesis-implementation-integrity` v1.2.0 supplies a fail-closed manifest
+  validator and runner with declared membership, defect-pinned fixtures,
+  changed-surface closure, expected polarity, full terminal coverage, named
+  enforcement boundaries, and explicit unverified remainder. Doctrine now
+  requires extraction from authoritative sources and locates enforcement at
+  the state-changing receipt consumer.
+- **Disclosure categories preserve attention without weakening the gate.**
+  `synthesis-disclosure-policy` v1.1.0 defines one-time category approval with
+  frozen evidence predicates, narrow register and surface scope, positive or
+  neutral claims, Class-X exclusion, and fail-closed ambiguity.
+
+### Changed
+
+- **Checkpoint and autonomous closeout sweep executable scratch state.**
+  `synthesis-checkpoint` v1.6.0 and `synthesis-autopilot` v1.3.0 require cited
+  scripts and inputs to reach the durable tier before a checkpoint closes.
+- **The gated release and repository CI consume the R5 acceptance universe.**
+  `synthesis-skills-manager` v2.2.0 runs the lifecycle and integrity tests plus
+  the closed acceptance manifest before publication.
+
 ## [4.53.1] - 2026-08-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
 - **Closed acceptance manifests are executable release evidence.**
   `synthesis-implementation-integrity` v1.2.0 supplies a fail-closed manifest
   validator and runner with declared membership, defect-pinned fixtures,
-  changed-surface closure, expected polarity, full terminal coverage, named
-  enforcement boundaries, and explicit unverified remainder. Doctrine now
-  requires extraction from authoritative sources and locates enforcement at
-  the state-changing receipt consumer.
+  exact changed-surface closure against a boundary-supplied Git diff, expected
+  polarity, full terminal coverage, named enforcement boundaries, and explicit
+  unverified remainder. Receipts bind a one-use transaction, exact head/tree,
+  manifest digest, and changed-path digest while explicitly denying that the
+  runner itself issues authority. Doctrine now requires extraction from
+  authoritative sources and locates enforcement at the state-changing receipt
+  consumer.
 - **Disclosure categories preserve attention without weakening the gate.**
   `synthesis-disclosure-policy` v1.1.0 defines one-time category approval with
   frozen evidence predicates, narrow register and surface scope, positive or
@@ -33,7 +36,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   scripts and inputs to reach the durable tier before a checkpoint closes.
 - **The gated release and repository CI consume the R5 acceptance universe.**
   `synthesis-skills-manager` v2.2.0 runs the lifecycle and integrity tests plus
-  the closed acceptance manifest before publication.
+  the closed acceptance manifest before publication. The release boundary and
+  CI use the same receipt consumer: it derives the authoritative change base,
+  parses the fresh result, recomputes every Git and content binding, verifies
+  closed terminal coverage, and refuses if the worktree changes during the
+  transaction.
 
 ## [4.53.1] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers 
   the closed acceptance manifest before publication. The release boundary and
   CI use the same receipt consumer: it derives the authoritative change base,
   parses the fresh result, recomputes every Git and content binding, verifies
-  closed terminal coverage, and refuses if the worktree changes during the
-  transaction.
+  closed terminal coverage, carries the accepted state through the release,
+  expires it on any source change, and pushes the immutable accepted commit
+  rather than a mutable branch name.
 
 ## [4.53.1] - 2026-08-26
 

--- a/skills/synthesis-autopilot/SKILL.md
+++ b/skills/synthesis-autopilot/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-thinking-framework", "synthesis-context-lifecycle", "synthesis-checkpoint", "synthesis-anti-shortcuts", "synthesis-grounding-discipline", "synthesis-implementation-integrity", "synthesis-project-management", "synthesis-adversarial-review"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.2.0"
+  version: "1.3.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -179,6 +179,11 @@ When a phase reaches a gated action, prepare everything up to the gate (the draf
 5. **Phase loop** — for each phase: re-read the plan file and coordination board; execute with anti-shortcut discipline; classify each decision per the protocol above; dispatch sub-agents per the hygiene rules below; directly orchestrate any adversarial counterpart and count principal courier crossings; record the sufficiency checkpoint; then update the plan file, and at natural checkpoints run the synthesis-context-lifecycle session protocol so CONTEXT.md and the session log stay current.
 6. **Verify** — before declaring the mission complete, run synthesis-implementation-integrity (or the domain analog). Fix what it finds; verification that only reports is not verification.
 7. **Close** — session-end per synthesis-context-lifecycle (context files updated, work committed where applicable); release the coordination claims; completion report in plain language: what shipped, what was decided and why, the batched questions; then the completion alert.
+
+The close step includes a scratchpad sweep: **What executable state or required
+input data still exists only in this session's scratchpad?** If a durable
+record cites its output, preserve the script and required inputs under
+resources/scripts/ before the checkpoint can close.
 
 ## Sub-Agent Fan-Out Hygiene
 

--- a/skills/synthesis-checkpoint/SKILL.md
+++ b/skills/synthesis-checkpoint/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.5.0"
+  version: "1.6.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -158,6 +158,11 @@ Show this verification step in the response. It is the L4 visible-verification m
 ### Step 6 — Update CONTEXT.md if it was stale
 
 If Step 3 revealed CONTEXT.md was out of date (later commits exist that aren't reflected in its "Last session" or "Recent Sessions" sections), update CONTEXT.md in place to reflect verified facts. Leave the correction session-attributed and locally receipted; publish it in the next explicit remote handoff or day-end batch. This prevents the next local client from inheriting the stale cache without creating a network round trip at every checkpoint.
+
+Before the checkpoint closes, ask: **What executable state or required input
+data still exists only in this session's scratchpad?** If a durable record
+cites its output, preserve the script and required inputs under
+resources/scripts/ before the checkpoint can close.
 
 ## Output Format
 

--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.11.0"
+  version: "1.12.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -658,6 +658,36 @@ If any question cannot be answered from CONTEXT.md alone (with a pointer to REFE
 
 ---
 
+## Executable Working State — resources/scripts/
+
+Durable prose is incomplete when its cited computation exists only in the
+session that wrote it. If a script produces a number or conclusion cited in a
+durable record, preserve the script and every required input before recording
+the result. Put that executable working state under `resources/scripts/` and
+cite its canonical, project-relative path from the artifact or session record.
+
+Each preserved computation carries a `resources/scripts/README.md` that names:
+
+- the script and its purpose;
+- every input, dependency, and expected output;
+- the regeneration order and exact invocation;
+- whether each input is immutable, append-only, or intentionally refreshed;
+- the success and failure exit behavior.
+
+Portable means a cold resumer can run the script from repository state. A
+script that depends on a session-temporary download, chat attachment, shell
+variable, or scratchpad value is not preserved until that required state is
+also stored at a project-relative path or documented as an independently
+obtainable immutable input.
+
+The context doctor reports `artifact-cites-missing-script` when a Markdown file
+directly under `resources/artifacts/` cites a nonexistent, non-regular, escaped,
+or symlink-traversing `resources/scripts/` target. That check establishes path
+existence and portability at the citation boundary; it does not prove the
+script is correct, the inputs are sufficient, or the regenerated conclusion is
+valid. Those questions remain with the artifact's acceptance evidence and the
+implementation-integrity review.
+
 ## The Context Doctor — verification, not diligence
 
 Everything above describes what a well-maintained context layer looks like. None of it verifies that yours *is* one. That gap matters more than it first appears: the durable layer is what makes cross-agent, cross-machine resumption possible, so it is the foundation every other guarantee stands on — and until you can check it, its health is an assertion by the same agent that was supposed to maintain it.
@@ -684,6 +714,7 @@ What it checks:
 | Cross-tier agreement | index.yaml status agrees with the CONTEXT.md header; completed projects carry `completed_date`; indexed projects have directories and vice versa |
 | Freshness | index.yaml `last_session` and the CONTEXT.md header agree with real git history |
 | Durability | tier files are tracked by git; local mode reports recoverable uncommitted or ahead state as warnings; remote mode requires a clean upstream-current branch |
+| Executable state | artifact citations to missing, non-regular, escaped, or symlink-traversing `resources/scripts/` targets warn; existence does not establish correctness |
 | Disclosure | anything unverifiable is reported rather than skipped — unreadable status headers and freshness that cannot be established both surface as findings |
 
 Exit codes follow the guard contract: `0` healthy, `1` defects found, `2` the doctor could not establish ground truth. The third is the important one — an unreadable source or a source outside git exits 2 rather than reporting health, because a check that cannot run must never look like a check that passed.

--- a/skills/synthesis-context-lifecycle/scripts/context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_doctor.py
@@ -698,6 +698,7 @@ CHECKS = [
 
 
 SCRIPT_CITATION = re.compile(
+    r"(?<![A-Za-z0-9_./-])"
     r"(?P<reference>(?:resources/scripts/|\.\./scripts/)"
     r"[A-Za-z0-9_./-]*[A-Za-z0-9_-])"
 )

--- a/skills/synthesis-context-lifecycle/scripts/context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_doctor.py
@@ -63,7 +63,7 @@ from pathlib import Path
 # missing the doctor must fail loudly rather than silently skip a check.
 import context_currency
 
-DOCTOR_VERSION = "1.5.0"
+DOCTOR_VERSION = "1.6.0"
 
 # Budgets from the tiered context architecture.
 CONTEXT_BUDGET_ACTIVE = 150
@@ -693,7 +693,64 @@ CHECKS = [
     "unpushed-context",
     "freshness-unverifiable",
     "record-unreadable",
+    "artifact-cites-missing-script",
 ]
+
+
+SCRIPT_CITATION = re.compile(
+    r"(?P<reference>(?:resources/scripts/|\.\./scripts/)"
+    r"[A-Za-z0-9_./-]*[A-Za-z0-9_-])"
+)
+
+
+def cited_script_findings(project_path: Path) -> list[tuple[Path, str, str]]:
+    """Return artifact citations whose executable target is not durable.
+
+    This is deliberately an existence and boundary check. A regular file at
+    the cited path is not evidence that the code is correct or reproducible.
+    """
+
+    artifacts = project_path / "resources" / "artifacts"
+    scripts = project_path / "resources" / "scripts"
+    if not artifacts.is_dir():
+        return []
+
+    scripts_lexical = Path(os.path.abspath(os.fspath(scripts)))
+    findings: list[tuple[Path, str, str]] = []
+    seen: set[tuple[Path, str]] = set()
+    for artifact in sorted(artifacts.glob("*.md")):
+        if not artifact.is_file() or artifact.is_symlink():
+            continue
+        for match in SCRIPT_CITATION.finditer(read_text(artifact)):
+            reference = match.group("reference")
+            key = (artifact, reference)
+            if key in seen:
+                continue
+            seen.add(key)
+            if reference.startswith("resources/scripts/"):
+                candidate = project_path / reference
+            else:
+                candidate = artifact.parent / reference
+            candidate_lexical = Path(os.path.abspath(os.fspath(candidate)))
+
+            try:
+                relative = candidate_lexical.relative_to(scripts_lexical)
+            except ValueError:
+                findings.append((artifact, reference, "escapes resources/scripts/"))
+                continue
+
+            cursor = scripts_lexical
+            unsafe = cursor.is_symlink()
+            for part in relative.parts:
+                cursor = cursor / part
+                if cursor.is_symlink():
+                    unsafe = True
+                    break
+            if unsafe:
+                findings.append((artifact, reference, "traverses a symlink"))
+            elif not candidate_lexical.is_file():
+                findings.append((artifact, reference, "is not a regular file"))
+    return findings
 
 
 def audit_project(
@@ -790,6 +847,17 @@ def audit_project(
                 f"{REFERENCE_BUDGET} — the project's scope may be too broad",
                 "split the project, or move narrative into sessions/",
             )
+
+    # --- executable working-state durability ------------------------------
+    for artifact, citation, reason in cited_script_findings(project_path):
+        audit.add(
+            "artifact-cites-missing-script",
+            "warning",
+            f"{artifact.name} cites {citation}, but that target {reason}",
+            "preserve the portable script and every required input under "
+            "resources/scripts/, then update the artifact citation; this check "
+            "establishes existence only and does not prove the script is correct",
+        )
 
     # --- cross-tier agreement ----------------------------------------------
     if index_entry is None:

--- a/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
@@ -294,6 +294,19 @@ class ContextDoctorTests(unittest.TestCase):
 
         self.assertIn("artifact-cites-missing-script", checks_in(self.fx.audit()))
 
+    def test_cross_project_script_citation_is_not_a_local_missing_script(self):
+        project = self.fx.project("alpha")
+        artifacts = project / "resources" / "artifacts"
+        artifacts.mkdir(parents=True)
+        (artifacts / "result.md").write_text(
+            "See `projects/other/resources/scripts/rebuild.py`.\n",
+            encoding="utf-8",
+        )
+        self.fx.index([{"id": "alpha", "status": "active"}])
+        self.fx.commit()
+
+        self.assertNotIn("artifact-cites-missing-script", checks_in(self.fx.audit()))
+
     # --- cross-tier agreement ---------------------------------------------
 
     def test_status_disagreement_is_caught(self):

--- a/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
@@ -51,6 +51,7 @@ class Fixture:
         run_git(root, "config", "user.email", "test@example.invalid")
         run_git(root, "config", "user.name", "Test")
         run_git(root, "config", "commit.gpgsign", "false")
+        run_git(root, "config", "core.hooksPath", "/dev/null")
         self.remote = root.parent / f"{root.name}-remote.git"
         self.has_remote = with_remote
         if with_remote:
@@ -238,6 +239,60 @@ class ContextDoctorTests(unittest.TestCase):
         self.fx.index([{"id": "alpha", "status": "active"}])
         self.fx.commit()
         self.assertEqual(self.fx.audit("--warnings-as-defects")["code"], 1)
+
+    # --- executable working-state tier ------------------------------------
+
+    def test_artifact_cites_missing_script_warns(self):
+        project = self.fx.project("alpha")
+        artifacts = project / "resources" / "artifacts"
+        artifacts.mkdir(parents=True)
+        (artifacts / "result.md").write_text(
+            "Regenerate with `resources/scripts/rebuild.py`.\n", encoding="utf-8"
+        )
+        self.fx.index([{"id": "alpha", "status": "active"}])
+        self.fx.commit()
+
+        result = self.fx.audit()
+        finding = next(
+            item
+            for item in result["data"]["findings"]
+            if item["check"] == "artifact-cites-missing-script"
+        )
+        self.assertEqual(finding["severity"], "warning")
+        self.assertIn("rebuild.py", finding["message"])
+        self.assertEqual(result["code"], 0)
+
+    def test_artifact_cites_existing_script_passes(self):
+        project = self.fx.project("alpha")
+        artifacts = project / "resources" / "artifacts"
+        scripts = project / "resources" / "scripts"
+        artifacts.mkdir(parents=True)
+        scripts.mkdir(parents=True)
+        (artifacts / "result.md").write_text(
+            "Regenerate with `resources/scripts/rebuild.py`.\n", encoding="utf-8"
+        )
+        (scripts / "rebuild.py").write_text("print('ok')\n", encoding="utf-8")
+        self.fx.index([{"id": "alpha", "status": "active"}])
+        self.fx.commit()
+
+        self.assertNotIn("artifact-cites-missing-script", checks_in(self.fx.audit()))
+
+    def test_artifact_cites_symlinked_script_warns(self):
+        project = self.fx.project("alpha")
+        artifacts = project / "resources" / "artifacts"
+        scripts = project / "resources" / "scripts"
+        artifacts.mkdir(parents=True)
+        scripts.mkdir(parents=True)
+        outside = self.fx.root.parent / "outside.py"
+        outside.write_text("print('outside')\n", encoding="utf-8")
+        (scripts / "rebuild.py").symlink_to(outside)
+        (artifacts / "result.md").write_text(
+            "Regenerate with `resources/scripts/rebuild.py`.\n", encoding="utf-8"
+        )
+        self.fx.index([{"id": "alpha", "status": "active"}])
+        self.fx.commit()
+
+        self.assertIn("artifact-cites-missing-script", checks_in(self.fx.audit()))
 
     # --- cross-tier agreement ---------------------------------------------
 

--- a/skills/synthesis-disclosure-policy/SKILL.md
+++ b/skills/synthesis-disclosure-policy/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.0.0"
+  version: "1.1.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -148,6 +148,32 @@ public-surface repositories rather than guessing.
 - **Human layer:** the person owns every Class-A approval and every
   Class-X override. The system's job is to make the decision explicit,
   informed, and durable — never to make it for them.
+
+## Category Allowlists Without Approval Fatigue
+
+A sound disclosure gate preserves human attention for consequential choices.
+When trivial, repetitive prompts teach the principal to rubber-stamp every
+dialog, the fail-closed mechanism is no longer producing informed decisions:
+approval fatigue is a failure mode of fail-closed design.
+
+A category allowlist is appropriate only when the principal approves the
+category once and the category has an executable membership test. Its record
+must define:
+
+1. the exact surface and register in which it applies;
+2. a predicate grounded in independent public evidence authored or controlled
+   by the principal;
+3. the permitted claim shape, which must remain positive or neutral;
+4. explicit exclusions and an owner for amendments;
+5. evidence that each use satisfies the frozen predicate, without silently
+   growing the category.
+
+The category reduces repeated Class-A decisions; it never turns an entity into
+a general disclosure allowance. Class X is never category-allowlisted. A
+negative statement, operational detail, private provenance, identifying
+aggregation, predicate mismatch, or ambiguity remains Class A and returns to
+the principal. Category membership narrows approval noise; it does not weaken
+the five tests or manufacture precedent.
 
 ## Maintenance protocol
 

--- a/skills/synthesis-implementation-integrity/SKILL.md
+++ b/skills/synthesis-implementation-integrity/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.1.0"
+  version: "1.2.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -343,6 +343,52 @@ After running the passes, produce this report:
 - **Low** — quality or maintainability concern, not a runtime issue
 
 ---
+
+## Executable Acceptance Manifests
+
+For a non-trivial release, prose that says which tests passed is an
+author-written claim ledger, not executable acceptance evidence. Declare the
+acceptance universe in a machine-consumed manifest and execute it with
+`acceptance_suite.py run` at the release boundary.
+
+The manifest must declare `membership: closed`, a `production_entry_point`, an
+`enforcing_boundary`, any state-changing `receipt_consumer`, the
+`expected_status` for each case, and an explicit `unverified_remainder`. Every
+case names the defect that motivated it and a runnable fixture. Every changed
+production surface names at least one case, and every declared case maps back
+to a changed surface. For a defect-pinning change, preserve evidence that the
+fixture commit predates the green implementation; a test added after the code
+cannot prove that it would have caught the original gap.
+
+Run every declared case to a terminal state and distinguish pass, expected
+failure, unexpected failure, execution error, and not-run coverage. A closed
+manifest makes the measured universe explicit; it does not prove behavior
+outside that universe or turn the author into an independent reviewer.
+
+## Extract, Do Not Restate
+
+When a verifier needs a value already owned by another artifact, extract it
+from the authoritative source at verification time. A second hand-maintained
+copy is another source of truth, not corroboration. Two checks that restate the
+same author's interpretation preserve the same shared author blind spot and
+can agree while the real source disagrees.
+
+If the authoritative source cannot be parsed or reached, report the dimension
+as unverifiable. Do not substitute a remembered value, a prose summary, or a
+parallel parser whose input was copied from the same claim.
+
+## Authority Lives at the Boundary
+
+A standalone verifier is evidence, not enforcement. Enforcement exists only
+when the state-changing consumer refuses the operation without a fresh,
+matching, transaction-bound receipt from the declared verifier. Record the
+receipt consumer, the enforcing operation, and the metadata class so an
+acceptance-test result cannot masquerade as an authority grant.
+
+A verifier can establish membership, execution, polarity, and coverage for its
+declared universe. It does not manufacture approval, disclosure authority, or
+permission for the state change it precedes; those remain with their owning
+boundary and principal.
 
 ## Anti-Patterns This Protocol Prevents
 

--- a/skills/synthesis-implementation-integrity/SKILL.md
+++ b/skills/synthesis-implementation-integrity/SKILL.md
@@ -356,9 +356,13 @@ The manifest must declare `membership: closed`, a `production_entry_point`, an
 `expected_status` for each case, and an explicit `unverified_remainder`. Every
 case names the defect that motivated it and a runnable fixture. Every changed
 production surface names at least one case, and every declared case maps back
-to a changed surface. For a defect-pinning change, preserve evidence that the
-fixture commit predates the green implementation; a test added after the code
-cannot prove that it would have caught the original gap.
+to a changed surface. The enforcing boundary supplies the change base and
+derives the actual base-to-head file universe from Git; schema-2 acceptance
+requires exact equality between that authoritative universe and
+`changed_surfaces`. The manifest does not get to declare its own completeness.
+For a defect-pinning change, preserve evidence that the fixture commit predates
+the green implementation; a test added after the code cannot prove that it
+would have caught the original gap.
 
 Run every declared case to a terminal state and distinguish pass, expected
 failure, unexpected failure, execution error, and not-run coverage. A closed
@@ -384,6 +388,13 @@ when the state-changing consumer refuses the operation without a fresh,
 matching, transaction-bound receipt from the declared verifier. Record the
 receipt consumer, the enforcing operation, and the metadata class so an
 acceptance-test result cannot masquerade as an authority grant.
+
+The consumer generates a one-use transaction identifier, supplies the
+authoritative Git base, and recomputes the head commit, tree, manifest digest,
+changed-path set, and changed-path digest after execution. It proceeds only
+when the parsed result binds every one of those fields, all declared cases are
+terminal and matched, and the worktree remains clean. Process exit status by
+itself is not receipt consumption.
 
 A verifier can establish membership, execution, polarity, and coverage for its
 declared universe. It does not manufacture approval, disclosure authority, or

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -15,7 +15,7 @@ changed_surfaces:
   - path: skills/synthesis-context-lifecycle/SKILL.md
     cases: [scripts-tier-contract]
   - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
-    cases: [missing-script-warning, existing-script-accepted, symlink-script-refused]
+    cases: [missing-script-warning, existing-script-accepted, symlink-script-refused, cross-project-script-reference]
   - path: skills/synthesis-implementation-integrity/SKILL.md
     cases: [acceptance-manifest-doctrine, extract-dont-restate, authority-at-boundary]
   - path: skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
@@ -97,6 +97,10 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_artifact_cites_symlinked_script_warns
     motivating_defect: agent-heuristic-cited-script-could-resolve-outside-the-project
+  - id: cross-project-script-reference
+    control_class: acceptance-test
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_cross_project_script_citation_is_not_a_local_missing_script
+    motivating_defect: agent-heuristic-cross-project-reference-was-misread-as-a-project-local-script-citation
   - id: scratchpad-sweep
     control_class: diagnostic
     fixture: scripts/test_r5_contract.py::test_checkpoint_and_autopilot_ask_the_scratchpad_sweep_question

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,7 +1,7 @@
 # AGENT HEURISTIC: R5 is the first suite authored against the generalized
 # executable-manifest contract. The controlling plan specifies the required
 # semantics, while this manifest records the exact public release universe.
-schema: 1
+schema: 2
 suite: synthesis-interoperability-integrity-controls-r5
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -34,9 +34,9 @@ changed_surfaces:
   - path: skills/synthesis-disclosure-policy/SKILL.md
     cases: [category-allowlist]
   - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [release-wiring, release-receipt-consumer]
+    cases: [release-wiring, release-receipt-consumer, release-receipt-binding]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [release-wiring, release-receipt-consumer, ci-receipt-consumer]
+    cases: [release-wiring, release-receipt-consumer, release-receipt-binding, ci-receipt-consumer]
   - path: skills/synthesis-skills-manager/SKILL.md
     cases: [release-wiring]
   - path: .github/workflows/validate.yml
@@ -146,6 +146,10 @@ cases:
     control_class: enforced-gate
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_release_boundary_consumes_fresh_bound_acceptance_receipt
     motivating_defect: review-release-boundary-consumed-subprocess-status-without-validating-a-transaction-bound-result
+  - id: release-receipt-binding
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_release_receipt_validator_rejects_every_binding_mismatch
+    motivating_defect: review-consumer-could-trust-a-result-not-bound-to-the-current-transaction-manifest-or-git-tree
   - id: ci-wiring
     control_class: enforced-gate
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_repository_ci_executes_r5_integrity_suite

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,0 +1,111 @@
+# AGENT HEURISTIC: R5 is the first suite authored against the generalized
+# executable-manifest contract. The controlling plan specifies the required
+# semantics, while this manifest records the exact public release universe.
+schema: 1
+suite: synthesis-interoperability-integrity-controls-r5
+membership: closed
+production_entry_point: scripts/acceptance_suite.py run
+enforcing_boundary: release.py and repository CI before publication
+receipt_consumer: synthesis-skills-manager release.py and repository Validate CI
+expected_status: pass
+metadata_class: acceptance-test
+issues_authority_receipt: false
+unverified_remainder: historical fixture chronology, semantic adequacy outside the declared cases, installed-client parity, independent review, publication, and deployment
+changed_surfaces:
+  - path: skills/synthesis-context-lifecycle/SKILL.md
+    cases: [scripts-tier-contract]
+  - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
+    cases: [missing-script-warning, existing-script-accepted, symlink-script-refused]
+  - path: skills/synthesis-implementation-integrity/SKILL.md
+    cases: [acceptance-manifest-doctrine, extract-dont-restate, authority-at-boundary]
+  - path: skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
+    cases: [manifest-closed-membership, manifest-boundary-and-status, manifest-unique-cases, runner-terminal-matrix, runner-status-mismatch, enforced-gate-consumer, changed-surface-closure]
+  - path: skills/synthesis-checkpoint/SKILL.md
+    cases: [scratchpad-sweep]
+  - path: skills/synthesis-autopilot/SKILL.md
+    cases: [scratchpad-sweep]
+  - path: skills/synthesis-disclosure-policy/SKILL.md
+    cases: [category-allowlist]
+  - path: skills/synthesis-skills-manager/scripts/release.py
+    cases: [release-wiring]
+  - path: .github/workflows/validate.yml
+    cases: [ci-wiring]
+  - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
+    cases: [shipped-manifest-self-consumption]
+cases:
+  - id: manifest-closed-membership
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_manifest_rejects_open_membership
+    motivating_defect: engagement-author-written-suite-had-no-closed-declared-universe
+  - id: manifest-boundary-and-status
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_manifest_requires_boundary_and_expected_status
+    motivating_defect: engagement-suite-described-tests-without-naming-the-boundary-or-terminal-expectation
+  - id: manifest-unique-cases
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_manifest_rejects_duplicate_case_ids
+    motivating_defect: engagement-duplicate-probe-identities-collapsed-before-coverage-was-checked
+  - id: runner-terminal-matrix
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_runner_records_every_probe_terminal_state
+    motivating_defect: engagement-crashed-attack-left-unrun-probes-indistinguishable-from-adjudicated-probes
+  - id: runner-status-mismatch
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_runner_refuses_expected_status_mismatch
+    motivating_defect: engagement-exit-status-was-treated-as-coverage-and-expected-polarity
+  - id: enforced-gate-consumer
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_enforced_gate_requires_receipt_consumer
+    motivating_defect: engagement-standalone-verifier-was-presented-as-enforcement-authority
+  - id: changed-surface-closure
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_changed_surfaces_reference_existing_cases
+    motivating_defect: engagement-changed-surfaces-reached-green-without-a-defect-pinning-fixture
+  - id: shipped-manifest-self-consumption
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates
+    motivating_defect: engagement-suite-manifest-was-a-sidecar-claim-not-consumed-by-its-own-tool
+  - id: scripts-tier-contract
+    control_class: diagnostic
+    fixture: scripts/test_r5_contract.py::test_scripts_tier_contract_is_owned_by_context_lifecycle
+    motivating_defect: intake-executable-working-state-had-no-durable-tier
+  - id: missing-script-warning
+    control_class: acceptance-test
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_artifact_cites_missing_script_warns
+    motivating_defect: intake-context-doctor-reported-healthy-while-cited-working-code-was-ephemeral
+  - id: existing-script-accepted
+    control_class: acceptance-test
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_artifact_cites_existing_script_passes
+    motivating_defect: agent-heuristic-missing-script-detector-could-cry-wolf-on-the-reference-layout
+  - id: symlink-script-refused
+    control_class: acceptance-test
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_artifact_cites_symlinked_script_warns
+    motivating_defect: agent-heuristic-cited-script-could-resolve-outside-the-project
+  - id: scratchpad-sweep
+    control_class: diagnostic
+    fixture: scripts/test_r5_contract.py::test_checkpoint_and_autopilot_ask_the_scratchpad_sweep_question
+    motivating_defect: intake-executable-state-died-with-the-originating-session
+  - id: acceptance-manifest-doctrine
+    control_class: diagnostic
+    fixture: scripts/test_r5_contract.py::test_integrity_requires_executable_closed_acceptance_manifests
+    motivating_defect: engagement-author-written-acceptance-suite-was-trusted-as-independent-proof
+  - id: extract-dont-restate
+    control_class: diagnostic
+    fixture: scripts/test_r5_contract.py::test_integrity_requires_extract_dont_restate
+    motivating_defect: engagement-two-parsers-restated-one-author-and-shared-the-same-blind-spot
+  - id: authority-at-boundary
+    control_class: diagnostic
+    fixture: scripts/test_r5_contract.py::test_integrity_locates_authority_at_the_state_changing_boundary
+    motivating_defect: engagement-standalone-check-was-confused-with-a-required-receipt-consumer
+  - id: category-allowlist
+    control_class: diagnostic
+    fixture: scripts/test_r5_contract.py::test_disclosure_categories_preserve_attention_for_real_approval_gates
+    motivating_defect: intake-trivial-naming-gates-trained-principal-rubber-stamping
+  - id: release-wiring
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_required_checks_execute_r5_integrity_suite
+    motivating_defect: engagement-new-acceptance-control-could-remain-outside-the-gated-release
+  - id: ci-wiring
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_repository_ci_executes_r5_integrity_suite
+    motivating_defect: engagement-local-release-check-and-pr-ci-could-verify-different-universes

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -19,7 +19,7 @@ changed_surfaces:
   - path: skills/synthesis-implementation-integrity/SKILL.md
     cases: [acceptance-manifest-doctrine, extract-dont-restate, authority-at-boundary]
   - path: skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
-    cases: [manifest-closed-membership, manifest-boundary-and-status, manifest-unique-cases, runner-terminal-matrix, runner-status-mismatch, enforced-gate-consumer, changed-surface-closure]
+    cases: [manifest-closed-membership, manifest-boundary-and-status, manifest-unique-cases, runner-terminal-matrix, runner-status-mismatch, enforced-gate-consumer, changed-surface-closure, manifest-root-relative, manifest-symlink-refused]
   - path: skills/synthesis-checkpoint/SKILL.md
     cases: [scratchpad-sweep]
   - path: skills/synthesis-autopilot/SKILL.md
@@ -28,8 +28,16 @@ changed_surfaces:
     cases: [category-allowlist]
   - path: skills/synthesis-skills-manager/scripts/release.py
     cases: [release-wiring]
+  - path: skills/synthesis-skills-manager/SKILL.md
+    cases: [release-wiring]
   - path: .github/workflows/validate.yml
     cases: [ci-wiring]
+  - path: .claude-plugin/plugin.json
+    cases: [release-wiring]
+  - path: .codex-plugin/plugin.json
+    cases: [release-wiring]
+  - path: CHANGELOG.md
+    cases: [release-wiring]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
 cases:
@@ -61,6 +69,14 @@ cases:
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_changed_surfaces_reference_existing_cases
     motivating_defect: engagement-changed-surfaces-reached-green-without-a-defect-pinning-fixture
+  - id: manifest-root-relative
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_manifest_path_is_resolved_from_repo_root
+    motivating_defect: agent-heuristic-relative-manifest-path-depended-on-caller-working-directory
+  - id: manifest-symlink-refused
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_manifest_rejects_symlinked_fixture
+    motivating_defect: agent-heuristic-fixture-could-leave-the-declared-repository-through-a-symlink
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -34,9 +34,9 @@ changed_surfaces:
   - path: skills/synthesis-disclosure-policy/SKILL.md
     cases: [category-allowlist]
   - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [release-wiring, release-receipt-consumer, release-receipt-binding]
+    cases: [release-wiring, release-receipt-consumer, release-receipt-binding, publish-boundary-expiry, publish-exact-ref, publish-authority-topology]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [release-wiring, release-receipt-consumer, release-receipt-binding, ci-receipt-consumer]
+    cases: [release-wiring, release-receipt-consumer, release-receipt-binding, ci-receipt-consumer, publish-boundary-expiry, publish-exact-ref, publish-authority-topology]
   - path: skills/synthesis-skills-manager/SKILL.md
     cases: [release-wiring]
   - path: .github/workflows/validate.yml
@@ -158,3 +158,15 @@ cases:
     control_class: enforced-gate
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_repository_ci_uses_receipt_consumer_with_authoritative_base
     motivating_defect: review-ci-invoked-the-runner-directly-without-a-boundary-supplied-base-or-result-consumer
+  - id: publish-boundary-expiry
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_publish_refuses_when_receipt_bound_head_changes
+    motivating_defect: terminal-review-accepted-head-was-discarded-before-the-state-changing-publish-boundary
+  - id: publish-exact-ref
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_publish_dry_run_names_exact_receipt_bound_ref
+    motivating_defect: terminal-review-publish-resolved-a-mutable-main-branch-after-acceptance-consumption
+  - id: publish-authority-topology
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_main_carries_acceptance_authority_to_publish_boundary
+    motivating_defect: terminal-review-run-required-checks-collapsed-the-accepted-state-to-a-boolean-before-publish

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -6,20 +6,27 @@ suite: synthesis-interoperability-integrity-controls-r5
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run
 enforcing_boundary: release.py and repository CI before publication
-receipt_consumer: synthesis-skills-manager release.py and repository Validate CI
+receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
+change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: historical fixture chronology, semantic adequacy outside the declared cases, installed-client parity, independent review, publication, and deployment
+unverified_remainder: historical fixture chronology, semantic adequacy beyond the authoritative base-to-head Git diff and declared cases, installed-client parity, independent review, publication, and deployment
 changed_surfaces:
   - path: skills/synthesis-context-lifecycle/SKILL.md
     cases: [scripts-tier-contract]
   - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
     cases: [missing-script-warning, existing-script-accepted, symlink-script-refused, cross-project-script-reference]
+  - path: skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
+    cases: [missing-script-warning, existing-script-accepted, symlink-script-refused, cross-project-script-reference]
   - path: skills/synthesis-implementation-integrity/SKILL.md
     cases: [acceptance-manifest-doctrine, extract-dont-restate, authority-at-boundary]
   - path: skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
-    cases: [manifest-closed-membership, manifest-boundary-and-status, manifest-unique-cases, runner-terminal-matrix, runner-status-mismatch, enforced-gate-consumer, changed-surface-closure, manifest-root-relative, manifest-symlink-refused]
+    cases: [manifest-closed-membership, manifest-boundary-and-status, manifest-unique-cases, runner-terminal-matrix, runner-status-mismatch, enforced-gate-consumer, changed-surface-closure, manifest-root-relative, manifest-symlink-refused, authoritative-git-change-universe, transaction-bound-receipt]
+  - path: skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+    cases: [manifest-closed-membership, manifest-boundary-and-status, manifest-unique-cases, runner-terminal-matrix, runner-status-mismatch, enforced-gate-consumer, changed-surface-closure, manifest-root-relative, manifest-symlink-refused, authoritative-git-change-universe, transaction-bound-receipt, shipped-manifest-self-consumption]
+  - path: skills/synthesis-implementation-integrity/scripts/test_r5_contract.py
+    cases: [scripts-tier-contract, scratchpad-sweep, acceptance-manifest-doctrine, extract-dont-restate, authority-at-boundary, category-allowlist]
   - path: skills/synthesis-checkpoint/SKILL.md
     cases: [scratchpad-sweep]
   - path: skills/synthesis-autopilot/SKILL.md
@@ -27,11 +34,13 @@ changed_surfaces:
   - path: skills/synthesis-disclosure-policy/SKILL.md
     cases: [category-allowlist]
   - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [release-wiring]
+    cases: [release-wiring, release-receipt-consumer]
+  - path: skills/synthesis-skills-manager/scripts/test_release.py
+    cases: [release-wiring, release-receipt-consumer, ci-receipt-consumer]
   - path: skills/synthesis-skills-manager/SKILL.md
     cases: [release-wiring]
   - path: .github/workflows/validate.yml
-    cases: [ci-wiring]
+    cases: [ci-wiring, ci-receipt-consumer]
   - path: .claude-plugin/plugin.json
     cases: [release-wiring]
   - path: .codex-plugin/plugin.json
@@ -77,6 +86,14 @@ cases:
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_manifest_rejects_symlinked_fixture
     motivating_defect: agent-heuristic-fixture-could-leave-the-declared-repository-through-a-symlink
+  - id: authoritative-git-change-universe
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_schema2_rejects_undeclared_git_changed_surface
+    motivating_defect: review-author-declared-changed-surfaces-omitted-a-broken-production-file-while-remaining-green
+  - id: transaction-bound-receipt
+    control_class: acceptance-test
+    fixture: scripts/test_acceptance_suite.py::test_schema2_receipt_binds_transaction_and_git_state
+    motivating_defect: review-runner-result-was-not-bound-to-the-release-transaction-or-exact-git-state
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates
@@ -125,7 +142,15 @@ cases:
     control_class: enforced-gate
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_required_checks_execute_r5_integrity_suite
     motivating_defect: engagement-new-acceptance-control-could-remain-outside-the-gated-release
+  - id: release-receipt-consumer
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_release_boundary_consumes_fresh_bound_acceptance_receipt
+    motivating_defect: review-release-boundary-consumed-subprocess-status-without-validating-a-transaction-bound-result
   - id: ci-wiring
     control_class: enforced-gate
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_repository_ci_executes_r5_integrity_suite
     motivating_defect: engagement-local-release-check-and-pr-ci-could-verify-different-universes
+  - id: ci-receipt-consumer
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_repository_ci_uses_receipt_consumer_with_authoritative_base
+    motivating_defect: review-ci-invoked-the-runner-directly-without-a-boundary-supplied-base-or-result-consumer

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -37,6 +37,8 @@ changed_surfaces:
     cases: [release-wiring, release-receipt-consumer, release-receipt-binding, publish-boundary-expiry, publish-exact-ref, publish-authority-topology]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
     cases: [release-wiring, release-receipt-consumer, release-receipt-binding, ci-receipt-consumer, ci-authoritative-base-available, publish-boundary-expiry, publish-exact-ref, publish-authority-topology]
+  - path: skills/synthesis-project-management/scripts/test_coordination.py
+    cases: [coordinated-pointer-fallback-fixture]
   - path: skills/synthesis-skills-manager/SKILL.md
     cases: [release-wiring]
   - path: .github/workflows/validate.yml
@@ -98,6 +100,10 @@ cases:
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates
     motivating_defect: engagement-suite-manifest-was-a-sidecar-claim-not-consumed-by-its-own-tool
+  - id: coordinated-pointer-fallback-fixture
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_r4_active_pointer_resolves_committing_session
+    motivating_defect: agent-heuristic-pointer-fallback-fixture-inherited-the-real-coordination-session-and-failed-the-release-gate
   - id: scripts-tier-contract
     control_class: diagnostic
     fixture: scripts/test_r5_contract.py::test_scripts_tier_contract_is_owned_by_context_lifecycle

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -36,11 +36,11 @@ changed_surfaces:
   - path: skills/synthesis-skills-manager/scripts/release.py
     cases: [release-wiring, release-receipt-consumer, release-receipt-binding, publish-boundary-expiry, publish-exact-ref, publish-authority-topology]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [release-wiring, release-receipt-consumer, release-receipt-binding, ci-receipt-consumer, publish-boundary-expiry, publish-exact-ref, publish-authority-topology]
+    cases: [release-wiring, release-receipt-consumer, release-receipt-binding, ci-receipt-consumer, ci-authoritative-base-available, publish-boundary-expiry, publish-exact-ref, publish-authority-topology]
   - path: skills/synthesis-skills-manager/SKILL.md
     cases: [release-wiring]
   - path: .github/workflows/validate.yml
-    cases: [ci-wiring, ci-receipt-consumer]
+    cases: [ci-wiring, ci-receipt-consumer, ci-authoritative-base-available]
   - path: .claude-plugin/plugin.json
     cases: [release-wiring]
   - path: .codex-plugin/plugin.json
@@ -158,6 +158,10 @@ cases:
     control_class: enforced-gate
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_repository_ci_uses_receipt_consumer_with_authoritative_base
     motivating_defect: review-ci-invoked-the-runner-directly-without-a-boundary-supplied-base-or-result-consumer
+  - id: ci-authoritative-base-available
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_repository_ci_fetches_authoritative_base_history
+    motivating_defect: pr-ci-named-the-event-base-sha-but-shallow-checkout-made-that-revision-unavailable
   - id: publish-boundary-expiry
     control_class: enforced-gate
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_publish_refuses_when_receipt_bound_head_changes

--- a/skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
@@ -8,8 +8,10 @@ approval or replace the state-changing boundary that consumes its result.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -23,6 +25,10 @@ except Exception:  # pragma: no cover - exercised only in dependency failure
 
 VALID_EXPECTED_STATUSES = {"pass", "fail"}
 VALID_SCHEMAS = {1, 2}
+SCHEMA2_CHANGE_BASE_POLICY = "boundary-supplied-git-diff"
+SCHEMA2_RECEIPT_CONSUMER = (
+    "synthesis-skills-manager.release.consume-acceptance.v1"
+)
 
 
 class ManifestError(Exception):
@@ -69,6 +75,32 @@ def _nonempty_string(document: dict[str, Any], field: str, errors: list[str]) ->
         errors.append(f"{field} must be a non-empty string")
         return ""
     return value.strip()
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _git(root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(root), *arguments],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise ManifestError(f"git evidence could not be established: {exc}") from exc
+
+
+def _git_value(root: Path, *arguments: str, label: str) -> str:
+    completed = _git(root, *arguments)
+    value = completed.stdout.strip()
+    if completed.returncode != 0 or not value:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "no output"
+        raise ManifestError(f"{label} could not be established: {detail}")
+    return value
 
 
 def _load_manifest(path: Path, root: Path) -> tuple[Path, dict[str, Any]]:
@@ -179,7 +211,19 @@ def validate_manifest(
         )
 
     if has_enforced_gate:
-        _nonempty_string(document, "receipt_consumer", errors)
+        receipt_consumer = _nonempty_string(document, "receipt_consumer", errors)
+    else:
+        receipt_consumer = str(document.get("receipt_consumer") or "").strip()
+
+    if schema == 2:
+        if document.get("change_base_policy") != SCHEMA2_CHANGE_BASE_POLICY:
+            errors.append(
+                f"schema 2 change_base_policy must be {SCHEMA2_CHANGE_BASE_POLICY}"
+            )
+        if receipt_consumer != SCHEMA2_RECEIPT_CONSUMER:
+            errors.append(
+                f"schema 2 receipt_consumer must be {SCHEMA2_RECEIPT_CONSUMER}"
+            )
 
     raw_surfaces = document.get("changed_surfaces")
     if schema == 2 and (not isinstance(raw_surfaces, list) or not raw_surfaces):
@@ -192,6 +236,7 @@ def validate_manifest(
         raw_surfaces = []
 
     mapped_cases: set[str] = set()
+    surface_paths: set[str] = set()
     surface_records: list[dict[str, Any]] = []
     for position, raw_surface in enumerate(raw_surfaces):
         label = f"changed_surfaces[{position}]"
@@ -201,11 +246,19 @@ def validate_manifest(
         raw_path = raw_surface.get("path")
         if not isinstance(raw_path, str) or not raw_path.strip():
             errors.append(f"{label}.path must be a non-empty string")
+            normalized_path = ""
         else:
             try:
-                _bounded_regular_file(root / raw_path, root, f"{label}.path")
+                surface_file = _bounded_regular_file(
+                    root / raw_path, root, f"{label}.path"
+                )
+                normalized_path = surface_file.relative_to(root).as_posix()
+                if normalized_path in surface_paths:
+                    errors.append(f"duplicate changed surface: {normalized_path}")
+                surface_paths.add(normalized_path)
             except ManifestError as exc:
                 errors.append(str(exc))
+                normalized_path = raw_path
 
         surface_cases = raw_surface.get("cases")
         if not isinstance(surface_cases, list) or not surface_cases:
@@ -218,7 +271,7 @@ def validate_manifest(
                 errors.append(f"{label}.cases references unknown case {mapped_id}")
             else:
                 mapped_cases.add(mapped_id)
-        surface_records.append({"path": raw_path, "cases": surface_cases})
+        surface_records.append({"path": normalized_path, "cases": surface_cases})
 
     if schema == 2:
         for case_id in sorted(case_ids - mapped_cases):
@@ -233,6 +286,114 @@ def validate_manifest(
         "cases": case_records,
         "changed_surfaces": surface_records,
     }, []
+
+
+def authoritative_git_evidence(
+    validated: dict[str, Any],
+    root: Path,
+    change_base: str | None,
+    transaction_id: str | None,
+) -> dict[str, Any]:
+    """Bind a schema-2 run to the boundary-selected Git change universe."""
+
+    if not change_base:
+        raise ManifestError(
+            "schema 2 run requires a boundary-supplied --change-base"
+        )
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]{0,255}", change_base):
+        raise ManifestError("change-base is not a safe Git revision")
+    if not transaction_id or not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}", transaction_id
+    ):
+        raise ManifestError(
+            "schema 2 run requires a valid boundary-supplied --transaction-id"
+        )
+
+    inside = _git(root, "rev-parse", "--is-inside-work-tree")
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        raise ManifestError(
+            "authoritative Git change universe is unavailable: repo-root is not a Git worktree"
+        )
+    dirty = _git(root, "status", "--porcelain", "--untracked-files=all")
+    if dirty.returncode != 0:
+        raise ManifestError(
+            "authoritative Git change universe is unavailable: git status failed"
+        )
+    if dirty.stdout.strip():
+        raise ManifestError(
+            "authoritative Git change universe requires a clean worktree"
+        )
+
+    base_sha = _git_value(
+        root,
+        "rev-parse",
+        "--verify",
+        f"{change_base}^{{commit}}",
+        label="change-base commit",
+    )
+    head_sha = _git_value(
+        root,
+        "rev-parse",
+        "--verify",
+        "HEAD^{commit}",
+        label="change-head commit",
+    )
+    ancestor = _git(root, "merge-base", "--is-ancestor", base_sha, head_sha)
+    if ancestor.returncode != 0:
+        raise ManifestError(
+            "boundary-supplied change-base is not an ancestor of HEAD"
+        )
+    head_tree = _git_value(
+        root,
+        "rev-parse",
+        "--verify",
+        f"{head_sha}^{{tree}}",
+        label="change-head tree",
+    )
+    changed = _git(
+        root,
+        "diff",
+        "--name-only",
+        "--diff-filter=ACDMRTUXB",
+        f"{base_sha}..{head_sha}",
+        "--",
+    )
+    if changed.returncode != 0:
+        detail = changed.stderr.strip() or "git diff failed"
+        raise ManifestError(
+            f"authoritative Git change universe could not be established: {detail}"
+        )
+    changed_paths = sorted(
+        {line.strip() for line in changed.stdout.splitlines() if line.strip()}
+    )
+    declared_paths = sorted(
+        {surface["path"] for surface in validated["changed_surfaces"]}
+    )
+    undeclared = sorted(set(changed_paths) - set(declared_paths))
+    not_changed = sorted(set(declared_paths) - set(changed_paths))
+    if undeclared or not_changed:
+        details: list[str] = []
+        if undeclared:
+            details.append("undeclared changed path(s): " + ", ".join(undeclared))
+        if not_changed:
+            details.append("declared but unchanged path(s): " + ", ".join(not_changed))
+        raise ManifestError(
+            "authoritative Git change universe does not equal changed_surfaces: "
+            + "; ".join(details)
+        )
+
+    manifest_bytes = validated["manifest"].read_bytes()
+    changed_serialized = ("\n".join(changed_paths) + "\n").encode("utf-8")
+    return {
+        "receipt_schema": "acceptance-run-receipt-v1",
+        "transaction_id": transaction_id,
+        "change_base": base_sha,
+        "change_head": head_sha,
+        "head_tree": head_tree,
+        "manifest_sha256": _sha256_bytes(manifest_bytes),
+        "changed_paths": changed_paths,
+        "changed_paths_sha256": _sha256_bytes(changed_serialized),
+    }
 
 
 def validation_receipt(validated: dict[str, Any]) -> dict[str, Any]:
@@ -252,7 +413,11 @@ def validation_receipt(validated: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def execute(validated: dict[str, Any], root: Path) -> tuple[dict[str, Any], int]:
+def execute(
+    validated: dict[str, Any],
+    root: Path,
+    git_evidence: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], int]:
     document = validated["document"]
     results: list[dict[str, Any]] = []
     for case in validated["cases"]:
@@ -313,6 +478,8 @@ def execute(validated: dict[str, Any], root: Path) -> tuple[dict[str, Any], int]
         case["matched"] for case in results
     )
     receipt = validation_receipt(validated)
+    if git_evidence:
+        receipt.update(git_evidence)
     receipt.update(
         {
             "ok": ok,
@@ -362,6 +529,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--manifest", required=True)
     parser.add_argument("--repo-root", required=True)
     parser.add_argument("--json", action="store_true")
+    parser.add_argument("--change-base")
+    parser.add_argument("--transaction-id")
     return parser.parse_args(argv)
 
 
@@ -382,7 +551,19 @@ def main(argv: list[str] | None = None) -> int:
     if args.action == "validate":
         emit(validation_receipt(validated), args.json)
         return 0
-    payload, returncode = execute(validated, root)
+    git_evidence = None
+    if validated["document"]["schema"] == 2:
+        try:
+            git_evidence = authoritative_git_evidence(
+                validated,
+                root,
+                args.change_base,
+                args.transaction_id,
+            )
+        except ManifestError as exc:
+            emit({"ok": False, "errors": [str(exc)]}, args.json)
+            return 2
+    payload, returncode = execute(validated, root, git_evidence)
     emit(payload, args.json)
     return returncode
 

--- a/skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Validate and execute a closed, defect-pinned acceptance manifest.
+
+The manifest is evidence about a declared test universe. It does not grant
+approval or replace the state-changing boundary that consumes its result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - exercised only in dependency failure
+    yaml = None
+
+
+VALID_EXPECTED_STATUSES = {"pass", "fail"}
+VALID_SCHEMAS = {1, 2}
+
+
+class ManifestError(Exception):
+    """The declared acceptance universe cannot be established."""
+
+
+def _canonical_root(raw: str) -> Path:
+    root = Path(raw).expanduser()
+    try:
+        root = root.resolve(strict=True)
+    except OSError as exc:
+        raise ManifestError(f"repo-root is not readable: {root}: {exc}") from exc
+    if not root.is_dir():
+        raise ManifestError(f"repo-root is not a directory: {root}")
+    return root
+
+
+def _lexical_path(raw: Path) -> Path:
+    return Path(os.path.abspath(os.fspath(raw.expanduser())))
+
+
+def _bounded_regular_file(path: Path, root: Path, label: str) -> Path:
+    """Require a regular file inside root without traversing a symlink."""
+
+    candidate = _lexical_path(path)
+    try:
+        relative = candidate.relative_to(root)
+    except ValueError as exc:
+        raise ManifestError(f"{label} escapes repo-root: {path}") from exc
+
+    cursor = root
+    for part in relative.parts:
+        cursor = cursor / part
+        if cursor.is_symlink():
+            raise ManifestError(f"{label} traverses a symlink: {path}")
+    if not candidate.is_file():
+        raise ManifestError(f"{label} is not a regular file: {path}")
+    return candidate
+
+
+def _nonempty_string(document: dict[str, Any], field: str, errors: list[str]) -> str:
+    value = document.get(field)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{field} must be a non-empty string")
+        return ""
+    return value.strip()
+
+
+def _load_manifest(path: Path, root: Path) -> tuple[Path, dict[str, Any]]:
+    if yaml is None:
+        raise ManifestError("PyYAML is required to read acceptance manifests")
+    manifest = _bounded_regular_file(path, root, "manifest")
+    try:
+        loaded = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise ManifestError(f"manifest is unreadable: {manifest}: {exc}") from exc
+    if not isinstance(loaded, dict):
+        raise ManifestError("manifest root must be a mapping")
+    return manifest, loaded
+
+
+def validate_manifest(
+    manifest_path: Path, root: Path
+) -> tuple[dict[str, Any] | None, list[str]]:
+    try:
+        manifest_file, document = _load_manifest(manifest_path, root)
+    except ManifestError as exc:
+        return None, [str(exc)]
+
+    errors: list[str] = []
+    schema = document.get("schema")
+    if (
+        not isinstance(schema, int)
+        or isinstance(schema, bool)
+        or schema not in VALID_SCHEMAS
+    ):
+        errors.append(f"schema must be one of {sorted(VALID_SCHEMAS)}")
+    _nonempty_string(document, "suite", errors)
+    if document.get("membership") != "closed":
+        errors.append("membership must be closed")
+    _nonempty_string(document, "production_entry_point", errors)
+    _nonempty_string(document, "enforcing_boundary", errors)
+    expected_default = _nonempty_string(document, "expected_status", errors)
+    if expected_default and expected_default not in VALID_EXPECTED_STATUSES:
+        errors.append("expected_status must be pass or fail")
+    _nonempty_string(document, "unverified_remainder", errors)
+
+    raw_cases = document.get("cases")
+    if not isinstance(raw_cases, list) or not raw_cases:
+        errors.append("cases must be a non-empty list")
+        raw_cases = []
+
+    case_ids: set[str] = set()
+    case_records: list[dict[str, Any]] = []
+    has_enforced_gate = False
+    for position, raw_case in enumerate(raw_cases):
+        label = f"cases[{position}]"
+        if not isinstance(raw_case, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        case_id = raw_case.get("id")
+        if not isinstance(case_id, str) or not case_id.strip():
+            errors.append(f"{label}.id must be a non-empty string")
+            continue
+        case_id = case_id.strip()
+        if case_id in case_ids:
+            errors.append(f"duplicate case id: {case_id}")
+        case_ids.add(case_id)
+
+        control_class = raw_case.get("control_class")
+        if not isinstance(control_class, str) or not control_class.strip():
+            errors.append(f"case {case_id} control_class must be a non-empty string")
+        elif control_class == "enforced-gate":
+            has_enforced_gate = True
+
+        motivating_defect = raw_case.get("motivating_defect")
+        if not isinstance(motivating_defect, str) or not motivating_defect.strip():
+            errors.append(
+                f"case {case_id} motivating_defect must be a non-empty string"
+            )
+
+        expected = raw_case.get("expected_status", expected_default)
+        if expected not in VALID_EXPECTED_STATUSES:
+            errors.append(f"case {case_id} expected_status must be pass or fail")
+
+        fixture = raw_case.get("fixture")
+        fixture_file: Path | None = None
+        fixture_node = ""
+        if not isinstance(fixture, str) or "::" not in fixture:
+            errors.append(f"case {case_id} fixture must use file.py::node syntax")
+        else:
+            fixture_path_raw, fixture_node = fixture.split("::", 1)
+            if not fixture_path_raw or not fixture_node:
+                errors.append(f"case {case_id} fixture must use file.py::node syntax")
+            else:
+                try:
+                    fixture_file = _bounded_regular_file(
+                        manifest_file.parent / fixture_path_raw,
+                        root,
+                        f"case {case_id} fixture",
+                    )
+                except ManifestError as exc:
+                    errors.append(str(exc))
+
+        case_records.append(
+            {
+                "id": case_id,
+                "control_class": control_class,
+                "motivating_defect": motivating_defect,
+                "expected_status": expected,
+                "fixture_file": fixture_file,
+                "fixture_node": fixture_node,
+            }
+        )
+
+    if has_enforced_gate:
+        _nonempty_string(document, "receipt_consumer", errors)
+
+    raw_surfaces = document.get("changed_surfaces")
+    if schema == 2 and (not isinstance(raw_surfaces, list) or not raw_surfaces):
+        errors.append("schema 2 changed_surfaces must be a non-empty list")
+        raw_surfaces = []
+    elif raw_surfaces is None:
+        raw_surfaces = []
+    elif not isinstance(raw_surfaces, list):
+        errors.append("changed_surfaces must be a list")
+        raw_surfaces = []
+
+    mapped_cases: set[str] = set()
+    surface_records: list[dict[str, Any]] = []
+    for position, raw_surface in enumerate(raw_surfaces):
+        label = f"changed_surfaces[{position}]"
+        if not isinstance(raw_surface, dict):
+            errors.append(f"{label} must be a mapping")
+            continue
+        raw_path = raw_surface.get("path")
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            errors.append(f"{label}.path must be a non-empty string")
+        else:
+            try:
+                _bounded_regular_file(root / raw_path, root, f"{label}.path")
+            except ManifestError as exc:
+                errors.append(str(exc))
+
+        surface_cases = raw_surface.get("cases")
+        if not isinstance(surface_cases, list) or not surface_cases:
+            errors.append(f"{label}.cases must be a non-empty list")
+            surface_cases = []
+        for mapped_id in surface_cases:
+            if not isinstance(mapped_id, str) or not mapped_id:
+                errors.append(f"{label}.cases contains an invalid case id")
+            elif mapped_id not in case_ids:
+                errors.append(f"{label}.cases references unknown case {mapped_id}")
+            else:
+                mapped_cases.add(mapped_id)
+        surface_records.append({"path": raw_path, "cases": surface_cases})
+
+    if schema == 2:
+        for case_id in sorted(case_ids - mapped_cases):
+            errors.append(f"case {case_id} is not mapped to a changed surface")
+
+    if errors:
+        return None, errors
+
+    return {
+        "document": document,
+        "manifest": manifest_file,
+        "cases": case_records,
+        "changed_surfaces": surface_records,
+    }, []
+
+
+def validation_receipt(validated: dict[str, Any]) -> dict[str, Any]:
+    document = validated["document"]
+    return {
+        "ok": True,
+        "schema": document["schema"],
+        "suite": document["suite"],
+        "membership": document["membership"],
+        "cases_declared": len(validated["cases"]),
+        "production_entry_point": document["production_entry_point"],
+        "enforcing_boundary": document["enforcing_boundary"],
+        "receipt_consumer": document.get("receipt_consumer"),
+        "metadata_class": document.get("metadata_class", "acceptance-test"),
+        "issues_authority_receipt": False,
+        "unverified_remainder": document["unverified_remainder"],
+    }
+
+
+def execute(validated: dict[str, Any], root: Path) -> tuple[dict[str, Any], int]:
+    document = validated["document"]
+    results: list[dict[str, Any]] = []
+    for case in validated["cases"]:
+        node_id = f"{case['fixture_file']}::{case['fixture_node']}"
+        try:
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "-q",
+                    "-p",
+                    "no:cacheprovider",
+                    node_id,
+                ],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=False,
+                env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+                timeout=300,
+            )
+            status = (
+                "passed"
+                if completed.returncode == 0
+                else "failed"
+                if completed.returncode == 1
+                else "errored"
+            )
+            returncode: int | None = completed.returncode
+            stdout = completed.stdout
+            stderr = completed.stderr
+        except (OSError, subprocess.SubprocessError) as exc:
+            status = "errored"
+            returncode = None
+            stdout = ""
+            stderr = str(exc)
+
+        expected = case["expected_status"]
+        matched = status == {"pass": "passed", "fail": "failed"}[expected]
+        results.append(
+            {
+                "id": case["id"],
+                "control_class": case["control_class"],
+                "motivating_defect": case["motivating_defect"],
+                "fixture": node_id,
+                "status": status,
+                "expected_status": expected,
+                "matched": matched,
+                "returncode": returncode,
+                "stdout": stdout,
+                "stderr": stderr,
+            }
+        )
+
+    terminal = len(results)
+    ok = terminal == len(validated["cases"]) and all(
+        case["matched"] for case in results
+    )
+    receipt = validation_receipt(validated)
+    receipt.update(
+        {
+            "ok": ok,
+            "coverage": {
+                "declared": len(validated["cases"]),
+                "terminal": terminal,
+                "not_run": len(validated["cases"]) - terminal,
+            },
+            "cases": results,
+        }
+    )
+    return receipt, 0 if ok else 1
+
+
+def emit(payload: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    if "errors" in payload:
+        for error in payload["errors"]:
+            print(f"ERROR {error}")
+        return
+    if "cases" in payload:
+        for case in payload["cases"]:
+            marker = "PASS" if case["matched"] else "FAIL"
+            print(
+                f"{marker} {case['id']}: {case['status']} "
+                f"(expected {case['expected_status']})"
+            )
+        coverage = payload["coverage"]
+        print(
+            f"acceptance suite: {coverage['terminal']}/{coverage['declared']} "
+            f"terminal; {coverage['not_run']} not run"
+        )
+        return
+    print(
+        f"acceptance manifest: {payload['cases_declared']} declared case(s); "
+        f"membership={payload['membership']}"
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate or run a closed acceptance manifest."
+    )
+    parser.add_argument("action", choices=("validate", "run"))
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        root = _canonical_root(args.repo_root)
+    except ManifestError as exc:
+        emit({"ok": False, "errors": [str(exc)]}, args.json)
+        return 2
+    manifest_path = Path(args.manifest).expanduser()
+    if not manifest_path.is_absolute():
+        manifest_path = root / manifest_path
+    validated, errors = validate_manifest(manifest_path, root)
+    if validated is None:
+        emit({"ok": False, "errors": errors}, args.json)
+        return 2
+    if args.action == "validate":
+        emit(validation_receipt(validated), args.json)
+        return 0
+    payload, returncode = execute(validated, root)
+    emit(payload, args.json)
+    return returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -329,4 +329,5 @@ def test_shipped_manifest_validates() -> None:
     result = json.loads(completed.stdout)
     assert result["ok"] is True
     assert result["membership"] == "closed"
-    assert result["cases_declared"] == 31
+    # AGENT HEURISTIC: the coordinated-shell fixture is the 32nd closed case.
+    assert result["cases_declared"] == 32

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RUNNER = SCRIPT_DIR / "acceptance_suite.py"
+SKILL_ROOT = SCRIPT_DIR.parent
+REPO_ROOT = SKILL_ROOT.parents[1]
+
+
+def fixture_file(root: Path) -> Path:
+    tests = root / "tests"
+    tests.mkdir(parents=True, exist_ok=True)
+    target = tests / "test_probe.py"
+    target.write_text(
+        "def test_pass():\n    assert True\n\n"
+        "def test_fail():\n    assert False\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+def manifest_payload() -> dict:
+    return {
+        "schema": 1,
+        "suite": "fixture-suite",
+        "membership": "closed",
+        "production_entry_point": "tool.py run",
+        "enforcing_boundary": "before fixture state change",
+        "receipt_consumer": "fixture boundary",
+        "expected_status": "pass",
+        "unverified_remainder": "behavior outside declared probes",
+        "changed_surfaces": [
+            {"path": "tool.py", "cases": ["passing-probe"]},
+        ],
+        "cases": [
+            {
+                "id": "passing-probe",
+                "control_class": "acceptance-test",
+                "fixture": "tests/test_probe.py::test_pass",
+                "motivating_defect": "fixture-defect",
+            }
+        ],
+    }
+
+
+def write_manifest(root: Path, payload: dict) -> Path:
+    path = root / "acceptance-suite.yaml"
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def run_cli(root: Path, action: str, manifest: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            action,
+            "--manifest",
+            str(manifest),
+            "--repo-root",
+            str(root),
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_manifest_rejects_open_membership(tmp_path: Path) -> None:
+    fixture_file(tmp_path)
+    payload = manifest_payload()
+    payload["membership"] = "open"
+    completed = run_cli(tmp_path, "validate", write_manifest(tmp_path, payload))
+
+    assert completed.returncode == 2
+    assert "membership must be closed" in completed.stdout
+
+
+def test_manifest_requires_boundary_and_expected_status(tmp_path: Path) -> None:
+    fixture_file(tmp_path)
+    for missing, message in (
+        ("enforcing_boundary", "enforcing_boundary"),
+        ("expected_status", "expected_status"),
+    ):
+        payload = manifest_payload()
+        payload.pop(missing)
+        completed = run_cli(tmp_path, "validate", write_manifest(tmp_path, payload))
+        assert completed.returncode == 2
+        assert message in completed.stdout
+
+
+def test_manifest_rejects_duplicate_case_ids(tmp_path: Path) -> None:
+    fixture_file(tmp_path)
+    payload = manifest_payload()
+    payload["cases"].append(dict(payload["cases"][0]))
+    completed = run_cli(tmp_path, "validate", write_manifest(tmp_path, payload))
+
+    assert completed.returncode == 2
+    assert "duplicate case id" in completed.stdout
+
+
+def test_runner_records_every_probe_terminal_state(tmp_path: Path) -> None:
+    fixture_file(tmp_path)
+    payload = manifest_payload()
+    payload["changed_surfaces"][0]["cases"].append("failing-probe")
+    payload["cases"].append(
+        {
+            "id": "failing-probe",
+            "control_class": "acceptance-test",
+            "fixture": "tests/test_probe.py::test_fail",
+            "motivating_defect": "fixture-negative-polarity",
+            "expected_status": "fail",
+        }
+    )
+    completed = run_cli(tmp_path, "run", write_manifest(tmp_path, payload))
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    result = json.loads(completed.stdout)
+    assert result["coverage"] == {"declared": 2, "terminal": 2, "not_run": 0}
+    assert [(case["id"], case["status"], case["matched"]) for case in result["cases"]] == [
+        ("passing-probe", "passed", True),
+        ("failing-probe", "failed", True),
+    ]
+
+
+def test_runner_refuses_expected_status_mismatch(tmp_path: Path) -> None:
+    fixture_file(tmp_path)
+    payload = manifest_payload()
+    payload["cases"][0]["fixture"] = "tests/test_probe.py::test_fail"
+    completed = run_cli(tmp_path, "run", write_manifest(tmp_path, payload))
+
+    assert completed.returncode == 1
+    result = json.loads(completed.stdout)
+    assert result["cases"][0]["status"] == "failed"
+    assert result["cases"][0]["expected_status"] == "pass"
+    assert result["cases"][0]["matched"] is False
+
+
+def test_enforced_gate_requires_receipt_consumer(tmp_path: Path) -> None:
+    fixture_file(tmp_path)
+    payload = manifest_payload()
+    payload.pop("receipt_consumer")
+    payload["cases"][0]["control_class"] = "enforced-gate"
+    completed = run_cli(tmp_path, "validate", write_manifest(tmp_path, payload))
+
+    assert completed.returncode == 2
+    assert "receipt_consumer" in completed.stdout
+
+
+def test_changed_surfaces_reference_existing_cases(tmp_path: Path) -> None:
+    fixture_file(tmp_path)
+    payload = manifest_payload()
+    payload["changed_surfaces"][0]["cases"] = ["missing-case"]
+    completed = run_cli(tmp_path, "validate", write_manifest(tmp_path, payload))
+
+    assert completed.returncode == 2
+    assert "missing-case" in completed.stdout
+
+
+def test_shipped_manifest_validates() -> None:
+    completed = run_cli(REPO_ROOT, "validate", SKILL_ROOT / "acceptance-suite.yaml")
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    result = json.loads(completed.stdout)
+    assert result["ok"] is True
+    assert result["membership"] == "closed"
+    assert result["cases_declared"] == 19

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -166,6 +166,42 @@ def test_changed_surfaces_reference_existing_cases(tmp_path: Path) -> None:
     assert "missing-case" in completed.stdout
 
 
+def test_manifest_path_is_resolved_from_repo_root(tmp_path: Path) -> None:
+    fixture_file(tmp_path)
+    write_manifest(tmp_path, manifest_payload())
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "validate",
+            "--manifest",
+            "acceptance-suite.yaml",
+            "--repo-root",
+            str(tmp_path),
+            "--json",
+        ],
+        cwd=tmp_path.parent,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_manifest_rejects_symlinked_fixture(tmp_path: Path) -> None:
+    fixture_file(tmp_path)
+    outside = tmp_path.parent / "outside_probe.py"
+    outside.write_text("def test_pass():\n    assert True\n", encoding="utf-8")
+    target = tmp_path / "tests" / "test_probe.py"
+    target.unlink()
+    target.symlink_to(outside)
+    completed = run_cli(tmp_path, "validate", write_manifest(tmp_path, manifest_payload()))
+
+    assert completed.returncode == 2
+    assert "symlink" in completed.stdout
+
+
 def test_shipped_manifest_validates() -> None:
     completed = run_cli(REPO_ROOT, "validate", SKILL_ROOT / "acceptance-suite.yaml")
 
@@ -173,4 +209,4 @@ def test_shipped_manifest_validates() -> None:
     result = json.loads(completed.stdout)
     assert result["ok"] is True
     assert result["membership"] == "closed"
-    assert result["cases_declared"] == 19
+    assert result["cases_declared"] == 21

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -329,4 +329,4 @@ def test_shipped_manifest_validates() -> None:
     result = json.loads(completed.stdout)
     assert result["ok"] is True
     assert result["membership"] == "closed"
-    assert result["cases_declared"] == 26
+    assert result["cases_declared"] == 27

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -209,4 +209,4 @@ def test_shipped_manifest_validates() -> None:
     result = json.loads(completed.stdout)
     assert result["ok"] is True
     assert result["membership"] == "closed"
-    assert result["cases_declared"] == 21
+    assert result["cases_declared"] == 22

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -29,7 +29,7 @@ def fixture_file(root: Path) -> Path:
 
 def manifest_payload() -> dict:
     return {
-        "schema": 1,
+        "schema": 2,
         "suite": "fixture-suite",
         "membership": "closed",
         "production_entry_point": "tool.py run",

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -29,7 +29,7 @@ def fixture_file(root: Path) -> Path:
 
 def manifest_payload() -> dict:
     return {
-        "schema": 2,
+        "schema": 1,
         "suite": "fixture-suite",
         "membership": "closed",
         "production_entry_point": "tool.py run",
@@ -73,6 +73,52 @@ def run_cli(root: Path, action: str, manifest: Path) -> subprocess.CompletedProc
         text=True,
         check=False,
     )
+
+
+def init_change_repository(root: Path) -> str:
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    for key, value in (
+        ("user.name", "Acceptance Fixture"),
+        ("user.email", "acceptance@example.invalid"),
+        ("core.hooksPath", "/dev/null"),
+    ):
+        subprocess.run(
+            ["git", "-C", str(root), "config", key, value],
+            check=True,
+        )
+    subprocess.run(
+        ["git", "-C", str(root), "commit", "--allow-empty", "-qm", "base"],
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def commit_change_repository(root: Path) -> None:
+    subprocess.run(["git", "-C", str(root), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "commit", "-qm", "candidate"],
+        check=True,
+    )
+
+
+def schema2_payload() -> dict:
+    payload = manifest_payload()
+    payload["schema"] = 2
+    payload["change_base_policy"] = "boundary-supplied-git-diff"
+    payload["receipt_consumer"] = (
+        "synthesis-skills-manager.release.consume-acceptance.v1"
+    )
+    payload["changed_surfaces"] = [
+        {"path": "tool.py", "cases": ["passing-probe"]},
+        {"path": "tests/test_probe.py", "cases": ["passing-probe"]},
+        {"path": "acceptance-suite.yaml", "cases": ["passing-probe"]},
+    ]
+    return payload
 
 
 def test_manifest_rejects_open_membership(tmp_path: Path) -> None:
@@ -202,6 +248,80 @@ def test_manifest_rejects_symlinked_fixture(tmp_path: Path) -> None:
     assert "symlink" in completed.stdout
 
 
+def test_schema2_rejects_undeclared_git_changed_surface(tmp_path: Path) -> None:
+    base = init_change_repository(tmp_path)
+    fixture_file(tmp_path)
+    (tmp_path / "undeclared_production.py").write_text(
+        "raise RuntimeError('must be declared')\n",
+        encoding="utf-8",
+    )
+    manifest = write_manifest(tmp_path, schema2_payload())
+    commit_change_repository(tmp_path)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "run",
+            "--manifest",
+            str(manifest),
+            "--repo-root",
+            str(tmp_path),
+            "--change-base",
+            base,
+            "--transaction-id",
+            "fixture-undeclared-change",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "undeclared_production.py" in completed.stdout
+    assert "authoritative Git change universe" in completed.stdout
+
+
+def test_schema2_receipt_binds_transaction_and_git_state(tmp_path: Path) -> None:
+    base = init_change_repository(tmp_path)
+    fixture_file(tmp_path)
+    manifest = write_manifest(tmp_path, schema2_payload())
+    commit_change_repository(tmp_path)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(RUNNER),
+            "run",
+            "--manifest",
+            str(manifest),
+            "--repo-root",
+            str(tmp_path),
+            "--change-base",
+            base,
+            "--transaction-id",
+            "fixture-transaction",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    receipt = json.loads(completed.stdout)
+    assert receipt["receipt_schema"] == "acceptance-run-receipt-v1"
+    assert receipt["transaction_id"] == "fixture-transaction"
+    assert receipt["change_base"] == base
+    assert receipt["change_head"]
+    assert receipt["head_tree"]
+    assert receipt["manifest_sha256"]
+    assert receipt["changed_paths_sha256"]
+    assert receipt["changed_paths"] == sorted(
+        ["acceptance-suite.yaml", "tests/test_probe.py", "tool.py"]
+    )
+    assert receipt["issues_authority_receipt"] is False
+
+
 def test_shipped_manifest_validates() -> None:
     completed = run_cli(REPO_ROOT, "validate", SKILL_ROOT / "acceptance-suite.yaml")
 
@@ -209,4 +329,4 @@ def test_shipped_manifest_validates() -> None:
     result = json.loads(completed.stdout)
     assert result["ok"] is True
     assert result["membership"] == "closed"
-    assert result["cases_declared"] == 22
+    assert result["cases_declared"] == 26

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -329,4 +329,4 @@ def test_shipped_manifest_validates() -> None:
     result = json.loads(completed.stdout)
     assert result["ok"] is True
     assert result["membership"] == "closed"
-    assert result["cases_declared"] == 30
+    assert result["cases_declared"] == 31

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -329,4 +329,4 @@ def test_shipped_manifest_validates() -> None:
     result = json.loads(completed.stdout)
     assert result["ok"] is True
     assert result["membership"] == "closed"
-    assert result["cases_declared"] == 27
+    assert result["cases_declared"] == 30

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -15,6 +15,7 @@ REPO_ROOT = SKILL_ROOT.parents[1]
 
 
 def fixture_file(root: Path) -> Path:
+    (root / "tool.py").write_text("# production boundary fixture\n", encoding="utf-8")
     tests = root / "tests"
     tests.mkdir(parents=True, exist_ok=True)
     target = tests / "test_probe.py"

--- a/skills/synthesis-implementation-integrity/scripts/test_r5_contract.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_r5_contract.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def skill(name: str) -> str:
+    return (REPO_ROOT / "skills" / name / "SKILL.md").read_text(encoding="utf-8")
+
+
+def section(text: str, heading: str) -> str:
+    match = re.search(rf"^## {re.escape(heading)}\s*$", text, re.MULTILINE)
+    assert match, f"missing section: {heading}"
+    following = re.search(r"^## ", text[match.end() :], re.MULTILINE)
+    end = match.end() + following.start() if following else len(text)
+    return text[match.end() : end]
+
+
+def normalized(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_scripts_tier_contract_is_owned_by_context_lifecycle() -> None:
+    contract = normalized(
+        section(skill("synthesis-context-lifecycle"), "Executable Working State — resources/scripts/")
+    )
+
+    assert "If a script produces a number or conclusion cited in a durable record" in contract
+    assert "preserve the script and every required input before recording the result" in contract
+    assert "README.md" in contract
+    assert "regeneration order" in contract
+    assert "session-temporary" in contract
+    assert "resources/scripts/" in contract
+    assert "does not prove the script is correct" in contract
+
+
+def test_checkpoint_and_autopilot_ask_the_scratchpad_sweep_question() -> None:
+    question = (
+        "What executable state or required input data still exists only in this "
+        "session's scratchpad?"
+    )
+    action = (
+        "If a durable record cites its output, preserve the script and required "
+        "inputs under resources/scripts/ before the checkpoint can close."
+    )
+
+    for name in ("synthesis-checkpoint", "synthesis-autopilot"):
+        text = normalized(skill(name))
+        assert question in text, name
+        assert action in text, name
+
+
+def test_integrity_requires_executable_closed_acceptance_manifests() -> None:
+    contract = normalized(
+        section(skill("synthesis-implementation-integrity"), "Executable Acceptance Manifests")
+    )
+
+    for required in (
+        "membership: closed",
+        "production_entry_point",
+        "enforcing_boundary",
+        "receipt_consumer",
+        "expected_status",
+        "unverified_remainder",
+        "acceptance_suite.py run",
+    ):
+        assert required in contract
+    assert "Every changed production surface names at least one case" in contract
+    assert "fixture commit predates the green implementation" in contract
+    assert "author-written claim ledger" in contract
+
+
+def test_integrity_requires_extract_dont_restate() -> None:
+    contract = normalized(
+        section(skill("synthesis-implementation-integrity"), "Extract, Do Not Restate")
+    )
+
+    assert "extract it from the authoritative source at verification time" in contract
+    assert "second hand-maintained copy" in contract
+    assert "shared author blind spot" in contract
+    assert "unverifiable" in contract
+
+
+def test_integrity_locates_authority_at_the_state_changing_boundary() -> None:
+    contract = normalized(
+        section(skill("synthesis-implementation-integrity"), "Authority Lives at the Boundary")
+    )
+
+    assert "standalone verifier is evidence, not enforcement" in contract
+    assert "state-changing consumer" in contract
+    assert "fresh, matching, transaction-bound receipt" in contract
+    assert "metadata class" in contract
+    assert "does not manufacture approval" in contract
+
+
+def test_disclosure_categories_preserve_attention_for_real_approval_gates() -> None:
+    contract = normalized(
+        section(skill("synthesis-disclosure-policy"), "Category Allowlists Without Approval Fatigue")
+    )
+
+    assert "principal approves the category once" in contract
+    assert "independent public evidence" in contract
+    assert "positive or neutral" in contract
+    assert "Class X is never category-allowlisted" in contract
+    assert "ambiguity remains Class A" in contract
+    assert "rubber-stamp" in contract
+    assert "approval fatigue is a failure mode of fail-closed design" in contract

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -1079,8 +1079,13 @@ def test_r4_rename_from_unclaimed_path_is_refused(
 
 
 def test_r4_active_pointer_resolves_committing_session(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # AGENT HEURISTIC: this fixture exercises pointer fallback, so the caller's
+    # real coordination identity must not silently replace the fixture input.
+    monkeypatch.delenv("SYNTHESIS_COORDINATION_SESSION", raising=False)
     root = staged_repository(tmp_path)
     (root / "claimed").mkdir()
     (root / "claimed" / "inside.md").write_text("inside\n", encoding="utf-8")

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -265,9 +265,14 @@ The sequence, each stage gating the next:
   Git at the release boundary, requires exact manifest coverage, and parses a
   fresh result bound to a one-use transaction, head commit and tree, manifest
   digest, and changed-path digest. The boundary recomputes those fields and
-  rechecks the clean worktree before it can authorize publication. CI invokes
-  the same consumer with the pull request base supplied by its event record.
-- **Publish** pushes `main` to *every* configured push remote.
+  rechecks the clean worktree before it can authorize publication. The
+  accepted-state object survives the check phase and expires when any binding
+  changes. CI invokes the same consumer with the pull request base supplied by
+  its event record.
+- **Publish** revalidates the accepted state immediately before every remote
+  mutation and pushes the immutable accepted commit SHA to `refs/heads/main`,
+  never a mutable local branch name. This is the PRINCIPAL RULE D4 repair for
+  `R5-REV-002`.
 - **Install** uses each client's own commands, in the order each client
   requires. For Codex that means `plugin marketplace upgrade` **before**
   `plugin add`, because Codex installs *from* its git marketplace snapshot —

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -250,6 +250,7 @@ clients behind their own source with nothing visibly wrong.
 python3 skills/synthesis-skills-manager/scripts/release.py --repo-root .
 python3 .../release.py --dry-run       # print the plan, mutate nothing
 python3 .../release.py --check-only    # preflight + required checks, no publish
+python3 .../release.py --acceptance-only # consume the bound acceptance result (CI)
 python3 .../release.py --install-only  # refresh + verify clients (new machine, drift recovery)
 ```
 
@@ -260,6 +261,12 @@ The sequence, each stage gating the next:
 - **Preflight** refuses to proceed unless both plugin manifests agree, the
   newest CHANGELOG entry matches them, and the tree is clean. It also refuses
   to run against an installed cache mistaken for the source checkout.
+- **Acceptance consumption** derives the base-to-head change universe from
+  Git at the release boundary, requires exact manifest coverage, and parses a
+  fresh result bound to a one-use transaction, head commit and tree, manifest
+  digest, and changed-path digest. The boundary recomputes those fields and
+  rechecks the clean worktree before it can authorize publication. CI invokes
+  the same consumer with the pull request base supplied by its event record.
 - **Publish** pushes `main` to *every* configured push remote.
 - **Install** uses each client's own commands, in the order each client
   requires. For Codex that means `plugin marketplace upgrade` **before**

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.1.0"
+  version: "2.2.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -122,6 +122,15 @@ class Result:
         return [s for s in self.steps if not s.ok]
 
 
+@dataclass(frozen=True)
+class AcceptanceAuthority:
+    """The exact accepted state that must survive to the publish boundary."""
+
+    change_base: str
+    expected: dict[str, object]
+    receipt: dict[str, object]
+
+
 def run(cmd: list[str], cwd: Path | None = None, timeout: int = 900) -> subprocess.CompletedProcess:
     return subprocess.run(
         cmd, cwd=str(cwd) if cwd else None, capture_output=True, text=True, timeout=timeout
@@ -262,20 +271,25 @@ def validate_acceptance_receipt(
     return True, "fresh transaction-bound receipt consumed"
 
 
-def consume_acceptance(repo: Path, result: Result, dry_run: bool) -> bool:
-    if dry_run:
-        return result.add("checks.acceptance.r5", True, "dry-run")
+def consume_acceptance(
+    repo: Path, result: Result, dry_run: bool
+) -> AcceptanceAuthority | None:
+    # PRINCIPAL RULE (controlling plan D4): even a dry run reconstructs the
+    # receipt. Skipping it would make the dry-run publish path unable to prove
+    # that authority remains current at the boundary it models.
     change_base, detail = acceptance_change_base(repo)
     if not change_base:
-        return result.add(
+        result.add(
             "checks.acceptance.r5",
             False,
             f"authoritative change-base unavailable: {detail}",
         )
+        return None
     transaction_id = secrets.token_hex(16)
     expected, detail = acceptance_expectation(repo, change_base, transaction_id)
     if expected is None:
-        return result.add("checks.acceptance.r5", False, detail)
+        result.add("checks.acceptance.r5", False, detail)
+        return None
     command = [
         "python3",
         str(ACCEPTANCE_RUNNER),
@@ -293,33 +307,69 @@ def consume_acceptance(repo: Path, result: Result, dry_run: bool) -> bool:
     completed = run(command, cwd=repo)
     if completed.returncode != 0:
         tail = (completed.stdout or completed.stderr).strip().splitlines()
-        return result.add(
+        result.add(
             "checks.acceptance.r5",
             False,
             tail[-1] if tail else "acceptance runner failed",
         )
+        return None
     try:
         receipt = json.loads(completed.stdout)
     except (TypeError, json.JSONDecodeError) as exc:
-        return result.add(
+        result.add(
             "checks.acceptance.r5", False, f"runner receipt is not valid JSON: {exc}"
         )
+        return None
     refreshed, detail = acceptance_expectation(repo, change_base, transaction_id)
     if refreshed is None or refreshed != expected:
-        return result.add(
+        result.add(
             "checks.acceptance.r5",
             False,
             detail or "source state changed while acceptance executed",
         )
+        return None
     status = run(["git", "status", "--porcelain", "--untracked-files=all"], cwd=repo)
     if status.returncode != 0 or status.stdout.strip():
-        return result.add(
+        result.add(
             "checks.acceptance.r5",
             False,
             "source worktree changed while acceptance executed",
         )
+        return None
     valid, detail = validate_acceptance_receipt(receipt, expected)
-    return result.add("checks.acceptance.r5", valid, detail)
+    result.add("checks.acceptance.r5", valid, detail)
+    if not valid:
+        return None
+    return AcceptanceAuthority(
+        change_base=change_base,
+        expected=expected,
+        receipt=receipt,
+    )
+
+
+def revalidate_acceptance_authority(
+    repo: Path, authority: AcceptanceAuthority
+) -> tuple[bool, str]:
+    """Expire authority unless every accepted source binding still matches."""
+
+    transaction_id = authority.expected.get("transaction_id")
+    if not isinstance(transaction_id, str) or not transaction_id:
+        return False, "accepted transaction id is unavailable"
+    refreshed, detail = acceptance_expectation(
+        repo, authority.change_base, transaction_id
+    )
+    if refreshed is None:
+        return False, detail
+    if refreshed != authority.expected:
+        return False, "accepted source state changed before publication"
+    status = run(
+        ["git", "status", "--porcelain", "--untracked-files=all"], cwd=repo
+    )
+    if status.returncode != 0:
+        return False, "source worktree state could not be established"
+    if status.stdout.strip():
+        return False, "source worktree changed before publication"
+    return validate_acceptance_receipt(authority.receipt, authority.expected)
 
 
 def read_manifest_version(path: Path) -> str | None:
@@ -504,11 +554,24 @@ def preflight(repo: Path, result: Result, install_only: bool) -> str | None:
     return version
 
 
-def publish(repo: Path, result: Result, dry_run: bool) -> bool:
-    """Push main to every configured push remote."""
+def publish(
+    repo: Path,
+    result: Result,
+    dry_run: bool,
+    authority: AcceptanceAuthority,
+) -> bool:
+    """Push the exact receipt-bound commit to every configured push remote."""
     branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo).stdout.strip()
     if not result.add("publish.on-main", branch == "main", f"branch={branch or 'unknown'}"):
         return False
+    valid, detail = revalidate_acceptance_authority(repo, authority)
+    if not result.add("publish.acceptance", valid, detail):
+        return False
+    accepted_head = authority.expected.get("change_head")
+    if not isinstance(accepted_head, str) or not accepted_head:
+        return result.add(
+            "publish.accepted-head", False, "receipt-bound head is unavailable"
+        )
     remotes = sorted(
         {
             line.split()[0]
@@ -519,18 +582,29 @@ def publish(repo: Path, result: Result, dry_run: bool) -> bool:
     if not result.add("publish.remotes", bool(remotes), ", ".join(remotes) or "none configured"):
         return False
     for remote in remotes:
+        valid, detail = revalidate_acceptance_authority(repo, authority)
+        if not result.add(f"publish.acceptance.{remote}", valid, detail):
+            return False
+        refspec = f"{accepted_head}:refs/heads/main"
         if dry_run:
-            result.add(f"publish.push.{remote}", True, "dry-run")
+            result.add(f"publish.push.{remote}", True, f"dry-run: {refspec}")
             continue
-        completed = run(["git", "push", remote, "main"], cwd=repo, timeout=600)
+        # PRINCIPAL RULE (controlling plan D4): the pushed object is immutable.
+        # A concurrent branch movement cannot substitute a different commit
+        # after the final authority check.
+        completed = run(
+            ["git", "push", remote, refspec], cwd=repo, timeout=600
+        )
         if completed.returncode != 0:
             tail = (completed.stderr or completed.stdout).strip().splitlines()
             return result.add(f"publish.push.{remote}", False, tail[-1] if tail else "push failed")
-        result.add(f"publish.push.{remote}", True, "pushed")
+        result.add(f"publish.push.{remote}", True, f"pushed {refspec}")
     return True
 
 
-def run_required_checks(repo: Path, result: Result, dry_run: bool) -> bool:
+def run_required_checks(
+    repo: Path, result: Result, dry_run: bool
+) -> AcceptanceAuthority | None:
     for name, command in REQUIRED_CHECKS:
         if dry_run:
             result.add(f"checks.{name}", True, "dry-run")
@@ -544,7 +618,7 @@ def run_required_checks(repo: Path, result: Result, dry_run: bool) -> bool:
             "" if passed else (tail[-1] if tail else "failed"),
         )
         if not passed:
-            return False
+            return None
     return consume_acceptance(repo, result, dry_run)
 
 
@@ -579,20 +653,21 @@ def main(argv: list[str] | None = None) -> int:
         if args.install_only or args.check_only:
             print("\nRELEASE ABORTED: --acceptance-only cannot be combined with other modes.")
             return 2
-        if not consume_acceptance(repo, result, args.dry_run):
+        if consume_acceptance(repo, result, args.dry_run) is None:
             print("\nACCEPTANCE REFUSED: no release authority was issued.")
             return 1
         print(f"\nACCEPTANCE CONSUMED for {version}. Nothing published or installed.")
         return 0
 
     if not args.install_only:
-        if not run_required_checks(repo, result, args.dry_run):
+        authority = run_required_checks(repo, result, args.dry_run)
+        if authority is None:
             print("\nRELEASE ABORTED: required checks failed. Nothing was published.")
             return 1
         if args.check_only:
             print(f"\nCHECKS PASSED for {version}. Nothing published (--check-only).")
             return 0
-        if not publish(repo, result, args.dry_run):
+        if not publish(repo, result, args.dry_run, authority):
             print("\nRELEASE ABORTED: publish failed. Clients left untouched.")
             return 1
 

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -74,6 +74,8 @@ REQUIRED_CHECKS: tuple[tuple[str, list[str]], ...] = (
     ("pytest.conformance", ["python3", "-m", "pytest", "skills/synthesis-agent-conformance/scripts/", "-q"]),
     ("pytest.coordination", ["python3", "-m", "pytest", "skills/synthesis-project-management/scripts/test_coordination.py", "-q"]),
     ("pytest.promotion-gate", ["python3", "-m", "pytest", "skills/synthesis-promotion-gate/scripts/", "-q"]),
+    ("pytest.context-lifecycle-integrity", ["python3", "-m", "pytest", "skills/synthesis-context-lifecycle/scripts/", "skills/synthesis-implementation-integrity/scripts/", "-q"]),
+    ("acceptance.r5", ["python3", "skills/synthesis-implementation-integrity/scripts/acceptance_suite.py", "run", "--manifest", "skills/synthesis-implementation-integrity/acceptance-suite.yaml", "--repo-root", "."]),
     ("pytest.release", ["python3", "-m", "pytest", "skills/synthesis-skills-manager/scripts/test_release.py", "-q"]),
     ("meeting-transcripts.completeness", ["python3", "skills/synthesis-meeting-transcripts/test_verify_transcripts.py"]),
     ("meeting-transcripts.primary", ["python3", "skills/synthesis-meeting-transcripts/test_transcript_primary.py"]),

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -28,6 +28,9 @@ Modes:
   --install-only  skip publishing; refresh and verify the clients only
                   (new machine, recovered drift, or a release pushed elsewhere)
   --check-only    preflight + required checks; no publish, no install
+  --acceptance-only
+                  consume a fresh acceptance result bound to this Git state;
+                  no publish or install (repository CI boundary)
   --dry-run       print the plan and run read-only steps; mutate nothing
 
 Exit codes: 0 released/verified, 1 a step failed, 2 preconditions unverifiable.
@@ -36,8 +39,10 @@ Exit codes: 0 released/verified, 1 a step failed, 2 preconditions unverifiable.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
+import secrets
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -65,6 +70,15 @@ except ImportError:  # pragma: no cover - resolved at runtime in the repo
 PLUGIN_NAME = "synthesis-skills"
 MARKETPLACE = "synthesis-engineering"
 MANIFESTS = (".claude-plugin/plugin.json", ".codex-plugin/plugin.json")
+ACCEPTANCE_MANIFEST = Path(
+    "skills/synthesis-implementation-integrity/acceptance-suite.yaml"
+)
+ACCEPTANCE_RUNNER = Path(
+    "skills/synthesis-implementation-integrity/scripts/acceptance_suite.py"
+)
+ACCEPTANCE_CONSUMER_ID = (
+    "synthesis-skills-manager.release.consume-acceptance.v1"
+)
 
 # The required checks, mirroring the repository's own verification contract.
 # Kept as data so a reader can see exactly what a release runs.
@@ -75,7 +89,6 @@ REQUIRED_CHECKS: tuple[tuple[str, list[str]], ...] = (
     ("pytest.coordination", ["python3", "-m", "pytest", "skills/synthesis-project-management/scripts/test_coordination.py", "-q"]),
     ("pytest.promotion-gate", ["python3", "-m", "pytest", "skills/synthesis-promotion-gate/scripts/", "-q"]),
     ("pytest.context-lifecycle-integrity", ["python3", "-m", "pytest", "skills/synthesis-context-lifecycle/scripts/", "skills/synthesis-implementation-integrity/scripts/", "-q"]),
-    ("acceptance.r5", ["python3", "skills/synthesis-implementation-integrity/scripts/acceptance_suite.py", "run", "--manifest", "skills/synthesis-implementation-integrity/acceptance-suite.yaml", "--repo-root", "."]),
     ("pytest.release", ["python3", "-m", "pytest", "skills/synthesis-skills-manager/scripts/test_release.py", "-q"]),
     ("meeting-transcripts.completeness", ["python3", "skills/synthesis-meeting-transcripts/test_verify_transcripts.py"]),
     ("meeting-transcripts.primary", ["python3", "skills/synthesis-meeting-transcripts/test_transcript_primary.py"]),
@@ -113,6 +126,200 @@ def run(cmd: list[str], cwd: Path | None = None, timeout: int = 900) -> subproce
     return subprocess.run(
         cmd, cwd=str(cwd) if cwd else None, capture_output=True, text=True, timeout=timeout
     )
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _git_value(repo: Path, arguments: list[str]) -> tuple[str | None, str]:
+    completed = run(["git", *arguments], cwd=repo)
+    value = completed.stdout.strip()
+    if completed.returncode != 0 or not value:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "no output"
+        return None, detail
+    return value, ""
+
+
+def acceptance_change_base(repo: Path) -> tuple[str | None, str]:
+    """Resolve the base at the release boundary, never from manifest prose."""
+
+    supplied = os.environ.get("SYNTHESIS_ACCEPTANCE_CHANGE_BASE", "").strip()
+    if supplied:
+        resolved, detail = _git_value(
+            repo, ["rev-parse", "--verify", f"{supplied}^{{commit}}"]
+        )
+        return resolved, detail
+
+    parents, detail = _git_value(repo, ["rev-list", "--parents", "-n", "1", "HEAD"])
+    if parents:
+        fields = parents.split()
+        if len(fields) >= 3:
+            return fields[1], "merge first parent"
+
+    branch, branch_detail = _git_value(repo, ["rev-parse", "--abbrev-ref", "HEAD"])
+    if branch and branch != "main":
+        base, merge_detail = _git_value(repo, ["merge-base", "HEAD", "origin/main"])
+        if base:
+            return base, "feature branch merge-base with origin/main"
+        return None, merge_detail
+    return None, detail or branch_detail or (
+        "set SYNTHESIS_ACCEPTANCE_CHANGE_BASE, use a feature branch with origin/main, "
+        "or run from the resulting merge commit"
+    )
+
+
+def acceptance_expectation(
+    repo: Path, change_base: str, transaction_id: str
+) -> tuple[dict[str, object] | None, str]:
+    base_sha, detail = _git_value(
+        repo, ["rev-parse", "--verify", f"{change_base}^{{commit}}"]
+    )
+    if not base_sha:
+        return None, f"change-base: {detail}"
+    head_sha, detail = _git_value(repo, ["rev-parse", "--verify", "HEAD^{commit}"])
+    if not head_sha:
+        return None, f"change-head: {detail}"
+    ancestor = run(["git", "merge-base", "--is-ancestor", base_sha, head_sha], cwd=repo)
+    if ancestor.returncode != 0:
+        return None, "change-base is not an ancestor of HEAD"
+    head_tree, detail = _git_value(
+        repo, ["rev-parse", "--verify", f"{head_sha}^{{tree}}"]
+    )
+    if not head_tree:
+        return None, f"head-tree: {detail}"
+    changed = run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACDMRTUXB",
+            f"{base_sha}..{head_sha}",
+            "--",
+        ],
+        cwd=repo,
+    )
+    if changed.returncode != 0:
+        return None, changed.stderr.strip() or "git diff failed"
+    changed_paths = sorted(
+        {line.strip() for line in changed.stdout.splitlines() if line.strip()}
+    )
+    manifest = repo / ACCEPTANCE_MANIFEST
+    try:
+        manifest_bytes = manifest.read_bytes()
+    except OSError as exc:
+        return None, f"acceptance manifest unreadable: {exc}"
+    serialized_paths = ("\n".join(changed_paths) + "\n").encode("utf-8")
+    return {
+        "transaction_id": transaction_id,
+        "change_base": base_sha,
+        "change_head": head_sha,
+        "head_tree": head_tree,
+        "manifest_sha256": _sha256_bytes(manifest_bytes),
+        "changed_paths": changed_paths,
+        "changed_paths_sha256": _sha256_bytes(serialized_paths),
+    }, ""
+
+
+def validate_acceptance_receipt(
+    receipt: object, expected: dict[str, object]
+) -> tuple[bool, str]:
+    if not isinstance(receipt, dict):
+        return False, "runner output is not a JSON object"
+    for field, expected_value in expected.items():
+        if receipt.get(field) != expected_value:
+            return False, f"receipt {field} does not match the release transaction"
+    fixed = {
+        "receipt_schema": "acceptance-run-receipt-v1",
+        "receipt_consumer": ACCEPTANCE_CONSUMER_ID,
+        "metadata_class": "acceptance-test",
+        "issues_authority_receipt": False,
+        "ok": True,
+    }
+    for field, expected_value in fixed.items():
+        if receipt.get(field) != expected_value:
+            return False, f"receipt {field} is invalid"
+    coverage = receipt.get("coverage")
+    if not isinstance(coverage, dict):
+        return False, "receipt coverage is missing"
+    declared = coverage.get("declared")
+    terminal = coverage.get("terminal")
+    if (
+        not isinstance(declared, int)
+        or isinstance(declared, bool)
+        or declared <= 0
+        or terminal != declared
+        or coverage.get("not_run") != 0
+    ):
+        return False, "receipt coverage is not closed and terminal"
+    cases = receipt.get("cases")
+    if (
+        not isinstance(cases, list)
+        or len(cases) != declared
+        or not all(isinstance(case, dict) and case.get("matched") is True for case in cases)
+    ):
+        return False, "receipt cases are incomplete or mismatched"
+    return True, "fresh transaction-bound receipt consumed"
+
+
+def consume_acceptance(repo: Path, result: Result, dry_run: bool) -> bool:
+    if dry_run:
+        return result.add("checks.acceptance.r5", True, "dry-run")
+    change_base, detail = acceptance_change_base(repo)
+    if not change_base:
+        return result.add(
+            "checks.acceptance.r5",
+            False,
+            f"authoritative change-base unavailable: {detail}",
+        )
+    transaction_id = secrets.token_hex(16)
+    expected, detail = acceptance_expectation(repo, change_base, transaction_id)
+    if expected is None:
+        return result.add("checks.acceptance.r5", False, detail)
+    command = [
+        "python3",
+        str(ACCEPTANCE_RUNNER),
+        "run",
+        "--manifest",
+        str(ACCEPTANCE_MANIFEST),
+        "--repo-root",
+        ".",
+        "--change-base",
+        change_base,
+        "--transaction-id",
+        transaction_id,
+        "--json",
+    ]
+    completed = run(command, cwd=repo)
+    if completed.returncode != 0:
+        tail = (completed.stdout or completed.stderr).strip().splitlines()
+        return result.add(
+            "checks.acceptance.r5",
+            False,
+            tail[-1] if tail else "acceptance runner failed",
+        )
+    try:
+        receipt = json.loads(completed.stdout)
+    except (TypeError, json.JSONDecodeError) as exc:
+        return result.add(
+            "checks.acceptance.r5", False, f"runner receipt is not valid JSON: {exc}"
+        )
+    refreshed, detail = acceptance_expectation(repo, change_base, transaction_id)
+    if refreshed is None or refreshed != expected:
+        return result.add(
+            "checks.acceptance.r5",
+            False,
+            detail or "source state changed while acceptance executed",
+        )
+    status = run(["git", "status", "--porcelain", "--untracked-files=all"], cwd=repo)
+    if status.returncode != 0 or status.stdout.strip():
+        return result.add(
+            "checks.acceptance.r5",
+            False,
+            "source worktree changed while acceptance executed",
+        )
+    valid, detail = validate_acceptance_receipt(receipt, expected)
+    return result.add("checks.acceptance.r5", valid, detail)
 
 
 def read_manifest_version(path: Path) -> str | None:
@@ -324,7 +531,6 @@ def publish(repo: Path, result: Result, dry_run: bool) -> bool:
 
 
 def run_required_checks(repo: Path, result: Result, dry_run: bool) -> bool:
-    ok = True
     for name, command in REQUIRED_CHECKS:
         if dry_run:
             result.add(f"checks.{name}", True, "dry-run")
@@ -332,10 +538,14 @@ def run_required_checks(repo: Path, result: Result, dry_run: bool) -> bool:
         completed = run(command, cwd=repo)
         passed = completed.returncode == 0
         tail = (completed.stdout or completed.stderr).strip().splitlines()
-        ok = result.add(f"checks.{name}", passed, "" if passed else (tail[-1] if tail else "failed")) and ok
+        result.add(
+            f"checks.{name}",
+            passed,
+            "" if passed else (tail[-1] if tail else "failed"),
+        )
         if not passed:
-            break
-    return ok
+            return False
+    return consume_acceptance(repo, result, dry_run)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -343,6 +553,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo-root", default=".", help="synthesis-skills checkout (default: cwd)")
     parser.add_argument("--install-only", action="store_true", help="refresh + verify clients only")
     parser.add_argument("--check-only", action="store_true", help="preflight + required checks only")
+    parser.add_argument(
+        "--acceptance-only",
+        action="store_true",
+        help="consume the transaction-bound acceptance receipt only",
+    )
     parser.add_argument("--dry-run", action="store_true", help="print the plan; mutate nothing")
     args = parser.parse_args(argv)
 
@@ -359,6 +574,16 @@ def main(argv: list[str] | None = None) -> int:
     if version is None or result.failed:
         print("\nRELEASE ABORTED: preflight failed. Nothing was published or installed.")
         return 2 if version is None else 1
+
+    if args.acceptance_only:
+        if args.install_only or args.check_only:
+            print("\nRELEASE ABORTED: --acceptance-only cannot be combined with other modes.")
+            return 2
+        if not consume_acceptance(repo, result, args.dry_run):
+            print("\nACCEPTANCE REFUSED: no release authority was issued.")
+            return 1
+        print(f"\nACCEPTANCE CONSUMED for {version}. Nothing published or installed.")
+        return 0
 
     if not args.install_only:
         if not run_required_checks(repo, result, args.dry_run):

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -158,20 +158,22 @@ def test_release_boundary_consumes_fresh_bound_acceptance_receipt(
     repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     calls: list[tuple[Path, bool]] = []
+    authority = object()
 
-    def consume(candidate: Path, result: release.Result, dry_run: bool) -> bool:
+    def consume(candidate: Path, result: release.Result, dry_run: bool) -> object:
         calls.append((candidate, dry_run))
-        return result.add(
+        result.add(
             "checks.acceptance.r5",
             True,
             "fresh transaction-bound receipt consumed",
         )
+        return authority
 
     monkeypatch.setattr(release, "REQUIRED_CHECKS", ())
     monkeypatch.setattr(release, "consume_acceptance", consume)
     result = release.Result()
 
-    assert release.run_required_checks(repo, result, dry_run=False)
+    assert release.run_required_checks(repo, result, dry_run=False) is authority
     assert calls == [(repo, False)]
     assert [(step.name, step.ok) for step in result.steps] == [
         ("checks.acceptance.r5", True)

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -140,6 +140,45 @@ def test_repository_ci_executes_release_wiring_tests() -> None:
     )
 
 
+def test_required_checks_execute_r5_integrity_suite() -> None:
+    commands = {name: command for name, command in release.REQUIRED_CHECKS}
+    assert commands["pytest.context-lifecycle-integrity"] == [
+        "python3",
+        "-m",
+        "pytest",
+        "skills/synthesis-context-lifecycle/scripts/",
+        "skills/synthesis-implementation-integrity/scripts/",
+        "-q",
+    ]
+    assert commands["acceptance.r5"] == [
+        "python3",
+        "skills/synthesis-implementation-integrity/scripts/acceptance_suite.py",
+        "run",
+        "--manifest",
+        "skills/synthesis-implementation-integrity/acceptance-suite.yaml",
+        "--repo-root",
+        ".",
+    ]
+
+
+def test_repository_ci_executes_r5_integrity_suite() -> None:
+    repository = Path(__file__).resolve().parents[3]
+    workflow = (repository / ".github" / "workflows" / "validate.yml").read_text(
+        encoding="utf-8"
+    )
+    assert (
+        "python -m pytest skills/synthesis-context-lifecycle/scripts/ "
+        "skills/synthesis-implementation-integrity/scripts/ -q"
+        in workflow
+    )
+    assert (
+        "python skills/synthesis-implementation-integrity/scripts/acceptance_suite.py "
+        "run --manifest skills/synthesis-implementation-integrity/acceptance-suite.yaml "
+        "--repo-root ."
+        in workflow
+    )
+
+
 # --- client reporting, fail-closed -----------------------------------------
 
 

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -177,6 +177,45 @@ def test_release_boundary_consumes_fresh_bound_acceptance_receipt(
     ]
 
 
+def test_release_receipt_validator_rejects_every_binding_mismatch() -> None:
+    expected = {
+        "transaction_id": "transaction-a",
+        "change_base": "a" * 40,
+        "change_head": "b" * 40,
+        "head_tree": "c" * 40,
+        "manifest_sha256": "d" * 64,
+        "changed_paths_sha256": "e" * 64,
+    }
+    receipt = {
+        **expected,
+        "receipt_schema": "acceptance-run-receipt-v1",
+        "receipt_consumer": "synthesis-skills-manager.release.consume-acceptance.v1",
+        "metadata_class": "acceptance-test",
+        "issues_authority_receipt": False,
+        "ok": True,
+        "coverage": {"declared": 2, "terminal": 2, "not_run": 0},
+        "cases": [{"id": "one", "matched": True}, {"id": "two", "matched": True}],
+    }
+
+    assert release.validate_acceptance_receipt(receipt, expected)[0]
+    for field in expected:
+        mutated = dict(receipt)
+        mutated[field] = "mismatch"
+        assert not release.validate_acceptance_receipt(mutated, expected)[0], field
+    for field, value in (
+        ("receipt_schema", "wrong"),
+        ("receipt_consumer", "wrong"),
+        ("metadata_class", "diagnostic"),
+        ("issues_authority_receipt", True),
+        ("ok", False),
+        ("coverage", {"declared": 2, "terminal": 1, "not_run": 1}),
+        ("cases", [{"id": "one", "matched": False}]),
+    ):
+        mutated = dict(receipt)
+        mutated[field] = value
+        assert not release.validate_acceptance_receipt(mutated, expected)[0], field
+
+
 def test_repository_ci_executes_r5_integrity_suite() -> None:
     repository = Path(__file__).resolve().parents[3]
     workflow = (repository / ".github" / "workflows" / "validate.yml").read_text(

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -240,6 +241,21 @@ def test_repository_ci_uses_receipt_consumer_with_authoritative_base() -> None:
     )
     assert "SYNTHESIS_ACCEPTANCE_CHANGE_BASE:" in workflow
     assert "github.event.pull_request.base.sha || github.event.before" in workflow
+
+
+def test_repository_ci_fetches_authoritative_base_history() -> None:
+    repository = Path(__file__).resolve().parents[3]
+    workflow = yaml.safe_load(
+        (repository / ".github" / "workflows" / "validate.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    checkout = next(
+        step
+        for step in workflow["jobs"]["conformance"]["steps"]
+        if step.get("uses") == "actions/checkout@v4"
+    )
+    assert checkout["with"]["fetch-depth"] == 0
 
 
 # AGENT HEURISTIC: these fixtures preserve the direct reviewer's concrete D4

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -13,6 +13,7 @@ converts an unknown into a false assurance.
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -237,6 +238,120 @@ def test_repository_ci_uses_receipt_consumer_with_authoritative_base() -> None:
     )
     assert "SYNTHESIS_ACCEPTANCE_CHANGE_BASE:" in workflow
     assert "github.event.pull_request.base.sha || github.event.before" in workflow
+
+
+# AGENT HEURISTIC: these fixtures preserve the direct reviewer's concrete D4
+# counterexample. A receipt that expires before publish is not release authority.
+def accepted_publish_fixture(tmp_path: Path) -> tuple[Path, object]:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repository)], check=True)
+    for key, value in (
+        ("user.name", "Release Fixture"),
+        ("user.email", "release@example.invalid"),
+        ("core.hooksPath", "/dev/null"),
+    ):
+        subprocess.run(
+            ["git", "-C", str(repository), "config", key, value], check=True
+        )
+    manifest = repository / release.ACCEPTANCE_MANIFEST
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text("fixture manifest\n", encoding="utf-8")
+    changed = repository / "production.py"
+    changed.write_text("BASE = True\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repository), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "commit", "-qm", "base"], check=True
+    )
+    base = subprocess.run(
+        ["git", "-C", str(repository), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    changed.write_text("ACCEPTED = True\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repository), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "commit", "-qm", "accepted"], check=True
+    )
+    expected, detail = release.acceptance_expectation(
+        repository, base, "fixture-transaction"
+    )
+    assert expected is not None, detail
+    receipt = {
+        **expected,
+        "receipt_schema": "acceptance-run-receipt-v1",
+        "receipt_consumer": release.ACCEPTANCE_CONSUMER_ID,
+        "metadata_class": "acceptance-test",
+        "issues_authority_receipt": False,
+        "ok": True,
+        "coverage": {"declared": 1, "terminal": 1, "not_run": 0},
+        "cases": [{"id": "fixture", "matched": True}],
+    }
+    authority = release.AcceptanceAuthority(
+        change_base=base, expected=expected, receipt=receipt
+    )
+    return repository, authority
+
+
+def test_publish_refuses_when_receipt_bound_head_changes(tmp_path: Path) -> None:
+    repository, authority = accepted_publish_fixture(tmp_path)
+    (repository / "undeclared.py").write_text("raise RuntimeError\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repository), "add", "-A"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "commit", "-qm", "changed"], check=True
+    )
+
+    result = release.Result()
+    assert release.publish(repository, result, True, authority) is False
+    assert any(
+        step.name == "publish.acceptance" and not step.ok for step in result.steps
+    )
+
+
+def test_publish_dry_run_names_exact_receipt_bound_ref(tmp_path: Path) -> None:
+    repository, authority = accepted_publish_fixture(tmp_path)
+    bare = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "remote", "add", "origin", str(bare)],
+        check=True,
+    )
+
+    result = release.Result()
+    assert release.publish(repository, result, True, authority) is True
+    expected_ref = f"{authority.expected['change_head']}:refs/heads/main"
+    assert any(
+        step.name == "publish.push.origin" and expected_ref in step.detail
+        for step in result.steps
+    )
+
+
+def test_main_carries_acceptance_authority_to_publish_boundary(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    authority = object()
+    received: list[object] = []
+
+    monkeypatch.setattr(release, "preflight", lambda *_args: "9.9.9")
+    monkeypatch.setattr(
+        release, "run_required_checks", lambda *_args: authority
+    )
+
+    def publish(
+        candidate: Path,
+        result: release.Result,
+        dry_run: bool,
+        accepted: object,
+    ) -> bool:
+        received.append(accepted)
+        return result.add("publish.fixture", True)
+
+    monkeypatch.setattr(release, "publish", publish)
+    monkeypatch.setattr(release, "refresh_client", lambda *_args: True)
+
+    assert release.main(["--repo-root", str(repo), "--dry-run"]) == 0
+    assert received == [authority]
 
 
 # --- client reporting, fail-closed -----------------------------------------

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -150,14 +150,30 @@ def test_required_checks_execute_r5_integrity_suite() -> None:
         "skills/synthesis-implementation-integrity/scripts/",
         "-q",
     ]
-    assert commands["acceptance.r5"] == [
-        "python3",
-        "skills/synthesis-implementation-integrity/scripts/acceptance_suite.py",
-        "run",
-        "--manifest",
-        "skills/synthesis-implementation-integrity/acceptance-suite.yaml",
-        "--repo-root",
-        ".",
+    assert "acceptance.r5" not in commands
+
+
+def test_release_boundary_consumes_fresh_bound_acceptance_receipt(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[Path, bool]] = []
+
+    def consume(candidate: Path, result: release.Result, dry_run: bool) -> bool:
+        calls.append((candidate, dry_run))
+        return result.add(
+            "checks.acceptance.r5",
+            True,
+            "fresh transaction-bound receipt consumed",
+        )
+
+    monkeypatch.setattr(release, "REQUIRED_CHECKS", ())
+    monkeypatch.setattr(release, "consume_acceptance", consume)
+    result = release.Result()
+
+    assert release.run_required_checks(repo, result, dry_run=False)
+    assert calls == [(repo, False)]
+    assert [(step.name, step.ok) for step in result.steps] == [
+        ("checks.acceptance.r5", True)
     ]
 
 
@@ -171,12 +187,16 @@ def test_repository_ci_executes_r5_integrity_suite() -> None:
         "skills/synthesis-implementation-integrity/scripts/ -q"
         in workflow
     )
-    assert (
-        "python skills/synthesis-implementation-integrity/scripts/acceptance_suite.py "
-        "run --manifest skills/synthesis-implementation-integrity/acceptance-suite.yaml "
-        "--repo-root ."
-        in workflow
+    assert "python skills/synthesis-skills-manager/scripts/release.py --repo-root . --acceptance-only" in workflow
+
+
+def test_repository_ci_uses_receipt_consumer_with_authoritative_base() -> None:
+    repository = Path(__file__).resolve().parents[3]
+    workflow = (repository / ".github" / "workflows" / "validate.yml").read_text(
+        encoding="utf-8"
     )
+    assert "SYNTHESIS_ACCEPTANCE_CHANGE_BASE:" in workflow
+    assert "github.event.pull_request.base.sha || github.event.before" in workflow
 
 
 # --- client reporting, fail-closed -----------------------------------------

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -184,6 +184,7 @@ def test_release_receipt_validator_rejects_every_binding_mismatch() -> None:
         "change_head": "b" * 40,
         "head_tree": "c" * 40,
         "manifest_sha256": "d" * 64,
+        "changed_paths": ["one.py"],
         "changed_paths_sha256": "e" * 64,
     }
     receipt = {


### PR DESCRIPTION
Adds the cohesive 4.54.0 integrity-control release with a closed 32-case acceptance universe.

Validation: the gated release checks and complete repository workflow passed locally. Nothing was published or installed.