### PR TITLE
Autopilot v2.0.0 — continuation contract for unattended runs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.67.0",
+  "version": "4.68.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.67.0",
+  "version": "4.68.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.68.0] - 2026-08-30
+
+**`synthesis-autopilot` v2.0.0 — unattended time is a scheduled property.**
+The motivating incident: an overnight delegation engaged the mode correctly,
+ran two phases, and then its turn ended — nothing runs between turns, so the
+session idled all night (a mid-night reboot passed unnoticed) and the phase
+that was the point never started. Every discipline held; the work still did
+not happen.
+
+- **Continuation contract:** an engagement whose horizon exceeds the current
+  turn must establish a VERIFIED continuation mechanism before its first turn
+  ends (background work that re-invokes the session, self-scheduled wakeups,
+  scheduler/cron re-entry, or a declared principal-side relaunch) — or say
+  plainly that it cannot run unattended. A survival table (turn end / session
+  death / reboot) matches mechanism to horizon; long horizons layer a
+  scheduler-class dead-man's switch under the inner loop.
+- **Mechanical stop-gate:** new `scripts/autopilot_gate.py` + a plugin Stop
+  hook refuse to let a session stop while a registered engagement is active,
+  unfinished, and has neither a recorded continuation nor an alerted blocker
+  nor an honest close. Abandoned engagements block later stops by design.
+- **Runaway and budget control:** plan files gain Continuation, Budget, and
+  Cycle-ledger sections; `autopilot_gate.py cycle` refuses to record a wake
+  that advanced nothing and names no external wait — a bare spin cannot be
+  logged. Stop conditions: goals met · blocker + alert · budget + alert.
+- **Capability probe before asserting absence:** a blocker claiming a
+  capability is missing must carry probe evidence — an agent that wrongly
+  believes it is blocked stops (a headless CLI was reported unreachable from
+  stale memory in the incident's aftermath while the same session had been
+  using it).
+- **Volatile-state rule:** scratchpad dies at reboots; derived state moves
+  into the project at EVERY phase boundary, not only at close.
+- **Adversary at scope time:** dispatching the counterpart during scope
+  definition (not only review) caught silently dropped artifacts in the real
+  case; now doctrine for discovery-shaped phases.
+
 ## [4.67.0] - 2026-08-29
 
 - **`synthesis-agent-correspondence` v3.1.1 — the send path is part of the

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **A captured directive is not a routed one (August 2026).** Release
-**4.67.0** adds the byte-faithful send-path rule (a provider-composed email path can rewrite your links; raw MIME stores your bytes). Previously: **4.66.0** makes persona signature links render as native hyperlinks per channel (HTML anchors in email, mrkdwn in Slack, plain fallback only where links are impossible). Previously: **4.65.0** makes the release gate verify installed bytes against source (version parity is not content parity), makes the currency audit refuse a zero scan, and adds dead-pattern and canonical-clean controls to the message-guard doctor. Previously: **4.64.0** teaches the context doctor to catch the failure that happens by
+**4.68.0** upgrades synthesis-autopilot for genuinely unattended runs: a verified continuation mechanism is now part of the delegation contract, enforced by a Stop-hook gate, with budget/runaway control and cycle ledgers. Previously: **4.67.0** adds the byte-faithful send-path rule (a provider-composed email path can rewrite your links; raw MIME stores your bytes). Previously: **4.66.0** makes persona signature links render as native hyperlinks per channel (HTML anchors in email, mrkdwn in Slack, plain fallback only where links are impossible). Previously: **4.65.0** makes the release gate verify installed bytes against source (version parity is not content parity), makes the currency audit refuse a zero scan, and adds dead-pattern and canonical-clean controls to the message-guard doctor. Previously: **4.64.0** teaches the context doctor to catch the failure that happens by
 default: an intake artifact that records a directive, reads as handled, and
 was never routed to numbered work, declined, or superseded. Intake-class
 artifacts now need a CONTEXT reference or a terminal routing marker, or the
-doctor warns. See the [4.67.0 release notes](CHANGELOG.md).
+doctor warns. See the [4.68.0 release notes](CHANGELOG.md).
 
 **A reviewer that did not write the code, reviewing the code (August 2026).**
 Release **4.63.0** repairs what an external adversarial review of

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-autopilot/scripts/autopilot_gate.py --gate",
+            "timeout": 15,
+            "statusMessage": "Checking autopilot engagements for a continuation"
+          }
+        ]
+      }
     ]
   }
 }

