### PR TITLE
Signature links render natively per channel

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.65.0",
+  "version": "4.66.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.65.0",
+  "version": "4.66.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.66.0] - 2026-08-29
+
+- **`synthesis-agent-correspondence` v3.1.0 — signature links render natively
+  per channel.** The persona name in a signature is a named hyperlink on every
+  channel that can render one; the visible-URL form is a last-resort fallback,
+  never a choice. Email is the load-bearing case: markdown link syntax never
+  renders in mail clients, so email sends and drafts carry an HTML body with
+  real anchors, with the plain form as the multipart alternative. Motivated by
+  a live Gmail signature that displayed its URL wrapped in a provider redirect
+  because the body went out as plain text.
+
 ## [4.65.0] - 2026-08-29
 
 Three fail-closed controls, each from a board-filed defect that had waited

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **A captured directive is not a routed one (August 2026).** Release
-**4.65.0** makes the release gate verify installed bytes against source (version parity is not content parity), makes the currency audit refuse a zero scan, and adds dead-pattern and canonical-clean controls to the message-guard doctor. Previously: **4.64.0** teaches the context doctor to catch the failure that happens by
+**4.66.0** makes persona signature links render as native hyperlinks per channel (HTML anchors in email, mrkdwn in Slack, plain fallback only where links are impossible). Previously: **4.65.0** makes the release gate verify installed bytes against source (version parity is not content parity), makes the currency audit refuse a zero scan, and adds dead-pattern and canonical-clean controls to the message-guard doctor. Previously: **4.64.0** teaches the context doctor to catch the failure that happens by
 default: an intake artifact that records a directive, reads as handled, and
 was never routed to numbered work, declined, or superseded. Intake-class
 artifacts now need a CONTEXT reference or a terminal routing marker, or the
-doctor warns. See the [4.65.0 release notes](CHANGELOG.md).
+doctor warns. See the [4.66.0 release notes](CHANGELOG.md).
 
 **A reviewer that did not write the code, reviewing the code (August 2026).**
 Release **4.63.0** repairs what an external adversarial review of

--- a/skills/synthesis-agent-correspondence/SKILL.md
+++ b/skills/synthesis-agent-correspondence/SKILL.md
@@ -12,7 +12,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "3.0.0"
+  version: "3.1.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -204,6 +204,39 @@ Whether a channel forces visible disclosure when an agent performs the send is a
 - **Slack forces it.** Slack's agent/bot connector auto-stamps a visible "Sent using [agent name]" tag the instant an agent, not the human, performs the send. No signature wording removes it — it's platform-level. Write the persona's signature to pre-explain the tag, since it will appear regardless.
 - **Most other channels don't.** Email the human sends by clicking "send" on an agent-drafted message carries no platform tag — the send action was human. A direct API send frequently carries none either, but that varies by provider. Where nothing is forced, disclosure is governed by the lane, not the channel.
 - **Check, don't guess.** Connector behavior changes with product updates. Verify each channel's current behavior before designing a signature around an assumption carried from another channel, or from memory.
+
+## Signature links render natively per channel (v3.1.0)
+
+The persona's name in a signature is a **named hyperlink on every channel that can
+render one**. A visible URL is the last-resort fallback for channels that genuinely
+cannot — never a stylistic choice, because the raw-URL form costs exactly the
+recipients the signature exists to serve.
+
+Link capability is a per-channel fact, verified against the actual send path like
+disclosure behavior above:
+
+- **Slack** renders `<https://example.com/|Name>` mrkdwn as a true link.
+- **Email renders HTML, never markdown.** `[Name](url)` in an email body is
+  literal text to every mail client. The signature (and therefore the whole body)
+  must go out as an HTML part — `<a href="https://example.com/">Name</a>` — via
+  whatever the send tool exposes (an html body format, or a dedicated html-body
+  parameter). When the tool takes both a plain and an html part, the html part
+  carries the anchor and the plain part carries the fallback form. A plain-text
+  body is not a softer version of the same signature: the receiving client
+  auto-links the raw URL and may wrap it in a tracking redirect, so the recipient
+  sees neither the clean name-link nor the clean URL. (Observed live: a
+  markdown-authored signature reached Gmail as plain text and displayed as the
+  name followed by a provider-redirect URL in parentheses.)
+- **Rich editors** (docs, wikis) take the platform's native link on the name.
+- **Channels with no rich text on the send path** (for example Google Chat
+  messages sent with user credentials, where named-link markup is app-only) use
+  the plain fallback: `Name (example.com)` — short and readable as text, chosen
+  for how it reads, not for auto-linking.
+
+Markdown link syntax remains the *notation* for drafts, approval prompts, and
+review surfaces; the wire format is the channel's own. Converting notation to the
+channel form is part of staging the send, and a compose gate should treat
+markdown reaching an email body as a defect, not a fallback.
 
 ## Three gates
 

