### PR TITLE
Release 4.63.0: repairs from the external adversarial review of 4.55.0-4.57.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.62.0",
+  "version": "4.63.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.62.0",
+  "version": "4.63.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.63.0] - 2026-08-29
+
+The repair release for the external adversarial review of 4.55.0–4.57.0
+(R-02: a second vendor's model reviewing four releases it did not write,
+from detached historical worktrees and runtime probes — 14 findings, seven
+ship-blocking). Every valid runtime and doctrine finding is repaired here;
+the review's two historical manifest-closure findings stand as audit records
+of already-shipped transactions.
+
+### Fixed
+
+- **`synthesis-context-lifecycle` v1.14.0 — item currency no longer fails
+  open.** A suffix that looks like a stamp but is not one ("(as of
+  yesterday)") passed as stamped, and a date-shaped impossibility
+  ("2026-02-30") was silently skipped; both now surface as
+  `item-marker-malformed`. An explicit `review 0d` horizon is honored
+  instead of being silently replaced with the 14-day default. The review
+  ledger's expiry suppression is per lifecycle, not per item text: an item
+  expired, carried, and re-stamped records its later expiry as the new miss
+  it is, with the governing stamp on every new event.
+- **`synthesis-daily-rituals` v2.28.0 — the blocking gap gate cannot be
+  walked past.** `sync_watermark.py status` refuses an empty surface set:
+  the store only knows surfaces already written, so a store-only status
+  exits 0 straight past a declared surface that has never been swept. Both
+  ritual checklists now carry the exact status invocation with every
+  declared surface passed explicitly — the release prose said to run it and
+  no operational step did.
+- **`synthesis-slack-sync` v3.7.0 — the sweep consumes preflight instead of
+  contradicting it.** v3.6.0 banned config-derived ids while the numbered
+  steps still said "for each channel in the config." Step 0 now defines the
+  mandatory resolved-target preflight; Steps 1/3/3b iterate only its output;
+  an empty resolved set refuses the sweep; unresolved surfaces are reported
+  as unresolved. Stale frontmatter metadata caught up.
+- **`synthesis-meeting-transcripts` v0.9.0 — "declared means fetched" gets
+  an execution path.** Step 0 enumerates the declared window, fetches every
+  member, and accounts for every member with machine-readable unclosed
+  gaps; the single-meeting protocol serves explicit requests only. Stale
+  frontmatter metadata caught up.
+- **`synthesis-decision-packet` v1.3.0 — ids survive browser coercion.**
+  Row ids must be non-empty strings: JSON `1` and `"1"` become the same
+  localStorage key, so JSON-distinct ids could silently share saved state.
+  The schema comment claiming a recommendation "pre-selects" a button now
+  says marked-never-pre-selected, matching the shipped behavior, and the
+  control-marker fixture is mutation-hardened — it previously passed with
+  the marker implementation deleted.
+
 ## [4.62.0] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A reviewer that did not write the code, reviewing the code (August 2026).**
+Release **4.63.0** repairs what an external adversarial review of
+4.55.0–4.57.0 found — a second vendor's model attacking four releases from
+detached worktrees and runtime probes: item-currency stamps that failed
+open, a blocking gap gate that could be walked past at bootstrap, sweep
+steps that contradicted their own preflight rule, a declared-fetch policy
+with no execution path, and packet ids that collided after browser
+coercion. Seven ship-blocking findings, every valid one repaired in one
+release. See the [4.63.0 release notes](CHANGELOG.md).
+
 **Two directions that remove the principal as transport (August 2026).**
 Release **4.62.0** pairs the decision packet with a generalized handoff
 queue: work moves between agents as sha-pinned files in the project

--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.13.0"
+  version: "1.14.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-context-lifecycle/scripts/context_currency.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_currency.py
@@ -223,13 +223,76 @@ def overdue_items(text: str, today: date | None = None) -> list[dict]:
         try:
             stamped = date.fromisoformat(item["date"])
         except ValueError:
+            # A stamp shaped like a date that is not one is a malformed stamp,
+            # not a fresh item; malformed_stamp_items() reports it.
             continue
-        horizon = item["review_days"] or DEFAULT_REVIEW_DAYS
+        # An explicit 0-day horizon is a statement ("review daily"), not an
+        # omission: `or` would silently replace it with the default and the
+        # item could sit past its declared horizon without a finding.
+        horizon = (
+            item["review_days"]
+            if item["review_days"] is not None
+            else DEFAULT_REVIEW_DAYS
+        )
         if (moment - stamped).days > horizon:
             item["age_days"] = (moment - stamped).days
             item["horizon_days"] = horizon
             overdue.append(item)
     return overdue
+
+
+def malformed_stamp_items(text: str) -> list[dict]:
+    """Open-section items whose currency stamp cannot be trusted.
+
+    Two shapes, both previously invisible: a suffix that looks like a stamp
+    but is not one ("(as of yesterday)") slipped through the unstamped
+    exemption, and a stamp whose date string matches the pattern but is not a
+    real date ("2026-02-30") was silently skipped. A malformed stamp must not
+    read as a valid one — that is exactly how an unverifiable age passes as
+    current.
+    """
+    headings = [(m.start(), m.group(1)) for m in SECTION_HEADING.finditer(text)]
+    pattern_stamped: set[tuple[str, str]] = set()
+    malformed: list[dict] = []
+    for item in item_markers(text):
+        # Every regex-matching stamp is owned by this loop: valid ones are
+        # fine, impossible dates are malformed. Either way the suffix branch
+        # below must not double-report the same line.
+        pattern_stamped.add((item["section"], item["text"]))
+        try:
+            date.fromisoformat(item["date"])
+        except ValueError:
+            if not item["done"]:
+                malformed.append(
+                    {
+                        "section": item["section"],
+                        "text": item["text"],
+                        "reason": f"stamp date {item['date']} is not a real date",
+                    }
+                )
+    for match in ITEM_LINE.finditer(text):
+        section = _section_of(headings, match.start())
+        if not OPEN_SECTION.search(section):
+            continue
+        if (match.group("box") or " ").strip().lower() == "x":
+            continue
+        body = match.group("text").strip()
+        if not (body.endswith(")") and "as of" in body):
+            continue
+        if any(
+            body.startswith(stamped_text)
+            for stamped_section, stamped_text in pattern_stamped
+            if stamped_section == section
+        ):
+            continue
+        malformed.append(
+            {
+                "section": section,
+                "text": body,
+                "reason": "the '(as of ...)' suffix does not parse as a stamp",
+            }
+        )
+    return malformed
 
 
 def unstamped_open_sections(text: str) -> list[str]:
