### PR TITLE
Give decision packets a reader contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.60.0",
+  "version": "4.61.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.60.0",
+  "version": "4.61.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.61.0] - 2026-08-29
+
+### Added
+
+- **`synthesis-decision-packet` v1.1.0 — the reader contract.** The origin
+  measurement gained a dark twin, measured on the same principal: a 15-row
+  packet written in project-internal language collected **0 of 15**
+  decisions — every mechanical property worked and none of it mattered,
+  because the rows named things only the authoring session knew. The
+  principal's verdict: "written in some alien or machine language."
+  Structure without comprehension collects nothing.
+
+  A packet is now doctrinally a stranger-read document, authored against
+  `synthesis-reader-briefing`'s four questions. The spec gains `audience`
+  (who reads this and what they already know), a packet-level `glossary`
+  (one-clause meanings, rendered as a collapsible band), and per-row
+  `impact` blocks stating the consequences of accepting and of declining
+  the recommendation — in the principal's terms, never internal treatment
+  vocabulary. The generator renders all three, warns on missing
+  audience/impact, and refuses outright under `--strict-reader`, which the
+  skill requires for any packet handed to a principal. Options are to be
+  labeled by consequence, and internal IDs may chip but never name a row.
+  Seven new regression tests; existing specs build unchanged.
+
 ## [4.60.0] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Structure without comprehension collects nothing (August 2026).**
+Release **4.61.0** gives decision packets a reader contract. A packet whose
+mechanics all worked collected zero decisions because its rows spoke the
+authoring session's internal language; the skill now requires an audience
+line, per-row accept/decline impact in the principal's terms, and a glossary
+for surviving terms of art — with `--strict-reader` making the contract
+enforceable at build time. See the [4.61.0 release notes](CHANGELOG.md).
+
 **A body-perfect article can still fail as a package (August 2026).**
 Release **4.60.0** upgrades the writing-quality stack from a real 30-article
 publication wave: article packages now get a title-only stranger test, a

--- a/skills/synthesis-decision-packet/SKILL.md
+++ b/skills/synthesis-decision-packet/SKILL.md
@@ -5,14 +5,14 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.0.0"
+  version: "1.1.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
 
 # Decision Packet
 
-**Version 1.0.0** (2026-08-28)
+**Version 1.1.0** (2026-08-29)
 
 An agent that has analysed N items needs N decisions from its principal. Every default shape
 fails at scale, and the measurement that produced this skill is blunt: **26 rounds of per-item
@@ -86,11 +86,48 @@ Requirements, not suggestions. Each is why it worked.
 - **Recommend against your own prior work where that is true**, including failed hypotheses. A
   packet that only argues one way is a sales document, and the buttons stop being trusted.
 
+## The reader contract (v1.1.0) — comprehension is a load-bearing property
+
+The origin measurement has a dark twin, measured on the same principal on
+2026-08-29: **a 15-row packet written in project-internal language collected
+0 of 15 decisions.** Every mechanical property above worked — filters,
+persistence, marked recommendations — and none of it mattered, because the
+rows named things only the authoring session knew ("C1", "holdout",
+"quarantine", "protected strata"). The principal's verdict: "written in some
+alien or machine language." Structure without comprehension collects
+nothing. The packets that ran 30/30 were about things the principal already
+knew — articles, titles, links.
+
+So a packet is a **stranger-read document**, and authoring one starts where
+`synthesis-reader-briefing` starts: who reads this, what do they bring, what
+does it ask, what do they leave with. Then, per row:
+
+- **The label is plain language.** Internal IDs may appear as chips; they
+  are never the name.
+- **Context says what the thing IS** in words the reader already has,
+  before any result about it.
+- **An `impact` block states consequences, both ways** — what actually
+  happens if they take the recommendation and if they don't, in outcomes
+  the principal cares about (what ships, what it costs, what dies), never
+  in internal treatment vocabulary. The generator renders it distinctly.
+- **Options are labeled by consequence,** not by the agent's internal
+  verbs. "Keep it out of your published skill; test once more" beats
+  "retest".
+- **Every surviving term of art gets a one-clause gloss** — inline on first
+  use, or in the packet-level `glossary` band.
+- **`audience` names the reader.** One sentence. If you cannot write it,
+  you do not know who the packet is for, and neither will they.
+
+`--strict-reader` makes the generator refuse a packet missing `audience` or
+per-row `impact`. **Use it for every packet handed to a principal.** The
+warnings print either way; strictness is the difference between a warning
+you read and a packet they cannot.
+
 ## Use
 
 ```bash
 python3 scripts/build_packet.py --schema              # the spec format
-python3 scripts/build_packet.py spec.json -o packet.html
+python3 scripts/build_packet.py spec.json -o packet.html --strict-reader
 python3 scripts/build_packet.py spec.json --stdout    # to a pipe
 ```
 