--- a/skills/synthesis-agent-correspondence/scripts/test_signature_channels.py
+++ b/skills/synthesis-agent-correspondence/scripts/test_signature_channels.py
@@ -1,0 +1,32 @@
+"""The signature-link channel contract (v3.1.0) stays in the doctrine.
+
+Motivating incident (2026-08-29): a markdown-authored persona signature
+reached Gmail as a plain-text body; the recipient saw the persona name
+followed by a provider-redirect URL in parentheses — neither the named
+link nor a clean URL.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL = Path(__file__).resolve().parents[1] / "SKILL.md"
+
+
+def test_named_hyperlink_rule_present() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    assert "Signature links render natively per channel" in text
+    assert "named hyperlink on every channel that can" in text
+    assert "last-resort fallback" in text
+
+
+def test_email_html_never_markdown() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    assert "Email renders HTML, never markdown" in text
+    assert '<a href="https://example.com/">Name</a>' in text
+    assert "markdown reaching an email body as a defect" in text
+
+
+def test_fallback_and_notation_distinction() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    assert "Name (example.com)" in text
+    assert "notation" in text and "wire format is the channel's own" in text

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,9 +1,9 @@
-# AGENT HEURISTIC: authored for the 4.65.0 board-sweep controls release.
+# AGENT HEURISTIC: authored for the 4.66.0 signature-channel-links release.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff, proved by the runner before release.py consumes
 # the receipt.
 schema: 2
-suite: synthesis-board-sweep-controls-release
+suite: synthesis-signature-channel-links-release
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run
 enforcing_boundary: release.py and repository CI before publication
@@ -12,22 +12,12 @@ change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: doctor_clean_controls adoption is per-config and behavioral — the mechanism ships, each workspace supplies its own canonical messages; installed-client parity, independent review, publication, and deployment
+unverified_remainder: rendering on each real platform is verified by a human reading the actual client (a Gmail draft is filed for that); per-channel capability facts (e.g. Google Chat user-send markup) are re-verified when a send path changes, per the doctrine itself
 changed_surfaces:
-  - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [content-parity-detects-drift, content-parity-passes-equal-trees, content-parity-fails-closed-without-source]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [content-parity-detects-drift, content-parity-passes-equal-trees, content-parity-fails-closed-without-source]
-  - path: skills/synthesis-context-lifecycle/scripts/context_currency.py
-    cases: [zero-scan-fails-closed, project-directory-accepted]
-  - path: skills/synthesis-context-lifecycle/scripts/test_context_currency.py
-    cases: [zero-scan-fails-closed, project-directory-accepted]
-  - path: skills/synthesis-message-guard/scripts/message_guard.py
-    cases: [dead-surrogate-pattern-detected, config-clean-controls-scan]
-  - path: skills/synthesis-message-guard/scripts/test_message_guard.py
-    cases: [dead-surrogate-pattern-detected, config-clean-controls-scan]
-  - path: skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
-    cases: [watermark-cli-fixtures-use-live-dates]
+  - path: skills/synthesis-agent-correspondence/SKILL.md
+    cases: [named-hyperlink-rule, email-html-never-markdown, fallback-notation-distinction]
+  - path: skills/synthesis-agent-correspondence/scripts/test_signature_channels.py
+    cases: [named-hyperlink-rule, email-html-never-markdown, fallback-notation-distinction]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -39,38 +29,18 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: content-parity-detects-drift
-    control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_deep_verify_fails_on_content_drift_despite_version_parity
-    motivating_defect: an-unbumped-version-left-one-client-loading-stale-files-while-both-reported-current
-  - id: content-parity-passes-equal-trees
+  - id: named-hyperlink-rule
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_deep_verify_passes_when_report_disk_and_content_agree
-    motivating_defect: a-verification-that-cannot-pass-a-correct-install-teaches-people-to-route-around-it
-  - id: content-parity-fails-closed-without-source
+    fixture: ../synthesis-agent-correspondence/scripts/test_signature_channels.py::test_named_hyperlink_rule_present
+    motivating_defect: a-live-gmail-signature-displayed-its-url-wrapped-in-a-provider-redirect-instead-of-a-named-link
+  - id: email-html-never-markdown
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_deep_verify_fails_closed_without_source_repo
-    motivating_defect: a-content-check-that-silently-skips-when-unsupplied-is-the-false-green-it-replaces
-  - id: zero-scan-fails-closed
-    control_class: enforced-gate
-    fixture: ../synthesis-context-lifecycle/scripts/test_context_currency.py::test_zero_scan_fails_closed
-    motivating_defect: pointed-at-a-projects-own-subtree-the-audit-printed-a-green-zero-finding-scan-of-nothing
-  - id: project-directory-accepted
+    fixture: ../synthesis-agent-correspondence/scripts/test_signature_channels.py::test_email_html_never_markdown
+    motivating_defect: markdown-link-syntax-authored-for-review-surfaces-reached-a-plain-text-email-body
+  - id: fallback-notation-distinction
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_context_currency.py::test_project_directory_is_accepted_directly
-    motivating_defect: the-sibling-doctor-takes-a-project-dir-so-callers-hand-this-tool-the-same-shape
-  - id: dead-surrogate-pattern-detected
-    control_class: enforced-gate
-    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_dead_surrogate_pattern_detection
-    motivating_defect: a-surrogate-escaped-emoji-pattern-matched-nothing-for-months-while-the-doctor-stayed-green
-  - id: config-clean-controls-scan
-    control_class: acceptance-test
-    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_config_clean_controls_scan
-    motivating_defect: the-built-in-clean-control-passed-while-every-real-legitimate-message-was-being-blocked
-  - id: watermark-cli-fixtures-use-live-dates
-    control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_status_exits_zero_when_current
-    motivating_defect: a-frozen-authorship-date-in-a-subprocess-fixture-rotted-red-the-first-utc-midnight-after-it-shipped
+    fixture: ../synthesis-agent-correspondence/scripts/test_signature_channels.py::test_fallback_and_notation_distinction
+    motivating_defect: a-fallback-treated-as-a-stylistic-choice-costs-exactly-the-recipients-the-signature-serves
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates


### PR DESCRIPTION
synthesis-agent-correspondence v3.1.0: a persona signature's name is a named hyperlink on every channel that can render one — HTML anchors in email bodies (markdown never renders in mail clients), mrkdwn in Slack, native links in rich editors, visible-URL plain form only where links are impossible (e.g. Google Chat user-credential sends). Motivated by a live Gmail signature displaying its URL wrapped in Google's redirect because the body went out plain-text. Doctrine fixtures + fresh transaction manifest; acceptance consumed locally. This PR merges only on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)