@@ -394,6 +457,13 @@ def audit_project(project: Path, today: date | None = None) -> list[dict]:
             "detail": f"'{section}' lists live items with no '(as of ...)' "
                       "stamps — their age is unverifiable, so an entry written "
                       "weeks ago is indistinguishable from one written today",
+        })
+    for item in malformed_stamp_items(text):
+        findings.append({
+            "project": str(project), "kind": "item-marker-malformed",
+            "section": item["section"],
+            "detail": f"'{item['section']}' item \"{item['text']}\" carries a "
+                      f"stamp that cannot be trusted: {item['reason']}",
         })
     return findings
 

--- a/skills/synthesis-context-lifecycle/scripts/context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_doctor.py
@@ -1005,7 +1005,11 @@ def audit_project(
                 "add '*State as of:*' markers to Current State and What's "
                 "Next per the tiered-context template",
             )
-        elif kind in ("item-marker-stale", "item-marker-absent"):
+        elif kind in (
+            "item-marker-stale",
+            "item-marker-absent",
+            "item-marker-malformed",
+        ):
             # Warnings, not defects, and deliberately so: item stamping is a new
             # convention, and turning an entire corpus red on the day it lands
             # is how a guard teaches people to route around it. These surface in

--- a/skills/synthesis-context-lifecycle/scripts/review_ledger.py
+++ b/skills/synthesis-context-lifecycle/scripts/review_ledger.py
@@ -74,6 +74,7 @@ def record(
     transition: str,
     detail: str = "",
     today: date | None = None,
+    stamp: str = "",
 ) -> dict:
     if transition not in TRANSITIONS:
         raise ValueError(f"unknown transition: {transition}")
@@ -84,6 +85,8 @@ def record(
         "transition": transition,
         "detail": detail,
     }
+    if stamp:
+        event["stamp"] = stamp
     path = ledger_path(root)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as handle:
@@ -98,13 +101,29 @@ def _key(project: str, item: str, transition: str) -> tuple[str, str, str]:
 def scan(root: Path, today: date | None = None, projects_dir: str = "projects") -> int:
     """Record an expiry for every stamped item now past its review horizon.
 
-    Idempotent: an item already recorded as expired is not recorded again, so a
-    daily run cannot manufacture duplicate misses for the same forgotten thing.
+    Idempotent per lifecycle, not per text: the same stamp's expiry is never
+    recorded twice, but an item that was expired, carried, and re-stamped is a
+    NEW lifecycle — its later expiry is a new miss and must be recorded. Keying
+    suppression on text alone silenced every expiry cycle after the first.
     """
     moment = today or date.today()
+    events = read_events(root)
     seen = {
-        _key(e.get("project", ""), e.get("item", ""), e.get("transition", ""))
-        for e in read_events(root)
+        (
+            e.get("project", ""),
+            (e.get("item") or "").strip(),
+            e.get("transition", ""),
+            e.get("stamp", ""),
+        )
+        for e in events
+    }
+    # Events written before stamps were recorded cover the lifecycles current
+    # at their recording date: a legacy expiry suppresses stamps no newer than
+    # its own timestamp, and nothing after.
+    legacy_cover = {
+        (e.get("project", ""), (e.get("item") or "").strip()): e.get("ts", "")
+        for e in events
+        if e.get("transition") == "expired-unactioned" and not e.get("stamp")
     }
     added = 0
     projects = Path(root) / projects_dir
@@ -117,8 +136,11 @@ def scan(root: Path, today: date | None = None, projects_dir: str = "projects") 
         except OSError:
             continue
         for item in context_currency.overdue_items(text, today=moment):
-            key = _key(project.name, item["text"], "expired-unactioned")
+            key = (project.name, item["text"].strip(), "expired-unactioned", item["date"])
             if key in seen:
+                continue
+            legacy_ts = legacy_cover.get((project.name, item["text"].strip()))
+            if legacy_ts and item["date"] <= legacy_ts:
                 continue
             record(
                 root,
@@ -131,6 +153,7 @@ def scan(root: Path, today: date | None = None, projects_dir: str = "projects") 
                     f"(section '{item['section']}')"
                 ),
                 today=moment,
+                stamp=item["date"],
             )
             seen.add(key)
             added += 1

