### PR TITLE
Mechanically enforce persona-signature wire forms

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.68.0",
+  "version": "4.69.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.68.0",
+  "version": "4.69.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.69.0] - 2026-08-30
+
+**`synthesis-message-guard` engine v1.3.0 — signature wire forms become
+mechanical.** One day after the per-platform signature doctrine shipped, a
+persona-signed email to executives went out `body_format: plain` — composed
+from a compaction summary instead of the loaded skill — so the signature
+rendered as a bare visible URL and dropped its method link. Correct,
+freshly-updated, ABSOLUTE doctrine naming the exact tool and parameter did
+not bind, because nothing read it and nothing checked the result.
+
+- New optional `signature_link_enforcement` config: when an outgoing
+  message carries a persona marker, the gate refuses (1) persona-signed
+  email without `body_format: "html"`, (2) markdown link notation in email
+  bodies, and (3) any configured persona domain appearing as visible text
+  rather than inside a link construct (href, Slack mrkdwn, or markdown
+  notation) — with a configured exempt list for genuinely link-incapable
+  channels, where the visible form is the legitimate form.
+- Unsigned traffic is never taxed: the checks trigger only on marker
+  presence. Absent config = checks off; adopt deliberately.
+- The self-attested branding boolean in grounding ledgers now has a
+  mechanical backstop: the gate verifies the link form itself instead of
+  trusting the typed field.
+
 ## [4.68.0] - 2026-08-30
 
 **`synthesis-autopilot` v2.0.0 — unattended time is a scheduled property.**

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **A captured directive is not a routed one (August 2026).** Release
-**4.68.0** upgrades synthesis-autopilot for genuinely unattended runs: a verified continuation mechanism is now part of the delegation contract, enforced by a Stop-hook gate, with budget/runaway control and cycle ledgers. Previously: **4.67.0** adds the byte-faithful send-path rule (a provider-composed email path can rewrite your links; raw MIME stores your bytes). Previously: **4.66.0** makes persona signature links render as native hyperlinks per channel (HTML anchors in email, mrkdwn in Slack, plain fallback only where links are impossible). Previously: **4.65.0** makes the release gate verify installed bytes against source (version parity is not content parity), makes the currency audit refuse a zero scan, and adds dead-pattern and canonical-clean controls to the message-guard doctor. Previously: **4.64.0** teaches the context doctor to catch the failure that happens by
+**4.69.0** makes persona-signature wire forms mechanically enforced at the send gate (HTML-path email, no visible-URL fallback on link-capable channels). Previously: **4.68.0** upgrades synthesis-autopilot for genuinely unattended runs: a verified continuation mechanism is now part of the delegation contract, enforced by a Stop-hook gate, with budget/runaway control and cycle ledgers. Previously: **4.67.0** adds the byte-faithful send-path rule (a provider-composed email path can rewrite your links; raw MIME stores your bytes). Previously: **4.66.0** makes persona signature links render as native hyperlinks per channel (HTML anchors in email, mrkdwn in Slack, plain fallback only where links are impossible). Previously: **4.65.0** makes the release gate verify installed bytes against source (version parity is not content parity), makes the currency audit refuse a zero scan, and adds dead-pattern and canonical-clean controls to the message-guard doctor. Previously: **4.64.0** teaches the context doctor to catch the failure that happens by
 default: an intake artifact that records a directive, reads as handled, and
 was never routed to numbered work, declined, or superseded. Intake-class
 artifacts now need a CONTEXT reference or a terminal routing marker, or the
-doctor warns. See the [4.68.0 release notes](CHANGELOG.md).
+doctor warns. See the [4.69.0 release notes](CHANGELOG.md).
 
 **A reviewer that did not write the code, reviewing the code (August 2026).**
 Release **4.63.0** repairs what an external adversarial review of

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,27 +1,23 @@
-# AGENT HEURISTIC: authored for the 4.68.0 autopilot-continuation release.
+# AGENT HEURISTIC: authored for the 4.69.0 signature-wire-enforcement release.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff, proved by the runner before release.py consumes
 # the receipt.
 schema: 2
-suite: synthesis-autopilot-continuation-release
+suite: synthesis-signature-wire-enforcement-release
 membership: closed
-production_entry_point: skills/synthesis-autopilot/scripts/autopilot_gate.py --gate
-enforcing_boundary: plugin Stop hook on every session stop while an engagement is registered
+production_entry_point: skills/synthesis-message-guard/scripts/message_guard.py --gate
+enforcing_boundary: PreToolUse gate on every send/draft tool call
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the live Stop-hook path requires each client to load the new plugin hook (Codex hook trust is a human decision by design and will show one pending definition until the principal trusts it); which continuation mechanisms exist is a per-harness fact the doctrine requires probing at engagement rather than assuming
+unverified_remainder: enforcement activates only where the user's patterns.json adopts the signature_link_enforcement key (config is deliberately user-local); the incident session's own compose-from-compaction-summary habit is doctrine and cannot be mechanized here
 changed_surfaces:
-  - path: skills/synthesis-autopilot/SKILL.md
-    cases: [doctrine-carries-continuation-contract]
-  - path: skills/synthesis-autopilot/scripts/autopilot_gate.py
-    cases: [gate-blocks-silent-idle, gate-passes-with-continuation, gate-passes-with-alerted-blocker, gate-passes-after-honest-close, unreadable-record-fails-closed, bare-spin-unrecordable, blocker-requires-alert]
-  - path: skills/synthesis-autopilot/scripts/test_autopilot_gate.py
-    cases: [gate-blocks-silent-idle, gate-passes-with-continuation, gate-passes-with-alerted-blocker, gate-passes-after-honest-close, unreadable-record-fails-closed, bare-spin-unrecordable, blocker-requires-alert, doctrine-carries-continuation-contract]
-  - path: hooks/hooks.json
-    cases: [gate-blocks-silent-idle]
+  - path: skills/synthesis-message-guard/scripts/message_guard.py
+    cases: [incident-shape-blocks, html-anchors-pass, slack-mrkdwn-passes, markdown-in-email-blocks, linkless-fallback-exempt, unsigned-traffic-untaxed, absent-config-off]
+  - path: skills/synthesis-message-guard/scripts/test_message_guard.py
+    cases: [incident-shape-blocks, html-anchors-pass, slack-mrkdwn-passes, markdown-in-email-blocks, linkless-fallback-exempt, unsigned-traffic-untaxed, absent-config-off]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -33,38 +29,34 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: gate-blocks-silent-idle
+  - id: incident-shape-blocks
     control_class: enforced-gate
-    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_gate_blocks_active_engagement_without_continuation
-    motivating_defect: an-overnight-engagement-idled-all-night-because-nothing-caused-the-next-turn-and-nothing-noticed
-  - id: gate-passes-with-continuation
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_wire_incident_shape_blocks
+    motivating_defect: a-persona-signed-email-to-executives-went-out-plain-one-day-after-the-doctrine-named-the-exact-parameter
+  - id: html-anchors-pass
     control_class: acceptance-test
-    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_gate_passes_once_continuation_recorded
-    motivating_defect: a-gate-that-cannot-pass-a-correctly-continued-run-teaches-agents-to-delete-its-state
-  - id: gate-passes-with-alerted-blocker
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_wire_html_anchors_pass
+    motivating_defect: a-gate-that-blocks-the-canonical-form-teaches-operators-to-route-around-it
+  - id: slack-mrkdwn-passes
     control_class: acceptance-test
-    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_gate_passes_with_alerted_blocker
-    motivating_defect: stopping-blocked-is-legitimate-exactly-when-the-principal-was-actually-told
-  - id: gate-passes-after-honest-close
-    control_class: acceptance-test
-    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_gate_passes_after_honest_close
-    motivating_defect: an-incomplete-close-with-a-reason-beats-an-abandonment-nobody-recorded
-  - id: unreadable-record-fails-closed
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_wire_slack_mrkdwn_passes
+    motivating_defect: slack-wire-forms-are-correct-links-and-must-not-be-taxed
+  - id: markdown-in-email-blocks
     control_class: enforced-gate
-    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_unreadable_record_fails_closed
-    motivating_defect: an-unreadable-engagement-cannot-prove-it-was-continued
-  - id: bare-spin-unrecordable
-    control_class: enforced-gate
-    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_bare_spin_cannot_be_recorded
-    motivating_defect: the-principal-fears-loops-that-burn-usage-limits-without-value-so-a-no-progress-wake-must-name-its-external-wait
-  - id: blocker-requires-alert
-    control_class: enforced-gate
-    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_blocker_requires_alert_attestation
-    motivating_defect: a-blocker-nobody-was-told-about-is-the-silent-stop-restated
-  - id: doctrine-carries-continuation-contract
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_wire_markdown_in_email_blocks
+    motivating_defect: markdown-notation-never-renders-in-mail-clients
+  - id: linkless-fallback-exempt
     control_class: acceptance-test
-    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_doctrine_carries_continuation_contract
-    motivating_defect: a-contract-that-lives-only-in-code-gets-routed-around-by-the-next-session-that-never-reads-code
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_wire_linkless_fallback_tool_exempt
+    motivating_defect: the-visible-form-is-the-legitimate-form-exactly-where-links-cannot-render
+  - id: unsigned-traffic-untaxed
+    control_class: acceptance-test
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_wire_unsigned_traffic_untaxed
+    motivating_defect: a-domain-mentioned-in-prose-is-not-a-signature
+  - id: absent-config-off
+    control_class: acceptance-test
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_wire_absent_config_is_off
+    motivating_defect: enforcement-is-adopted-deliberately-per-config-never-sprung-on-unconfigured-users
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-message-guard/scripts/message_guard.py
+++ b/skills/synthesis-message-guard/scripts/message_guard.py
@@ -51,7 +51,7 @@ import tempfile
 import time
 from datetime import datetime, timezone
 
