### PR TITLE
Anchor sync windows on the last write; make recorded gaps blocking

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.55.1",
+  "version": "4.56.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.55.1",
+  "version": "4.56.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.56.0] - 2026-08-27
+
+### Added
+
+- **Sync windows follow the last write, not the last run.** `synthesis-daily-rituals`
+  gains `scripts/sync_watermark.py`: each surface records the last date actually
+  WRITTEN, every sync computes its window from that watermark, and the watermark
+  advances only after a successful write. A window anchored on when the previous
+  run executed cannot see its own holes — skip a run and the gap is never
+  revisited, because the next window starts near today rather than at the last
+  day on disk. Surfaces are tracked independently, so one closing never vouches
+  for another.
+- **A recorded gap is now blocking.** `sync_watermark.py status` exits non-zero
+  while any surface has an unclosed gap, so a ritual step can fail on it. A gap
+  that genuinely cannot close is deferred with an explicit reason, and the
+  deferral lasts one working day — an indefinite silence is how a recorded gap
+  becomes furniture. This closes a loop that was previously open: the `gaps`
+  field was honest and completely inert, because writing a gap and closing one
+  are different acts and nothing forced the second.
+
+### Changed
+
+- **`synthesis-meeting-transcripts`: declared means fetched.** Agent judgment is
+  removed from deciding which declared transcripts are worth fetching. Relevance
+  is judged after fetching, when content is visible, never before from a title.
+  The workspace retired this same failure shape once already when activity-based
+  gating was removed from repository syncing.
+- **`synthesis-slack-sync`: read targets come from preflight.** Deriving ids from
+  config inside a sweep is banned. Where an entry carries two id-like fields, the
+  wrong one usually resolves — so the bug hides for months and then surfaces as a
+  phantom dead surface for exactly one person. Resolution belongs in one place
+  that fails closed, and readers take the resolved value from it.
+
 ## [4.55.1] - 2026-08-27
 
 ### Fixed

--- a/skills/synthesis-daily-rituals/SKILL.md
+++ b/skills/synthesis-daily-rituals/SKILL.md
@@ -19,6 +19,42 @@ metadata:
 
 Standard day-start and day-end rituals for synthesis engineering projects. These are the global (per-person) checklists. Each project may have a project-specific supplement that extends these with channel-specific sync, repo-specific checks, and stakeholder-specific communications.
 
+## v2.27.0 — Sync windows follow the last write, and a recorded gap blocks
+
+v2.27.0 (2026-08-27) replaces run-anchored sync windows with per-surface
+watermarks, and makes a recorded gap something a later run must act on.
+
+**The defect.** A window anchored on when the previous run *executed* cannot see
+its own holes. Skip a run and the hole it leaves is never revisited, because the
+next window starts at now-minus-a-bit rather than at the last day actually
+written to disk. Nothing persisted "the mirror is complete through date X", so
+no run could detect what it had missed. Compounding it, the `gaps` field was
+honest and completely inert: writing a gap and closing a gap are different acts,
+and nothing forced the second. A gap was recorded in three consecutive artifacts
+and no run ever read those lines back.
+
+**The rule.** Each surface carries a watermark — the last date actually
+WRITTEN, never the last date attempted — in `~/.synthesis/sync-watermarks/`,
+managed by `scripts/sync_watermark.py`:
+
+- every sync computes its window from the watermark, so a hole is revisited
+  automatically and nobody has to notice it;
+- the watermark advances only after a successful write, so a run that fetches
+  nothing, errors, or is interrupted cannot declare the day covered;
+- `sync_watermark.py status --workspace W` exits non-zero while any surface has
+  an unclosed gap. Run it in Day-Start Step 3 and Day-End Step 1. An open gap is
+  closed this run or deferred with an explicit reason, and a deferral lasts one
+  working day — an indefinite silence is how a recorded gap becomes furniture.
+
+Surfaces are tracked independently: one surface closing never vouches for
+another, which is the completeness claim that hid the original gap.
+
+**The general lesson, worth more than the fix.** Detection that nothing consumes
+changes nothing. The gap field was accurate every time it was written; what was
+missing was any mechanism that read it back. When adding a check, ask what
+consumes its output and what happens when the answer is bad — a finding with no
+consumer is a note to self.
+
 ## v2.26.0 — Lead-time meeting preps: high-stakes meetings get prepared a business day ahead
 
 Same-day prep packs (v2.12.0) are right for routine meetings and structurally wrong for

