### PR TITLE
Enforce the project status vocabulary in the context doctor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.57.0",
+  "version": "4.58.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.57.0",
+  "version": "4.58.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.58.0] - 2026-08-29
+
+### Added
+
+- **`synthesis-context-lifecycle` v1.13.0 — the status vocabulary is enforced,
+  not assumed.** An unvalidated vocabulary is not a vocabulary. Two failures on
+  a real 127-project corpus made the case. `complete` survived for months as a
+  typo of `completed`, and rather than reject it the doctor *absorbed* it,
+  hardcoding the typo into its terminal set. Worse, `superseded` was absent from
+  that set while also not being a completion word to the header parser, so a
+  superseded project parsed as making no completion claim at all: it sat
+  permanently as `record-unreadable` and never received its cross-tier check.
+  Five projects were silently exempt, two of them for months.
+
+  A status the doctor does not recognise silently disables every check keyed off
+  it, which is the most expensive kind of quiet failure a health check can have
+  — indistinguishable from passing.
+
+  This release declares the canonical set — `active`, `paused`, `completed`,
+  `archived` — where status answers exactly one question: does this project
+  claim attention. Everything orthogonal becomes a qualifier field (`bounded`,
+  `superseded_by`, `wake_when`, `blocked_by`, `completed_date`), so the
+  vocabulary should not have to grow as new distinctions appear. The new
+  `status-vocabulary` check reports an unknown status as a defect and a retired
+  one as a warning naming its replacement; retired values stay readable so an
+  unmigrated corpus is diagnosed rather than rejected. Run against a live corpus
+  the check immediately found two retired statuses in workspaces that had not
+  been migrated.
+
 ## [4.57.0] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A status the doctor cannot read is a check that never runs (August 2026).**
+Release **4.58.0** makes the project status vocabulary enforceable. On a real
+corpus one status was a typo the doctor had *absorbed* into its terminal set
+rather than rejected, and another was missing from that set entirely — so five
+projects parsed as making no completion claim and quietly skipped their
+cross-tier check. Status now answers one question, does this claim attention,
+with four values; everything orthogonal is a qualifier field, so the vocabulary
+does not have to grow. A new `status-vocabulary` check fails on the unknown and
+warns on the retired, naming what each should become. See the
+[4.58.0 release notes](CHANGELOG.md).
+
 **A coordination claim now reaches the Git index (August 2026).** Release
 **4.53.0** adds `coordination.py check-staged`: before a configured commit can
 proceed, the active board session must name the exact worktree and branch, and

--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.12.0"
+  version: "1.13.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -718,6 +718,23 @@ What it checks:
 | Disclosure | anything unverifiable is reported rather than skipped — unreadable status headers and freshness that cannot be established both surface as findings |
 
 Exit codes follow the guard contract: `0` healthy, `1` defects found, `2` the doctor could not establish ground truth. The third is the important one — an unreadable source or a source outside git exits 2 rather than reporting health, because a check that cannot run must never look like a check that passed.
+
+**The status vocabulary is enforced, not assumed** (v1.13.0). `status` answers
+one question — does this project claim attention — with four values: `active`,
+`paused`, `completed`, `archived`. Everything orthogonal is a qualifier field
+(`bounded`, `superseded_by`, `wake_when`, `blocked_by`, `completed_date`), so the
+vocabulary does not have to grow as new distinctions appear.
+
+The `status-vocabulary` check reports an unrecognised status as a **defect** and
+a retired one as a **warning** naming what it should become. This exists because
+an unvalidated vocabulary is not a vocabulary: on a real corpus, `complete`
+survived for months as a typo of `completed` and this tool *absorbed* it,
+hardcoding it into the terminal set rather than rejecting it. Worse, `superseded`
+was absent from that set while also not being a completion word to the header
+parser, so five projects parsed as making no completion claim at all — they sat
+permanently as `record-unreadable` and never received their cross-tier check. A
+status the doctor does not recognise silently disables every check keyed off it,
+which is the most expensive kind of quiet failure a health check can have.
 
 **Nothing is skipped silently.** A check that cannot run reports that it could not run. When every recent commit touching a project is a repo-wide sweep, freshness is unverifiable and says so; when a CONTEXT.md has no parseable status header, the cross-check is reported as unavailable rather than passed. Silent skips are indistinguishable from clean results, and that is the property this tool exists to remove.
 