-ENGINE_VERSION = "1.1.0"
+ENGINE_VERSION = "1.3.0"
 
 
 def config_path():
@@ -127,6 +127,74 @@ def extract_text(tool_input, candidates):
         if isinstance(val, str) and val.strip():
             return key, val
     return None, None
+
+
+LINKED_CONSTRUCT_RX = None  # compiled lazily; strips forms that RENDER as links
+
+
+def _strip_linked_constructs(text):
+    """Remove every construct in which a URL legitimately rides: HTML href
+    attributes, Slack <url|label> / <url> mrkdwn, and markdown (url)
+    notation. What remains is VISIBLE text; a persona domain surviving the
+    strip is the visible-URL fallback form."""
+    import re as _re
+    global LINKED_CONSTRUCT_RX
+    if LINKED_CONSTRUCT_RX is None:
+        LINKED_CONSTRUCT_RX = _re.compile(
+            r'href\s*=\s*"[^"]*"'
+            r"|href\s*=\s*'[^']*'"
+            r"|<https?://[^>|\s]*(?:\|[^>]*)?>"
+            r"|\]\(https?://[^)]*\)"
+        )
+    return LINKED_CONSTRUCT_RX.sub(" ", text)
+
+
+def signature_wire_failures(tool_name, tool_input, text, cfg):
+    """Enforce the signature link-form rules (2026-08-30 incident: a
+    persona-signed email to executives went out body_format plain, so the
+    signature rendered as a bare visible URL and dropped its method link —
+    one day after the doctrine naming the exact tool and parameter shipped.
+    Correct doctrine did not bind because nothing read it; this does).
+
+    Configured via the OPTIONAL patterns.json key signature_link_enforcement:
+      { "markers": ["\\U0001F9DE", "\\U0001F916"],
+        "domains": ["ragenie.ai", "ragbot.ai"],
+        "html_body_format_tools": "send_gmail_message|draft_gmail_message",
+        "linkless_fallback_tools": "regex-of-tools-with-no-link-support" }
+    Checks run only when an outgoing message carries a persona marker, so
+    unsigned traffic is never taxed. Absent key = checks off (adopt
+    deliberately)."""
+    enforcement = cfg.get("signature_link_enforcement")
+    if not enforcement:
+        return []
+    markers = enforcement.get("markers", [])
+    if not any(m in text for m in markers):
+        return []
+    failures = []
+    import re as _re
+    html_tools = enforcement.get("html_body_format_tools")
+    if html_tools and _re.search(html_tools, tool_name):
+        if tool_input.get("body_format", "plain") != "html":
+            failures.append(
+                "persona-signed email MUST use body_format html — the "
+                "raw-MIME HTML path is the only permitted email form "
+                "(comms doctrine v4.3.1); the plain default renders the "
+                "signature as a bare URL")
+        if _re.search(r"\]\(https?://", text):
+            failures.append(
+                "markdown link notation never renders in email bodies; "
+                "convert to HTML anchors before staging")
+    fallback_tools = enforcement.get("linkless_fallback_tools")
+    if fallback_tools and _re.search(fallback_tools, tool_name):
+        return failures  # visible-URL form is the legitimate form here
+    stripped = _strip_linked_constructs(text)
+    exposed = [d for d in enforcement.get("domains", []) if d in stripped]
+    if exposed:
+        failures.append(
+            "persona signature uses the visible-URL fallback (%s appears "
+            "as text, not inside a link) on a link-capable channel — the "
+            "persona name must BE the hyperlink" % ", ".join(exposed))
+    return failures
 
 
 def check_header_hygiene(tool_input):
@@ -275,6 +343,13 @@ def run_gate():
                   "messages on the principal's behalf (see the writing-voice "
                   "skill). Rewrite the message; do not paraphrase the banned "
                   "phrase into a synonym of itself." % detail)
+
+        wire_fails = signature_wire_failures(tool_name, tool_input, text, cfg)
+        if wire_fails:
+            block("signature wire-form violation — " + " | ".join(wire_fails)
+                  + ". Load the comms skill and use its exact per-platform "
+                  "wire forms; the visible-URL form is only for channels "
+                  "that cannot render links.")
 
         header_fails = check_header_hygiene(tool_input)
         if header_fails:

--- a/skills/synthesis-message-guard/scripts/test_message_guard.py
+++ b/skills/synthesis-message-guard/scripts/test_message_guard.py
@@ -107,3 +107,81 @@ def test_config_clean_controls_scan() -> None:
     over_broad = [("bad-brand", re.compile("ragbot", re.IGNORECASE))]
     hits2, _ = MODULE.scan_text(canonical, over_broad, cwarn)
     assert hits2, "an over-broad pattern must be visible to the control"
+
+
+# --- signature wire-form enforcement (2026-08-30 incident) ------------------
+
+WIRE_CFG = {
+    "signature_link_enforcement": {
+        "markers": ["\U0001F9DE", "\U0001F916"],
+        "domains": ["ragenie.ai", "ragbot.ai", "synthesiswriting.org"],
+        "html_body_format_tools": "send_gmail_message|draft_gmail_message",
+        "linkless_fallback_tools": "workspace-mcp__send_message$",
+    }
+}
+
+RAGENIE_PLAIN = ("\U0001F9DE\u200d\u2642\ufe0f I wrote this with my Ragenie "
+                 "(ragenie.ai) \u2014 synthesis writing: I personally write")
+RAGENIE_HTML = ("\U0001F9DE\u200d\u2642\ufe0f <em>I wrote this with my "
+                "<a href=\"https://ragenie.ai/\">Ragenie</a> \u2014 "
+                "<a href=\"https://synthesiswriting.org/#from-a-message\">"
+                "synthesis writing</a>: I personally write</em>")
+RAGBOT_SLACK = ("\U0001F916 _I\u2019m Rajiv\u2019s "
+                "<https://ragbot.ai/|Ragbot>, sent under his standing "
+                "direction \u2014 he reads every reply_")
+
+
+def test_wire_incident_shape_blocks() -> None:
+    """The exact 2026-08-30 failure: persona-signed email, body_format
+    plain, bare visible domain — the doctrine existed and nothing read it."""
+    fails = MODULE.signature_wire_failures(
+        "mcp__workspace-mcp__send_gmail_message",
+        {"body_format": "plain"}, RAGENIE_PLAIN, WIRE_CFG)
+    joined = " ".join(fails)
+    assert "body_format html" in joined
+    assert "visible-URL fallback" in joined
+
+
+def test_wire_html_anchors_pass() -> None:
+    fails = MODULE.signature_wire_failures(
+        "mcp__workspace-mcp__send_gmail_message",
+        {"body_format": "html"}, RAGENIE_HTML, WIRE_CFG)
+    assert fails == []
+
+
+def test_wire_slack_mrkdwn_passes() -> None:
+    fails = MODULE.signature_wire_failures(
+        "mcp__abc__slack_send_message", {}, RAGBOT_SLACK, WIRE_CFG)
+    assert fails == []
+
+
+def test_wire_markdown_in_email_blocks() -> None:
+    text = ("\U0001F916 _I\u2019m Rajiv\u2019s "
+            "[Ragbot](https://ragbot.ai/) \u2014 he approved this_")
+    fails = MODULE.signature_wire_failures(
+        "mcp__workspace-mcp__draft_gmail_message",
+        {"body_format": "html"}, text, WIRE_CFG)
+    assert any("markdown" in f for f in fails)
+
+
+def test_wire_linkless_fallback_tool_exempt() -> None:
+    """Google Chat user sends cannot render links; the visible form is the
+    legitimate form there."""
+    fails = MODULE.signature_wire_failures(
+        "mcp__workspace-mcp__send_message", {},
+        "\U0001F916 I\u2019m Rajiv\u2019s Ragbot (ragbot.ai)", WIRE_CFG)
+    assert fails == []
+
+
+def test_wire_unsigned_traffic_untaxed() -> None:
+    fails = MODULE.signature_wire_failures(
+        "mcp__workspace-mcp__send_gmail_message", {"body_format": "plain"},
+        "Plain operational note mentioning ragbot.ai in prose.", WIRE_CFG)
+    assert fails == []
+
+
+def test_wire_absent_config_is_off() -> None:
+    fails = MODULE.signature_wire_failures(
+        "mcp__workspace-mcp__send_gmail_message", {"body_format": "plain"},
+        RAGENIE_PLAIN, {})
+    assert fails == []


### PR DESCRIPTION
One day after the per-platform signature doctrine shipped, a persona-signed email to executives went out body_format plain (composed from a compaction summary, skill unloaded) — the visible-URL fallback on a link-capable channel, method link dropped. Correct ABSOLUTE doctrine did not bind because nothing read it and nothing checked the result. message-guard engine v1.3.0 adds config-adopted signature_link_enforcement: marker-triggered checks refusing plain-body persona email, markdown in email bodies, and visible persona domains outside link constructs, with a linkless-channel exempt list. 7 new fixtures (12 total in suite); fresh manifest; acceptance consumed locally. Merges only on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)