@@ -139,6 +176,8 @@ regression-tested in `scripts/test_build_packet.py`.
 ## Related
 
 - `references/worked-example.md` — a complete spec and what it produces.
+- `synthesis-reader-briefing` — the four questions every packet is authored
+  against; the reader contract above is that skill applied to this medium.
 - `synthesis-thinking-framework` — for deciding *what* to recommend before you build the packet.
 - `synthesis-anti-shortcuts` — a packet whose rows hedge instead of recommending is the
   asking-as-shortcut costume in a new medium.

--- a/skills/synthesis-decision-packet/scripts/build_packet.py
+++ b/skills/synthesis-decision-packet/scripts/build_packet.py
@@ -36,6 +36,16 @@ Decision-packet spec (JSON)
   "storage_key": "csa-review-2026-09",   optional; defaults to a slug of the title.
                                          Change it to reset everyone's saved state.
   "summary_intro": "Paste this back to the agent.",  optional
+  "audience":    "One sentence: who reads this and what they already know.",
+                                          optional in the format, REQUIRED by the
+                                          reader contract in SKILL.md - it is the
+                                          audience you must write every row for.
+  "glossary": [                           optional - one-clause meanings for every
+    {"term": "holdout",                   term of art any row still needs after
+     "meaning": "test material set aside  plain-language rewriting. Rendered as a
+      in advance so a rule is judged on   collapsible band under the intro.
+      text it was not tuned on"}
+  ],
 
   "options": [                            REQUIRED — the default choice set for every row
     {"value": "fix-now",  "label": "Fix now",  "tone": "danger"},
@@ -58,6 +68,13 @@ Decision-packet spec (JSON)
       "label": "Unbounded retry loop in the publish worker",   REQUIRED
       "context":  "What the reader needs to judge it.",        optional
       "reasoning":"Why the agent recommends what it does.",    optional
+      "impact": {                          optional in the format, REQUIRED by the
+        "accept": "What actually happens   reader contract: the consequences of
+                   if they take your       agreeing and of not agreeing, stated in
+                   recommendation.",       outcomes the principal cares about -
+        "decline": "What happens if they   never in internal treatment vocabulary.
+                   do not."
+      },
       "recommendation": "fix-now",        optional but STRONGLY expected — pre-selects
                                           a button. No recommendation on any row means
                                           the packet is a questionnaire; see the
@@ -147,6 +164,34 @@ def validate(spec: dict) -> list[str]:
         if dis is not None:
             if not isinstance(dis, dict) or not dis.get("a") or not dis.get("b"):
                 problems.append(f"rows[{i}] ({rid}) disagreement needs both 'a' and 'b'")
+        imp = r.get("impact")
+        if imp is not None and (not isinstance(imp, dict)
+                                or not imp.get("accept") or not imp.get("decline")):
+            problems.append(f"rows[{i}] ({rid}) impact needs both 'accept' and 'decline'")
+
+    gl = spec.get("glossary")
+    if gl is not None:
+        if not isinstance(gl, list):
+            problems.append("glossary must be a list of {term, meaning}")
+        else:
+            for gi, g in enumerate(gl):
+                if not isinstance(g, dict) or not g.get("term") or not g.get("meaning"):
+                    problems.append(f"glossary[{gi}] needs both 'term' and 'meaning'")
+
+    # Reader contract (see SKILL.md): a packet is a stranger-read document.
+    # These are READER-class findings - warnings by default, fatal under
+    # --strict-reader, which SKILL.md requires for packets handed to a
+    # principal. Measured origin: a 15-row packet written in project-internal
+    # language collected 0 decisions from the same principal whose plain-
+    # language packets ran 30/30.
+    if not spec.get("audience"):
+        problems.append("READER: no 'audience' - name who reads this and what they already know, then write every row for that reader")
+    missing_impact = [str(r.get("id")) for r in rows
+                      if isinstance(r, dict) and not r.get("impact")]
+    if missing_impact:
+        problems.append(
+            "READER: rows without an 'impact' block (what happens if they accept / decline, in the principal's terms): "
+            + ", ".join(missing_impact))
 
     recommended = sum(1 for r in rows if isinstance(r, dict) and r.get("recommendation"))
     if recommended == 0:
@@ -203,6 +248,14 @@ body {
 header h1 { font-size: 25px; line-height: 1.2; margin: 0 0 6px; letter-spacing: -0.01em; }
 header .sub { color: var(--ink-2); margin: 0 0 14px; }
 header .intro { color: var(--ink-2); max-width: 74ch; margin: 0 0 20px; }
+header .aud { color: var(--ink-3); font-size: 13px; margin: -10px 0 16px; }
+details.gloss { margin: 0 0 20px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); }
+details.gloss summary { cursor: pointer; padding: 8px 12px; font-size: 13px; color: var(--ink-2); }
+details.gloss dl { margin: 0; padding: 4px 14px 12px; font-size: 13px; }
+details.gloss dt { font-weight: 600; margin-top: 6px; }
+details.gloss dd { margin: 0; color: var(--ink-2); }
+.impact { border-left: 3px solid var(--line); padding: 6px 10px; margin: 8px 0; font-size: 13.5px; }
+.impact b { color: var(--ink-2); }
 .counts { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 18px; }
 .count {
   background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
@@ -324,6 +377,8 @@ header .intro { color: var(--ink-2); max-width: 74ch; margin: 0 0 20px; }
   <h1>__TITLE__</h1>
   __SUBTITLE__
   __INTRO__
+  __AUDIENCE__
+  __GLOSSARY__
 </header>
 
 <div class="counts" id="counts"></div>
@@ -465,6 +520,10 @@ header .intro { color: var(--ink-2); max-width: 74ch; margin: 0 0 20px; }
       head += '<div class="links">' + row.links.map(function (l) {
         return '<a href="' + esc(l.href) + '" target="_blank" rel="noopener">' + esc(l.label) + "</a>";
       }).join(" · ") + "</div>";
+    }
+    if (row.impact) {
+      head += '<div class="impact"><b>If you take the recommendation:</b> ' + esc(row.impact.accept) +
+              '<br><b>If you don\u2019t:</b> ' + esc(row.impact.decline) + "</div>";
     }
     if (row.disagreement) {
       var d = row.disagreement;
@@ -696,6 +755,19 @@ def build(spec: dict) -> str:
     out = out.replace("__TITLE__", html.escape(title))
     out = out.replace("__SUBTITLE__", f'<p class="sub">{html.escape(str(sub))}</p>' if sub else "")
     out = out.replace("__INTRO__", f'<p class="intro">{html.escape(str(intro))}</p>' if intro else "")
+    aud = spec.get("audience")
+    out = out.replace("__AUDIENCE__",
+                      f'<p class="aud">Written for: {html.escape(str(aud))}</p>' if aud else "")
+    gl = spec.get("glossary") or []
+    if gl:
+        items = "".join(
+            f"<dt>{html.escape(str(g['term']))}</dt><dd>{html.escape(str(g['meaning']))}</dd>"
+            for g in gl if isinstance(g, dict))
+        out = out.replace(
+            "__GLOSSARY__",
+            f'<details class="gloss"><summary>Terms used below ({len(gl)})</summary><dl>{items}</dl></details>')
+    else:
+        out = out.replace("__GLOSSARY__", "")
     out = out.replace(
         "__SUMMARY_INTRO__",
         html.escape(str(spec.get("summary_intro")
@@ -713,6 +785,9 @@ def main() -> int:
     ap.add_argument("--schema", action="store_true", help="print the spec schema and exit")
     ap.add_argument("--allow-small", action="store_true",
                     help="build even with fewer than five rows (see the anti-trigger)")
+    ap.add_argument("--strict-reader", action="store_true",
+                    help="make reader-contract findings (missing audience/impact) fatal; "
+                         "SKILL.md requires this for packets handed to a principal")
     args = ap.parse_args()
 
     if args.schema:
@@ -729,12 +804,15 @@ def main() -> int:
         return 2
 
     problems = validate(spec)
-    hard = [p for p in problems if not p.startswith("NOTE:")]
+    hard = [p for p in problems if not p.startswith(("NOTE:", "READER:"))]
     soft = [p for p in problems if p.startswith("NOTE:")]
-    for p in soft:
+    reader = [p for p in problems if p.startswith("READER:")]
+    for p in soft + reader:
         print(p, file=sys.stderr)
     if soft and not args.allow_small:
         hard.append("refusing to build a sub-five-row packet without --allow-small")
+    if reader and args.strict_reader:
+        hard.append("reader contract unmet (--strict-reader): see READER findings above")
     if hard:
         print("\nwill not build:", file=sys.stderr)
         for p in hard:

--- a/skills/synthesis-decision-packet/scripts/test_build_packet.py
+++ b/skills/synthesis-decision-packet/scripts/test_build_packet.py
@@ -286,6 +286,78 @@ def test_output_is_self_contained():
     assert not external, f"packet must be self-contained; found external refs: {external}"
 
 
+# ---------------------------------------------------------------------------
+# The reader contract (v1.1.0) - born from a measured failure: a 15-row packet
+# written in project-internal language collected 0 decisions from the same
+# principal whose plain-language packets ran 30/30. Structure without
+# comprehension collects nothing.
+# ---------------------------------------------------------------------------
+
+def test_impact_block_renders_both_consequences():
+    s = spec()
+    s["rows"][0]["impact"] = {"accept": "The rule waits for one more test round.",
+                              "decline": "The strongest candidate from this research is discarded."}
+    out = bp.build(s)
+    assert "If you take the recommendation:" in out
+    assert "The rule waits for one more test round." in out
+    assert "The strongest candidate from this research is discarded." in out
+
+
+def test_glossary_renders_as_a_terms_band_and_escapes():
+    s = spec(glossary=[{"term": "holdout", "meaning": "material set aside <before> tuning"}])
+    out = bp.build(s)
+    assert "Terms used below (1)" in out
+    assert "holdout" in out
+    band = re.search(r'<details class="gloss">.*?</details>', out, re.S).group(0)
+    assert "&lt;before&gt;" in band and "<before>" not in band
+
+
+def test_audience_line_renders_under_the_intro():
+    s = spec(audience="Rajiv, who has not read this project's research records")
+    out = bp.build(s)
+    assert "Written for:" in out
+    assert "who has not read" in out
+
+
+def test_reader_findings_are_warnings_by_default():
+    problems = bp.validate(spec())
+    reader = [x for x in problems if x.startswith("READER:")]
+    assert reader, "a spec with no audience and no impact must raise READER findings"
+    hard = [x for x in problems if not x.startswith(("NOTE:", "READER:"))]
+    assert not hard, f"reader findings must not hard-fail validate(): {hard}"
+
+
+def test_reader_contract_satisfied_raises_no_reader_findings():
+    s = spec(audience="A principal with no project context")
+    for r in s["rows"]:
+        r["impact"] = {"accept": "Nothing changes today.", "decline": "The item is dropped."}
+    problems = bp.validate(s)
+    assert not [x for x in problems if x.startswith("READER:")]
+
+
+def test_strict_reader_flag_refuses_an_alien_packet(tmp_path=None):
+    import tempfile, subprocess, json as _json, pathlib as _pl
+    with tempfile.TemporaryDirectory() as td:
+        sp = _pl.Path(td) / "s.json"
+        sp.write_text(_json.dumps(spec()))
+        proc = subprocess.run(
+            [sys.executable, str(HERE / "build_packet.py"), str(sp),
+             "--stdout", "--strict-reader"],
+            capture_output=True, text=True)
+        assert proc.returncode != 0, "strict-reader must refuse a packet missing audience/impact"
+        assert "READER:" in proc.stderr
+
+
+def test_malformed_impact_and_glossary_are_hard_errors():
+    s = spec()
+    s["rows"][0]["impact"] = {"accept": "only one half"}
+    problems = bp.validate(s)
+    assert any("impact needs both" in x for x in problems)
+    s2 = spec(glossary=[{"term": "x"}])
+    problems2 = bp.validate(s2)
+    assert any("glossary[0] needs both" in x for x in problems2)
+
+
 def _run_all():
     fns = [(n, f) for n, f in sorted(globals().items())
            if n.startswith("test_") and callable(f)]

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,13 +1,10 @@
-# AGENT HEURISTIC: authored for the writing-quality batch-review release
-# (content-quality restoration + corpus-level review, article-writing Phase 4
-# package gates, reader-briefing dependency contract, content-framing
-# dependency-driven linking, fact-checking circular grounding). The manifest
-# records this release's exact public universe; the runner proves the
-# declaration against the authoritative base-to-head Git diff, so a surface
-# that changes without being declared — or is declared without changing —
-# refuses authority.
+# AGENT HEURISTIC: authored for the decision-packet reader-contract release.
+# The manifest records this release's exact public universe; the runner proves
+# the declaration against the authoritative base-to-head Git diff, so a
+# surface that changes without being declared — or is declared without
+# changing — refuses authority.
 schema: 2
-suite: synthesis-writing-quality-batch-review-release
+suite: synthesis-decision-packet-reader-contract-release
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run
 enforcing_boundary: release.py and repository CI before publication
@@ -16,32 +13,14 @@ change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: detector thresholds are tuned on synthetic fixtures and one real batch, not a labeled corpus; the Phase 4 package gates are review doctrine whose enforcement is procedural rather than executable; the fact-checking SKILL.md remains marginally over the 500-line guideline pre-existing; blinded confirmatory corpus scoring, installed-client parity, independent review, publication, and deployment
+unverified_remainder: whether the reader contract's mechanical half (audience and impact present) is sufficient for comprehension — plain language itself remains authorial judgment the generator cannot verify; installed-client parity, independent review, publication, and deployment
 changed_surfaces:
-  - path: skills/synthesis-content-quality/scripts/corpus_repetition.py
-    cases: [shared-construction-is-found, ordinary-english-survives, boilerplate-is-classified-not-flagged, ignored-phrase-silences-its-subruns, replacement-set-is-measured-on-the-same-axes]
-  - path: skills/synthesis-content-quality/tests/test_corpus_repetition.py
-    cases: [shared-construction-is-found, ordinary-english-survives, boilerplate-is-classified-not-flagged, ignored-phrase-silences-its-subruns, replacement-set-is-measured-on-the-same-axes]
-  - path: skills/synthesis-content-quality/SKILL.md
-    cases: [restoration-is-purely-additive]
-  - path: skills/synthesis-content-quality/references/philosophy-and-application.md
-    cases: [restoration-is-purely-additive]
-  - path: skills/synthesis-content-quality/tests/fixtures/writing_quality_evidence_corrections.json
-    cases: [restoration-is-purely-additive, version-stamp-is-the-only-baseline-change]
-  - path: skills/synthesis-article-writing/SKILL.md
+  - path: skills/synthesis-decision-packet/SKILL.md
     cases: [shipped-manifest-self-consumption]
-  - path: skills/synthesis-article-writing/references/publication-review-fixtures.md
-    cases: [shipped-manifest-self-consumption]
-  - path: skills/synthesis-reader-briefing/SKILL.md
-    cases: [shipped-manifest-self-consumption]
-  - path: skills/synthesis-content-framing/SKILL.md
-    cases: [shipped-manifest-self-consumption]
-  - path: skills/synthesis-content-framing/references/quality-gates.md
-    cases: [shipped-manifest-self-consumption]
-  - path: skills/synthesis-fact-checking/SKILL.md
-    cases: [shipped-manifest-self-consumption]
-  - path: skills/synthesis-fact-checking/references/citation-laundering-detection.md
-    cases: [shipped-manifest-self-consumption]
+  - path: skills/synthesis-decision-packet/scripts/build_packet.py
+    cases: [impact-renders-both-consequences, glossary-band-renders-escaped, audience-line-renders, reader-findings-warn-by-default, strict-reader-refuses-alien-packet, satisfied-contract-is-quiet, malformed-blocks-hard-fail]
+  - path: skills/synthesis-decision-packet/scripts/test_build_packet.py
+    cases: [impact-renders-both-consequences, glossary-band-renders-escaped, audience-line-renders, reader-findings-warn-by-default, strict-reader-refuses-alien-packet, satisfied-contract-is-quiet, malformed-blocks-hard-fail]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -53,34 +32,34 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: shared-construction-is-found
+  - id: impact-renders-both-consequences
     control_class: acceptance-test
-    fixture: ../synthesis-content-quality/tests/test_corpus_repetition.py::SharedRunTests::test_shared_construction_across_two_documents_is_found
-    motivating_defect: a-corpus-checker-that-misses-the-shared-construction-it-exists-to-find-reads-as-coverage-while-covering-nothing
-  - id: ordinary-english-survives
+    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_impact_block_renders_both_consequences
+    motivating_defect: consequences-stated-only-in-the-agents-head-leave-the-principal-choosing-between-labels-they-cannot-weigh
+  - id: glossary-band-renders-escaped
     control_class: acceptance-test
-    fixture: ../synthesis-content-quality/tests/test_corpus_repetition.py::SharedRunTests::test_ordinary_english_overlap_does_not_flag
-    motivating_defect: a-threshold-that-flags-ordinary-english-drowns-the-report-and-teaches-reviewers-to-ignore-it
-  - id: boilerplate-is-classified-not-flagged
+    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_glossary_renders_as_a_terms_band_and_escapes
+    motivating_defect: a-term-of-art-with-no-gloss-turns-a-decision-row-into-a-foreign-language-sentence
+  - id: audience-line-renders
     control_class: acceptance-test
-    fixture: ../synthesis-content-quality/tests/test_corpus_repetition.py::SharedRunTests::test_high_df_run_is_classified_boilerplate_not_finding
-    motivating_defect: deliberate-series-boilerplate-flagged-as-a-finding-buries-the-accidental-repetition-the-tool-is-for
-  - id: ignored-phrase-silences-its-subruns
+    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_audience_line_renders_under_the_intro
+    motivating_defect: a-packet-that-cannot-name-its-reader-was-written-for-nobody-and-reads-that-way
+  - id: reader-findings-warn-by-default
     control_class: acceptance-test
-    fixture: ../synthesis-content-quality/tests/test_corpus_repetition.py::SharedRunTests::test_ignore_file_suppresses_known_phrase
-    motivating_defect: an-ignore-entry-that-leaves-its-own-fragments-flagged-makes-the-allowlist-useless-in-practice
-  - id: replacement-set-is-measured-on-the-same-axes
+    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_reader_findings_are_warnings_by_default
+    motivating_defect: making-the-new-contract-fatal-by-default-would-break-every-existing-spec-and-teach-users-to-bypass-the-gate
+  - id: strict-reader-refuses-alien-packet
     control_class: acceptance-test
-    fixture: ../synthesis-content-quality/tests/test_corpus_repetition.py::TitleShapeTests::test_replacement_set_with_new_formula_flags
-    motivating_defect: a-cure-measured-only-against-the-disease-it-names-is-not-measured-and-the-real-batch-produced-exactly-that-cure
-  - id: restoration-is-purely-additive
+    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_strict_reader_flag_refuses_an_alien_packet
+    motivating_defect: the-measured-failure-a-structurally-perfect-packet-in-machine-language-collected-zero-of-fifteen-decisions
+  - id: satisfied-contract-is-quiet
     control_class: acceptance-test
-    fixture: ../synthesis-content-quality/tests/test_no_removals.py::NoRemovalsTests::test_every_baseline_file_and_nonblank_line_remains
-    motivating_defect: a-restoration-that-quietly-rewrites-a-surviving-rule-undoes-upgrades-while-claiming-to-add
-  - id: version-stamp-is-the-only-baseline-change
+    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_reader_contract_satisfied_raises_no_reader_findings
+    motivating_defect: a-gate-that-nags-compliant-specs-teaches-authors-to-ignore-its-output-entirely
+  - id: malformed-blocks-hard-fail
     control_class: acceptance-test
-    fixture: ../synthesis-content-quality/tests/test_no_removals.py::NoRemovalsTests::test_correction_allowlist_is_exact_and_baseline_bound
-    motivating_defect: an-allowlist-edit-beyond-the-version-stamp-would-let-an-evidence-correction-slip-in-without-review
+    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_malformed_impact_and_glossary_are_hard_errors
+    motivating_defect: a-half-filled-impact-block-renders-as-a-broken-promise-about-exactly-one-side-of-the-decision
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates


### PR DESCRIPTION
## Summary

`synthesis-decision-packet` v1.1.0. Measured motivation: a 15-row packet whose mechanics all worked (filters, persistence, marked recommendations) collected **0 of 15** decisions from the same principal whose plain-language packets ran 30/30 — its rows were written in the authoring session's internal language. Structure without comprehension collects nothing.

- Spec gains `audience`, packet-level `glossary`, and per-row `impact` (accept/decline consequences in the principal's terms); generator renders all three.
- Missing audience/impact produce READER-class warnings; `--strict-reader` makes them fatal and SKILL.md requires it for packets handed to a principal.
- Options doctrine: labels by consequence, never internal treatment vocabulary; IDs chip but never name.
- Seven regression tests; all existing specs build unchanged (28/28 suite green).
- SKILL.md documents the incident beside the origin measurement and anchors authoring on `synthesis-reader-briefing`'s four questions.

## Verification

- Source conformance 204/204; decision-packet suite 28/28; content-quality suite 23/23.
- Acceptance transaction bound to this release's exact changed surfaces; green on the committed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)