--- a/skills/synthesis-daily-rituals/scripts/sync_watermark.py
+++ b/skills/synthesis-daily-rituals/scripts/sync_watermark.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Per-surface sync watermarks: the last date actually WRITTEN, not last run.
+
+A sync window anchored on when the previous run executed cannot see its own
+holes. Skip a run and the hole is never revisited, because the next window
+starts at now-minus-a-bit rather than at the last day on disk. Nothing persists
+"the mirror is complete through date X", so no run can detect what it missed.
+
+A watermark fixes that by construction rather than by diligence:
+
+* the window is computed from the watermark, so a hole is revisited
+  automatically on the next run — no one has to notice it;
+* the watermark advances only on a successful WRITE, so a run that fetches
+  nothing, errors, or is interrupted cannot silently declare the day covered;
+* `status` exits non-zero while any surface has an unclosed, undeferred gap,
+  which is what makes a recorded gap load-bearing instead of prose. A gap that
+  genuinely cannot close this run must be deferred WITH A REASON, and the
+  deferral is itself dated and re-surfaced.
+
+That last point is the whole design. Detection that nothing consumes changes
+nothing: three consecutive artifacts recorded the same gap in prose and no run
+ever read those lines back.
+
+    sync_watermark.py window   --workspace W --surface S
+    sync_watermark.py advance  --workspace W --surface S --through YYYY-MM-DD
+    sync_watermark.py defer    --workspace W --surface S --reason TEXT
+    sync_watermark.py status   --workspace W [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+STORE_DIRNAME = "sync-watermarks"
+# A deferral silences a gap for one working day, never indefinitely: an
+# indefinite silence is how a gap becomes furniture.
+DEFERRAL_MAX_AGE = timedelta(days=1)
+
+
+def store_path(workspace: str, home: Path | None = None) -> Path:
+    root = home or Path(
+        os.environ.get("SYNTHESIS_HOME", str(Path.home() / ".synthesis"))
+    )
+    safe = "".join(c for c in workspace if c.isalnum() or c in "-_") or "default"
+    return root / STORE_DIRNAME / f"{safe}.json"
+
+
+def load(workspace: str, home: Path | None = None) -> dict:
+    path = store_path(workspace, home)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"surfaces": {}, "deferrals": {}}
+    if not isinstance(data, dict):
+        return {"surfaces": {}, "deferrals": {}}
+    data.setdefault("surfaces", {})
+    data.setdefault("deferrals", {})
+    return data
+
+
+def save(workspace: str, data: dict, home: Path | None = None) -> None:
+    path = store_path(workspace, home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(path)
+
+
+def _as_date(text: str) -> date | None:
+    try:
+        return date.fromisoformat(str(text)[:10])
+    except (TypeError, ValueError):
+        return None
+
+
+def window(
+    workspace: str, surface: str, today: date | None = None, home: Path | None = None
+) -> dict:
+    """The range this run must cover for one surface."""
+    moment = today or date.today()
+    data = load(workspace, home)
+    entry = data["surfaces"].get(surface) or {}
+    through = _as_date(entry.get("through", ""))
+    if through is None:
+        return {
+            "surface": surface,
+            "bootstrap": True,
+            "from": None,
+            "to": moment.isoformat(),
+            "gap_days": None,
+            "detail": "no watermark yet — this surface has never recorded a "
+                      "successful write, so the window cannot be narrowed",
+        }
+    start = through + timedelta(days=1)
+    return {
+        "surface": surface,
+        "bootstrap": False,
+        "from": start.isoformat(),
+        "to": moment.isoformat(),
+        "gap_days": max((moment - through).days - 1, 0),
+        "detail": f"mirror complete through {through.isoformat()}",
+    }
+
+
+def advance(
+    workspace: str,
+    surface: str,
+    through: str,
+    today: date | None = None,
+    home: Path | None = None,
+) -> dict:
+    """Record a successful write. Never moves a watermark backwards."""
+    moment = today or date.today()
+    new = _as_date(through)
+    if new is None:
+        raise ValueError(f"not a date: {through}")
+    if new > moment:
+        raise ValueError(f"refusing a future watermark: {through} > {moment}")
+    data = load(workspace, home)
+    entry = data["surfaces"].get(surface) or {}
+    old = _as_date(entry.get("through", ""))
+    if old is not None and new < old:
+        return {"surface": surface, "through": old.isoformat(), "moved": False,
+                "detail": f"refused: {through} is behind the recorded {old}"}
+    data["surfaces"][surface] = {
+        "through": new.isoformat(),
+        "updated_at": datetime.now().isoformat(timespec="seconds"),
+    }
+    # A surface that just wrote has no outstanding gap, so its deferral is spent.
+    data["deferrals"].pop(surface, None)
+    save(workspace, data, home)
+    return {"surface": surface, "through": new.isoformat(), "moved": True,
+            "detail": "watermark advanced"}
+
+
+def defer(
+    workspace: str,
+    surface: str,
+    reason: str,
+    today: date | None = None,
+    home: Path | None = None,
+) -> dict:
+    if not reason.strip():
+        raise ValueError("a deferral requires a reason")
+    moment = today or date.today()
+    data = load(workspace, home)
+    data["deferrals"][surface] = {
+        "reason": reason.strip(),
+        "deferred_on": moment.isoformat(),
+    }
+    save(workspace, data, home)
+    return {"surface": surface, "deferred_on": moment.isoformat()}
+
+
+def status(
+    workspace: str,
+    surfaces: list[str] | None = None,
+    today: date | None = None,
+    home: Path | None = None,
+) -> dict:
+    moment = today or date.today()
+    data = load(workspace, home)
+    names = sorted(set(surfaces or []) | set(data["surfaces"]))
+    rows, blocking = [], []
+    for surface in names:
+        info = window(workspace, surface, moment, home)
+        gap = info["bootstrap"] or (info["gap_days"] or 0) > 0
+        deferral = data["deferrals"].get(surface) or {}
+        deferred_on = _as_date(deferral.get("deferred_on", ""))
+        live_deferral = (
+            deferred_on is not None and (moment - deferred_on) <= DEFERRAL_MAX_AGE
+        )
+        row = {
+            "surface": surface,
+            "through": (data["surfaces"].get(surface) or {}).get("through"),
+            "gap": gap,
+            "gap_days": info["gap_days"],
+            "bootstrap": info["bootstrap"],
+            "deferred": bool(live_deferral),
+            "deferral_reason": deferral.get("reason") if live_deferral else None,
+            "stale_deferral": bool(deferred_on and not live_deferral),
+        }
+        rows.append(row)
+        if gap and not live_deferral:
+            blocking.append(surface)
+    return {"workspace": workspace, "as_of": moment.isoformat(),
+            "surfaces": rows, "blocking": blocking}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name in ("window", "advance", "defer", "status"):
+        p = sub.add_parser(name)
+        p.add_argument("--workspace", required=True)
+        p.add_argument("--json", action="store_true")
+        if name != "status":
+            p.add_argument("--surface", required=True)
+        else:
+            p.add_argument("--surface", action="append", default=[])
+        if name == "advance":
+            p.add_argument("--through", required=True)
+        if name == "defer":
+            p.add_argument("--reason", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "window":
+            result = window(args.workspace, args.surface)
+        elif args.command == "advance":
+            result = advance(args.workspace, args.surface, args.through)
+        elif args.command == "defer":
+            result = defer(args.workspace, args.surface, args.reason)
+        else:
+            result = status(args.workspace, args.surface)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if getattr(args, "json", False):
+        print(json.dumps(result, indent=2))
+    elif args.command == "status":
+        for row in result["surfaces"]:
+            state = (
+                "BLOCKING" if row["gap"] and not row["deferred"]
+                else "deferred" if row["gap"] else "current"
+            )
+            through = row["through"] or "never written"
+            extra = f" — {row['deferral_reason']}" if row["deferred"] else ""
+            print(f"  {state:9s} {row['surface']:22s} through {through}{extra}")
+        if result["blocking"]:
+            print(
+                f"\n{len(result['blocking'])} surface(s) with an unclosed gap: "
+                + ", ".join(result["blocking"])
+                + "\nClose them this run, or record an explicit reason with "
+                "`sync_watermark.py defer`. A gap in prose is not a closed gap."
+            )
+    else:
+        print(json.dumps(result, indent=2))
+
+    if args.command == "status" and result["blocking"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
+++ b/skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
@@ -1,0 +1,219 @@
+"""Regressions for per-surface sync watermarks.
+
+Derived from a real failure, not an imagined one: a local mirror gap spanning
+six days was recorded in three consecutive ritual artifacts and never closed.
+Each run synced "since the last ritual", anchored on when the previous run
+executed, so the hole the skipped run left was never revisited. The gaps the
+artifacts honestly recorded were prose, and no run read those lines back.
+
+Two properties make the repair structural rather than a matter of diligence:
+the window is computed from the last successful WRITE so a hole is revisited
+automatically, and an unclosed gap makes `status` exit non-zero so a later run
+has to act on it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("sync_watermark.py")
+SPEC = importlib.util.spec_from_file_location("sync_watermark", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+WS = "testspace"
+TODAY = date(2026, 8, 28)
+
+
+# --- the window follows writes, not runs ----------------------------------
+
+
+def test_window_starts_after_the_last_written_day(tmp_path: Path) -> None:
+    MODULE.advance(WS, "slack", "2026-08-20", today=TODAY, home=tmp_path)
+
+    got = MODULE.window(WS, "slack", today=TODAY, home=tmp_path)
+
+    assert got["from"] == "2026-08-21"
+    assert got["to"] == "2026-08-28"
+
+
+def test_a_skipped_run_leaves_a_gap_the_next_run_must_cover(tmp_path: Path) -> None:
+    """The verbatim failure: written through 8/20, nothing since, and the next
+    window must reach back to 8/21 rather than starting near today."""
+    MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
+
+    got = MODULE.window(WS, "slack", today=TODAY, home=tmp_path)
+
+    assert got["from"] == "2026-08-21"
+    assert got["gap_days"] == 7
+
+
+def test_no_watermark_reports_bootstrap_rather_than_guessing(tmp_path: Path) -> None:
+    got = MODULE.window(WS, "email", today=TODAY, home=tmp_path)
+
+    assert got["bootstrap"] is True
+    assert got["from"] is None
+
+
+# --- the watermark advances only on a successful write --------------------
+
+
+def test_watermark_never_moves_backwards(tmp_path: Path) -> None:
+    MODULE.advance(WS, "slack", "2026-08-26", today=TODAY, home=tmp_path)
+
+    result = MODULE.advance(WS, "slack", "2026-08-22", today=TODAY, home=tmp_path)
+
+    assert result["moved"] is False
+    assert result["through"] == "2026-08-26"
+
+
+def test_future_watermark_is_refused(tmp_path: Path) -> None:
+    """A run cannot declare tomorrow covered."""
+    try:
+        MODULE.advance(WS, "slack", "2026-09-01", today=TODAY, home=tmp_path)
+    except ValueError as exc:
+        assert "future" in str(exc)
+    else:
+        raise AssertionError("a future watermark must be refused")
+
+
+# --- an unclosed gap is blocking, which is what makes it load-bearing -----
+
+
+def test_status_blocks_while_a_gap_is_open(tmp_path: Path) -> None:
+    MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
+
+    result = MODULE.status(WS, ["slack"], today=TODAY, home=tmp_path)
+
+    assert result["blocking"] == ["slack"]
+
+
+def test_status_is_clear_once_the_gap_closes(tmp_path: Path) -> None:
+    MODULE.advance(WS, "slack", "2026-08-28", today=TODAY, home=tmp_path)
+
+    assert MODULE.status(WS, ["slack"], today=TODAY, home=tmp_path)["blocking"] == []
+
+
+def test_deferral_requires_a_reason(tmp_path: Path) -> None:
+    try:
+        MODULE.defer(WS, "slack", "   ", today=TODAY, home=tmp_path)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("a reason-less deferral must be refused")
+
+
+def test_explicit_deferral_unblocks_for_one_day_only(tmp_path: Path) -> None:
+    """A deferral silences a gap for a day, never indefinitely — an indefinite
+    silence is how a recorded gap becomes furniture."""
+    MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
+    MODULE.defer(WS, "slack", "Slack API outage", today=TODAY, home=tmp_path)
+
+    same_day = MODULE.status(WS, ["slack"], today=TODAY, home=tmp_path)
+    later = MODULE.status(WS, ["slack"], today=date(2026, 8, 31), home=tmp_path)
+
+    assert same_day["blocking"] == []
+    assert later["blocking"] == ["slack"]
+    assert later["surfaces"][0]["stale_deferral"] is True
+
+
+def test_a_successful_write_spends_the_deferral(tmp_path: Path) -> None:
+    MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
+    MODULE.defer(WS, "slack", "outage", today=TODAY, home=tmp_path)
+    MODULE.advance(WS, "slack", "2026-08-28", today=TODAY, home=tmp_path)
+
+    row = MODULE.status(WS, ["slack"], today=TODAY, home=tmp_path)["surfaces"][0]
+    assert row["deferred"] is False
+
+
+def test_surfaces_are_tracked_independently(tmp_path: Path) -> None:
+    """One surface closing must not vouch for another — the completeness claim
+    that hid the original gap."""
+    MODULE.advance(WS, "slack", "2026-08-28", today=TODAY, home=tmp_path)
+    MODULE.advance(WS, "email", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
+
+    assert MODULE.status(WS, ["slack", "email"], today=TODAY, home=tmp_path)[
+        "blocking"
+    ] == ["email"]
+
+
+# --- the gate is consumable by a ritual -----------------------------------
+
+
+def test_cli_status_exits_nonzero_while_blocking(tmp_path: Path) -> None:
+    """The property that makes this load-bearing: a ritual step can fail on it."""
+    env = {"SYNTHESIS_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
+    MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
+
+    done = subprocess.run(
+        [sys.executable, str(SCRIPT), "status", "--workspace", WS, "--json"],
+        capture_output=True, text=True, env=env,
+    )
+
+    assert done.returncode == 1
+    assert json.loads(done.stdout)["blocking"] == ["slack"]
+
+
+def test_cli_status_exits_zero_when_current(tmp_path: Path) -> None:
+    env = {"SYNTHESIS_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
+    MODULE.advance(WS, "slack", "2026-08-28", today=TODAY, home=tmp_path)
+
+    done = subprocess.run(
+        [sys.executable, str(SCRIPT), "status", "--workspace", WS, "--json"],
+        capture_output=True, text=True, env=env,
+    )
+
+    assert done.returncode == 0
+
+
+def test_store_is_scoped_per_workspace(tmp_path: Path) -> None:
+    """Engagement workspaces must not read each other's sync state."""
+    MODULE.advance("alpha", "slack", "2026-08-28", today=TODAY, home=tmp_path)
+
+    assert MODULE.window("beta", "slack", today=TODAY, home=tmp_path)["bootstrap"]
+
+
+# --- the documented rules the mechanism depends on ------------------------
+
+SKILLS_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_rituals_document_the_watermark_and_blocking_gap() -> None:
+    """A mechanism nobody is told to run is not a control."""
+    text = (SKILLS_ROOT / "synthesis-daily-rituals" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "sync_watermark.py" in text
+    assert "last date actually" in text.lower()
+    assert "exits non-zero" in text
+
+
+def test_transcripts_forbid_a_judgment_gate_before_fetching() -> None:
+    """Declared means fetched; relevance is judged after fetching, not from a
+    title. The same shape was already retired once for repository syncing."""
+    text = (SKILLS_ROOT / "synthesis-meeting-transcripts" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "does not get a vote" in text
+    assert "after* fetching" in text or "after fetching" in text
+
+
+def test_slack_sync_bans_deriving_read_ids_in_the_sweep() -> None:
+    """Two id-like fields per entry is a trap that hides until someone leaves."""
+    text = (SKILLS_ROOT / "synthesis-slack-sync" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "preflight" in text
+    assert "banned" in text
+    assert "dm_id" in text

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,10 +1,10 @@
-# AGENT HEURISTIC: authored for the item-currency section-scope correction.
-# The manifest records this release's exact public universe; the runner proves
-# the declaration against the authoritative base-to-head Git diff, so a surface
-# that changes without being declared — or is declared without changing —
-# refuses authority.
+# AGENT HEURISTIC: authored for the sync-watermark release. The manifest
+# records this release's exact public universe; the runner proves the
+# declaration against the authoritative base-to-head Git diff, so a surface that
+# changes without being declared — or is declared without changing — refuses
+# authority.
 schema: 2
-suite: synthesis-item-currency-section-scope
+suite: synthesis-sync-watermarks-and-declared-fetching
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run
 enforcing_boundary: release.py and repository CI before publication
@@ -13,12 +13,18 @@ change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: adoption of the stamp convention by existing records, installed-client parity, independent review, publication, and deployment
+unverified_remainder: adoption of watermarks by existing workspaces (no workspace has recorded a watermark yet, so the window and blocking paths are fixture-proven but unexercised by live ritual runs), the preflight read-target rule which is documented here but enforced by each workspace's own preflight tool, installed-client parity, independent review, publication, and deployment
 changed_surfaces:
-  - path: skills/synthesis-context-lifecycle/scripts/context_currency.py
-    cases: [item-current-state-prose-exempt, item-obligation-sections-still-held, item-prose-exempt, item-unstamped-unverifiable]
-  - path: skills/synthesis-context-lifecycle/scripts/test_item_currency.py
-    cases: [item-current-state-prose-exempt, item-obligation-sections-still-held, item-prose-exempt, item-unstamped-unverifiable]
+  - path: skills/synthesis-daily-rituals/scripts/sync_watermark.py
+    cases: [window-follows-last-write, skipped-run-gap-is-revisited, watermark-never-regresses, future-watermark-refused, unclosed-gap-blocks, deferral-requires-reason, deferral-expires, surfaces-independent, gate-is-consumable, store-scoped-per-workspace]
+  - path: skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
+    cases: [window-follows-last-write, skipped-run-gap-is-revisited, watermark-never-regresses, future-watermark-refused, unclosed-gap-blocks, deferral-requires-reason, deferral-expires, surfaces-independent, gate-is-consumable, store-scoped-per-workspace, rituals-document-the-gate, transcripts-forbid-judgment-gate, slack-bans-derived-read-ids]
+  - path: skills/synthesis-daily-rituals/SKILL.md
+    cases: [rituals-document-the-gate]
+  - path: skills/synthesis-meeting-transcripts/SKILL.md
+    cases: [transcripts-forbid-judgment-gate]
+  - path: skills/synthesis-slack-sync/SKILL.md
+    cases: [slack-bans-derived-read-ids]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -28,22 +34,58 @@ changed_surfaces:
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
 cases:
-  - id: item-current-state-prose-exempt
+  - id: window-follows-last-write
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_current_state_prose_is_not_held_to_item_stamps
-    motivating_defect: matching-current-state-demanded-a-date-from-prose-and-double-covered-body-currency-140-of-294-flagged-items
-  - id: item-obligation-sections-still-held
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_window_starts_after_the_last_written_day
+    motivating_defect: a-window-anchored-on-the-previous-run-cannot-see-the-hole-a-skipped-run-left
+  - id: skipped-run-gap-is-revisited
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_obligation_sections_are_still_held
-    motivating_defect: narrowing-a-guard-can-silently-exempt-the-sections-it-exists-to-cover
-  - id: item-prose-exempt
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_a_skipped_run_leaves_a_gap_the_next_run_must_cover
+    motivating_defect: a-six-day-mirror-gap-was-recorded-in-three-artifacts-and-never-revisited
+  - id: watermark-never-regresses
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_prose_sections_do_not_demand_stamps
-    motivating_defect: demanding-dates-from-narrative-bullets-would-train-bypass
-  - id: item-unstamped-unverifiable
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_watermark_never_moves_backwards
+    motivating_defect: a-regressing-watermark-would-silently-re-open-days-already-mirrored
+  - id: future-watermark-refused
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_unstamped_open_items_are_reported_as_unverifiable
-    motivating_defect: an-undated-item-was-indistinguishable-from-one-written-today
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_future_watermark_is_refused
+    motivating_defect: a-run-must-not-be-able-to-declare-a-day-covered-before-it-happens
+  - id: unclosed-gap-blocks
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_status_blocks_while_a_gap_is_open
+    motivating_defect: the-gaps-field-was-honest-and-completely-inert-because-nothing-read-it-back
+  - id: deferral-requires-reason
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_deferral_requires_a_reason
+    motivating_defect: a-reasonless-deferral-is-indistinguishable-from-forgetting
+  - id: deferral-expires
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_explicit_deferral_unblocks_for_one_day_only
+    motivating_defect: an-indefinite-silence-is-how-a-recorded-gap-becomes-furniture
+  - id: surfaces-independent
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_surfaces_are_tracked_independently
+    motivating_defect: one-surface-closing-vouched-for-others-and-hid-the-original-gap
+  - id: gate-is-consumable
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_status_exits_nonzero_while_blocking
+    motivating_defect: detection-that-no-step-can-fail-on-changes-nothing
+  - id: store-scoped-per-workspace
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_store_is_scoped_per_workspace
+    motivating_defect: engagement-workspaces-must-not-read-each-others-sync-state
+  - id: rituals-document-the-gate
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_rituals_document_the_watermark_and_blocking_gap
+    motivating_defect: a-mechanism-nobody-is-told-to-run-is-not-a-control
+  - id: transcripts-forbid-judgment-gate
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_transcripts_forbid_a_judgment_gate_before_fetching
+    motivating_defect: title-based-triage-deprioritised-declared-transcripts-holding-a-live-action-item-and-a-contradicting-date
+  - id: slack-bans-derived-read-ids
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_slack_sync_bans_deriving_read_ids_in_the_sweep
+    motivating_defect: a-reader-that-picks-between-two-id-fields-works-until-the-person-leaves-then-looks-like-a-config-defect
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-meeting-transcripts/SKILL.md
+++ b/skills/synthesis-meeting-transcripts/SKILL.md
@@ -10,6 +10,34 @@ metadata:
   source_type: "public"
 ---
 
+## v0.8.0 — Declared means fetched: no judgment gate before fetching
+
+v0.8.0 (2026-08-27) removes agent judgment from the decision of *which* declared
+transcripts to fetch.
+
+**The defect.** The sweep enumerated documents and recorded their ids, but
+fetching was gated on the agent deciding what looked worth fetching. That
+judgment deprioritised several meetings as routine standups. One held a live
+action item for the principal; another carried a launch date contradicting the
+one recorded everywhere else, so the corpus held two incompatible dates and
+nothing surfaced the conflict.
+
+**The rule.** If a transcript is declared in scope for the window, it is
+fetched. The agent does not get a vote on which declared items are interesting.
+Relevance is judged *after* fetching, when the content is visible — never
+before, from a title.
+
+**Why this shape is already settled here.** The workspace retired this exact
+failure once before, when "sync when active" gating was removed from the repo
+list after a repository drifted for six weeks behind a judgment that it looked
+inactive. Titles and activity heuristics are not evidence about content. A
+declared set exists precisely so that no per-item judgment stands between the
+list and the fetch; re-introducing one at a lower level rebuilds the failure the
+declared set was meant to prevent.
+
+A run that cannot fetch a declared item records it as an unclosed gap rather
+than silently omitting it.
+
 ## v0.7.0 — Source grade is now executable
 
 The standing kernel rule already says that a verbatim transcript is the only

--- a/skills/synthesis-slack-sync/SKILL.md
+++ b/skills/synthesis-slack-sync/SKILL.md
@@ -16,6 +16,32 @@ A protocol for syncing Slack channels and threads to local transcript files usin
 
 This skill provides the **protocol** — the sync methodology, thread re-reading discipline, transcript format, and action plan update rules. A per-project **config file** provides the specifics: which channels, which paths, which DMs. Prefer `.agents/slack-sync.yaml`; existing `.claude/slack-sync.yaml` configs remain supported.
 
+## v3.6.0 — Read targets come from preflight; deriving ids in the sweep is banned
+
+v3.6.0 (2026-08-27) fixes a class of bug that hides for months and then looks
+like something else entirely.
+
+**The defect.** A DM config entry carries two id-like fields: `id`, the user id
+(`U…`), and `dm_id`, the conversation id (`D…`). A reader that reaches for `id`
+hands a user id to a conversation-read API. That resolves implicitly while the
+account is active, so the mistake is invisible — and it starts failing only once
+that person leaves. The symptom then appears as a phantom "dead surface" for
+exactly one person, which reads as a configuration problem. It cost days of
+false unreadable-DM reports and a wrong public claim that the config was
+misaligned, when the config was correct and the reader was not.
+
+**The rule.** Sweeps take their read targets from preflight output, which emits
+the resolved read id per surface and fails closed when one cannot be resolved.
+Deriving ids from config inside the sweep is banned. A sweep that cannot obtain
+a resolved read target reports that surface as unresolved — never as unreadable,
+and never as a config defect, since it has no evidence for either.
+
+**Generalize it.** Any config whose entries carry two id-like fields has this
+trap, and the failure is always asymmetric: the wrong field usually works, so
+the bug is discovered by an unrelated change months later. Where two ids exist,
+resolution belongs in one place that fails closed, and every reader takes the
+resolved value from it rather than choosing a field.
+
 ## v3.5.0 — Backfills and archive imports
 
 v3.5.0 (2026-08-19) adds a section for the operation a windowed sync is not: reading a


### PR DESCRIPTION
## The pattern behind all three changes

Detection existed and was good; nothing consumed its output. A gap field that was accurate every time it was written, and no run that ever read those lines back. Closing that loop matters more than any individual fix here.

## 1 & 2 — Watermarks, and gaps that block

A sync window anchored on when the previous run *executed* cannot see its own holes. Skip a run and the hole is never revisited, because the next window starts near today rather than at the last day actually written to disk. Nothing persisted "the mirror is complete through date X", so no run could detect what it had missed. Separately, the `gaps` field was honest and completely inert: writing a gap and closing a gap are different acts, and nothing forced the second.

These are one mechanism, not two. `scripts/sync_watermark.py` records the last date actually **written** per surface; every window is computed from it, so a hole is revisited automatically rather than by someone noticing. The watermark advances only after a successful write, so a run that fetches nothing, errors, or is interrupted cannot declare the day covered. `status` exits non-zero while a gap is open, which is what makes a recorded gap something a ritual step can fail on. A gap that genuinely cannot close is deferred **with a reason**, and the deferral expires in one working day — an indefinite silence is how a recorded gap becomes furniture.

Surfaces are tracked independently: one surface closing never vouches for another.

## 3 — Declared means fetched

Agent judgment is removed from deciding which declared transcripts are worth fetching. Title-based triage is not evidence about content. This is the same failure shape the workspace already retired when activity-based gating was removed from repository syncing; the precedent existed and had not been applied here.

## 4 — Read targets come from preflight

Where a config entry carries two id-like fields, a reader that picks the wrong one usually still resolves — so the bug hides for months and then surfaces as a phantom "dead surface" for exactly one person, reading as a config defect. Resolution belongs in one place that fails closed; readers take the resolved value from it. Deriving ids inside a sweep is banned, and the rule is stated generally because any two-id config has this trap.

## Tests

17 fixtures, every one derived from the real failure rather than invented, including the CLI exit-code property that makes the gate consumable.

## Note

The motivating incident is client-confidential. Only mechanisms appear here; the diff was scanned and carries no organization names, person names, or figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)