--- a/skills/synthesis-context-lifecycle/scripts/test_item_currency.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_item_currency.py
@@ -190,7 +190,7 @@ def test_item_findings_are_warnings_not_defects(tmp_path: Path) -> None:
     on the day it lands is how a guard teaches people to route around it. These
     must surface without blocking a session end, which is reserved for defects."""
     source = Path(__file__).with_name("context_doctor.py").read_text(encoding="utf-8")
-    marker = 'elif kind in ("item-marker-stale", "item-marker-absent"):'
+    marker = '"item-marker-malformed",'
     assert marker in source, "doctor no longer maps the item kinds"
     block = source.split(marker, 1)[1].split("audit.add(", 1)[1][:200]
 
@@ -249,3 +249,56 @@ def test_obligation_sections_are_still_held(tmp_path: Path) -> None:
         )
         kinds = [f["kind"] for f in MODULE.audit_project(project, today=TODAY)]
         assert "item-marker-absent" in kinds, heading
+
+
+# --- R-02 external-review repairs: fail-open stamps and zero-day horizons --
+
+
+def test_zero_day_horizon_is_honored_not_defaulted(tmp_path: Path) -> None:
+    """'review 0d' is a statement (review daily), not an omission: `or`
+    silently replaced it with the 14-day default, so a daily-review item
+    could sit two weeks dark (R-02 external review)."""
+    project = _project(
+        tmp_path,
+        "**Last session:** 2026-08-27\n\n"
+        "## Open\n"
+        "- [ ] Watch this daily (as of 2026-08-26, review 0d)\n",
+    )
+    stale = [f for f in MODULE.audit_project(project, today=TODAY)
+             if f["kind"] == "item-marker-stale"]
+
+    assert len(stale) == 1
+    assert "0-day review horizon" in stale[0]["detail"]
+
+
+def test_malformed_stamp_suffix_is_flagged_not_exempted(tmp_path: Path) -> None:
+    """'(as of yesterday)' matched the unstamped-exemption heuristic and
+    passed as stamped; a stamp that does not parse must not read as one."""
+    project = _project(
+        tmp_path,
+        "**Last session:** 2026-08-27\n\n"
+        "## Open\n"
+        "- [ ] Chase the ask (as of yesterday)\n",
+    )
+    malformed = [f for f in MODULE.audit_project(project, today=TODAY)
+                 if f["kind"] == "item-marker-malformed"]
+
+    assert len(malformed) == 1
+    assert "does not parse" in malformed[0]["detail"]
+
+
+def test_impossible_stamp_date_is_flagged_not_skipped(tmp_path: Path) -> None:
+    """A date-shaped stamp that is not a real date was silently skipped by
+    the overdue scan, so the item read as current forever."""
+    project = _project(
+        tmp_path,
+        "**Last session:** 2026-08-27\n\n"
+        "## Open\n"
+        "- [ ] Bad stamp (as of 2026-02-30, review 7d)\n",
+    )
+    findings = MODULE.audit_project(project, today=TODAY)
+    malformed = [f for f in findings if f["kind"] == "item-marker-malformed"]
+
+    assert len(malformed) == 1
+    assert "not a real date" in malformed[0]["detail"]
+    assert not [f for f in findings if f["kind"] == "item-marker-stale"]

--- a/skills/synthesis-context-lifecycle/scripts/test_review_ledger.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_review_ledger.py
@@ -201,3 +201,38 @@ def test_expired_items_are_summarised_for_the_review_question(
     assert report["totals"]["closed"] == 1
     missed = [e for e in report["events"] if e["transition"] == "expired-unactioned"]
     assert "Missed thing" in missed[0]["item"]
+
+
+def test_a_restamped_item_can_expire_again(tmp_path: Path) -> None:
+    """Idempotence is per lifecycle, not per text: expired -> carried ->
+    re-stamped -> expired again is TWO misses, and keying suppression on the
+    item text alone silenced every cycle after the first (R-02 external
+    review)."""
+    root = _workspace(tmp_path, "personal")
+    project = _project(
+        root,
+        "alpha",
+        "**Last session:** 2026-08-27\n\n"
+        "## Open\n"
+        "- [ ] Recurring ask (as of 2026-08-01, review 7d)\n",
+    )
+
+    assert MODULE.scan(root, today=TODAY) == 1
+    MODULE.record(root, "alpha", "Recurring ask", "carried")
+
+    # The same lifecycle stays idempotent.
+    assert MODULE.scan(root, today=TODAY) == 0
+
+    # A fresh stamp opens a new lifecycle; its later expiry is a new miss.
+    (project / "CONTEXT.md").write_text(
+        "**Last session:** 2026-08-27\n\n"
+        "## Open\n"
+        "- [ ] Recurring ask (as of 2026-08-15, review 7d)\n",
+        encoding="utf-8",
+    )
+    assert MODULE.scan(root, today=TODAY) == 1
+
+    expiries = [e for e in MODULE.read_events(root)
+                if e["transition"] == "expired-unactioned"]
+    assert len(expiries) == 2
+    assert {e.get("stamp") for e in expiries} == {"2026-08-01", "2026-08-15"}

--- a/skills/synthesis-daily-rituals/SKILL.md
+++ b/skills/synthesis-daily-rituals/SKILL.md
@@ -10,7 +10,7 @@ depends_on:
   - synthesis-checkpoint
 metadata:
   author: "Rajiv Pant"
-  version: "2.27.0"
+  version: "2.28.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -583,6 +583,14 @@ The set of remotes for each repo comes from `git remote -v` inside that repo. Th
 - [ ] **Email sync (v2.19.0)** — when the workspace routinely syncs email (established `transcripts/email/` practice or explicit config): sweep the window's inbound mail AND the user's own sent mail (sent items are correspondence records too — the user's outbound exec mail is often the day's most consequential artifact), using the workspace's designated email tooling and account. Save to the workspace convention (e.g., `transcripts/email/YYYY-MM-DD-<slug>.md`).
 - [ ] **Document-comment sync (v2.19.0)** — when the workspace has an established docs-sweep practice (`transcripts/docs/` or explicit config): Drive documents modified in the window, open comment threads where the newest reply is not the user's (ball in their court), and engagement on documents the user shared out.
 - [ ] **Name any surface not swept.** The declared surface set is the complete decision (v2.12.1 applied to channels); a sync that skips one must say so in its report rather than reporting as complete.
+- [ ] **Watermark gate (v2.28.0):** after the sweeps, run
+  `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s>` with
+  **every declared surface passed explicitly** — the store only knows surfaces
+  that have already been written, so a status that consults only the store
+  walks straight past a declared surface that has never been swept (the
+  command refuses an empty surface set for exactly that reason). Non-zero exit
+  means an unclosed gap: close it this run or defer it with an explicit
+  reason before the ritual proceeds.
 - [ ] Run any project-specific sync steps (see project supplement).
 
 #### 3c. Meeting Transcripts
@@ -1054,6 +1062,11 @@ The Weekly Loose-Ends Review (Step 10) attaches to whichever ritual runs first o
 - [ ] **Run `/synthesis-slack-sync`** for final capture of the day. The `synthesis-slack-sync` skill ensures all channels, threads, and DMs are captured.
 - [ ] **Google Chat final capture (v2.17.0)** — if the workspace declares `.agents/gchat-sync.yaml`, run the same Chat sweep as Day-Start Step 3b for the day's window (fresh space enumeration; raw sender IDs preserved).
 - [ ] **Email + document-comment final capture (v2.19.0)** — when the workspace syncs those surfaces (per Day-Start 3b's declared-set rule): the day's inbound and sent mail, meeting transcripts for any meeting that ended since the last sync, and document comments/engagement for the day's window. Name any surface not swept.
+- [ ] **Watermark gate (v2.28.0):** run
+  `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s>` with
+  every declared surface passed explicitly (same rule and same reason as
+  Day-Start Step 3b's gate). The day does not close over a blocking gap:
+  close it or defer it with a reason now.
 - [ ] Update CONTEXT.md to mark any items resolved by day's conversations (so tomorrow's day-start does not re-propose them).
 
 ### 2. Source-Code Sync

--- a/skills/synthesis-daily-rituals/scripts/sync_watermark.py
+++ b/skills/synthesis-daily-rituals/scripts/sync_watermark.py
@@ -209,6 +209,20 @@ def main(argv: list[str] | None = None) -> int:
             p.add_argument("--reason", required=True)
     args = parser.parse_args(argv)
 
+    if args.command == "status" and not args.surface:
+        # The declared surface set must come from the caller (the ritual's
+        # config), because the store only knows surfaces that have already
+        # been written: a declared surface with no successful write is
+        # exactly the gap this gate exists to block, and a status that
+        # consults only the store exits 0 straight past it.
+        print(
+            "error: status requires the declared surface set — pass every "
+            "declared surface with --surface (repeatable); an empty set "
+            "cannot authorize a ritual",
+            file=sys.stderr,
+        )
+        return 2
+
     try:
         if args.command == "window":
             result = window(args.workspace, args.surface)

--- a/skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
+++ b/skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
@@ -154,7 +154,8 @@ def test_cli_status_exits_nonzero_while_blocking(tmp_path: Path) -> None:
     MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
 
     done = subprocess.run(
-        [sys.executable, str(SCRIPT), "status", "--workspace", WS, "--json"],
+        [sys.executable, str(SCRIPT), "status", "--workspace", WS,
+         "--surface", "slack", "--json"],
         capture_output=True, text=True, env=env,
     )
 
@@ -167,7 +168,8 @@ def test_cli_status_exits_zero_when_current(tmp_path: Path) -> None:
     MODULE.advance(WS, "slack", "2026-08-28", today=TODAY, home=tmp_path)
 
     done = subprocess.run(
-        [sys.executable, str(SCRIPT), "status", "--workspace", WS, "--json"],
+        [sys.executable, str(SCRIPT), "status", "--workspace", WS,
+         "--surface", "slack", "--json"],
         capture_output=True, text=True, env=env,
     )
 
@@ -198,18 +200,27 @@ def test_rituals_document_the_watermark_and_blocking_gap() -> None:
 
 
 def test_transcripts_forbid_a_judgment_gate_before_fetching() -> None:
-    """Declared means fetched; relevance is judged after fetching, not from a
-    title. The same shape was already retired once for repository syncing."""
+    """Declared means fetched — and (post R-02 review) the policy must have an
+    execution path, not just phrasing: the declared-window sweep enumerates the
+    set, fetches every member, and accounts for every member."""
     text = (SKILLS_ROOT / "synthesis-meeting-transcripts" / "SKILL.md").read_text(
         encoding="utf-8"
     )
 
     assert "does not get a vote" in text
     assert "after* fetching" in text or "after fetching" in text
+    # The execution path itself (v0.9.0): a numbered sweep step, complete
+    # enumeration, and machine-readable unclosed gaps.
+    assert "### Step 0: Declared-window sweep" in text
+    assert "Enumerate the declared set" in text
+    assert "unclosed gap" in text
+    assert "Account for every member" in text
 
 
 def test_slack_sync_bans_deriving_read_ids_in_the_sweep() -> None:
-    """Two id-like fields per entry is a trap that hides until someone leaves."""
+    """Two id-like fields per entry is a trap that hides until someone leaves —
+    and (post R-02 review) the sweep steps must consume the preflight rather
+    than contradict it: no numbered step may iterate the config for ids."""
     text = (SKILLS_ROOT / "synthesis-slack-sync" / "SKILL.md").read_text(
         encoding="utf-8"
     )
@@ -217,3 +228,51 @@ def test_slack_sync_bans_deriving_read_ids_in_the_sweep() -> None:
     assert "preflight" in text
     assert "banned" in text
     assert "dm_id" in text
+    # The operational consumption (v3.7.0): a mandatory Step 0 and steps that
+    # iterate its resolved output — the config-iteration phrasing the external
+    # review caught must stay gone.
+    assert "### Step 0: Preflight" in text
+    assert "resolved-target list" in text
+    assert "For each channel in the config" not in text
+    assert "For each DM channel in the config" not in text
+    assert "RESOLVED_CONVERSATION_ID" in text
+
+
+def test_cli_status_refuses_an_empty_surface_set(tmp_path: Path) -> None:
+    """The declared set must come from the caller: the store only knows
+    surfaces already written, so a store-only status walks straight past a
+    declared surface that has never been swept (R-02 external review)."""
+    env = {"SYNTHESIS_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
+    done = subprocess.run(
+        [sys.executable, str(SCRIPT), "status", "--workspace", WS, "--json"],
+        capture_output=True, text=True, env=env,
+    )
+
+    assert done.returncode == 2
+    assert "declared surface set" in done.stderr
+
+
+def test_cli_status_blocks_a_declared_surface_never_written(tmp_path: Path) -> None:
+    """The bootstrap bypass itself: no advance() has ever run, and the
+    declared surface must still block rather than vanish."""
+    env = {"SYNTHESIS_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
+    done = subprocess.run(
+        [sys.executable, str(SCRIPT), "status", "--workspace", WS,
+         "--surface", "slack", "--json"],
+        capture_output=True, text=True, env=env,
+    )
+
+    assert done.returncode == 1
+    assert json.loads(done.stdout)["blocking"] == ["slack"]
+
+
+
+def test_rituals_carry_the_watermark_gate_invocation() -> None:
+    """The release prose said to run status in Day-Start Step 3 and Day-End
+    Step 1; the external review found no operational step actually did. Both
+    checklists must carry the exact invocation with explicit surfaces."""
+    text = (SKILLS_ROOT / "synthesis-daily-rituals" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert text.count("sync_watermark.py status --workspace <W> --surface <s>") >= 2
+    assert "refuses an empty surface set" in text or "every declared surface passed explicitly" in text

--- a/skills/synthesis-decision-packet/SKILL.md
+++ b/skills/synthesis-decision-packet/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.2.0"
+  version: "1.3.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-decision-packet/scripts/build_packet.py
+++ b/skills/synthesis-decision-packet/scripts/build_packet.py
@@ -75,9 +75,11 @@ Decision-packet spec (JSON)
         "decline": "What happens if they   never in internal treatment vocabulary.
                    do not."
       },
-      "recommendation": "fix-now",        optional but STRONGLY expected — pre-selects
-                                          a button. No recommendation on any row means
-                                          the packet is a questionnaire; see the
+      "recommendation": "fix-now",        optional but STRONGLY expected — MARKS
+                                          a button (never pre-selects it: a packet
+                                          that opens decided records nobody's
+                                          judgment). No recommendation on any row
+                                          means the packet is a questionnaire; see the
                                           anti-trigger in SKILL.md.
       "severity": "high",                 optional ∈ {high, medium, low, none}
                                           — drives the coloured rail
@@ -144,10 +146,20 @@ def validate(spec: dict) -> list[str]:
         rid = r.get("id")
         if not rid:
             problems.append(f"rows[{i}] missing required field: id")
-        elif rid in seen:
-            problems.append(f"rows[{i}] duplicate id {rid!r} — ids key localStorage and must be unique")
+        elif not isinstance(rid, str) or not rid.strip():
+            # Ids key localStorage and DOM datasets, which coerce every value
+            # to a string: JSON 1 and "1" become the same browser key, so two
+            # JSON-distinct ids can silently share saved state. Only non-empty
+            # strings are ids.
+            problems.append(
+                f"rows[{i}] id {rid!r} must be a non-empty string — browser "
+                "storage coerces ids to strings, so non-string ids can "
+                "collide after coercion"
+            )
+        elif rid.strip() in seen:
+            problems.append(f"rows[{i}] duplicate id {rid.strip()!r} — ids key localStorage and must be unique")
         else:
-            seen.add(rid)
+            seen.add(rid.strip())
         if not r.get("label"):
             problems.append(f"rows[{i}] ({rid}) missing required field: label")
         sev = r.get("severity")

--- a/skills/synthesis-decision-packet/scripts/test_build_packet.py
+++ b/skills/synthesis-decision-packet/scripts/test_build_packet.py
@@ -127,8 +127,19 @@ def test_every_copy_path_reports_its_outcome():
 # ---------------------------------------------------------------------------
 
 def test_recommendation_is_marked_on_the_control_not_only_prose():
+    """Mutation-hardened: an external review deleted the marker statements and
+    this test still passed, because it only asserted generic button plumbing.
+    It now asserts the exact marking behavior it is named for."""
     out = bp.build(spec())
-    assert 'aria-pressed' in out and 'b.dataset.value = o.value' in out
+    # The marked-control affordance itself: the data attribute and the
+    # accessible title, set exactly when the option is the recommendation.
+    assert 'b.dataset.recommended = "true";' in out
+    assert 'b.title = "The agent recommends this";' in out
+    assert "row.recommendation === o.value" in out
+    # The visual treatment binds to the marker, and marking never presses:
+    # aria-pressed derives from saved state alone (guarded by the fresh-packet
+    # test), while the recommended styling keys off data-recommended.
+    assert 'button[data-recommended="true"]' in out
     assert "recommended: " in out, "the recommendation must be shown on the control, not just in text"
 
 
@@ -378,3 +389,35 @@ def _run_all():
 
 if __name__ == "__main__":
     sys.exit(_run_all())
+
+
+def test_ids_that_collide_after_browser_coercion_are_refused():
+    """JSON 1 and "1" become the same localStorage key; the generator must
+    refuse the collision instead of emitting a packet whose rows share saved
+    state (found by the R-02 external review)."""
+    s = spec()
+    s["rows"][0]["id"] = 1
+    s["rows"][1]["id"] = "1"
+    assert any("non-empty string" in p for p in bp.validate(s))
+
+    with tempfile.TemporaryDirectory() as d:
+        sp = pathlib.Path(d) / "s.json"
+        sp.write_text(json.dumps(s), encoding="utf-8")
+        out_file = pathlib.Path(d) / "o.html"
+        r = subprocess.run(
+            [sys.executable, str(HERE / "build_packet.py"), str(sp),
+             "-o", str(out_file)],
+            capture_output=True, text=True,
+        )
+        assert r.returncode == 2, r.stdout + r.stderr
+        assert not out_file.exists(), "no output may be created for a colliding spec"
+
+
+def test_whitespace_and_boolean_ids_are_refused():
+    s = spec()
+    s["rows"][0]["id"] = "  "
+    assert any("non-empty string" in p for p in bp.validate(s))
+
+    s = spec()
+    s["rows"][0]["id"] = True
+    assert any("non-empty string" in p for p in bp.validate(s))

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,10 +1,10 @@
-# AGENT HEURISTIC: authored for the 4.62.0 packet/handoff-wiring release.
+# AGENT HEURISTIC: authored for the 4.63.0 external-review repair release.
 # The manifest records this release's exact public universe; the runner proves
 # the declaration against the authoritative base-to-head Git diff, so a
 # surface that changes without being declared — or is declared without
 # changing — refuses authority.
 schema: 2
-suite: synthesis-packet-handoff-wiring-release
+suite: synthesis-r02-repair-release
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run
 enforcing_boundary: release.py and repository CI before publication
@@ -13,22 +13,36 @@ change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: whether autopilot sessions actually reach for the packet at the documented thresholds — doctrine adoption is behavioral, not testable here; consumer-side self-naming checks in gates other than the public release gate; installed-client parity, independent review, publication, and deployment
+unverified_remainder: behavioral adoption of the ritual watermark gate and the sweep preflight in live workspaces; the two historical manifest-closure findings (R02-455-001, R02-457-001) which audit already-shipped transactions and cannot be repaired retroactively; installed-client parity, independent review, publication, and deployment
 changed_surfaces:
-  - path: skills/synthesis-implementation-integrity/scripts/acceptance_suite.py
-    cases: [consumer-format-accepts-alternate, consumer-format-refuses-malformed]
-  - path: skills/synthesis-implementation-integrity/scripts/test_acceptance_suite.py
-    cases: [consumer-format-accepts-alternate, consumer-format-refuses-malformed]
-  - path: skills/synthesis-project-management/scripts/handoff.py
-    cases: [handoff-flow, handoff-tamper-refusal, handoff-identity-required]
-  - path: skills/synthesis-project-management/scripts/test_handoff.py
-    cases: [handoff-flow, handoff-tamper-refusal, handoff-identity-required, pm-doc-contract, autopilot-wiring-doc, packet-doc-pointer]
-  - path: skills/synthesis-project-management/SKILL.md
-    cases: [pm-doc-contract]
-  - path: skills/synthesis-autopilot/SKILL.md
-    cases: [autopilot-wiring-doc]
+  - path: skills/synthesis-context-lifecycle/SKILL.md
+    cases: [release-changelog-parity]
+  - path: skills/synthesis-context-lifecycle/scripts/context_currency.py
+    cases: [zero-day-horizon-honored, malformed-suffix-flagged, impossible-date-flagged]
+  - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
+    cases: [doctor-maps-malformed-kind]
+  - path: skills/synthesis-context-lifecycle/scripts/review_ledger.py
+    cases: [restamped-item-expires-again]
+  - path: skills/synthesis-context-lifecycle/scripts/test_item_currency.py
+    cases: [zero-day-horizon-honored, malformed-suffix-flagged, impossible-date-flagged, doctor-maps-malformed-kind]
+  - path: skills/synthesis-context-lifecycle/scripts/test_review_ledger.py
+    cases: [restamped-item-expires-again]
+  - path: skills/synthesis-daily-rituals/SKILL.md
+    cases: [rituals-carry-the-gate]
+  - path: skills/synthesis-daily-rituals/scripts/sync_watermark.py
+    cases: [status-refuses-empty-set, never-written-surface-blocks]
+  - path: skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
+    cases: [status-refuses-empty-set, never-written-surface-blocks, rituals-carry-the-gate, sweep-consumes-preflight, declared-sweep-has-execution-path]
+  - path: skills/synthesis-slack-sync/SKILL.md
+    cases: [sweep-consumes-preflight]
+  - path: skills/synthesis-meeting-transcripts/SKILL.md
+    cases: [declared-sweep-has-execution-path]
   - path: skills/synthesis-decision-packet/SKILL.md
-    cases: [packet-doc-pointer]
+    cases: [release-changelog-parity]
+  - path: skills/synthesis-decision-packet/scripts/build_packet.py
+    cases: [coercion-collision-refused, nonstring-ids-refused, marker-test-mutation-hardened]
+  - path: skills/synthesis-decision-packet/scripts/test_build_packet.py
+    cases: [coercion-collision-refused, nonstring-ids-refused, marker-test-mutation-hardened]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -40,38 +54,58 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: consumer-format-accepts-alternate
+  - id: zero-day-horizon-honored
     control_class: acceptance-test
-    fixture: scripts/test_acceptance_suite.py::test_schema2_accepts_any_wellformed_consume_acceptance_consumer
-    motivating_defect: three-private-releases-shipped-in-one-week-on-suite-green-because-no-second-repository-could-declare-a-transaction-bound-gate
-  - id: consumer-format-refuses-malformed
+    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_zero_day_horizon_is_honored_not_defaulted
+    motivating_defect: an-explicit-review-daily-horizon-was-silently-replaced-with-the-fourteen-day-default
+  - id: malformed-suffix-flagged
     control_class: acceptance-test
-    fixture: scripts/test_acceptance_suite.py::test_schema2_refuses_malformed_consumer_id
-    motivating_defect: a-free-text-consumer-field-would-let-a-receipt-name-a-boundary-that-does-not-exist
-  - id: handoff-flow
+    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_malformed_stamp_suffix_is_flagged_not_exempted
+    motivating_defect: a-suffix-that-looks-like-a-stamp-but-is-not-one-passed-as-stamped-and-the-item-read-as-current-forever
+  - id: impossible-date-flagged
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_write_read_done_flow
-    motivating_defect: the-principal-as-courier-copied-prompts-between-agents-twenty-plus-times-in-one-engagement
-  - id: handoff-tamper-refusal
+    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_impossible_stamp_date_is_flagged_not_skipped
+    motivating_defect: a-date-shaped-impossibility-was-silently-skipped-by-the-overdue-scan
+  - id: doctor-maps-malformed-kind
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_read_refuses_tampered_payload
-    motivating_defect: a-payload-changed-after-handoff-executes-instructions-nobody-reviewed
-  - id: handoff-identity-required
+    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_item_findings_are_warnings_not_defects
+    motivating_defect: a-new-finding-kind-nothing-reports-is-a-check-that-does-not-exist
+  - id: restamped-item-expires-again
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_read_refuses_without_identity
-    motivating_defect: a-guessed-reader-identity-can-claim-another-agents-work
-  - id: pm-doc-contract
+    fixture: ../synthesis-context-lifecycle/scripts/test_review_ledger.py::test_a_restamped_item_can_expire_again
+    motivating_defect: text-keyed-suppression-silenced-every-expiry-cycle-after-the-first
+  - id: status-refuses-empty-set
+    control_class: enforced-gate
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_status_refuses_an_empty_surface_set
+    motivating_defect: a-store-only-status-exited-zero-straight-past-a-declared-surface-never-swept
+  - id: never-written-surface-blocks
+    control_class: enforced-gate
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_status_blocks_a_declared_surface_never_written
+    motivating_defect: the-bootstrap-bypass-the-shipped-test-registered-the-surface-before-testing-status-and-could-not-expose
+  - id: rituals-carry-the-gate
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_pm_skill_documents_the_handoff_queue
-    motivating_defect: an-undocumented-queue-gets-rediscovered-as-a-private-convention-instead-of-a-shared-mechanism
-  - id: autopilot-wiring-doc
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_rituals_carry_the_watermark_gate_invocation
+    motivating_defect: release-prose-mandated-an-invocation-that-no-operational-step-contained
+  - id: sweep-consumes-preflight
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_autopilot_wires_packet_and_handoff
-    motivating_defect: autopilot-carried-a-batched-questions-requirement-with-no-concrete-mechanism-and-per-item-conversation-returned
-  - id: packet-doc-pointer
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_slack_sync_bans_deriving_read_ids_in_the_sweep
+    motivating_defect: numbered-sweep-steps-iterated-the-config-for-ids-while-the-rule-above-them-banned-exactly-that
+  - id: declared-sweep-has-execution-path
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_handoff.py::test_decision_packet_names_concrete_handoff_path
-    motivating_defect: the-paired-direction-was-doctrine-without-a-path-so-nobody-could-run-it
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_transcripts_forbid_a_judgment_gate_before_fetching
+    motivating_defect: a-policy-with-no-numbered-execution-path-is-phrasing-not-behavior
+  - id: coercion-collision-refused
+    control_class: enforced-gate
+    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_ids_that_collide_after_browser_coercion_are_refused
+    motivating_defect: json-distinct-ids-that-coerce-to-one-browser-key-silently-shared-saved-state
+  - id: nonstring-ids-refused
+    control_class: acceptance-test
+    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_whitespace_and_boolean_ids_are_refused
+    motivating_defect: whitespace-and-boolean-ids-are-the-same-coercion-trap-in-other-clothes
+  - id: marker-test-mutation-hardened
+    control_class: acceptance-test
+    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_recommendation_is_marked_on_the_control_not_only_prose
+    motivating_defect: the-named-marker-test-passed-with-the-marker-implementation-deleted
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -36,7 +36,13 @@ changed_surfaces:
   - path: skills/synthesis-slack-sync/SKILL.md
     cases: [sweep-consumes-preflight]
   - path: skills/synthesis-meeting-transcripts/SKILL.md
-    cases: [declared-sweep-has-execution-path]
+    cases: [declared-sweep-has-execution-path, script-version-parity]
+  - path: skills/synthesis-meeting-transcripts/verify_transcripts.py
+    cases: [script-version-parity]
+  - path: skills/synthesis-meeting-transcripts/transcript_primary.py
+    cases: [script-version-parity]
+  - path: skills/synthesis-meeting-transcripts/test_version_parity.py
+    cases: [script-version-parity]
   - path: skills/synthesis-decision-packet/SKILL.md
     cases: [release-changelog-parity]
   - path: skills/synthesis-decision-packet/scripts/build_packet.py
@@ -106,6 +112,10 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_recommendation_is_marked_on_the_control_not_only_prose
     motivating_defect: the-named-marker-test-passed-with-the-marker-implementation-deleted
+  - id: script-version-parity
+    control_class: acceptance-test
+    fixture: ../synthesis-meeting-transcripts/test_version_parity.py::test_executable_components_match_the_skill_version
+    motivating_defect: executable-components-reporting-an-older-version-than-the-skill-that-ships-them-cannot-be-audited-in-the-field
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-meeting-transcripts/SKILL.md
+++ b/skills/synthesis-meeting-transcripts/SKILL.md
@@ -5,10 +5,20 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "0.7.0"
+  version: "0.9.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
+
+## v0.9.0 — The declared set gets an execution path
+
+v0.9.0 (2026-08-29) closes the gap an external adversarial review found in
+v0.8.0: the policy said "declared means fetched" while the operative protocol
+only resolved one user-named meeting. Step 0 now defines the declared-window
+sweep — enumerate the declared set for the window, fetch every member, and
+account for every member in the report with unclosed gaps recorded
+machine-readably. Frontmatter version also catches up; v0.8.0 shipped with
+stale skill metadata.
 
 ## v0.8.0 — Declared means fetched: no judgment gate before fetching
 
@@ -307,6 +317,26 @@ If the config file is missing, the skill should warn and ask the user to create 
 ---
 
 ## Protocol
+
+### Step 0: Declared-window sweep (v0.9.0 — how "declared means fetched" executes)
+
+The single-meeting path below serves an explicit user request. A ritual sync
+(Day-Start 3c, Day-End Step 1) runs this sweep instead, because the policy
+above has to have an execution path or it is prose:
+
+1. **Enumerate the declared set** for the window from
+   `.agents/meeting-transcripts.yaml`: every declared meeting pattern crossed
+   with every occurrence that ended inside the window. The enumeration is the
+   complete decision — no per-item judgment about which meetings look
+   interesting stands between the list and the fetch.
+2. **Run Steps 2–5 for every member.** Relevance is judged after fetching,
+   from content.
+3. **Account for every member.** The sync report carries one line per
+   declared member: fetched (with path), or an **unclosed gap** naming the
+   member, the window, and the failure ("no doc found", "fetch failed",
+   "verbatim half missing"). A member missing from the report is the defect
+   this step exists to prevent; a gap is closed this run or carried as a
+   blocking item, never dropped.
 
 ### Step 1: Resolve the meeting
 

--- a/skills/synthesis-meeting-transcripts/test_version_parity.py
+++ b/skills/synthesis-meeting-transcripts/test_version_parity.py
@@ -1,0 +1,33 @@
+"""The skill's executable components must report the skill's own version.
+
+An external review of 4.56.0 found three skills shipping frontmatter behind
+their body versions; this repository's transcripts checker already enforces
+script-to-frontmatter parity at CI, and this pytest-visible fixture makes the
+same contract consumable by the closed acceptance manifest.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def _frontmatter_version() -> str:
+    text = (HERE / "SKILL.md").read_text(encoding="utf-8")
+    match = re.search(r'^\s*version:\s*"([^"]+)"', text, re.M)
+    assert match, "SKILL.md frontmatter version not found"
+    return match.group(1)
+
+
+def _script_version(name: str) -> str:
+    text = (HERE / name).read_text(encoding="utf-8")
+    match = re.search(r'^SCRIPT_VERSION = "([^"]+)"$', text, re.M)
+    assert match, f"{name} SCRIPT_VERSION not found"
+    return match.group(1)
+
+
+def test_executable_components_match_the_skill_version() -> None:
+    skill = _frontmatter_version()
+    assert _script_version("verify_transcripts.py") == skill
+    assert _script_version("transcript_primary.py") == skill

