### PR TITLE
Content-parity, zero-scan, and doctor-control safeguards

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.64.0",
+  "version": "4.65.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.64.0",
+  "version": "4.65.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.65.0] - 2026-08-29
+
+Three fail-closed controls, each from a board-filed defect that had waited
+for an owner.
+
+- **`synthesis-skills-manager` release.py verifies installed CONTENT, not
+  only versions.** `verify.<client>.content` compares every source
+  `skills/` file byte-for-byte against the installed tree and refuses
+  success on drift — closing the 2026-08-24 false-green where an unbumped
+  version left one client loading stale files while both reported current.
+  Version parity is not content parity; now the release gate knows it.
+- **`synthesis-context-lifecycle` context_currency.py fails closed on a
+  zero scan.** Pointed at a directory holding no project records (the
+  documented misuse: a project's own subdirectory), it now exits 2 naming
+  what it expected instead of printing a green zero-finding result, and a
+  project directory carrying CONTEXT.md at its root is audited directly —
+  matching the sibling doctor's `--project` convention.
+- **`synthesis-message-guard` doctor gains two config controls.** A
+  pattern authored with surrogate-escape sequences (which can never match
+  real decoded text — the 2026-08-07 dead-emoji-pattern incident) now
+  fails the doctor, and `doctor_clean_controls` in patterns.json runs
+  canonical real messages through the live scanner so a pattern change
+  that starts blocking legitimate traffic fails loudly (the 2026-08-03
+  incident class).
+
 ## [4.64.0] - 2026-08-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **A captured directive is not a routed one (August 2026).** Release
-**4.64.0** teaches the context doctor to catch the failure that happens by
+**4.65.0** makes the release gate verify installed bytes against source (version parity is not content parity), makes the currency audit refuse a zero scan, and adds dead-pattern and canonical-clean controls to the message-guard doctor. Previously: **4.64.0** teaches the context doctor to catch the failure that happens by
 default: an intake artifact that records a directive, reads as handled, and
 was never routed to numbered work, declined, or superseded. Intake-class
 artifacts now need a CONTEXT reference or a terminal routing marker, or the
-doctor warns. See the [4.64.0 release notes](CHANGELOG.md).
+doctor warns. See the [4.65.0 release notes](CHANGELOG.md).
 
 **A reviewer that did not write the code, reviewing the code (August 2026).**
 Release **4.63.0** repairs what an external adversarial review of

--- a/skills/synthesis-context-lifecycle/scripts/context_currency.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_currency.py
@@ -502,11 +502,31 @@ def main() -> int:
         if not root.is_dir():
             print(f"not a directory: {root}", file=sys.stderr)
             return 2
+        if (root / "CONTEXT.md").is_file():
+            # A project directory was passed directly (the sibling doctor's
+            # --project convention). Audit it rather than scanning its
+            # children for records they cannot contain.
+            scanned += 1
+            findings.extend(audit_project(root))
+            continue
         for project in sorted(p for p in root.iterdir() if p.is_dir()):
             if not (project / "CONTEXT.md").is_file():
                 continue
             scanned += 1
             findings.extend(audit_project(project))
+
+    if scanned == 0:
+        # Fail closed: a scan of nothing is not a clean scan (2026-08-24
+        # defect — pointed at a project's subdirectory, this printed
+        # "0 findings" and exited 0). Zero results are never evidence of
+        # absence.
+        print(
+            "no project records scanned: expected a projects container "
+            "(directories each holding CONTEXT.md) or a single project "
+            "directory holding CONTEXT.md at its root",
+            file=sys.stderr,
+        )
+        return 2
 
     if args.quiet:
         findings = [f for f in findings if f["kind"] in STALENESS_KINDS]

--- a/skills/synthesis-context-lifecycle/scripts/test_context_currency.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_currency.py
@@ -292,3 +292,49 @@ def test_coherent_header_reports_nothing() -> None:
 def test_header_incoherence_ignores_disjoint_families() -> None:
     text = "**Phase:** phase 2 rollout\n**Last session:** 2026-08-23 (round 9)\n"
     assert header_incoherence(text) == []
+
+
+# --- CLI zero-scan refusal (2026-08-24 fail-open) ---------------------------
+
+
+def _run_cli(tmp_path: Path, target: Path) -> "subprocess.CompletedProcess[str]":
+    import subprocess
+    import sys
+
+    script = Path(__file__).with_name("context_currency.py")
+    return subprocess.run(
+        [sys.executable, str(script), str(target)],
+        capture_output=True, text=True,
+    )
+
+
+def test_zero_scan_fails_closed(tmp_path: Path) -> None:
+    """Pointed at a directory holding no project records, the audit must
+    refuse (exit 2), never print a green zero-finding result — the real
+    misuse was passing a project's own subtree and reading 'clean'."""
+    empty = tmp_path / "not-a-projects-root"
+    (empty / "drafts").mkdir(parents=True)
+    completed = _run_cli(tmp_path, empty)
+    assert completed.returncode == 2
+    assert "no project records scanned" in completed.stderr
+
+
+def test_project_directory_is_accepted_directly(tmp_path: Path) -> None:
+    """The sibling doctor takes --project <dir>; passing the same shape
+    here must audit that record instead of scanning nothing."""
+    project = tmp_path / "some-project"
+    project.mkdir()
+    (project / "CONTEXT.md").write_text(
+        "**Phase:** Round 2 done\n**Last session:** 2026-08-23 (round 2)\n",
+        encoding="utf-8",
+    )
+    sessions = project / "sessions"
+    sessions.mkdir()
+    (sessions / "2026-08.md").write_text(
+        "### 2026-08-23 (round 2)\nwork\n", encoding="utf-8",
+    )
+    completed = _run_cli(tmp_path, project)
+    # The record IS audited (its markerless body is a legitimate finding);
+    # the defect under test was scanning nothing and reporting clean.
+    assert completed.returncode != 2
+    assert "scanned 1 project record(s)" in completed.stdout

--- a/skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
+++ b/skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
@@ -18,7 +18,7 @@ import importlib.util
 import json
 import subprocess
 import sys
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 
@@ -149,9 +149,16 @@ def test_surfaces_are_tracked_independently(tmp_path: Path) -> None:
 
 
 def test_cli_status_exits_nonzero_while_blocking(tmp_path: Path) -> None:
-    """The property that makes this load-bearing: a ritual step can fail on it."""
+    """The property that makes this load-bearing: a ritual step can fail on it.
+
+    The subprocess computes its own date.today(), so this fixture must use
+    live dates: a frozen watermark rotted the sibling green test the first
+    UTC midnight after authorship (caught 2026-08-30 in CI).
+    """
     env = {"SYNTHESIS_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
-    MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
+    stale_day = date.today() - timedelta(days=8)
+    MODULE.advance(WS, "slack", stale_day.isoformat(), today=stale_day,
+                   home=tmp_path)
 
     done = subprocess.run(
         [sys.executable, str(SCRIPT), "status", "--workspace", WS,
@@ -165,7 +172,9 @@ def test_cli_status_exits_nonzero_while_blocking(tmp_path: Path) -> None:
 
 def test_cli_status_exits_zero_when_current(tmp_path: Path) -> None:
     env = {"SYNTHESIS_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
-    MODULE.advance(WS, "slack", "2026-08-28", today=TODAY, home=tmp_path)
+    live_today = date.today()
+    MODULE.advance(WS, "slack", live_today.isoformat(), today=live_today,
+                   home=tmp_path)
 
     done = subprocess.run(
         [sys.executable, str(SCRIPT), "status", "--workspace", WS,

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,8 +1,9 @@
-# AGENT HEURISTIC: authored for the 4.64.0 intake-routing release. Fresh per
-# transaction: changed_surfaces must equal the authoritative base-to-head
-# Git diff, proved by the runner before release.py consumes the receipt.
+# AGENT HEURISTIC: authored for the 4.65.0 board-sweep controls release.
+# Fresh per transaction: changed_surfaces must equal the authoritative
+# base-to-head Git diff, proved by the runner before release.py consumes
+# the receipt.
 schema: 2
-suite: synthesis-intake-routing-release
+suite: synthesis-board-sweep-controls-release
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run
 enforcing_boundary: release.py and repository CI before publication
@@ -11,14 +12,20 @@ change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: whether teams actually add routing markers rather than route around the warning — adoption is behavioral; the honesty of any recorded routing, which is the reader's judgment by design; installed-client parity, independent review, publication, and deployment
+unverified_remainder: doctor_clean_controls adoption is per-config and behavioral — the mechanism ships, each workspace supplies its own canonical messages; installed-client parity, independent review, publication, and deployment
 changed_surfaces:
-  - path: skills/synthesis-context-lifecycle/SKILL.md
-    cases: [release-changelog-parity]
-  - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
-    cases: [unrouted-intake-warns, coverage-by-context-reference, coverage-by-terminal-marker, outputs-are-not-asks, mention-is-not-a-routing]
-  - path: skills/synthesis-context-lifecycle/scripts/test_intake_routing.py
-    cases: [unrouted-intake-warns, coverage-by-context-reference, coverage-by-terminal-marker, outputs-are-not-asks, mention-is-not-a-routing]
+  - path: skills/synthesis-skills-manager/scripts/release.py
+    cases: [content-parity-detects-drift, content-parity-passes-equal-trees, content-parity-fails-closed-without-source]
+  - path: skills/synthesis-skills-manager/scripts/test_release.py
+    cases: [content-parity-detects-drift, content-parity-passes-equal-trees, content-parity-fails-closed-without-source]
+  - path: skills/synthesis-context-lifecycle/scripts/context_currency.py
+    cases: [zero-scan-fails-closed, project-directory-accepted]
+  - path: skills/synthesis-context-lifecycle/scripts/test_context_currency.py
+    cases: [zero-scan-fails-closed, project-directory-accepted]
+  - path: skills/synthesis-message-guard/scripts/message_guard.py
+    cases: [dead-surrogate-pattern-detected, config-clean-controls-scan]
+  - path: skills/synthesis-message-guard/scripts/test_message_guard.py
+    cases: [dead-surrogate-pattern-detected, config-clean-controls-scan]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -30,29 +37,37 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: unrouted-intake-warns
+  - id: content-parity-detects-drift
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_deep_verify_fails_on_content_drift_despite_version_parity
+    motivating_defect: an-unbumped-version-left-one-client-loading-stale-files-while-both-reported-current
+  - id: content-parity-passes-equal-trees
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_intake_routing.py::test_endorsed_but_unrouted_intake_warns
-    motivating_defect: a-principal-directive-sat-endorsed-and-unrouted-for-four-days-with-nothing-warning
-  - id: coverage-by-context-reference
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_deep_verify_passes_when_report_disk_and_content_agree
+    motivating_defect: a-verification-that-cannot-pass-a-correct-install-teaches-people-to-route-around-it
+  - id: content-parity-fails-closed-without-source
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_intake_routing.py::test_context_reference_covers_an_intake
-    motivating_defect: a-check-that-nags-properly-routed-intakes-teaches-authors-to-ignore-it
-  - id: coverage-by-terminal-marker
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_deep_verify_fails_closed_without_source_repo
+    motivating_defect: a-content-check-that-silently-skips-when-unsupplied-is-the-false-green-it-replaces
+  - id: zero-scan-fails-closed
+    control_class: enforced-gate
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_currency.py::test_zero_scan_fails_closed
+    motivating_defect: pointed-at-a-projects-own-subtree-the-audit-printed-a-green-zero-finding-scan-of-nothing
+  - id: project-directory-accepted
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_intake_routing.py::test_terminal_routing_marker_covers_an_intake
-    motivating_defect: declined-and-superseded-are-legitimate-terminals-that-must-not-require-a-context-item
-  - id: outputs-are-not-asks
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_currency.py::test_project_directory_is_accepted_directly
+    motivating_defect: the-sibling-doctor-takes-a-project-dir-so-callers-hand-this-tool-the-same-shape
+  - id: dead-surrogate-pattern-detected
+    control_class: enforced-gate
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_dead_surrogate_pattern_detection
+    motivating_defect: a-surrogate-escaped-emoji-pattern-matched-nothing-for-months-while-the-doctor-stayed-green
+  - id: config-clean-controls-scan
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_intake_routing.py::test_non_intake_artifacts_are_not_held_to_routing
-    motivating_defect: holding-designs-and-plans-to-an-intake-rule-would-flood-the-corpus-with-false-warnings
-  - id: mention-is-not-a-routing
-    control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_intake_routing.py::test_marker_must_lead_a_line
-    motivating_defect: prose-that-mentions-the-marker-word-must-not-count-as-a-terminal-disposition
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_config_clean_controls_scan
+    motivating_defect: the-built-in-clean-control-passed-while-every-real-legitimate-message-was-being-blocked
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
-    fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates
+    fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
     motivating_defect: a-manifest-that-cannot-be-consumed-by-its-own-runner-issues-authority-it-never-earned
   - id: release-manifest-parity
     control_class: acceptance-test

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -26,6 +26,8 @@ changed_surfaces:
     cases: [dead-surrogate-pattern-detected, config-clean-controls-scan]
   - path: skills/synthesis-message-guard/scripts/test_message_guard.py
     cases: [dead-surrogate-pattern-detected, config-clean-controls-scan]
+  - path: skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
+    cases: [watermark-cli-fixtures-use-live-dates]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -65,6 +67,10 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_config_clean_controls_scan
     motivating_defect: the-built-in-clean-control-passed-while-every-real-legitimate-message-was-being-blocked
+  - id: watermark-cli-fixtures-use-live-dates
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_status_exits_zero_when_current
+    motivating_defect: a-frozen-authorship-date-in-a-subprocess-fixture-rotted-red-the-first-utc-midnight-after-it-shipped
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-message-guard/scripts/message_guard.py
+++ b/skills/synthesis-message-guard/scripts/message_guard.py
@@ -391,6 +391,39 @@ def run_doctor():
     report(len(hits2) == 0, "negative control (clean text passes)",
            "%d hits" % len(hits2))
 
+    # Dead-pattern control (2026-08-07 defect): a pattern authored with
+    # surrogate-escape sequences (a "\\ud83e\\uddde"-style pair in place of
+    # the real emoji character) compiles to lone surrogates that can never
+    # match decoded text, so the rule it encodes is silently OFF while the
+    # doctor stays green.
+    dead = [name for name, rx in (cblock + cwarn)
+            if any("\ud800" <= ch <= "\udfff" for ch in rx.pattern)]
+    report(not dead, "no dead surrogate-escape patterns",
+           ("%d pattern(s) can never match decoded text" % len(dead))
+           if dead else "all patterns use real characters")
+
+    # Config-supplied clean controls (2026-08-03 defect): the built-in
+    # clean control passed while every REAL legitimate message was being
+    # blocked, because it did not resemble the user's canonical traffic.
+    # patterns.json may carry doctor_clean_controls: known-legitimate
+    # messages that must pass the scanner exactly as sent.
+    clean_controls = cfg.get("doctor_clean_controls", [])
+    if clean_controls:
+        failing = []
+        for sample in clean_controls:
+            sample_hits, _ = scan_text(str(sample), cblock, cwarn)
+            if sample_hits:
+                failing.append(str(sample)[:60])
+        report(not failing, "config clean controls (canonical real "
+               "messages pass)",
+               "; ".join(failing) if failing
+               else "%d control(s) pass" % len(clean_controls))
+    else:
+        report(True, "config clean controls",
+               "none configured — add doctor_clean_controls with your "
+               "canonical legitimate messages so a pattern change that "
+               "blocks real traffic fails the doctor")
+
     sample_tools = [
         "mcp__abc123__slack_send_message",
         "mcp__abc123__slack_send_message_draft",

--- a/skills/synthesis-message-guard/scripts/test_message_guard.py
+++ b/skills/synthesis-message-guard/scripts/test_message_guard.py
@@ -70,3 +70,40 @@ def test_hook_config_rejects_missing_guard(tmp_path: Path) -> None:
     path = tmp_path / "hooks.json"
     write_hooks(path, MATCHER, "python3 another_guard.py --gate")
     assert not MODULE.hook_config_covers(path, SAMPLE_TOOLS)
+
+
+# --- doctor controls from the 2026-08 config incidents ----------------------
+
+
+def test_dead_surrogate_pattern_detection() -> None:
+    """A pattern whose source carries lone surrogates (the escaped-emoji
+    authoring mistake) can never match decoded text; the doctor's control
+    predicate must identify it while a real-character pattern passes."""
+    import re
+
+    dead_source = "\ud83e\uddde|RagBot"
+    live_source = "\U0001F9DE|RagBot"
+    def is_dead(rx):
+        return any("\ud800" <= ch <= "\udfff" for ch in rx.pattern)
+    assert is_dead(re.compile(dead_source))
+    assert not is_dead(re.compile(live_source))
+    # And the dead form genuinely fails to match the decoded emoji — the
+    # incident's mechanism, kept here as the reason the control exists.
+    assert re.compile(dead_source).search("\U0001F9DE hello") is None
+    assert re.compile(live_source).search("\U0001F9DE hello") is not None
+
+
+def test_config_clean_controls_scan() -> None:
+    """doctor_clean_controls entries run through the live scanner: a
+    canonical legitimate message must produce zero hits, and a config
+    change that starts blocking real traffic must be detectable."""
+    import re
+
+    cblock = [("bad-brand", re.compile("RagBot"))]
+    cwarn: list = []
+    canonical = "Ragbot here with the summary — details at ragbot.ai"
+    hits, _ = MODULE.scan_text(canonical, cblock, cwarn)
+    assert hits == []
+    over_broad = [("bad-brand", re.compile("ragbot", re.IGNORECASE))]
+    hits2, _ = MODULE.scan_text(canonical, over_broad, cwarn)
+    assert hits2, "an over-broad pattern must be visible to the control"

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -466,12 +466,56 @@ def installed_root(client: str, version: str) -> Path:
     return base / "plugins" / "cache" / MARKETPLACE / PLUGIN_NAME / version
 
 
-def deep_verify(client: str, expected: str, result: Result) -> bool:
-    """Verify a client twice: its own report, and the manifest it loads.
+def content_digest_report(source_repo: Path, installed: Path) -> tuple[bool, str]:
+    """Compare every source skills/ file against the installed tree by bytes.
 
-    The second half exists because the first half can lie. A stale marketplace
+    Version equality is a claim about a label; this is the check on the
+    content behind it. The motivating false-green (2026-08-24): a skill was
+    edited without a version bump, ``plugin update`` no-opped on the
+    unchanged version, and both clients reported current while one loaded
+    stale files. A release is not verified until the installed bytes equal
+    the source bytes, whatever the version strings say.
+    """
+    skills_root = source_repo / "skills"
+    if not skills_root.is_dir():
+        return False, f"source skills/ missing at {skills_root}"
+    mismatched: list[str] = []
+    missing: list[str] = []
+    compared = 0
+    for path in sorted(skills_root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(source_repo)
+        if "__pycache__" in rel.parts or rel.suffix == ".pyc":
+            continue
+        counterpart = installed / rel
+        if not counterpart.is_file():
+            missing.append(str(rel))
+            continue
+        compared += 1
+        if _sha256_bytes(path.read_bytes()) != _sha256_bytes(counterpart.read_bytes()):
+            mismatched.append(str(rel))
+    if compared == 0 and not missing:
+        return False, "no source files compared — refusing an empty verification"
+    if missing or mismatched:
+        sample = (missing + mismatched)[:3]
+        return False, (
+            f"{len(missing)} missing, {len(mismatched)} differing of "
+            f"{compared + len(missing)} source files (e.g. {', '.join(sample)})"
+        )
+    return True, f"{compared} files byte-equal to source"
+
+
+def deep_verify(client: str, expected: str, result: Result,
+                repo: Path | None = None) -> bool:
+    """Verify a client three ways: its report, the manifest it loads, and
+    the installed bytes against the source tree.
+
+    The later halves exist because the first can lie. A stale marketplace
     snapshot, a hand-made cache directory, or a partial install can all leave a
-    client reporting a version whose files are not the ones on disk.
+    client reporting a version whose files are not the ones on disk — and an
+    unbumped version can leave on-disk version equality vouching for stale
+    content.
     """
     reported, load_path = client_reported_version(client)
     ok_reported = result.add(
@@ -498,7 +542,19 @@ def deep_verify(client: str, expected: str, result: Result) -> bool:
         ok_disk,
         "; ".join(seen) if seen else "no readable plugin manifest at any reported root",
     )
-    return ok_reported and ok_disk
+    ok_content = False
+    if repo is not None:
+        content_root = next(
+            (c for c in candidates
+             if read_manifest_version(c / manifest_name / "plugin.json") == expected),
+            candidates[0],
+        )
+        ok_content, detail = content_digest_report(repo, content_root)
+        result.add(f"verify.{client}.content", ok_content, detail)
+    else:
+        result.add(f"verify.{client}.content", False,
+                   "no source repo supplied for content comparison")
+    return ok_reported and ok_disk and ok_content
 
 
 def refresh_client(client: str, result: Result, dry_run: bool) -> bool:
@@ -678,7 +734,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"\nDRY RUN complete for {version}. No state changed.")
         return 0
 
-    verified = all(deep_verify(client, version, result) for client in ("claude", "codex"))
+    verified = all(deep_verify(client, version, result, repo=repo)
+                   for client in ("claude", "codex"))
     if not verified or result.failed:
         print(
             f"\nRELEASE INCOMPLETE for {version}: "

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -405,7 +405,55 @@ def test_deep_verify_fails_when_cli_reports_but_disk_is_stale(
     assert names["verify.codex.on-disk"] is False
 
 
-def test_deep_verify_passes_when_report_and_disk_agree(
+def _seed_content(source: Path, installed: Path, drift: bool = False) -> None:
+    for base in (source, installed):
+        (base / "skills" / "demo" / "scripts").mkdir(parents=True, exist_ok=True)
+        (base / "skills" / "demo" / "SKILL.md").write_text("# demo\n", encoding="utf-8")
+        (base / "skills" / "demo" / "scripts" / "tool.py").write_text(
+            "print('v2')\n", encoding="utf-8")
+    if drift:
+        (installed / "skills" / "demo" / "scripts" / "tool.py").write_text(
+            "print('v1-stale')\n", encoding="utf-8")
+
+
+def test_deep_verify_passes_when_report_disk_and_content_agree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "cache" / "4.30.1"
+    source = tmp_path / "source"
+    (root / ".codex-plugin").mkdir(parents=True)
+    (root / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"version": "4.30.1"}), encoding="utf-8"
+    )
+    _seed_content(source, root)
+    monkeypatch.setattr(release, "client_reported_version", lambda client: ("4.30.1", str(root)))
+    monkeypatch.setattr(release, "installed_root", lambda client, version: root)
+    result = release.Result()
+    assert release.deep_verify("codex", "4.30.1", result, repo=source) is True
+
+
+def test_deep_verify_fails_on_content_drift_despite_version_parity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The 2026-08-24 false-green: versions equal everywhere, installed
+    bytes stale. Version parity is not content parity."""
+    root = tmp_path / "cache" / "4.30.1"
+    source = tmp_path / "source"
+    (root / ".codex-plugin").mkdir(parents=True)
+    (root / ".codex-plugin" / "plugin.json").write_text(
+        json.dumps({"version": "4.30.1"}), encoding="utf-8"
+    )
+    _seed_content(source, root, drift=True)
+    monkeypatch.setattr(release, "client_reported_version", lambda client: ("4.30.1", str(root)))
+    monkeypatch.setattr(release, "installed_root", lambda client, version: root)
+    result = release.Result()
+    assert release.deep_verify("codex", "4.30.1", result, repo=source) is False
+    names = {s.name: s.ok for s in result.steps}
+    assert names["verify.codex.on-disk"] is True
+    assert names["verify.codex.content"] is False
+
+
+def test_deep_verify_fails_closed_without_source_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     root = tmp_path / "cache" / "4.30.1"
@@ -416,7 +464,7 @@ def test_deep_verify_passes_when_report_and_disk_agree(
     monkeypatch.setattr(release, "client_reported_version", lambda client: ("4.30.1", str(root)))
     monkeypatch.setattr(release, "installed_root", lambda client, version: root)
     result = release.Result()
-    assert release.deep_verify("codex", "4.30.1", result) is True
+    assert release.deep_verify("codex", "4.30.1", result) is False
 
 
 def test_deep_verify_fails_when_client_silent(


### PR DESCRIPTION
Three fail-closed controls, each from a coordination-board-filed defect that had no owner until tonight's completeness sweep. (1) release.py gains verify.<client>.content — installed skills/ bytes must equal source regardless of version strings (the 2026-08-24 unbumped-version false-green, flagged three times on the board). (2) context_currency.py refuses a zero scan with exit 2 and accepts a project directory directly (the 2026-08-24 fail-open). (3) message_guard doctor detects dead surrogate-escape patterns and runs doctor_clean_controls canonical messages through the live scanner (the 2026-08-03 and 2026-08-07 config incidents). 61 tests across the three suites, all green locally. This PR merges only on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)