### PR TITLE
Release 4.62.0: packet/handoff wiring and consumer generalization

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.61.0",
+  "version": "4.62.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.61.0",
+  "version": "4.62.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.62.0] - 2026-08-29
+
+### Added
+
+- **The handoff queue reaches the public toolkit.** `synthesis-project-management`
+  v2.7.0 ships `scripts/handoff.py`, generalized from the working project
+  reference that removed a principal from twenty-plus prompt-courier
+  crossings in one engagement: a writer stores the counterpart's prompt as a
+  durable, sha256-pinned file under `resources/handoffs/`, the queue is
+  written atomically, and `read` refuses a payload whose bytes changed after
+  handoff. Reader identity is fail-closed — `--as` or
+  `SYNTHESIS_HANDOFF_SELF`, never a guess, because a guessed identity could
+  claim another agent's work. Nothing self-triggers: an agent acts on the
+  queue only when the principal's protocol says the other side is done.
+  Eleven tests, including the doctrine contracts.
+- **Autopilot calls the decision packet instead of describing one.**
+  `synthesis-autopilot` v1.4.0 wires `synthesis-decision-packet` in as the
+  batched-questions mechanism its protocol always required: simple user-only
+  batches stay chat prompts, complex batches are built with
+  `build_packet.py` — never reimplemented inline — and the packet's
+  integrity rules travel with it (recommendations marked, never
+  pre-selected; bulk recorded as bulk; one packet is one round-trip against
+  the plan's budget). Packet rows are rebuilt against any principal
+  corrections issued since drafting, so a correction-erased row cannot ride
+  through a rebuild. The handoff queue is named as the agent-to-agent
+  transport; queue and packet together are the two directions that remove
+  the principal as transport.
+
+### Changed
+
+- **Schema-2 acceptance manifests may name any consume-acceptance boundary.**
+  `synthesis-implementation-integrity`'s validator previously accepted
+  exactly one receipt consumer — the public release gate — which made an
+  honest transaction-bound gate impossible for any other repository; three
+  private releases shipped in one week on suite-green alone for lack of one.
+  The validator now enforces a format contract
+  (`*.consume-acceptance.vN`), and honesty stays enforced where it is
+  checkable: every consumer verifies at its own boundary that the receipt
+  names itself, exactly as the public release gate already does.
+
 ## [4.61.0] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Two directions that remove the principal as transport (August 2026).**
+Release **4.62.0** pairs the decision packet with a generalized handoff
+queue: work moves between agents as sha-pinned files in the project
+(`synthesis-project-management`'s new `handoff.py`), decisions move between
+agent and principal as one reviewable packet, and `synthesis-autopilot` now
+calls the packet as its batched-questions mechanism instead of describing
+one. Schema-2 acceptance manifests may now name any repository's
+consume-acceptance boundary, so private repositories can run the same
+transaction-bound release gate the public one does. See the
+[4.62.0 release notes](CHANGELOG.md).
+
 **Structure without comprehension collects nothing (August 2026).**
 Release **4.61.0** gives decision packets a reader contract. A packet whose
 mechanics all worked collected zero decisions because its rows spoke the

--- a/skills/synthesis-autopilot/SKILL.md
+++ b/skills/synthesis-autopilot/SKILL.md
@@ -2,10 +2,10 @@
 name: synthesis-autopilot
 description: "Execute an explicitly delegated whole task autonomously using the thinking framework, durable plan and context, checkpoints, anti-shortcut discipline, and implementation-integrity gate. Activate only for clear end-to-end delegation such as 'autopilot this,' 'take care of this for me,' 'handle this end to end,' or 'complete all phases autonomously'; never infer it from a single-step approval, discussion of autonomy, or ambiguous wording."
 license: "Apache-2.0"
-depends_on: ["synthesis-thinking-framework", "synthesis-context-lifecycle", "synthesis-checkpoint", "synthesis-anti-shortcuts", "synthesis-grounding-discipline", "synthesis-implementation-integrity", "synthesis-project-management", "synthesis-adversarial-review"]
+depends_on: ["synthesis-thinking-framework", "synthesis-context-lifecycle", "synthesis-checkpoint", "synthesis-anti-shortcuts", "synthesis-grounding-discipline", "synthesis-implementation-integrity", "synthesis-project-management", "synthesis-adversarial-review", "synthesis-decision-packet"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.3.0"
+  version: "1.4.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -107,7 +107,10 @@ blocked-state alert threshold.
 Dated entries: decision, thinking-framework mode used, rationale.
 
 ## Batched questions for the user
-Only questions the user alone can answer. Presented at checkpoints.
+Only questions the user alone can answer. Presented at checkpoints —
+simple batches as chat prompts, complex batches as a decision packet
+(synthesis-decision-packet). Packet paths and paste-back summaries
+recorded here.
 
 ## Sufficiency checkpoint
 Established, open, risk of shipping now, and the principal's ruling.
@@ -125,6 +128,8 @@ Every decision in an autonomous run falls into one of three classes:
 2. **Open and important → thinking framework.** Run synthesis-thinking-framework, choose, record the decision and rationale in the decisions log, and proceed. Autonomy means making these calls, not deferring them.
 3. **User-only → batch.** Facts only the user knows, genuine value trade-offs between goals the user holds, scope changes beyond the delegation. Add to the plan file's batched-questions section and continue with every piece of work that does not depend on the answer. Present the batch at a natural checkpoint — a phase boundary or the completion report.
 
+**Batch delivery has two forms, chosen by the batch, not by habit.** A simple batch — a few questions answerable in a sentence each, no evidence to weigh — goes as plain chat prompts (or the platform's structured-question facility). A complex batch — many rows, or rows that need a recommendation, reasoning, evidence links, or a notes field — is delivered as a **decision packet built by calling `synthesis-decision-packet`'s `build_packet.py`**, never reimplemented inline. The packet's integrity rules travel with it: recommendations marked but never pre-selected, bulk acceptance recorded as bulk, and the pasted-back summary logged in the decisions log with the bulk/individual distinction intact. One packet counts as one round-trip against the plan's budget — that is what makes the budget compatible with keeping every decision the principal's: the cost scales with sittings, not items. Rebuild a packet's rows against any corrections the principal has issued since the rows were drafted; a row that a correction erased must be dropped, not carried through a rebuild.
+
 **Never block the whole run on one question.** Re-sequence around it. Halt early only when *every* remaining path depends on an unanswered user-only question — that is a blocked state, reported per the alerts section.
 
 ## Cross-Agent Orchestration
@@ -134,6 +139,16 @@ transport. Use direct session-to-session dispatch where the runtime provides it.
 counterpart the bounded evidence package, production entry point, enforcing boundary,
 receipt consumer, principal outcome, and terminal return contract. Apply the sub-agent
 acceptance audit to its return before adopting any finding.
+
+When both agents share the project repository, the default transport is the handoff queue
+(`synthesis-project-management/scripts/handoff.py`): the writer stores the counterpart's
+prompt as a durable, hash-pinned file under `resources/handoffs/`, announces it on the
+coordination board, and the counterpart claims it with `handoff.py read` — no chat
+transcript crossing, no principal courier. The queue and the decision packet are the two
+directions that remove the principal as transport: work moves between agents through the
+queue; decisions move between agent and principal through the packet. The queue never
+self-triggers — a counterpart acts on it only when the principal's protocol says the other
+side is done.
 
 If a provider boundary genuinely has no direct transport, declare that before round one.
 Batch the payload, identify who must paste it, and count it as one of the plan's principal
@@ -218,5 +233,6 @@ Nothing above is specific to software. The mode runs the same for engineering, r
 | synthesis-grounding-discipline | Claim quality: provenance, cache re-verification, absence proof | Every recorded fact and status claim; before any write or deletion |
 | synthesis-implementation-integrity | Verification before completion claims | Before "done"; per-phase for high-stakes phases |
 | synthesis-adversarial-review | Bounded cross-agent attack, findings, sufficiency, and acceptance | When a plan calls for adversarial or independent review |
+| synthesis-decision-packet | Complex user-only batches as one honest, reviewable page | Decision protocol, class 3, complex batches |
 
 Each dependency works standalone. This mode is the sequencing that makes them one behavior: delegate once, and the stack runs itself.

--- a/skills/synthesis-decision-packet/SKILL.md
+++ b/skills/synthesis-decision-packet/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.1.0"
+  version: "1.2.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -169,9 +169,9 @@ regression-tested in `scripts/test_build_packet.py`.
 - **The adversarial review family** — this is where an engagement surfaces its unresolved
   disagreements. Pair it with a status for findings that are not open, not conceded, and not the
   agents' to close.
-- **Handoff queues** move work *between agents*. The decision packet moves decisions *between
-  agent and principal*. Together they are the two directions that stop routing everything through
-  a person as the transport layer.
+- **The handoff queue** (`synthesis-project-management/scripts/handoff.py`) moves work *between
+  agents*. The decision packet moves decisions *between agent and principal*. Together they are
+  the two directions that stop routing everything through a person as the transport layer.
 
 ## Related
 

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,10 +1,10 @@
-# AGENT HEURISTIC: authored for the decision-packet reader-contract release.
+# AGENT HEURISTIC: authored for the 4.62.0 packet/handoff-wiring release.
 # The manifest records this release's exact public universe; the runner proves
 # the declaration against the authoritative base-to-head Git diff, so a
 # surface that changes without being declared — or is declared without
 # changing — refuses authority.
 schema: 2
-suite: synthesis-decision-packet-reader-contract-release
+suite: synthesis-packet-handoff-wiring-release
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run
 enforcing_boundary: release.py and repository CI before publication
@@ -13,14 +13,22 @@ change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: whether the reader contract's mechanical half (audience and impact present) is sufficient for comprehension — plain language itself remains authorial judgment the generator cannot verify; installed-client parity, independent review, publication, and deployment
+unverified_remainder: whether autopilot sessions actually reach for the packet at the documented thresholds — doctrine adoption is behavioral, not testable here; consumer-side self-naming checks in gates other than the public release gate; installed-client parity, independent review, publication, and deployment
 changed_surfaces:
+  - path: skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
+    cases: [consumer-format-accepts-alternate, consumer-format-refuses-malformed]
+  - path: skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+    cases: [consumer-format-accepts-alternate, consumer-format-refuses-malformed]
+  - path: skills/synthesis-project-management/scripts/handoff.py
+    cases: [handoff-flow, handoff-tamper-refusal, handoff-identity-required]
+  - path: skills/synthesis-project-management/scripts/test_handoff.py
+    cases: [handoff-flow, handoff-tamper-refusal, handoff-identity-required, pm-doc-contract, autopilot-wiring-doc, packet-doc-pointer]
+  - path: skills/synthesis-project-management/SKILL.md
+    cases: [pm-doc-contract]
+  - path: skills/synthesis-autopilot/SKILL.md
+    cases: [autopilot-wiring-doc]
   - path: skills/synthesis-decision-packet/SKILL.md
-    cases: [shipped-manifest-self-consumption]
-  - path: skills/synthesis-decision-packet/scripts/build_packet.py
-    cases: [impact-renders-both-consequences, glossary-band-renders-escaped, audience-line-renders, reader-findings-warn-by-default, strict-reader-refuses-alien-packet, satisfied-contract-is-quiet, malformed-blocks-hard-fail]
-  - path: skills/synthesis-decision-packet/scripts/test_build_packet.py
-    cases: [impact-renders-both-consequences, glossary-band-renders-escaped, audience-line-renders, reader-findings-warn-by-default, strict-reader-refuses-alien-packet, satisfied-contract-is-quiet, malformed-blocks-hard-fail]
+    cases: [packet-doc-pointer]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -32,34 +40,38 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: impact-renders-both-consequences
+  - id: consumer-format-accepts-alternate
     control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_impact_block_renders_both_consequences
-    motivating_defect: consequences-stated-only-in-the-agents-head-leave-the-principal-choosing-between-labels-they-cannot-weigh
-  - id: glossary-band-renders-escaped
+    fixture: scripts/test_acceptance_suite.py::test_schema2_accepts_any_wellformed_consume_acceptance_consumer
+    motivating_defect: three-private-releases-shipped-in-one-week-on-suite-green-because-no-second-repository-could-declare-a-transaction-bound-gate
+  - id: consumer-format-refuses-malformed
     control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_glossary_renders_as_a_terms_band_and_escapes
-    motivating_defect: a-term-of-art-with-no-gloss-turns-a-decision-row-into-a-foreign-language-sentence
-  - id: audience-line-renders
+    fixture: scripts/test_acceptance_suite.py::test_schema2_refuses_malformed_consumer_id
+    motivating_defect: a-free-text-consumer-field-would-let-a-receipt-name-a-boundary-that-does-not-exist
+  - id: handoff-flow
     control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_audience_line_renders_under_the_intro
-    motivating_defect: a-packet-that-cannot-name-its-reader-was-written-for-nobody-and-reads-that-way
-  - id: reader-findings-warn-by-default
+    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_write_read_done_flow
+    motivating_defect: the-principal-as-courier-copied-prompts-between-agents-twenty-plus-times-in-one-engagement
+  - id: handoff-tamper-refusal
     control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_reader_findings_are_warnings_by_default
-    motivating_defect: making-the-new-contract-fatal-by-default-would-break-every-existing-spec-and-teach-users-to-bypass-the-gate
-  - id: strict-reader-refuses-alien-packet
+    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_read_refuses_tampered_payload
+    motivating_defect: a-payload-changed-after-handoff-executes-instructions-nobody-reviewed
+  - id: handoff-identity-required
     control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_strict_reader_flag_refuses_an_alien_packet
-    motivating_defect: the-measured-failure-a-structurally-perfect-packet-in-machine-language-collected-zero-of-fifteen-decisions
-  - id: satisfied-contract-is-quiet
+    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_read_refuses_without_identity
+    motivating_defect: a-guessed-reader-identity-can-claim-another-agents-work
+  - id: pm-doc-contract
     control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_reader_contract_satisfied_raises_no_reader_findings
-    motivating_defect: a-gate-that-nags-compliant-specs-teaches-authors-to-ignore-its-output-entirely
-  - id: malformed-blocks-hard-fail
+    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_pm_skill_documents_the_handoff_queue
+    motivating_defect: an-undocumented-queue-gets-rediscovered-as-a-private-convention-instead-of-a-shared-mechanism
+  - id: autopilot-wiring-doc
     control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_malformed_impact_and_glossary_are_hard_errors
-    motivating_defect: a-half-filled-impact-block-renders-as-a-broken-promise-about-exactly-one-side-of-the-decision
+    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_autopilot_wires_packet_and_handoff
+    motivating_defect: autopilot-carried-a-batched-questions-requirement-with-no-concrete-mechanism-and-per-item-conversation-returned
+  - id: packet-doc-pointer
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_decision_packet_names_concrete_handoff_path
+    motivating_defect: the-paired-direction-was-doctrine-without-a-path-so-nobody-could-run-it
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
@@ -29,6 +29,16 @@ SCHEMA2_CHANGE_BASE_POLICY = "boundary-supplied-git-diff"
 SCHEMA2_RECEIPT_CONSUMER = (
     "synthesis-skills-manager.release.consume-acceptance.v1"
 )
+# Schema 2 requires the manifest to name its consume-acceptance boundary, but
+# the validator no longer hardcodes one repository's boundary as the only
+# legal consumer: any state-changing gate may be named, provided the id keeps
+# the consume-acceptance contract shape. Honesty stays enforced where it is
+# checkable — each consumer verifies that the receipt names *itself* before
+# acting (the public release gate checks equality with its own id at its
+# boundary; any other gate must do the same).
+SCHEMA2_CONSUMER_PATTERN = re.compile(
+    r"^[a-z0-9][a-z0-9._-]*\.consume-acceptance\.v[0-9]+$"
+)
 
 
 class ManifestError(Exception):
@@ -220,9 +230,12 @@ def validate_manifest(
             errors.append(
                 f"schema 2 change_base_policy must be {SCHEMA2_CHANGE_BASE_POLICY}"
             )
-        if receipt_consumer != SCHEMA2_RECEIPT_CONSUMER:
+        if not SCHEMA2_CONSUMER_PATTERN.fullmatch(receipt_consumer or ""):
             errors.append(
-                f"schema 2 receipt_consumer must be {SCHEMA2_RECEIPT_CONSUMER}"
+                "schema 2 receipt_consumer must name a consume-acceptance "
+                "boundary matching "
+                f"{SCHEMA2_CONSUMER_PATTERN.pattern} "
+                f"(the public release gate's is {SCHEMA2_RECEIPT_CONSUMER})"
             )
 
     raw_surfaces = document.get("changed_surfaces")

--- a/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
+++ b/skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
@@ -346,3 +346,38 @@ def test_shipped_manifest_validates() -> None:
         for case_id in surface["cases"]
     }
     assert referenced == {case["id"] for case in declared["cases"]}
+
+
+def test_schema2_accepts_any_wellformed_consume_acceptance_consumer(
+    tmp_path: Path,
+) -> None:
+    fixture_file(tmp_path)
+    payload = schema2_payload()
+    payload["receipt_consumer"] = (
+        "another-repo.gated-release.consume-acceptance.v1"
+    )
+    completed = run_cli(tmp_path, "validate", write_manifest(tmp_path, payload))
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    receipt = json.loads(completed.stdout)
+    assert receipt["receipt_consumer"] == (
+        "another-repo.gated-release.consume-acceptance.v1"
+    )
+
+
+def test_schema2_refuses_malformed_consumer_id(tmp_path: Path) -> None:
+    fixture_file(tmp_path)
+    for malformed in (
+        "fixture boundary",
+        "release.v1",
+        "synthesis-skills-manager.release.consume-acceptance",
+        "Upper.Case.consume-acceptance.v1",
+        ".consume-acceptance.v1",
+    ):
+        payload = schema2_payload()
+        payload["receipt_consumer"] = malformed
+        completed = run_cli(
+            tmp_path, "validate", write_manifest(tmp_path, payload)
+        )
+        assert completed.returncode == 2, malformed
+        assert "consume-acceptance" in completed.stdout, malformed

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.6.0"
+  version: "2.7.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -498,6 +498,40 @@ Cross-computer recovery adds two preconditions: the source machine must reach
 fetch and fast-forward before Session Start. Offline, divergent, behind,
 unpublished, or overlapping-claim states are reported explicitly and are not
 remote-continuity passes.
+
+### The Handoff Queue — Work Transfer Between Agents
+
+The protocol above hands a project's *state* between tools. When two root
+sessions collaborate on one project — a writer producing a prompt for a
+counterpart, an executor returning work for a reviewer — the *work item*
+itself also needs a transport that is not the principal's clipboard.
+`scripts/handoff.py` is that transport:
+
+```bash
+handoff.py write --to codex --from claude --file prompt.md [--round N]
+handoff.py read  --as codex          # oldest pending addressed to me
+handoff.py list                      # full queue, both directions
+handoff.py done  --id h-XXXXXXXXXX   # close a claimed handoff
+```
+
+Prompts are stored as durable files under `resources/handoffs/` with a
+sha256 recorded at write time; `read` refuses a payload whose bytes have
+changed since the handoff. The queue (`resources/handoffs/queue.json`) is
+written atomically. Reader identity comes from `--as` or
+`SYNTHESIS_HANDOFF_SELF` — with neither, `read` refuses rather than guess,
+because guessing could claim another agent's work.
+
+Two rules keep this supervised:
+
+- **Nothing self-triggers.** An agent reads the queue when the principal, or
+  a coordination-board message the principal's protocol allows, says the
+  other side is done. Announce every `write` with `coordination.py message`
+  (the script prints the exact command). Supervision by exception is the
+  point; unattended is not uncontrolled.
+- **The queue is one of two directions.** It moves work *between agents*.
+  Decisions *between agent and principal* travel as a decision packet
+  (`synthesis-decision-packet`). Together they remove the principal as the
+  transport layer while leaving every crossing visible in the project.
 
 ### Parallel Sub-Agent Dispatch
 

--- a/skills/synthesis-project-management/scripts/handoff.py
+++ b/skills/synthesis-project-management/scripts/handoff.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Agent-to-agent handoff through the project itself, so the principal is not the courier.
+
+The decision packet (synthesis-decision-packet) moves decisions between agent
+and principal; this queue moves work between agents. Together they are the two
+directions that remove the principal as the transport layer: nobody should
+have to copy a prompt from one agent's chat into another's when both agents
+already share the project repository and the coordination board.
+
+  WRITER  finishing a round of work calls
+              handoff.py write --to codex --file prompt.md [--round 27]
+          which stores the prompt under resources/handoffs/, records it in the
+          queue as `pending`, and prints the board message that announces it.
+
+  READER  told that the other side has finished calls
+              handoff.py read --as codex
+          which returns the oldest pending handoff addressed to it, verifies
+          the stored hash, marks it `claimed`, and prints the prompt. No
+          copy-paste crosses the human.
+
+The principal keeps supervision without being transport: `handoff.py list`
+shows everything that was passed and in which direction, every prompt is a
+durable file in the project, and nothing self-triggers — an agent acts on the
+queue only when the principal (or a coordination-board message the principal
+allows) says the other side is done. That is the difference between
+unattended and uncontrolled.
+
+Usage:
+    handoff.py write --to AGENT --file PROMPT.md [--round N] [--summary TEXT]
+                     [--project-root DIR]
+    handoff.py read  --as AGENT [--project-root DIR]
+    handoff.py list  [--project-root DIR]
+    handoff.py done  --id HANDOFF_ID [--project-root DIR]
+
+Agent labels are free-form lowercase slugs; `claude` and `codex` are the
+documented convention for the two first-class clients. The reader's identity
+comes from --as or SYNTHESIS_HANDOFF_SELF; with neither, read refuses rather
+than guessing.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import pathlib
+import re
+import sys
+import tempfile
+
+AGENT_LABEL = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+def queue_paths(project_root: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    handoffs = project_root / "resources" / "handoffs"
+    return handoffs, handoffs / "queue.json"
+
+
+def load(queue_file: pathlib.Path) -> list:
+    if not queue_file.is_file():
+        return []
+    rows = json.loads(queue_file.read_text(encoding="utf-8"))
+    if not isinstance(rows, list):
+        raise SystemExit(f"FAIL: {queue_file} is not a JSON list")
+    return rows
+
+
+def save(handoffs: pathlib.Path, queue_file: pathlib.Path, rows: list) -> None:
+    handoffs.mkdir(parents=True, exist_ok=True)
+    # Atomic replace: two agents share this file; a torn write must be
+    # impossible even when a race loses an update.
+    fd, tmp_name = tempfile.mkstemp(dir=str(handoffs), prefix=".queue-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(rows, handle, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, queue_file)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def resolve_root(raw: str) -> pathlib.Path:
+    root = pathlib.Path(raw).expanduser().resolve()
+    if not root.is_dir():
+        raise SystemExit(f"FAIL: project root {root} is not a directory")
+    return root
+
+
+def cmd_write(a) -> int:
+    root = resolve_root(a.project_root)
+    handoffs, queue_file = queue_paths(root)
+    src = pathlib.Path(a.file).expanduser()
+    if not src.is_file():
+        print(f"FAIL: {src} does not exist")
+        return 2
+    if not AGENT_LABEL.match(a.to):
+        print(f"FAIL: --to must be a lowercase agent slug, got {a.to!r}")
+        return 2
+    if a.sender and not AGENT_LABEL.match(a.sender):
+        print(f"FAIL: --from must be a lowercase agent slug, got {a.sender!r}")
+        return 2
+    handoffs.mkdir(parents=True, exist_ok=True)
+    body = src.read_bytes()
+    digest = hashlib.sha256(body).hexdigest()
+    stamp = dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+    prefix = f"round-{a.round:02d}-" if a.round is not None else ""
+    name = f"{prefix}to-{a.to}-{stamp}.md"
+    (handoffs / name).write_bytes(body)
+
+    rows = load(queue_file)
+    handoff_id = f"h-{digest[:10]}"
+    rows.append(
+        {
+            "id": handoff_id,
+            "round": a.round,
+            "to": a.to,
+            "from": a.sender or os.environ.get("SYNTHESIS_HANDOFF_SELF", ""),
+            "file": f"resources/handoffs/{name}",
+            "sha256": digest,
+            "summary": a.summary or "",
+            "state": "pending",
+            "written": dt.datetime.now().isoformat(timespec="seconds"),
+        }
+    )
+    save(handoffs, queue_file, rows)
+    print(f"handoff {handoff_id} written for {a.to}: resources/handoffs/{name}")
+    print(f"sha256 {digest}")
+    print(
+        "\nAnnounce it on the coordination board so the other side finds it "
+        "without the principal relaying anything:"
+    )
+    print(
+        f"  coordination.py message --from <your-session-id> --to "
+        f'<their-session-id> --text "HANDOFF {handoff_id} is pending in '
+        f'resources/handoffs/{name} (sha256 {digest}). Run handoff.py read."'
+    )
+    return 0
+
+
+def cmd_read(a) -> int:
+    root = resolve_root(a.project_root)
+    handoffs, queue_file = queue_paths(root)
+    me = a.as_agent or os.environ.get("SYNTHESIS_HANDOFF_SELF", "")
+    if not me:
+        print(
+            "FAIL: reader identity is required — pass --as AGENT or set "
+            "SYNTHESIS_HANDOFF_SELF. Guessing an identity could claim "
+            "another agent's work."
+        )
+        return 2
+    rows = load(queue_file)
+    mine = [r for r in rows if r.get("to") == me and r.get("state") == "pending"]
+    if not mine:
+        print(f"no pending handoff addressed to {me!r}")
+        claimed = [
+            r for r in rows if r.get("to") == me and r.get("state") == "claimed"
+        ]
+        if claimed:
+            print(
+                f"({len(claimed)} already claimed and not marked done — "
+                f"see handoff.py list)"
+            )
+        return 1
+    row = sorted(mine, key=lambda r: r.get("written", ""))[0]
+    path = root / row["file"]
+    body = path.read_bytes()
+    actual = hashlib.sha256(body).hexdigest()
+    if actual != row["sha256"]:
+        print(
+            f"FAIL: {row['file']} has changed since it was handed off "
+            f"(queue {row['sha256'][:12]}, disk {actual[:12]}). "
+            "Refusing to act on it."
+        )
+        return 2
+    row["state"] = "claimed"
+    row["claimed"] = dt.datetime.now().isoformat(timespec="seconds")
+    save(handoffs, queue_file, rows)
+    round_note = f" · round {row['round']}" if row.get("round") is not None else ""
+    print(f"=== handoff {row['id']}{round_note} · from {row.get('from') or '?'} · {row['file']}")
+    if row.get("summary"):
+        print(f"=== {row['summary']}")
+    print("=" * 78)
+    print(body.decode("utf-8"))
+    return 0
+
+
+def cmd_list(a) -> int:
+    root = resolve_root(a.project_root)
+    _, queue_file = queue_paths(root)
+    rows = load(queue_file)
+    if not rows:
+        print("handoff queue is empty")
+        return 0
+    print(f"{'id':<14} {'rnd':>3} {'from':<8} {'to':<8} {'state':<9} file")
+    for r in rows:
+        rnd = r.get("round")
+        print(
+            f"{r['id']:<14} {rnd if rnd is not None else '-':>3} "
+            f"{(r.get('from') or '?'):<8} {r['to']:<8} {r['state']:<9} {r['file']}"
+        )
+    pending = [r for r in rows if r["state"] == "pending"]
+    print(
+        f"\n{len(pending)} pending: "
+        + (", ".join(f"{r['id']}->{r['to']}" for r in pending) or "none")
+    )
+    return 0
+
+
+def cmd_done(a) -> int:
+    root = resolve_root(a.project_root)
+    handoffs, queue_file = queue_paths(root)
+    rows = load(queue_file)
+    for r in rows:
+        if r["id"] == a.id:
+            r["state"] = "done"
+            r["completed"] = dt.datetime.now().isoformat(timespec="seconds")
+            save(handoffs, queue_file, rows)
+            print(f"{a.id} marked done")
+            return 0
+    print(f"FAIL: no handoff with id {a.id}")
+    return 2
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0], allow_abbrev=False
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    w = sub.add_parser("write")
+    w.add_argument("--to", required=True)
+    w.add_argument("--file", required=True)
+    w.add_argument("--round", type=int)
+    w.add_argument("--summary")
+    w.add_argument("--from", dest="sender")
+    w.add_argument("--project-root", default=".")
+    r = sub.add_parser("read")
+    r.add_argument("--as", dest="as_agent")
+    r.add_argument("--project-root", default=".")
+    ls = sub.add_parser("list")
+    ls.add_argument("--project-root", default=".")
+    d = sub.add_parser("done")
+    d.add_argument("--id", required=True)
+    d.add_argument("--project-root", default=".")
+    a = ap.parse_args()
+    return {
+        "write": cmd_write,
+        "read": cmd_read,
+        "list": cmd_list,
+        "done": cmd_done,
+    }[a.cmd](a)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/synthesis-project-management/scripts/test_handoff.py
+++ b/skills/synthesis-project-management/scripts/test_handoff.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "handoff.py"
+
+
+def run_cli(
+    project: Path, *args: str, env_extra: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    import os
+
+    env = dict(os.environ)
+    env.pop("SYNTHESIS_HANDOFF_SELF", None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args, "--project-root", str(project)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def write_prompt(project: Path, text: str = "do the next round\n") -> Path:
+    prompt = project / "prompt.md"
+    prompt.write_text(text, encoding="utf-8")
+    return prompt
+
+
+def test_write_read_done_flow(tmp_path: Path) -> None:
+    prompt = write_prompt(tmp_path)
+    written = run_cli(
+        tmp_path,
+        "write",
+        "--to",
+        "codex",
+        "--from",
+        "claude",
+        "--file",
+        str(prompt),
+        "--round",
+        "3",
+        "--summary",
+        "round three",
+    )
+    assert written.returncode == 0, written.stdout + written.stderr
+    assert "handoff h-" in written.stdout
+    handoff_id = written.stdout.split()[1]
+
+    queue = json.loads(
+        (tmp_path / "resources" / "handoffs" / "queue.json").read_text()
+    )
+    assert queue[0]["state"] == "pending"
+    assert queue[0]["to"] == "codex"
+    assert queue[0]["from"] == "claude"
+    assert queue[0]["round"] == 3
+
+    read = run_cli(tmp_path, "read", "--as", "codex")
+    assert read.returncode == 0, read.stdout + read.stderr
+    assert "do the next round" in read.stdout
+
+    queue = json.loads(
+        (tmp_path / "resources" / "handoffs" / "queue.json").read_text()
+    )
+    assert queue[0]["state"] == "claimed"
+
+    done = run_cli(tmp_path, "done", "--id", handoff_id)
+    assert done.returncode == 0
+    queue = json.loads(
+        (tmp_path / "resources" / "handoffs" / "queue.json").read_text()
+    )
+    assert queue[0]["state"] == "done"
+
+
+def test_read_refuses_without_identity(tmp_path: Path) -> None:
+    prompt = write_prompt(tmp_path)
+    run_cli(tmp_path, "write", "--to", "codex", "--file", str(prompt))
+    read = run_cli(tmp_path, "read")
+    assert read.returncode == 2
+    assert "identity is required" in read.stdout
+
+
+def test_read_uses_env_identity(tmp_path: Path) -> None:
+    prompt = write_prompt(tmp_path)
+    run_cli(tmp_path, "write", "--to", "codex", "--file", str(prompt))
+    read = run_cli(
+        tmp_path, "read", env_extra={"SYNTHESIS_HANDOFF_SELF": "codex"}
+    )
+    assert read.returncode == 0, read.stdout + read.stderr
+
+
+def test_read_refuses_tampered_payload(tmp_path: Path) -> None:
+    prompt = write_prompt(tmp_path)
+    written = run_cli(tmp_path, "write", "--to", "codex", "--file", str(prompt))
+    assert written.returncode == 0
+    stored = next((tmp_path / "resources" / "handoffs").glob("to-codex-*.md"))
+    stored.write_text("tampered\n", encoding="utf-8")
+
+    read = run_cli(tmp_path, "read", "--as", "codex")
+    assert read.returncode == 2
+    assert "has changed since it was handed off" in read.stdout
+    queue = json.loads(
+        (tmp_path / "resources" / "handoffs" / "queue.json").read_text()
+    )
+    assert queue[0]["state"] == "pending"
+
+
+def test_read_with_empty_queue_exits_one(tmp_path: Path) -> None:
+    read = run_cli(tmp_path, "read", "--as", "claude")
+    assert read.returncode == 1
+    assert "no pending handoff" in read.stdout
+
+
+def test_write_refuses_bad_agent_label(tmp_path: Path) -> None:
+    prompt = write_prompt(tmp_path)
+    written = run_cli(tmp_path, "write", "--to", "Not A Slug", "--file", str(prompt))
+    assert written.returncode == 2
+    assert "lowercase agent slug" in written.stdout
+
+
+def test_done_refuses_unknown_id(tmp_path: Path) -> None:
+    done = run_cli(tmp_path, "done", "--id", "h-missing")
+    assert done.returncode == 2
+    assert "no handoff with id" in done.stdout
+
+
+def test_round_is_optional(tmp_path: Path) -> None:
+    prompt = write_prompt(tmp_path)
+    written = run_cli(tmp_path, "write", "--to", "claude", "--file", str(prompt))
+    assert written.returncode == 0
+    queue = json.loads(
+        (tmp_path / "resources" / "handoffs" / "queue.json").read_text()
+    )
+    assert queue[0]["round"] is None
+    read = run_cli(tmp_path, "read", "--as", "claude")
+    assert read.returncode == 0

--- a/skills/synthesis-project-management/scripts/test_handoff.py
+++ b/skills/synthesis-project-management/scripts/test_handoff.py
@@ -139,3 +139,30 @@ def test_round_is_optional(tmp_path: Path) -> None:
     assert queue[0]["round"] is None
     read = run_cli(tmp_path, "read", "--as", "claude")
     assert read.returncode == 0
+
+
+SKILLS_ROOT = SCRIPT.parents[2]
+
+
+def test_pm_skill_documents_the_handoff_queue() -> None:
+    text = (SCRIPT.parent.parent / "SKILL.md").read_text(encoding="utf-8")
+    assert "### The Handoff Queue" in text
+    assert "scripts/handoff.py" in text
+    assert "Nothing self-triggers" in text
+
+
+def test_autopilot_wires_packet_and_handoff() -> None:
+    text = (SKILLS_ROOT / "synthesis-autopilot" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "synthesis-decision-packet" in text
+    assert "build_packet.py" in text
+    assert "handoff.py" in text
+    assert "never reimplemented inline" in text
+
+
+def test_decision_packet_names_concrete_handoff_path() -> None:
+    text = (SKILLS_ROOT / "synthesis-decision-packet" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "synthesis-project-management/scripts/handoff.py" in text


### PR DESCRIPTION
Approved work items R-04 (and the enabler for R-01) from the synthesis-agent-interoperability packet, 2026-08-29.

- **synthesis-project-management v2.7.0** — `scripts/handoff.py`: the agent-to-agent handoff queue, generalized from the working project reference. Sha-pinned payloads, atomic queue writes, fail-closed reader identity, board announcement, deliberately not self-triggering. Eleven tests including doctrine contracts.
- **synthesis-autopilot v1.4.0** — calls `synthesis-decision-packet` as its batched-questions mechanism (simple batches stay chat prompts; complex batches build a packet, never reimplemented inline; rows rebuilt against later principal corrections). Handoff queue named as the agent-to-agent transport.
- **synthesis-implementation-integrity** — schema-2 `receipt_consumer` becomes a format contract (`*.consume-acceptance.vN`) so a second repository can declare an honest transaction-bound gate; every consumer still verifies the receipt names itself at its own boundary.
- **synthesis-decision-packet v1.2.0** — relationship section points at the concrete handoff path.

Local evidence: conformance 204+2 PASS; 286 + 105 pytest across the required suites; installer, inbox, transcripts, compileall PASS; fresh schema-2 acceptance run 11/11 closed against change base 3ee9b4a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)