--- a/skills/synthesis-context-lifecycle/scripts/context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_doctor.py
@@ -545,8 +545,30 @@ LAST_SESSION_HEADER = re.compile(
     r"^\*\*Last session\:\*\*\s*(?P<value>.+?)\s*$", re.MULTILINE
 )
 DATE_IN_TEXT = re.compile(r"(\d{4}-\d{2}-\d{2})")
-COMPLETED_WORDS = ("complete", "completed", "shipped", "closed", "done")
+COMPLETED_WORDS = ("complete", "completed", "shipped", "closed", "done",
+                   "archived", "superseded")
 PAUSED_WORDS = ("paused", "on hold", "parked")
+
+# The canonical project-status vocabulary. Status answers one question -- does
+# this claim attention -- and everything orthogonal is a qualifier field
+# (bounded, superseded_by, wake_when, blocked_by, completed_date).
+CANONICAL_STATUSES = {"active", "paused", "completed", "archived"}
+
+# Statuses that mean the project is over. `superseded` is accepted for corpora
+# that have not migrated: it used to be absent here, which meant such a project
+# parsed as making no completion claim at all, sat permanently as
+# `record-unreadable`, and never got its cross-tier check. `complete` is a
+# tolerated typo of `completed` and is reported by the vocabulary check below.
+TERMINAL_STATUSES = {"completed", "complete", "archived", "superseded"}
+
+# Retired values, still readable so an unmigrated corpus is diagnosed rather
+# than rejected. The message names what each one should become.
+RETIRED_STATUSES = {
+    "new": "a Phase, not a lifecycle state -- use active or paused",
+    "ongoing": "conflates attention with boundedness -- use active/paused plus `bounded: false`",
+    "superseded": "use `archived` plus `superseded_by`",
+    "complete": "a typo of `completed`",
+}
 
 
 def read_text(path: Path) -> str:
@@ -683,6 +705,7 @@ CHECKS = [
     "reference-budget",
     "sessions-present",
     "status-agreement",
+    "status-vocabulary",
     "completed-date",
     "last-session-freshness",
     "context-header-freshness",
@@ -800,7 +823,7 @@ def audit_project(
     declared_complete = context_declares_completed(context_text)
 
     index_status = str((index_entry or {}).get("status") or "").strip().lower()
-    index_says_completed = index_status in {"completed", "complete", "archived"}
+    index_says_completed = index_status in TERMINAL_STATUSES
 
     # Budget depends on which lifecycle stage the project is actually in.
     treat_completed = index_says_completed or bool(declared_complete)
@@ -888,6 +911,26 @@ def audit_project(
                 "record says the other",
                 "decide the real status and set both",
             )
+        if index_status and index_status not in CANONICAL_STATUSES:
+            became = RETIRED_STATUSES.get(index_status)
+            if became:
+                audit.add(
+                    "status-vocabulary",
+                    "warning",
+                    f"index.yaml status `{index_status}` is retired -- {became}",
+                    "migrate the entry to the canonical vocabulary "
+                    f"{sorted(CANONICAL_STATUSES)}",
+                )
+            else:
+                audit.add(
+                    "status-vocabulary",
+                    "defect",
+                    f"index.yaml status `{index_status}` is not a known status -- "
+                    "an unrecognised status silently disables the checks that key "
+                    "off it",
+                    f"use one of {sorted(CANONICAL_STATUSES)}",
+                )
+
         if index_says_completed and not (index_entry or {}).get("completed_date"):
             audit.add(
                 "completed-date",

--- a/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
@@ -696,6 +696,62 @@ class ContextDoctorTests(unittest.TestCase):
         self.assertFalse(cd.context_declares_completed("**Status:** Paused"))
         self.assertIsNone(cd.context_declares_completed("no header here"))
 
+    # --- status vocabulary -------------------------------------------------
+
+    def test_unknown_status_is_a_defect(self):
+        """An unrecognised status silently disables every check keyed off it."""
+        self.fx.project("alpha", context="# P\n\n**Status:** Active\n")
+        self.fx.index([{"id": "alpha", "status": "wibble"}])
+        self.fx.commit()
+        self.assertIn("status-vocabulary", checks_in(self.fx.audit()))
+
+    def test_retired_status_is_a_warning_naming_its_replacement(self):
+        self.fx.project("alpha", context="# P\n\n**Status:** Active\n")
+        self.fx.index([{"id": "alpha", "status": "ongoing"}])
+        self.fx.commit()
+        findings = self.fx.audit()["data"]["findings"]
+        found = [f for f in findings if f["check"] == "status-vocabulary"]
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0]["severity"], "warning")
+        self.assertIn("bounded", found[0]["message"])
+
+    def test_canonical_statuses_produce_no_vocabulary_finding(self):
+        for status in sorted(cd.CANONICAL_STATUSES):
+            with self.subTest(status=status):
+                fx = Fixture(Path(self._tmp.name) / ("vocab-" + status))
+                terminal = status in cd.TERMINAL_STATUSES
+                ctx = ("# P\n\n**Status:** Completed\n" if terminal
+                       else "# P\n\n**Status:** Active\n")
+                fx.project("alpha", context=ctx)
+                entry = {"id": "alpha", "status": status}
+                if terminal:
+                    entry["completed_date"] = "2026-01-01"
+                fx.index([entry])
+                fx.commit()
+                self.assertNotIn("status-vocabulary", checks_in(fx.audit()))
+
+    def test_superseded_is_terminal(self):
+        """Regression, found 2026-08-28 on a real corpus.
+
+        `superseded` was absent from the terminal set AND from the header
+        parser's completion words. A superseded project therefore parsed as
+        making no completion claim at all: it sat permanently as
+        `record-unreadable` and never received its cross-tier check. Five real
+        projects were silently exempt. This pins both halves of the fix.
+        """
+        self.assertIn("superseded", cd.TERMINAL_STATUSES)
+        self.assertTrue(cd.context_declares_completed("**Status:** Superseded by `x`"))
+        self.assertTrue(cd.context_declares_completed("**Status:** Archived - closed"))
+
+    def test_superseded_project_gets_its_cross_tier_check(self):
+        self.fx.project("alpha", context="# P\n\n**Status:** Superseded by `beta`\n")
+        self.fx.index([{"id": "alpha", "status": "superseded",
+                        "completed_date": "2026-01-01"}])
+        self.fx.commit()
+        checks = checks_in(self.fx.audit())
+        self.assertNotIn("record-unreadable", checks)
+        self.assertNotIn("status-agreement", checks)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,10 +1,10 @@
-# AGENT HEURISTIC: authored for the decision-packet release. The manifest
-# records this release's exact public universe; the runner proves the
+# AGENT HEURISTIC: authored for the status-vocabulary-enforcement release. The
+# manifest records this release's exact public universe; the runner proves the
 # declaration against the authoritative base-to-head Git diff, so a surface that
 # changes without being declared — or is declared without changing — refuses
 # authority.
 schema: 2
-suite: synthesis-decision-packet-release
+suite: synthesis-status-vocabulary-release
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run
 enforcing_boundary: release.py and repository CI before publication
@@ -13,10 +13,14 @@ change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: browser behaviour of the generated packet beyond the emitted markup and script text (the fixtures assert on generated source, not on a live DOM), wiring the packet into autopilot as its batched-questions mechanism, installed-client parity, independent review, publication, and deployment
+unverified_remainder: migration of corpora outside the author's own workspaces (two retired statuses were found in unmigrated workspaces by this very check and are not fixed here), whether the four canonical values remain sufficient as new project shapes appear, installed-client parity, independent review, publication, and deployment
 changed_surfaces:
-  - path: skills/synthesis-decision-packet/scripts/test_build_packet.py
-    cases: [recommendation-marked-not-preselected, fresh-packet-has-nothing-selected]
+  - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
+    cases: [unknown-status-is-a-defect, retired-status-names-its-replacement, superseded-is-terminal]
+  - path: skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
+    cases: [unknown-status-is-a-defect, retired-status-names-its-replacement, superseded-is-terminal, canonical-statuses-are-silent, superseded-gets-its-cross-tier-check]
+  - path: skills/synthesis-context-lifecycle/SKILL.md
+    cases: [shipped-manifest-self-consumption]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -25,15 +29,29 @@ changed_surfaces:
     cases: [release-manifest-parity]
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
+  - path: README.md
+    cases: [release-changelog-parity]
 cases:
-  - id: recommendation-marked-not-preselected
+  - id: unknown-status-is-a-defect
     control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_recommendation_is_marked_on_the_control_not_only_prose
-    motivating_defect: the-test-name-said-preselected-while-the-implementation-deliberately-preselects-nothing-inviting-a-fix-toward-the-wrong-behaviour
-  - id: fresh-packet-has-nothing-selected
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_unknown_status_is_a_defect
+    motivating_defect: a-status-the-doctor-does-not-recognise-silently-disables-every-check-keyed-off-it-and-looks-identical-to-passing
+  - id: retired-status-names-its-replacement
     control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_a_fresh_packet_has_nothing_selected
-    motivating_defect: a-packet-that-opens-fully-decided-cannot-distinguish-i-agreed-from-i-never-looked
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_retired_status_is_a_warning_naming_its_replacement
+    motivating_defect: a-migration-warning-that-does-not-say-what-the-value-should-become-leaves-the-reader-to-guess-and-they-guess-wrong
+  - id: canonical-statuses-are-silent
+    control_class: acceptance-test
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_canonical_statuses_produce_no_vocabulary_finding
+    motivating_defect: a-vocabulary-check-that-fires-on-correct-values-trains-its-owner-to-ignore-it
+  - id: superseded-is-terminal
+    control_class: acceptance-test
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_superseded_is_terminal
+    motivating_defect: superseded-was-absent-from-the-terminal-set-and-from-the-header-parsers-completion-words-so-such-projects-parsed-as-making-no-completion-claim-at-all
+  - id: superseded-gets-its-cross-tier-check
+    control_class: acceptance-test
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_superseded_project_gets_its_cross_tier_check
+    motivating_defect: five-real-projects-sat-permanently-as-record-unreadable-and-never-received-the-cross-tier-check-that-would-have-caught-a-disagreement
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates


### PR DESCRIPTION
## Why

An unvalidated vocabulary is not a vocabulary. Two failures on a real corpus:

- **`complete` survived for months** as a typo of `completed`. Nothing rejected it, so this tool *absorbed* it — hardcoding it into the terminal set rather than reporting it.
- **`superseded` was absent from the terminal set** while also not being a completion word to the header parser. A superseded project therefore parsed as making *no completion claim at all*: it sat permanently as `record-unreadable` and never received its cross-tier check. Five projects were silently exempt, two of them for months.

A status the doctor does not recognise silently disables every check keyed off it. That is the most expensive kind of quiet failure a health check can have — it looks identical to passing.

## What changed

- Declares the canonical vocabulary: `active`, `paused`, `completed`, `archived`. Status answers one question — does this claim attention — and everything orthogonal is a qualifier field (`bounded`, `superseded_by`, `wake_when`, `blocked_by`, `completed_date`), so the vocabulary should not need to grow again.
- Teaches the header parser the terminal words (`archived`, `superseded`).
- Widens the terminal set so `superseded` stops being a silent exemption.
- Adds a `status-vocabulary` check: an unknown status is a **defect**; a retired one is a **warning naming its replacement**. Retired values stay readable so an unmigrated corpus is diagnosed rather than rejected.
- `synthesis-context-lifecycle` 1.12.0 → 1.13.0, with the rationale documented in the doctor section.

## Verification

- 5 new tests, including a regression pinning **both halves** of the silent-exemption bug (terminal set and header parser).
- Full repo suite green: **703 passed**.
- Run against a live 127-project corpus, the new check immediately found two retired statuses in workspaces that had not been migrated — earning its keep on first contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