--- a/skills/synthesis-autopilot/SKILL.md
+++ b/skills/synthesis-autopilot/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: synthesis-autopilot
-description: "Execute an explicitly delegated whole task autonomously using the thinking framework, durable plan and context, checkpoints, anti-shortcut discipline, and implementation-integrity gate. Activate only for clear end-to-end delegation such as 'autopilot this,' 'take care of this for me,' 'handle this end to end,' or 'complete all phases autonomously'; never infer it from a single-step approval, discussion of autonomy, or ambiguous wording."
+description: "Execute an explicitly delegated whole task autonomously using the thinking framework, durable plan and context, checkpoints, anti-shortcut discipline, and implementation-integrity gate — and, for unattended runs, a verified continuation mechanism with budget and runaway control, so overnight and multi-day engagements keep producing turns instead of idling silently. Activate only for clear end-to-end delegation such as 'autopilot this,' 'take care of this for me,' 'handle this end to end,' 'run overnight,' or 'complete all phases autonomously'; never infer it from a single-step approval, discussion of autonomy, or ambiguous wording."
 license: "Apache-2.0"
 depends_on: ["synthesis-thinking-framework", "synthesis-context-lifecycle", "synthesis-checkpoint", "synthesis-anti-shortcuts", "synthesis-grounding-discipline", "synthesis-implementation-integrity", "synthesis-project-management", "synthesis-adversarial-review", "synthesis-decision-packet"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.4.0"
+  version: "2.0.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -61,6 +61,93 @@ Engaging the mode means the user is taken to have said all of the following, onc
 5. **Verification before "done"** — synthesis-implementation-integrity (or the domain's analog: fact-checking and quality gates for content work) runs before any completion claim.
 6. **Standing rules remain in force** — nothing in this contract grants permissions the user's standing configuration withholds.
 
+## Continuation — Unattended Time Is a Scheduled Property
+
+The costliest way this mode fails is silently, at a turn boundary. The real
+incident that forced this section: a principal delegated an overnight run and
+went to sleep; the agent engaged the mode correctly, wrote the plan file, ran
+two phases, and then its turn ended. **Agent harnesses do not run between
+turns.** The session sat idle all night — the machine rebooted mid-night
+without interrupting anything, because nothing was executing — and the phase
+that was the entire point never started. Every discipline in this file held;
+the work still did not happen, because the contract said "complete the work
+end to end" and nothing caused the next turn to exist.
+
+**The rule: an engagement whose horizon extends beyond the current turn MUST
+establish a verified continuation mechanism before its first turn ends — or
+must say plainly, at engagement, that it cannot run unattended in this
+environment and negotiate what happens instead.** Claiming overnight autonomy
+without a continuation mechanism is a false capability claim, and the silence
+it produces is indistinguishable from progress until the principal wakes up.
+
+**Continuation mechanisms, by what they survive.** Verify what the current
+harness actually provides — do not assume from memory (see the capability
+probe rule below). The common classes:
+
+| Mechanism | Survives turn end | Survives session death | Survives reboot |
+|---|---|---|---|
+| In-flight background work whose completion re-invokes the session (dispatched agents, detached exec with a completion waiter, workflows) | yes | no | no |
+| Self-scheduled wakeup / dynamic loop (the harness re-invokes the session with a prompt on a cadence it sets) | yes | no | no |
+| Scheduled task / cron re-entry (a scheduler starts a fresh run that resumes from the plan file) | yes | yes | usually |
+| Principal-side relaunch instruction (documented command the principal or their machine runs) | yes | yes | yes |
+
+**Match the mechanism to the horizon, and layer for long ones.** A run
+measured in hours inside one sitting can ride background work and wakeups. A
+run measured across sleep, reboots, or days needs a scheduler-class re-entry
+as the dead-man's switch underneath whatever finer mechanism drives the
+inner loop — the plan file is the state that makes any fresh re-entry able
+to resume. When no mechanism exists at all, the honest engagement response
+is: "I can only make progress while turns are running; here is the relaunch
+command / loop invocation that would change that."
+
+**Re-entry protocol.** Every wake — wakeup, completion notification,
+scheduled re-entry, or a fresh session resuming — starts the same way: read
+the plan file first (it is the loop variable), read the coordination board,
+verify the plan's claimed state against ground truth (git, artifacts on
+disk — not memory), then continue the next unmet goal. Record every wake in
+the plan's cycle ledger.
+
+**Budget and runaway control.** The twin fear of the silent stop is the
+loop that burns the principal's usage limits without value. The plan file
+declares the budget up front: horizon, maximum cycles or wall-clock, and
+the per-cycle value test. Each cycle records what it advanced; a cycle that
+advanced nothing must name the external event it is waiting on, and waits
+use coarse cadences (do not poll for what a completion notification will
+deliver). Stop conditions are exactly: goals met · blocker recorded and
+principal alerted · budget exhausted and principal alerted. "Still running"
+is never itself evidence of value.
+
+**Capability probe before asserting absence.** An agent that wrongly
+believes it is blocked stops. In the motivating incident's aftermath, a
+session confidently reported that the counterpart CLI could not be reached
+unattended — stale knowledge stated as fact; the CLI had a working headless
+mode the same session had already used. Before any blocker or plan step
+claims a capability is absent ("X cannot run autonomously", "no way to
+reach Y"), run the probe — locate the binary, invoke the minimal command,
+read the tool schema — and record the probe's evidence with the claim.
+Zero results from memory are not evidence of absence.
+
+**Volatile state dies at reboots.** Scratchpad and temp directories are
+cleared by reboots and session ends — and long-horizon runs are exactly the
+runs that meet reboots. Anything a later phase, another agent, or a durable
+record depends on moves into the project (resources/) **at every phase
+boundary**, not only at close. Losing derived findings to a reboot mid-run
+means regenerating them on the next wake — paid for twice.
+
+**The mechanical backstop.** Doctrine that depends on the agent remembering
+it is the failure shape this section documents, so the gate is enforced:
+engagement registers with `scripts/autopilot_gate.py register --plan <plan>
+--mission "<done means>"`, and the plugin's Stop hook refuses to let a
+session stop while a registered engagement is active, unfinished, and has
+neither a recorded continuation (`autopilot_gate.py continuation`) nor an
+alerted blocker (`autopilot_gate.py blocker ... --alerted`) nor an honest
+close (`autopilot_gate.py close --goals-met | --incomplete <reason>`). The
+cycle ledger is mechanical too: `autopilot_gate.py cycle` refuses to record
+a wake that advanced nothing and names no external wait — there is no way
+to log a bare spin. An engagement abandoned by a dead session blocks the
+next session's stop BY DESIGN: abandonment must be loud, and the block
+message carries the honest close command.
+
 ## The Plan File
 
 The plan file is the mode's survival mechanism. Chat context compacts; the plan file does not.
@@ -98,6 +185,21 @@ depth, and why the planned review effort is proportionate.
 Counterpart sessions, direct dispatch path, provider-boundary exception if
 one exists, allowed principal courier crossings, current count, and the
 blocked-state alert threshold.
+
+## Continuation
+Mechanism causing the next turn, what it survives (turn end / session
+death / reboot), the next-wake condition or cadence, the dead-man's
+switch for long horizons, and how the mechanism was VERIFIED in this
+harness (probe evidence, not memory).
+
+## Budget
+Horizon; maximum cycles or wall-clock; the per-cycle value test; counters
+updated each cycle. Stop conditions: goals met · blocker + alert ·
+budget exhausted + alert.
+
+## Cycle ledger
+One line per wake: what advanced, or the named external wait. Appended
+mechanically via autopilot_gate.py cycle.
 
 ## Phases
 - [x] Phase 1 — ...
@@ -156,6 +258,14 @@ courier crossings. Never hide a manual crossing inside “send this to the revie
 round-trip budget is a tracked delivery cost; exceeding it triggers the blocked-state alert
 rather than silently recruiting the principal as orchestration middleware.
 
+**Dispatch the counterpart at scope-definition time, not only at review time,
+for discovery-shaped phases.** An adversary auditing the scope inventory while
+it is being built catches classifier drops and universe errors when they cost a
+correction, not a re-run — proven in the motivating overnight engagement, where
+a scope audit dispatched during Phase 0 found complete artifacts the primary
+classifier had silently dropped. Review-time dispatch remains for judging
+finished work; scope-time dispatch protects the universe the work runs over.
+
 Write the proportionality section before the first review round: principal outcome,
 closed artifact universe, consequence being prevented, justified control depth, and stop
 rule. Fewer rounds come from complete per-artifact coverage and stronger fixtures, never
@@ -186,19 +296,20 @@ When a phase reaches a gated action, prepare everything up to the gate (the draf
 
 ## The Execution Loop
 
-1. **Engage** — one-line acknowledgment with the plan-file path.
+1. **Engage** — one-line acknowledgment with the plan-file path; register the
+   engagement with the continuation gate (`autopilot_gate.py register`).
 2. **Anchor** — run synthesis-checkpoint: verified date, project state from disk, history from git.
 3. **Coordinate** — read the shared active-sessions board and claim every
    source area this run may write before editing.
-4. **Register** — attach to or create the synthesis project (synthesis-project-management); create the plan file.
-5. **Phase loop** — for each phase: re-read the plan file and coordination board; execute with anti-shortcut discipline; classify each decision per the protocol above; dispatch sub-agents per the hygiene rules below; directly orchestrate any adversarial counterpart and count principal courier crossings; record the sufficiency checkpoint; then update the plan file, and at natural checkpoints run the synthesis-context-lifecycle session protocol so CONTEXT.md and the session log stay current.
+4. **Register** — attach to or create the synthesis project (synthesis-project-management); create the plan file, including its Continuation and Budget sections. **If the horizon exceeds this turn, establish and verify the continuation mechanism NOW** — record it in the plan and via `autopilot_gate.py continuation` before any phase work makes the first turn long enough to forget.
+5. **Phase loop** — for each phase: re-read the plan file and coordination board; execute with anti-shortcut discipline; classify each decision per the protocol above; dispatch sub-agents per the hygiene rules below; directly orchestrate any adversarial counterpart and count principal courier crossings; record the sufficiency checkpoint; then update the plan file (cycle ledger included), **sweep the scratchpad — anything a later phase, another agent, or a durable record depends on moves into resources/ at THIS boundary, because volatile state dies at reboots** — and at natural checkpoints run the synthesis-context-lifecycle session protocol so CONTEXT.md and the session log stay current.
 6. **Verify** — before declaring the mission complete, run synthesis-implementation-integrity (or the domain analog). Fix what it finds; verification that only reports is not verification.
-7. **Close** — session-end per synthesis-context-lifecycle (context files updated, work committed where applicable); release the coordination claims; completion report in plain language: what shipped, what was decided and why, the batched questions; then the completion alert.
+7. **Close** — session-end per synthesis-context-lifecycle (context files updated, work committed where applicable); release the coordination claims; close the engagement (`autopilot_gate.py close --goals-met`, or `--incomplete <reason>` for an honest partial close); completion report in plain language: what shipped, what was decided and why, the batched questions; then the completion alert.
 
-The close step includes a scratchpad sweep: **What executable state or required
-input data still exists only in this session's scratchpad?** If a durable
-record cites its output, preserve the script and required inputs under
-resources/scripts/ before the checkpoint can close.
+The close step repeats the scratchpad sweep one final time: **What executable
+state or required input data still exists only in this session's scratchpad?**
+If a durable record cites its output, preserve the script and required inputs
+under resources/scripts/ before the checkpoint can close.
 
 ## Sub-Agent Fan-Out Hygiene
 

--- a/skills/synthesis-autopilot/scripts/autopilot_gate.py
+++ b/skills/synthesis-autopilot/scripts/autopilot_gate.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""autopilot_gate.py — the continuation stop-gate for autonomous engagements.
+
+The failure this exists to prevent (observed live, 2026-08-29): a principal
+delegated an overnight run and went to sleep; the agent engaged autopilot
+correctly, ran two phases, and then its turn ended. Nothing in the harness
+runs between turns, so the session sat idle all night — the machine even
+rebooted unnoticed, because nothing was executing — and the phase that was
+the entire point never started. The engagement LOOKED active the whole time.
+
+The gate makes that silent stop impossible. Engaging autopilot registers the
+engagement here; a Stop while any registered engagement is active and
+unfinished is refused unless the agent has done one of three legal things:
+
+  1. recorded a CONTINUATION — the verified mechanism that causes the next
+     turn (in-flight background work whose completion re-invokes the
+     session, a self-scheduled wakeup/loop, or a cron/scheduled re-entry);
+  2. recorded a BLOCKER — with the principal alerted, per the skill's
+     blocked-state alert rules;
+  3. CLOSED the engagement — goals met, or explicitly incomplete with a
+     reason.
+
+All three outs are satisfiable by the agent alone, so the gate can fail
+closed without deadlocking a session. An abandoned engagement from an
+earlier session blocks later stops BY DESIGN — abandonment must be loud;
+the block message carries the exact command to close it out honestly.
+
+Runaway control lives in `cycle`: recording a wake that advanced nothing
+requires a named external wait (`--waiting-on`). There is no way to record
+a bare spin, so a loop that is burning cycles without progress has to
+either name what it is waiting for or stop and alert.
+
+Modes:
+  register      --plan PATH --mission TEXT      begin an engagement
+  continuation  --plan PATH --mechanism TEXT --next-wake TEXT --survives TEXT
+  cycle         --plan PATH (--advanced TEXT | --no-advance --waiting-on TEXT)
+  blocker       --plan PATH --reason TEXT --alerted
+  close         --plan PATH (--goals-met | --incomplete TEXT)
+  --gate        Stop-hook mode: read payload on stdin, allow (0) or block (2)
+  --doctor      self-check with positive and negative controls
+  --test        hermetic behavioral suite
+
+Environment:
+  AUTOPILOT_GATE_STATE_DIR  registry dir
+                            (default ~/.synthesis/autopilot/engagements)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+ENGINE_VERSION = "1.0.0"
+
+
+def state_dir() -> Path:
+    return Path(os.environ.get(
+        "AUTOPILOT_GATE_STATE_DIR",
+        os.path.expanduser("~/.synthesis/autopilot/engagements"),
+    ))
+
+
+def entry_path(plan: str) -> Path:
+    plan = os.path.abspath(os.path.expanduser(plan))
+    key = hashlib.sha1(plan.encode()).hexdigest()[:12]
+    return state_dir() / f"{Path(plan).stem[:40]}-{key}.json"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def load(path: Path) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def save(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent))
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+    os.replace(tmp, path)
+
+
+def load_for_plan(plan: str) -> tuple[Path, dict]:
+    path = entry_path(plan)
+    if not path.exists():
+        print(f"no engagement registered for plan {plan} "
+              f"(expected {path}); run register first", file=sys.stderr)
+        raise SystemExit(2)
+    return path, load(path)
+
+
+def cmd_register(plan: str, mission: str, horizon: str) -> int:
+    if not mission.strip():
+        print("register: --mission must describe what done means",
+              file=sys.stderr)
+        return 2
+    path = entry_path(plan)
+    if path.exists() and load(path).get("status") == "active":
+        print(f"engagement already active for this plan: {path}")
+        return 0
+    save(path, {
+        "plan": os.path.abspath(os.path.expanduser(plan)),
+        "mission": mission.strip(),
+        "horizon": horizon,
+        "engaged_at": now_iso(),
+        "status": "active",
+        "goals_met": False,
+        "continuation": None,
+        "blocker": None,
+        "cycles": [],
+    })
+    print(f"engagement registered: {path}")
+    return 0
+
+
+def cmd_continuation(plan: str, mechanism: str, next_wake: str,
+                     survives: str) -> int:
+    for label, val in (("--mechanism", mechanism), ("--next-wake", next_wake),
+                       ("--survives", survives)):
+        if not val.strip():
+            print(f"continuation: {label} must be non-empty — an unnamed "
+                  "mechanism is the silent-idle failure restated",
+                  file=sys.stderr)
+            return 2
+    path, data = load_for_plan(plan)
+    data["continuation"] = {
+        "mechanism": mechanism.strip(),
+        "next_wake": next_wake.strip(),
+        "survives": survives.strip(),
+        "recorded_at": now_iso(),
+    }
+    save(path, data)
+    print(f"continuation recorded ({mechanism.strip()[:60]})")
+    return 0
+
+
+def cmd_cycle(plan: str, advanced: str | None, no_advance: bool,
+              waiting_on: str | None) -> int:
+    path, data = load_for_plan(plan)
+    if advanced and advanced.strip():
+        data["cycles"].append({"at": now_iso(), "advanced": advanced.strip()})
+    elif no_advance:
+        if not (waiting_on and waiting_on.strip()):
+            print("cycle: a wake that advanced nothing must name the external "
+                  "wait (--waiting-on). There is no way to record a bare "
+                  "spin — if nothing advanced and nothing external is "
+                  "awaited, the run is spinning: stop and alert instead.",
+                  file=sys.stderr)
+            return 2
+        data["cycles"].append({"at": now_iso(),
+                               "waiting_on": waiting_on.strip()})
+    else:
+        print("cycle: pass --advanced TEXT or --no-advance --waiting-on TEXT",
+              file=sys.stderr)
+        return 2
+    save(path, data)
+    print(f"cycle recorded ({len(data['cycles'])} total)")
+    return 0
+
+
+def cmd_blocker(plan: str, reason: str, alerted: bool) -> int:
+    if not reason.strip():
+        print("blocker: --reason must say what prevents the goals",
+              file=sys.stderr)
+        return 2
+    if not alerted:
+        print("blocker: pass --alerted only after the principal alert has "
+              "actually fired (the skill's blocked-state alert rules). A "
+              "blocker nobody was told about is the silent stop again.",
+              file=sys.stderr)
+        return 2
+    path, data = load_for_plan(plan)
+    data["blocker"] = {"reason": reason.strip(), "alerted_at": now_iso()}
+    save(path, data)
+    print("blocker recorded (principal alerted)")
+    return 0
+
+
+def cmd_close(plan: str, goals_met: bool, incomplete: str | None) -> int:
+    path, data = load_for_plan(plan)
+    if goals_met:
+        data["goals_met"] = True
+        data["status"] = "closed"
+        data["closed_at"] = now_iso()
+    elif incomplete and incomplete.strip():
+        data["status"] = "closed"
+        data["closed_incomplete"] = incomplete.strip()
+        data["closed_at"] = now_iso()
+    else:
+        print("close: pass --goals-met, or --incomplete REASON for an "
+              "honest incomplete close", file=sys.stderr)
+        return 2
+    save(path, data)
+    print(f"engagement closed: {path.name}")
+    return 0
+
+
+def gate() -> int:
+    try:
+        json.load(sys.stdin)  # payload read; content not needed for the rule
+    except Exception:
+        pass  # a stop gate must still evaluate registry state
+    root = state_dir()
+    if not root.is_dir():
+        return 0
+    offenders: list[str] = []
+    for path in sorted(root.glob("*.json")):
+        try:
+            data = load(path)
+        except Exception as exc:
+            print(f"autopilot-gate BLOCKED (fail closed): engagement record "
+                  f"{path} is unreadable ({exc}). Repair or remove it — an "
+                  "unreadable engagement cannot prove it was continued.",
+                  file=sys.stderr)
+            return 2
+        if data.get("status") != "active" or data.get("goals_met"):
+            continue
+        if data.get("continuation") or data.get("blocker"):
+            continue
+        offenders.append(
+            f"{data.get('mission', path.name)!r} (plan {data.get('plan')})")
+    if not offenders:
+        return 0
+    me = os.path.basename(__file__)
+    print(
+        "autopilot-gate BLOCKED: this session is stopping while an autopilot "
+        "engagement is active, unfinished, and has NO continuation — the "
+        "exact shape of the overnight silent-idle failure. Engagements: "
+        + "; ".join(offenders) + ". Before stopping, do exactly one: "
+        f"(1) establish the next turn and record it ({me} continuation "
+        "--plan P --mechanism ... --next-wake ... --survives ...), "
+        f"(2) alert the principal and record the blocker ({me} blocker "
+        "--plan P --reason ... --alerted), or "
+        f"(3) close the engagement honestly ({me} close --plan P "
+        "--goals-met | --incomplete REASON). An engagement another session "
+        "abandoned blocks here BY DESIGN — close it honestly rather than "
+        "deleting its record.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def run_doctor() -> int:
+    ok = True
+
+    def report(good: bool, label: str, detail: str = "") -> None:
+        nonlocal ok
+        print("  %s %s%s" % ("ok " if good else "FAIL", label,
+                             ": " + detail if detail else ""))
+        ok = ok and good
+
+    print(f"autopilot-gate doctor (engine v{ENGINE_VERSION})")
+    root = state_dir()
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        probe = root / ".doctor-probe"
+        probe.write_text("x", encoding="utf-8")
+        probe.unlink()
+        report(True, "state dir writable", str(root))
+    except Exception as exc:
+        report(False, "state dir writable", str(exc))
+    bad = 0
+    for path in root.glob("*.json"):
+        try:
+            load(path)
+        except Exception:
+            bad += 1
+    report(bad == 0, "registry parseable",
+           f"{bad} unreadable record(s)" if bad else "all records parse")
+    print("HEALTHY" if ok else "UNHEALTHY")
+    return 0 if ok else 2
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if not argv or argv[0] == "--gate":
+        return gate()
+    if argv[0] == "--doctor":
+        return run_doctor()
+
+    def val(flag: str) -> str | None:
+        return argv[argv.index(flag) + 1] if flag in argv else None
+
+    mode = argv[0]
+    plan = val("--plan") or ""
+    if not plan:
+        print(__doc__)
+        return 0 if mode in ("-h", "--help") else 2
+    if mode == "register":
+        return cmd_register(plan, val("--mission") or "",
+                            val("--horizon") or "unspecified")
+    if mode == "continuation":
+        return cmd_continuation(plan, val("--mechanism") or "",
+                                val("--next-wake") or "",
+                                val("--survives") or "")
+    if mode == "cycle":
+        return cmd_cycle(plan, val("--advanced"),
+                         "--no-advance" in argv, val("--waiting-on"))
+    if mode == "blocker":
+        return cmd_blocker(plan, val("--reason") or "", "--alerted" in argv)
+    if mode == "close":
+        return cmd_close(plan, "--goals-met" in argv, val("--incomplete"))
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/synthesis-autopilot/scripts/test_autopilot_gate.py
+++ b/skills/synthesis-autopilot/scripts/test_autopilot_gate.py
@@ -1,0 +1,112 @@
+"""Fixtures for the autopilot continuation stop-gate.
+
+Derived from the real 2026-08-29 overnight failure: an engagement ran two
+phases, the turn ended with no continuation mechanism, and the session sat
+idle all night — a reboot passed unnoticed because nothing was executing.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("autopilot_gate.py")
+SPEC = importlib.util.spec_from_file_location("autopilot_gate", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def run_cli(tmp_path: Path, *args: str, stdin: str = "{}"):
+    env = {**__import__("os").environ,
+           "AUTOPILOT_GATE_STATE_DIR": str(tmp_path)}
+    return subprocess.run([sys.executable, str(MODULE_PATH), *args],
+                          input=stdin, capture_output=True, text=True,
+                          env=env)
+
+
+def register(tmp_path: Path, plan: str = "/tmp/p/plan.md") -> None:
+    done = run_cli(tmp_path, "register", "--plan", plan,
+                   "--mission", "draft the backlog overnight")
+    assert done.returncode == 0, done.stderr
+
+
+def test_gate_passes_with_no_engagements(tmp_path: Path) -> None:
+    assert run_cli(tmp_path, "--gate").returncode == 0
+
+
+def test_gate_blocks_active_engagement_without_continuation(tmp_path) -> None:
+    """The overnight failure, encoded: active + unfinished + nothing
+    scheduled must refuse the stop."""
+    register(tmp_path)
+    done = run_cli(tmp_path, "--gate")
+    assert done.returncode == 2
+    assert "silent-idle" in done.stderr
+    assert "continuation" in done.stderr
+
+
+def test_gate_passes_once_continuation_recorded(tmp_path: Path) -> None:
+    register(tmp_path)
+    done = run_cli(tmp_path, "continuation", "--plan", "/tmp/p/plan.md",
+                   "--mechanism", "dynamic loop wakeup",
+                   "--next-wake", "20 minutes, plan file is the re-entry seed",
+                   "--survives", "turn end; not session kill (cron backstop set)")
+    assert done.returncode == 0, done.stderr
+    assert run_cli(tmp_path, "--gate").returncode == 0
+
+
+def test_gate_passes_with_alerted_blocker(tmp_path: Path) -> None:
+    register(tmp_path)
+    assert run_cli(tmp_path, "blocker", "--plan", "/tmp/p/plan.md",
+                   "--reason", "every path needs a principal-only answer",
+                   "--alerted").returncode == 0
+    assert run_cli(tmp_path, "--gate").returncode == 0
+
+
+def test_blocker_requires_alert_attestation(tmp_path: Path) -> None:
+    register(tmp_path)
+    done = run_cli(tmp_path, "blocker", "--plan", "/tmp/p/plan.md",
+                   "--reason", "stuck")
+    assert done.returncode == 2
+    assert "alert" in done.stderr
+
+
+def test_gate_passes_after_honest_close(tmp_path: Path) -> None:
+    register(tmp_path)
+    assert run_cli(tmp_path, "close", "--plan", "/tmp/p/plan.md",
+                   "--incomplete", "principal withdrew the goal").returncode == 0
+    assert run_cli(tmp_path, "--gate").returncode == 0
+
+
+def test_unreadable_record_fails_closed(tmp_path: Path) -> None:
+    (tmp_path / "broken.json").write_text("{not json", encoding="utf-8")
+    done = run_cli(tmp_path, "--gate")
+    assert done.returncode == 2
+    assert "unreadable" in done.stderr
+
+
+def test_bare_spin_cannot_be_recorded(tmp_path: Path) -> None:
+    """Runaway control: a wake that advanced nothing must name an external
+    wait; there is no way to log a bare spin."""
+    register(tmp_path)
+    done = run_cli(tmp_path, "cycle", "--plan", "/tmp/p/plan.md",
+                   "--no-advance")
+    assert done.returncode == 2
+    assert "spinning" in done.stderr
+    assert run_cli(tmp_path, "cycle", "--plan", "/tmp/p/plan.md",
+                   "--no-advance", "--waiting-on",
+                   "counterpart agent's review round").returncode == 0
+    assert run_cli(tmp_path, "cycle", "--plan", "/tmp/p/plan.md",
+                   "--advanced", "phase 2 drafted 4 articles").returncode == 0
+
+
+def test_doctrine_carries_continuation_contract() -> None:
+    skill = (MODULE_PATH.parents[1] / "SKILL.md").read_text(encoding="utf-8")
+    assert "Continuation" in skill
+    assert "Scheduled Property" in skill
+    assert "verified continuation mechanism" in skill
+    assert "autopilot_gate.py" in skill
+    assert "probe" in skill  # capability verification before asserting absence

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,23 +1,27 @@
-# AGENT HEURISTIC: authored for the 4.66.0 signature-channel-links release.
+# AGENT HEURISTIC: authored for the 4.68.0 autopilot-continuation release.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff, proved by the runner before release.py consumes
 # the receipt.
 schema: 2
-suite: synthesis-byte-faithful-send-path-release
+suite: synthesis-autopilot-continuation-release
 membership: closed
-production_entry_point: scripts/acceptance_suite.py run
-enforcing_boundary: release.py and repository CI before publication
+production_entry_point: skills/synthesis-autopilot/scripts/autopilot_gate.py --gate
+enforcing_boundary: plugin Stop hook on every session stop while an engagement is registered
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: rendering on each real platform is verified by a human reading the actual client (a Gmail draft is filed for that); per-channel capability facts (e.g. Google Chat user-send markup) are re-verified when a send path changes, per the doctrine itself
+unverified_remainder: the live Stop-hook path requires each client to load the new plugin hook (Codex hook trust is a human decision by design and will show one pending definition until the principal trusts it); which continuation mechanisms exist is a per-harness fact the doctrine requires probing at engagement rather than assuming
 changed_surfaces:
-  - path: skills/synthesis-agent-correspondence/SKILL.md
-    cases: [byte-faithful-send-path]
-  - path: skills/synthesis-agent-correspondence/scripts/test_signature_channels.py
-    cases: [byte-faithful-send-path]
+  - path: skills/synthesis-autopilot/SKILL.md
+    cases: [doctrine-carries-continuation-contract]
+  - path: skills/synthesis-autopilot/scripts/autopilot_gate.py
+    cases: [gate-blocks-silent-idle, gate-passes-with-continuation, gate-passes-with-alerted-blocker, gate-passes-after-honest-close, unreadable-record-fails-closed, bare-spin-unrecordable, blocker-requires-alert]
+  - path: skills/synthesis-autopilot/scripts/test_autopilot_gate.py
+    cases: [gate-blocks-silent-idle, gate-passes-with-continuation, gate-passes-with-alerted-blocker, gate-passes-after-honest-close, unreadable-record-fails-closed, bare-spin-unrecordable, blocker-requires-alert, doctrine-carries-continuation-contract]
+  - path: hooks/hooks.json
+    cases: [gate-blocks-silent-idle]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -29,10 +33,38 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: byte-faithful-send-path
+  - id: gate-blocks-silent-idle
+    control_class: enforced-gate
+    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_gate_blocks_active_engagement_without_continuation
+    motivating_defect: an-overnight-engagement-idled-all-night-because-nothing-caused-the-next-turn-and-nothing-noticed
+  - id: gate-passes-with-continuation
     control_class: acceptance-test
-    fixture: ../synthesis-agent-correspondence/scripts/test_signature_channels.py::test_send_path_byte_faithfulness_rule
-    motivating_defect: a-provider-composed-draft-path-rewrote-clean-hrefs-into-expiring-redirects-at-ingestion
+    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_gate_passes_once_continuation_recorded
+    motivating_defect: a-gate-that-cannot-pass-a-correctly-continued-run-teaches-agents-to-delete-its-state
+  - id: gate-passes-with-alerted-blocker
+    control_class: acceptance-test
+    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_gate_passes_with_alerted_blocker
+    motivating_defect: stopping-blocked-is-legitimate-exactly-when-the-principal-was-actually-told
+  - id: gate-passes-after-honest-close
+    control_class: acceptance-test
+    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_gate_passes_after_honest_close
+    motivating_defect: an-incomplete-close-with-a-reason-beats-an-abandonment-nobody-recorded
+  - id: unreadable-record-fails-closed
+    control_class: enforced-gate
+    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_unreadable_record_fails_closed
+    motivating_defect: an-unreadable-engagement-cannot-prove-it-was-continued
+  - id: bare-spin-unrecordable
+    control_class: enforced-gate
+    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_bare_spin_cannot_be_recorded
+    motivating_defect: the-principal-fears-loops-that-burn-usage-limits-without-value-so-a-no-progress-wake-must-name-its-external-wait
+  - id: blocker-requires-alert
+    control_class: enforced-gate
+    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_blocker_requires_alert_attestation
+    motivating_defect: a-blocker-nobody-was-told-about-is-the-silent-stop-restated
+  - id: doctrine-carries-continuation-contract
+    control_class: acceptance-test
+    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_doctrine_carries_continuation_contract
+    motivating_defect: a-contract-that-lives-only-in-code-gets-routed-around-by-the-next-session-that-never-reads-code
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates


### PR DESCRIPTION
Rajiv's directive via the publish-article-backlog session, motivated by the 2026-08-29 overnight run that idled all night after its first turn ended. synthesis-autopilot v2.0.0: (1) continuation is contract — a verified mechanism (background re-invocation, wakeup loops, scheduler re-entry, or declared principal-side relaunch) must exist before the first turn ends, with a survival table matching mechanism to horizon and a layered dead-man's switch for multi-day runs; (2) mechanical Stop-hook gate (autopilot_gate.py) refuses stops while an engagement is active, unfinished, and neither continued, blocked-with-alert, nor honestly closed; (3) runaway/budget control — plan-file Budget + Cycle-ledger sections, and a bare spin is mechanically unrecordable; (4) capability probe before asserting absence; (5) volatile-state sweep at every phase boundary; (6) adversary at scope time. 9 fixtures; source conformance 204/0; fresh manifest, acceptance consumed locally. Note: the new plugin Stop hook will show as one pending Codex hook-trust definition until Rajiv trusts it — human-controlled by design. This PR merges only on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)