--- a/skills/synthesis-meeting-transcripts/transcript_primary.py
+++ b/skills/synthesis-meeting-transcripts/transcript_primary.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 
-SCRIPT_VERSION = "0.7.0"
+SCRIPT_VERSION = "0.9.0"
 
 SLACK_PERMALINK_RE = re.compile(
     r"https://[A-Za-z0-9.-]+\.slack\.com/archives/[A-Z0-9]+/p(\d{16})(?!\d)"

--- a/skills/synthesis-meeting-transcripts/verify_transcripts.py
+++ b/skills/synthesis-meeting-transcripts/verify_transcripts.py
@@ -67,7 +67,7 @@ from pathlib import Path
 # own output could reveal that the copy being run was stale. This constant plus the banner
 # line below close that gap — if the printed version doesn't match SKILL.md's frontmatter
 # version, the copy being run is not the one you think it is.
-SCRIPT_VERSION = "0.7.0"
+SCRIPT_VERSION = "0.9.0"
 
 # Any HH:MM:SS or MM:SS anywhere — Gemini uses bare, bold, heading, and markdown-link forms
 TIMESTAMP_RE = re.compile(r"\b\d{1,2}:\d{2}(?::\d{2})?\b")

--- a/skills/synthesis-slack-sync/SKILL.md
+++ b/skills/synthesis-slack-sync/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-project-management"]
 metadata:
   author: "Rajiv Pant"
-  version: "3.5.0"
+  version: "3.7.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -15,6 +15,17 @@ metadata:
 A protocol for syncing Slack channels and threads to local transcript files using Slack MCP. Designed for AI-assisted workflows where an agent reads Slack on behalf of a user, saves transcripts locally, and updates a daily action plan.
 
 This skill provides the **protocol** — the sync methodology, thread re-reading discipline, transcript format, and action plan update rules. A per-project **config file** provides the specifics: which channels, which paths, which DMs. Prefer `.agents/slack-sync.yaml`; existing `.claude/slack-sync.yaml` configs remain supported.
+
+## v3.7.0 — The sweep steps consume preflight instead of contradicting it
+
+v3.7.0 (2026-08-29) closes the gap an external adversarial review found in
+v3.6.0: the rule banned config-derived ids while the numbered steps still
+said "for each channel in the config." Step 0 now defines the mandatory
+resolved-target preflight, Steps 1/3/3b iterate only its output, an empty
+resolved set refuses the sweep, and unresolved surfaces are reported as
+unresolved. The deterministic preflight script is extraction item P2; the
+contract binds now either way. Frontmatter version also catches up — v3.6.0
+shipped with stale skill metadata.
 
 ## v3.6.0 — Read targets come from preflight; deriving ids in the sweep is banned
 
@@ -339,12 +350,31 @@ python3 <synthesis-slack-sync-root>/thread_checker.py {transcripts_repo}/{transc
 
 Skip any file that does not yet exist (e.g., no DMs synced today). Combine the output from all runs into a single checklist. You MUST re-read every thread listed during Step 2. The script exists because manually deciding which threads to re-read has repeatedly failed — threads get skipped and messages get missed.
 
+### Step 0: Preflight — resolve every read target (v3.7.0, REQUIRED)
+
+Before any read, build the resolved-target list for this sweep. For every
+surface the config declares — channels, 1:1 DMs, group DMs — record the one
+id a conversation-read call accepts: the channel id for channels and group
+DMs, the **conversation id (`D…`), never the user id (`U…`)**, for DMs. A
+surface whose read id cannot be established is recorded as **unresolved**
+and reported that way — never as unreadable, never as a config defect,
+because the sweep has evidence for neither. An empty resolved-target list
+refuses the sweep rather than reporting a quiet day.
+
+Steps 1, 3, and 3b iterate ONLY this resolved-target list. Reaching back
+into the config for an id mid-sweep is the banned move from v3.6.0: where an
+entry carries two id-like fields, the wrong one usually resolves, so the bug
+hides until the person behind it leaves. (A deterministic preflight script
+generalizing the worked private implementation is queued as extraction item
+P2; until it lands, the resolved-target table is produced by hand at the top
+of the sweep and included in the sync report.)
+
 ### Step 1: Read channels for new top-level messages
 
-For each channel in the config:
+For each channel in the preflight's resolved-target list:
 
 ```
-slack_read_channel(channel_id, oldest=LAST_SYNC_TIMESTAMP, limit=30)
+slack_read_channel(resolved_channel_id, oldest=LAST_SYNC_TIMESTAMP, limit=30)
 ```
 
 - On **first sync of the day** (no channels transcript file exists yet): omit `oldest` or use midnight timestamp.
@@ -382,23 +412,26 @@ Rules:
 
 ### Step 3: Check DMs
 
-For each DM channel in the config:
+For each 1:1 DM in the preflight's resolved-target list:
 
 ```
-slack_read_channel(channel_id=DM_CHANNEL_ID, oldest=LAST_SYNC_TIMESTAMP, limit=20)
+slack_read_channel(channel_id=RESOLVED_CONVERSATION_ID, oldest=LAST_SYNC_TIMESTAMP, limit=20)
 ```
 
-Only check DMs that have active conversations. Don't read every DM — the config file specifies which ones are active.
+The resolved conversation id comes from preflight (Step 0), never from a
+config field chosen mid-sweep. Only check DMs the config marks active —
+preflight carries that scoping — and report any DM preflight marked
+unresolved instead of silently skipping it.
 
 ### Step 3b: Check Group DMs
 
-For each group DM channel in the config:
+For each group DM in the preflight's resolved-target list:
 
 ```
-slack_read_channel(channel_id=GROUP_DM_ID, oldest=LAST_SYNC_TIMESTAMP, limit=20)
+slack_read_channel(channel_id=RESOLVED_GROUP_DM_ID, oldest=LAST_SYNC_TIMESTAMP, limit=20)
 ```
 
-Group DMs (multi-party IMs) are separate from 1:1 DMs. They use channel IDs, not user IDs. Only check group DMs listed in the config.
+Group DMs (multi-party IMs) are separate from 1:1 DMs. They use channel IDs, not user IDs. Only check group DMs the preflight resolved from the config's declared list.
 
 ### Step 4: Save to local transcripts
 


### PR DESCRIPTION
R-02 (synthesis-agent-interoperability packet): a second vendor's model reviewed releases 4.55.0–4.57.0 from detached historical worktrees and runtime probes — 14 findings, 7 ship-blocking, rulings REJECT / ACCEPT-WITH-REPAIRS / REJECT / REJECT. This release repairs every valid runtime and doctrine finding:

- **context-lifecycle v1.14.0** — malformed stamps surface as `item-marker-malformed` instead of passing as stamped; explicit `review 0d` horizons honored; review-ledger expiry suppression keyed per lifecycle (stamp on every new event, legacy events cover only their own era).
- **daily-rituals v2.28.0** — `sync_watermark.py status` refuses an empty declared set (the bootstrap bypass); both ritual checklists carry the exact invocation the release prose mandated and no step contained.
- **slack-sync v3.7.0** — mandatory Step 0 resolved-target preflight; sweep steps iterate only its output; config-iteration phrasing gone; stale frontmatter caught up.
- **meeting-transcripts v0.9.0** — declared-window sweep gives "declared means fetched" an execution path with machine-readable unclosed gaps; stale frontmatter caught up.
- **decision-packet v1.3.0** — ids must be non-empty strings (browser-coercion collisions refused, no output emitted); schema wording says marked-never-pre-selected; marker fixture mutation-hardened.

Not repaired, by adjudication: R02-455-001 and R02-457-001 audit the closure of already-shipped release manifests — historical records, named in the manifest's unverified remainder. Findings file: synthesis-agent-interoperability project, resources/2026-08-29-r02-external-review-findings.yaml.

Local evidence: conformance 204+2 PASS; 555 tests across the required suites; compileall clean; fresh schema-2 acceptance 16/16 closed against change base ab50daf (20-path bijection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)