### PR TITLE
Release 4.64.0: the context doctor catches unrouted intake artifacts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.63.0",
+  "version": "4.64.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.63.0",
+  "version": "4.64.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.64.0] - 2026-08-29
+
+### Added
+
+- **`synthesis-context-lifecycle` v1.15.0 — captured directives cannot fall
+  through silently.** A principal directive was captured in an intake
+  artifact, endorsed in prose, and routed to no numbered work; nothing
+  warned for four days, exactly as the intake itself predicted ("not
+  evaluating is the only bad outcome, and it is the one that happens by
+  default"). The context doctor now warns (`intake-routing`) on any
+  intake-class artifact — filename carrying intake/brief/directive/catalogue
+  — that CONTEXT.md never references and that carries no terminal
+  `**Routed:**` / `**Declined:**` / `**Superseded:**` marker line. The check
+  is mechanical coverage per the extraction taxonomy: the script narrows,
+  and whether a recorded routing is honest stays the reader's judgment.
+  Five fixtures pin the failure shape, both coverage paths, the
+  outputs-are-not-asks boundary, and that a mid-sentence mention of the
+  marker is not a routing.
+
 ## [4.63.0] - 2026-08-29
 
 The repair release for the external adversarial review of 4.55.0–4.57.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A captured directive is not a routed one (August 2026).** Release
+**4.64.0** teaches the context doctor to catch the failure that happens by
+default: an intake artifact that records a directive, reads as handled, and
+was never routed to numbered work, declined, or superseded. Intake-class
+artifacts now need a CONTEXT reference or a terminal routing marker, or the
+doctor warns. See the [4.64.0 release notes](CHANGELOG.md).
+
 **A reviewer that did not write the code, reviewing the code (August 2026).**
 Release **4.63.0** repairs what an external adversarial review of
 4.55.0–4.57.0 found — a second vendor's model attacking four releases from

--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.14.0"
+  version: "1.15.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-context-lifecycle/scripts/context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_doctor.py
@@ -777,6 +777,43 @@ def cited_script_findings(project_path: Path) -> list[tuple[Path, str, str]]:
     return findings
 
 
+INTAKE_NAME = re.compile(r"(intake|brief|directive|catalogue)", re.IGNORECASE)
+ROUTING_MARKER = re.compile(
+    r"^\*\*(Routed|Declined|Superseded):\*\*", re.MULTILINE
+)
+
+
+def unrouted_intake_findings(project_path: Path) -> list[str]:
+    """Intake-class artifacts that no numbered work ever consumed.
+
+    The failure this catches: a directive arrives, gets captured in an
+    artifact, is endorsed in prose — and never becomes a numbered CONTEXT
+    item, a declination, or a supersession, so nothing ships and nothing
+    warns. Coverage is mechanical (the R-03 lane rule: the script narrows,
+    the model judges): an intake-named artifact is covered when CONTEXT.md
+    mentions its filename, or when the file itself carries a terminal
+    routing marker line (**Routed:** / **Declined:** / **Superseded:**).
+    Whether a recorded routing is honest stays a judgment for the reader.
+    """
+
+    artifacts = project_path / "resources" / "artifacts"
+    if not artifacts.is_dir():
+        return []
+    context_text = read_text(project_path / "CONTEXT.md")
+    unrouted: list[str] = []
+    for artifact in sorted(artifacts.glob("*.md")):
+        if not artifact.is_file() or artifact.is_symlink():
+            continue
+        if not INTAKE_NAME.search(artifact.name):
+            continue
+        if artifact.name in context_text:
+            continue
+        if ROUTING_MARKER.search(read_text(artifact)):
+            continue
+        unrouted.append(artifact.name)
+    return unrouted
+
+
 def audit_project(
     source: Source,
     project_id: str,
@@ -881,6 +918,21 @@ def audit_project(
             "preserve the portable script and every required input under "
             "resources/scripts/, then update the artifact citation; this check "
             "establishes existence only and does not prove the script is correct",
+        )
+
+    # --- intake routing coverage ------------------------------------------
+    # A captured directive that never becomes numbered work is the failure
+    # that happens by default: the artifact looks handled because it exists.
+    for intake_name in unrouted_intake_findings(project_path):
+        audit.add(
+            "intake-routing",
+            "warning",
+            f"{intake_name} is an intake-class artifact that CONTEXT.md never "
+            "references and that carries no routing marker — its asks may "
+            "have fallen through",
+            "route it to a numbered CONTEXT item, or add a terminal "
+            "'**Routed:**' / '**Declined:**' / '**Superseded:**' line to the "
+            "artifact stating where its asks went and why",
         )
 
     # --- cross-tier agreement ----------------------------------------------

--- a/skills/synthesis-context-lifecycle/scripts/test_intake_routing.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_intake_routing.py
@@ -1,0 +1,101 @@
+"""Fixtures for the intake-routing coverage check.
+
+Origin: a principal directive (evaluate the A2A protocol) was captured in an
+intake artifact on 2026-08-25, endorsed in prose, and never routed to
+numbered work; nothing warned for four days. The intake itself predicted
+this: "not evaluating is the only bad outcome, and it is the one that
+happens by default."
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("context_doctor.py")
+SPEC = importlib.util.spec_from_file_location("context_doctor", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def _project(tmp_path: Path, context: str) -> Path:
+    project = tmp_path / "projects" / "alpha"
+    (project / "resources" / "artifacts").mkdir(parents=True)
+    (project / "CONTEXT.md").write_text(context, encoding="utf-8")
+    return project
+
+
+def _artifact(project: Path, name: str, body: str) -> None:
+    (project / "resources" / "artifacts" / name).write_text(
+        body, encoding="utf-8"
+    )
+
+
+def test_endorsed_but_unrouted_intake_warns(tmp_path: Path) -> None:
+    """The A2A failure shape: captured, endorsed, routed nowhere."""
+    project = _project(tmp_path, "**Last session:** 2026-08-29\n\n## Open\n")
+    _artifact(
+        project,
+        "2026-08-25-intake-open-standards.md",
+        "# Intake\n\nThe principal directed an evaluation. Strongly agreed.\n",
+    )
+
+    assert MODULE.unrouted_intake_findings(project) == [
+        "2026-08-25-intake-open-standards.md"
+    ]
+
+
+def test_context_reference_covers_an_intake(tmp_path: Path) -> None:
+    project = _project(
+        tmp_path,
+        "**Last session:** 2026-08-29\n\n"
+        "20. [ ] Evaluate per "
+        "[the intake](resources/artifacts/2026-08-25-intake-open-standards.md).\n",
+    )
+    _artifact(
+        project,
+        "2026-08-25-intake-open-standards.md",
+        "# Intake\n\nThe principal directed an evaluation.\n",
+    )
+
+    assert MODULE.unrouted_intake_findings(project) == []
+
+
+def test_terminal_routing_marker_covers_an_intake(tmp_path: Path) -> None:
+    project = _project(tmp_path, "**Last session:** 2026-08-29\n")
+    _artifact(
+        project,
+        "2026-08-28-extraction-brief.md",
+        "# Brief\n\n**Routed:** CONTEXT item 18, 2026-08-29.\n\nDetail...\n",
+    )
+    _artifact(
+        project,
+        "2026-08-25-defect-catalogue.md",
+        "# Catalogue\n\n**Declined:** superseded by the shipped review skill.\n",
+    )
+
+    assert MODULE.unrouted_intake_findings(project) == []
+
+
+def test_non_intake_artifacts_are_not_held_to_routing(tmp_path: Path) -> None:
+    """Designs, evaluations, and plans are outputs, not asks."""
+    project = _project(tmp_path, "**Last session:** 2026-08-29\n")
+    _artifact(project, "2026-08-29-a2a-evaluation.md", "# Evaluation\n")
+    _artifact(project, "2026-08-26-autopilot-plan.md", "# Plan\n")
+
+    assert MODULE.unrouted_intake_findings(project) == []
+
+
+def test_marker_must_lead_a_line(tmp_path: Path) -> None:
+    """Prose that merely mentions the word Routed is not a routing."""
+    project = _project(tmp_path, "**Last session:** 2026-08-29\n")
+    _artifact(
+        project,
+        "2026-08-25-intake-x.md",
+        "# Intake\n\nThis should eventually be **Routed:** somewhere.\n",
+    )
+
+    assert MODULE.unrouted_intake_findings(project) == [
+        "2026-08-25-intake-x.md"
+    ]

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,10 +1,8 @@
-# AGENT HEURISTIC: authored for the 4.63.0 external-review repair release.
-# The manifest records this release's exact public universe; the runner proves
-# the declaration against the authoritative base-to-head Git diff, so a
-# surface that changes without being declared — or is declared without
-# changing — refuses authority.
+# AGENT HEURISTIC: authored for the 4.64.0 intake-routing release. Fresh per
+# transaction: changed_surfaces must equal the authoritative base-to-head
+# Git diff, proved by the runner before release.py consumes the receipt.
 schema: 2
-suite: synthesis-r02-repair-release
+suite: synthesis-intake-routing-release
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run
 enforcing_boundary: release.py and repository CI before publication
@@ -13,42 +11,14 @@ change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: behavioral adoption of the ritual watermark gate and the sweep preflight in live workspaces; the two historical manifest-closure findings (R02-455-001, R02-457-001) which audit already-shipped transactions and cannot be repaired retroactively; installed-client parity, independent review, publication, and deployment
+unverified_remainder: whether teams actually add routing markers rather than route around the warning — adoption is behavioral; the honesty of any recorded routing, which is the reader's judgment by design; installed-client parity, independent review, publication, and deployment
 changed_surfaces:
   - path: skills/synthesis-context-lifecycle/SKILL.md
     cases: [release-changelog-parity]
-  - path: skills/synthesis-context-lifecycle/scripts/context_currency.py
-    cases: [zero-day-horizon-honored, malformed-suffix-flagged, impossible-date-flagged]
   - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
-    cases: [doctor-maps-malformed-kind]
-  - path: skills/synthesis-context-lifecycle/scripts/review_ledger.py
-    cases: [restamped-item-expires-again]
-  - path: skills/synthesis-context-lifecycle/scripts/test_item_currency.py
-    cases: [zero-day-horizon-honored, malformed-suffix-flagged, impossible-date-flagged, doctor-maps-malformed-kind]
-  - path: skills/synthesis-context-lifecycle/scripts/test_review_ledger.py
-    cases: [restamped-item-expires-again]
-  - path: skills/synthesis-daily-rituals/SKILL.md
-    cases: [rituals-carry-the-gate]
-  - path: skills/synthesis-daily-rituals/scripts/sync_watermark.py
-    cases: [status-refuses-empty-set, never-written-surface-blocks]
-  - path: skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
-    cases: [status-refuses-empty-set, never-written-surface-blocks, rituals-carry-the-gate, sweep-consumes-preflight, declared-sweep-has-execution-path]
-  - path: skills/synthesis-slack-sync/SKILL.md
-    cases: [sweep-consumes-preflight]
-  - path: skills/synthesis-meeting-transcripts/SKILL.md
-    cases: [declared-sweep-has-execution-path, script-version-parity]
-  - path: skills/synthesis-meeting-transcripts/verify_transcripts.py
-    cases: [script-version-parity]
-  - path: skills/synthesis-meeting-transcripts/transcript_primary.py
-    cases: [script-version-parity]
-  - path: skills/synthesis-meeting-transcripts/test_version_parity.py
-    cases: [script-version-parity]
-  - path: skills/synthesis-decision-packet/SKILL.md
-    cases: [release-changelog-parity]
-  - path: skills/synthesis-decision-packet/scripts/build_packet.py
-    cases: [coercion-collision-refused, nonstring-ids-refused, marker-test-mutation-hardened]
-  - path: skills/synthesis-decision-packet/scripts/test_build_packet.py
-    cases: [coercion-collision-refused, nonstring-ids-refused, marker-test-mutation-hardened]
+    cases: [unrouted-intake-warns, coverage-by-context-reference, coverage-by-terminal-marker, outputs-are-not-asks, mention-is-not-a-routing]
+  - path: skills/synthesis-context-lifecycle/scripts/test_intake_routing.py
+    cases: [unrouted-intake-warns, coverage-by-context-reference, coverage-by-terminal-marker, outputs-are-not-asks, mention-is-not-a-routing]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -60,62 +30,26 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: zero-day-horizon-honored
+  - id: unrouted-intake-warns
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_zero_day_horizon_is_honored_not_defaulted
-    motivating_defect: an-explicit-review-daily-horizon-was-silently-replaced-with-the-fourteen-day-default
-  - id: malformed-suffix-flagged
+    fixture: ../synthesis-context-lifecycle/scripts/test_intake_routing.py::test_endorsed_but_unrouted_intake_warns
+    motivating_defect: a-principal-directive-sat-endorsed-and-unrouted-for-four-days-with-nothing-warning
+  - id: coverage-by-context-reference
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_malformed_stamp_suffix_is_flagged_not_exempted
-    motivating_defect: a-suffix-that-looks-like-a-stamp-but-is-not-one-passed-as-stamped-and-the-item-read-as-current-forever
-  - id: impossible-date-flagged
+    fixture: ../synthesis-context-lifecycle/scripts/test_intake_routing.py::test_context_reference_covers_an_intake
+    motivating_defect: a-check-that-nags-properly-routed-intakes-teaches-authors-to-ignore-it
+  - id: coverage-by-terminal-marker
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_impossible_stamp_date_is_flagged_not_skipped
-    motivating_defect: a-date-shaped-impossibility-was-silently-skipped-by-the-overdue-scan
-  - id: doctor-maps-malformed-kind
+    fixture: ../synthesis-context-lifecycle/scripts/test_intake_routing.py::test_terminal_routing_marker_covers_an_intake
+    motivating_defect: declined-and-superseded-are-legitimate-terminals-that-must-not-require-a-context-item
+  - id: outputs-are-not-asks
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_item_currency.py::test_item_findings_are_warnings_not_defects
-    motivating_defect: a-new-finding-kind-nothing-reports-is-a-check-that-does-not-exist
-  - id: restamped-item-expires-again
+    fixture: ../synthesis-context-lifecycle/scripts/test_intake_routing.py::test_non_intake_artifacts_are_not_held_to_routing
+    motivating_defect: holding-designs-and-plans-to-an-intake-rule-would-flood-the-corpus-with-false-warnings
+  - id: mention-is-not-a-routing
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_review_ledger.py::test_a_restamped_item_can_expire_again
-    motivating_defect: text-keyed-suppression-silenced-every-expiry-cycle-after-the-first
-  - id: status-refuses-empty-set
-    control_class: enforced-gate
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_status_refuses_an_empty_surface_set
-    motivating_defect: a-store-only-status-exited-zero-straight-past-a-declared-surface-never-swept
-  - id: never-written-surface-blocks
-    control_class: enforced-gate
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_status_blocks_a_declared_surface_never_written
-    motivating_defect: the-bootstrap-bypass-the-shipped-test-registered-the-surface-before-testing-status-and-could-not-expose
-  - id: rituals-carry-the-gate
-    control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_rituals_carry_the_watermark_gate_invocation
-    motivating_defect: release-prose-mandated-an-invocation-that-no-operational-step-contained
-  - id: sweep-consumes-preflight
-    control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_slack_sync_bans_deriving_read_ids_in_the_sweep
-    motivating_defect: numbered-sweep-steps-iterated-the-config-for-ids-while-the-rule-above-them-banned-exactly-that
-  - id: declared-sweep-has-execution-path
-    control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_transcripts_forbid_a_judgment_gate_before_fetching
-    motivating_defect: a-policy-with-no-numbered-execution-path-is-phrasing-not-behavior
-  - id: coercion-collision-refused
-    control_class: enforced-gate
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_ids_that_collide_after_browser_coercion_are_refused
-    motivating_defect: json-distinct-ids-that-coerce-to-one-browser-key-silently-shared-saved-state
-  - id: nonstring-ids-refused
-    control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_whitespace_and_boolean_ids_are_refused
-    motivating_defect: whitespace-and-boolean-ids-are-the-same-coercion-trap-in-other-clothes
-  - id: marker-test-mutation-hardened
-    control_class: acceptance-test
-    fixture: ../synthesis-decision-packet/scripts/test_build_packet.py::test_recommendation_is_marked_on_the_control_not_only_prose
-    motivating_defect: the-named-marker-test-passed-with-the-marker-implementation-deleted
-  - id: script-version-parity
-    control_class: acceptance-test
-    fixture: ../synthesis-meeting-transcripts/test_version_parity.py::test_executable_components_match_the_skill_version
-    motivating_defect: executable-components-reporting-an-older-version-than-the-skill-that-ships-them-cannot-be-audited-in-the-field
+    fixture: ../synthesis-context-lifecycle/scripts/test_intake_routing.py::test_marker_must_lead_a_line
+    motivating_defect: prose-that-mentions-the-marker-word-must-not-count-as-a-terminal-disposition
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates


### PR DESCRIPTION
The systemic fix for the routing failure found today: a principal directive was captured in an intake artifact on 2026-08-25, endorsed in prose, and routed to no numbered work — nothing warned for four days, exactly as the intake predicted.

- **context-lifecycle v1.15.0** — new `intake-routing` warning: any `resources/artifacts` file whose name carries intake/brief/directive/catalogue must be referenced from CONTEXT.md or carry a terminal `**Routed:**` / `**Declined:**` / `**Superseded:**` marker. Script narrows; routing honesty stays the reader's judgment (the extraction-taxonomy lane rule).
- Five fixtures: the failure shape, both coverage paths, outputs-are-not-asks, and mention-is-not-a-routing.

Local evidence: conformance 204 PASS; 188 tests across the touched suites; fresh schema-2 acceptance 8/8 closed against the merge base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)