### PR TITLE
Byte-faithful send-path rule

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.66.0",
+  "version": "4.67.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.66.0",
+  "version": "4.67.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.67.0] - 2026-08-29
+
+- **`synthesis-agent-correspondence` v3.1.1 — the send path is part of the
+  channel.** A provider-composed send path can rewrite clean hrefs at
+  ingestion (observed live: Gmail's composer wrapping every link in an
+  expiring redirect), while a raw-MIME path stores the bytes you built.
+  Prefer the byte-faithful path and verify a path once by reading the
+  stored message back in raw form. Proven by raw-MIME comparison of two
+  drafts filed minutes apart through the two paths.
+
 ## [4.66.0] - 2026-08-29
 
 - **`synthesis-agent-correspondence` v3.1.0 — signature links render natively

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **A captured directive is not a routed one (August 2026).** Release
-**4.66.0** makes persona signature links render as native hyperlinks per channel (HTML anchors in email, mrkdwn in Slack, plain fallback only where links are impossible). Previously: **4.65.0** makes the release gate verify installed bytes against source (version parity is not content parity), makes the currency audit refuse a zero scan, and adds dead-pattern and canonical-clean controls to the message-guard doctor. Previously: **4.64.0** teaches the context doctor to catch the failure that happens by
+**4.67.0** adds the byte-faithful send-path rule (a provider-composed email path can rewrite your links; raw MIME stores your bytes). Previously: **4.66.0** makes persona signature links render as native hyperlinks per channel (HTML anchors in email, mrkdwn in Slack, plain fallback only where links are impossible). Previously: **4.65.0** makes the release gate verify installed bytes against source (version parity is not content parity), makes the currency audit refuse a zero scan, and adds dead-pattern and canonical-clean controls to the message-guard doctor. Previously: **4.64.0** teaches the context doctor to catch the failure that happens by
 default: an intake artifact that records a directive, reads as handled, and
 was never routed to numbered work, declined, or superseded. Intake-class
 artifacts now need a CONTEXT reference or a terminal routing marker, or the
-doctor warns. See the [4.66.0 release notes](CHANGELOG.md).
+doctor warns. See the [4.67.0 release notes](CHANGELOG.md).
 
 **A reviewer that did not write the code, reviewing the code (August 2026).**
 Release **4.63.0** repairs what an external adversarial review of

--- a/skills/synthesis-agent-correspondence/SKILL.md
+++ b/skills/synthesis-agent-correspondence/SKILL.md
@@ -12,7 +12,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "3.1.0"
+  version: "3.1.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -237,6 +237,16 @@ Markdown link syntax remains the *notation* for drafts, approval prompts, and
 review surfaces; the wire format is the channel's own. Converting notation to the
 channel form is part of staging the send, and a compose gate should treat
 markdown reaching an email body as a defect, not a fallback.
+
+**The send path is part of the channel (v3.1.1).** Two tools for the same
+mailbox can store different bytes: a tool that takes structured fields and lets
+the provider compose the message server-side may rewrite your hrefs (observed
+live: Gmail's composer wrapping every link in an expiring `google.com/url`
+redirect at ingestion), while a tool that submits raw MIME stores the bytes you
+built. When both exist, prefer the byte-faithful path — and verify a path once
+by reading the stored message back in raw form before trusting it with real
+correspondence. A link that looks right in the client can still be wrapped
+underneath; only the stored bytes settle it.
 
 ## Three gates
 

--- a/skills/synthesis-agent-correspondence/scripts/test_signature_channels.py
+++ b/skills/synthesis-agent-correspondence/scripts/test_signature_channels.py
@@ -30,3 +30,13 @@ def test_fallback_and_notation_distinction() -> None:
     text = SKILL.read_text(encoding="utf-8")
     assert "Name (example.com)" in text
     assert "notation" in text and "wire format is the channel's own" in text
+
+
+def test_send_path_byte_faithfulness_rule() -> None:
+    """v3.1.1: a provider-composed send path rewrote clean hrefs into
+    expiring redirects at ingestion; the byte-faithful raw path did not.
+    Verified by raw-MIME read-back of two drafts, 2026-08-29."""
+    text = SKILL.read_text(encoding="utf-8")
+    assert "The send path is part of the channel" in text
+    assert "raw MIME stores the bytes you" in text
+    assert "reading the stored message back in raw form" in text

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -3,7 +3,7 @@
 # base-to-head Git diff, proved by the runner before release.py consumes
 # the receipt.
 schema: 2
-suite: synthesis-signature-channel-links-release
+suite: synthesis-byte-faithful-send-path-release
 membership: closed
 production_entry_point: scripts/acceptance_suite.py run
 enforcing_boundary: release.py and repository CI before publication
@@ -15,9 +15,9 @@ issues_authority_receipt: false
 unverified_remainder: rendering on each real platform is verified by a human reading the actual client (a Gmail draft is filed for that); per-channel capability facts (e.g. Google Chat user-send markup) are re-verified when a send path changes, per the doctrine itself
 changed_surfaces:
   - path: skills/synthesis-agent-correspondence/SKILL.md
-    cases: [named-hyperlink-rule, email-html-never-markdown, fallback-notation-distinction]
+    cases: [byte-faithful-send-path]
   - path: skills/synthesis-agent-correspondence/scripts/test_signature_channels.py
-    cases: [named-hyperlink-rule, email-html-never-markdown, fallback-notation-distinction]
+    cases: [byte-faithful-send-path]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -29,18 +29,10 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: named-hyperlink-rule
+  - id: byte-faithful-send-path
     control_class: acceptance-test
-    fixture: ../synthesis-agent-correspondence/scripts/test_signature_channels.py::test_named_hyperlink_rule_present
-    motivating_defect: a-live-gmail-signature-displayed-its-url-wrapped-in-a-provider-redirect-instead-of-a-named-link
-  - id: email-html-never-markdown
-    control_class: acceptance-test
-    fixture: ../synthesis-agent-correspondence/scripts/test_signature_channels.py::test_email_html_never_markdown
-    motivating_defect: markdown-link-syntax-authored-for-review-surfaces-reached-a-plain-text-email-body
-  - id: fallback-notation-distinction
-    control_class: acceptance-test
-    fixture: ../synthesis-agent-correspondence/scripts/test_signature_channels.py::test_fallback_and_notation_distinction
-    motivating_defect: a-fallback-treated-as-a-stylistic-choice-costs-exactly-the-recipients-the-signature-serves
+    fixture: ../synthesis-agent-correspondence/scripts/test_signature_channels.py::test_send_path_byte_faithfulness_rule
+    motivating_defect: a-provider-composed-draft-path-rewrote-clean-hrefs-into-expiring-redirects-at-ingestion
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates


### PR DESCRIPTION
agent-correspondence v3.1.1: the send path is part of the channel. A provider-composed email path rewrote clean hrefs into expiring google.com/url redirects at ingestion (proven by raw-MIME read-back of two drafts filed minutes apart); the raw-MIME path stored the bytes unchanged. Doctrine: prefer the byte-faithful path, verify a path once by reading the stored message back raw. Fixture + fresh manifest; acceptance consumed locally. Merges only on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)