### PR TITLE
Add stable, edge, and pinned plugin lifecycle

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.73.0",
+  "version": "4.74.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.73.0",
+  "version": "4.74.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.74.0] - 2026-09-01
+
+**`synthesis-onboarding` v1.3.0 — plugin upgrades now have a lifecycle instead
+of a floating default.** Stable is the default release-gated channel, edge is
+an explicit opt-in to `main`, and organization manifests can set an exact
+`version_pin` backed by an immutable release tag. The engine configures both
+native marketplaces to the selected Git ref and records the effective policy
+in its receipt.
+
+SessionStart now compares the executing plugin-cache manifest with the selected
+release target and surfaces an update or policy-mismatch notice. The onboarding
+doctor performs the same comparison, distinguishes behind from ahead, and
+returns unverifiable rather than green when it cannot establish current release
+state. Release discovery uses a bounded cache; stale evidence stays labeled.
+
+The gated publisher now advances `main`, `stable`, and `vX.Y.Z` from the exact
+acceptance-bound commit in one atomic push per remote. The one-command bootstrap
+follows stable by default and maps the explicit edge channel to `main`.
+
 ## [4.73.0] - 2026-08-31
 
 **`synthesis-context-lifecycle` doctor v1.8.1 — a cited directory of scripts is

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ without tool-owned workflow copies or date-field drift. See the
 ### One-command onboarding (new machines, non-engineers, whole ecosystem)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/synthesisengineering/synthesis-skills/main/onboard.sh | sh
+curl -fsSL https://raw.githubusercontent.com/synthesisengineering/synthesis-skills/stable/onboard.sh | sh
 ```
 
 The `synthesis-onboarding` engine converges your machine: plugin installed
@@ -536,7 +536,9 @@ into whichever of Claude Code / Codex is present, optional
 Close active Claude Code and Codex sessions before re-running the bootstrap;
 it explicitly updates versioned plugin caches, repairs the remaining setup,
 and never overwrites files you edited. Organizations layer their own knowledge bases and shared
-skills on the same engine with one declarative manifest (no installer code);
+skills on the same engine with one declarative manifest (no installer code).
+Stable is the default release channel, edge follows `main`, and organizations
+can pin an exact plugin version in the manifest;
 see `skills/synthesis-onboarding/references/org-manifest.md`.
 
 ### Native plugin for ChatGPT, Codex, and Claude Code

--- a/onboard.sh
+++ b/onboard.sh
@@ -3,7 +3,7 @@
 # synthesis ecosystem. Close active Claude Code and Codex sessions before a
 # re-run: the default update refreshes their versioned plugin caches.
 #
-#   curl -fsSL https://raw.githubusercontent.com/synthesisengineering/synthesis-skills/main/onboard.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/synthesisengineering/synthesis-skills/stable/onboard.sh | sh
 #   curl -fsSL .../onboard.sh | sh -s -- install --with-personal-workspace alice
 #
 # Running from a checkout uses that checkout as the source; otherwise the
@@ -13,6 +13,14 @@ set -eu
 
 PUBLIC_REPO="https://github.com/synthesisengineering/synthesis-skills.git"
 ENGINE_REL="skills/synthesis-onboarding/scripts/onboard.py"
+CHANNEL="${SYNTHESIS_ONBOARD_CHANNEL:-stable}"
+case "$CHANNEL" in
+  stable) SOURCE_REF="stable" ;;
+  edge) SOURCE_REF="main" ;;
+  *)
+    echo "SYNTHESIS_ONBOARD_CHANNEL must be stable or edge (got: $CHANNEL)."
+    exit 2 ;;
+esac
 
 if ! command -v git >/dev/null 2>&1; then
   echo "git is required and not found."
@@ -32,18 +40,19 @@ else
   SRC="${SYNTHESIS_ONBOARD_SOURCE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/synthesis-skills}"
   # -e, not -d: .git is a file in git worktrees
   if [ -e "$SRC/.git" ]; then
-    if ! git -C "$SRC" pull --ff-only; then
+    if ! git -C "$SRC" fetch origin "$SOURCE_REF" || \
+       ! git -C "$SRC" checkout --detach FETCH_HEAD; then
       if [ "${SYNTHESIS_ONBOARD_ALLOW_STALE:-}" = "1" ]; then
-        echo "warning: continuing with the cached copy at $SRC (allow-stale)"
+        echo "warning: continuing with the cached copy at $SRC; $CHANNEL could not be verified (allow-stale)"
       else
-        echo "Could not refresh $SRC — refusing to install from stale sources."
+        echo "Could not refresh $CHANNEL from $SRC — refusing to install from stale sources."
         echo "Fix network access and re-run, or set SYNTHESIS_ONBOARD_ALLOW_STALE=1."
         exit 1
       fi
     fi
   else
     mkdir -p "$(dirname "$SRC")"
-    git clone "$PUBLIC_REPO" "$SRC"
+    git clone --branch "$SOURCE_REF" --single-branch "$PUBLIC_REPO" "$SRC"
   fi
 fi
 

--- a/skills/synthesis-agent-conformance/scripts/session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/session_context.py
@@ -34,6 +34,13 @@ PROJECT_MANAGEMENT_SCRIPTS_DIR = (
 )
 if str(PROJECT_MANAGEMENT_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(PROJECT_MANAGEMENT_SCRIPTS_DIR))
+ONBOARDING_SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "synthesis-onboarding"
+    / "scripts"
+)
+if str(ONBOARDING_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(ONBOARDING_SCRIPTS_DIR))
 
 from project_context import extract, next_actions, record_freshness
 from active_project import load_and_validate
@@ -47,6 +54,7 @@ from live_receipt import (
     transcript_binds_session,
     validate_receipt_event_directory,
 )
+from plugin_currency import sessionstart_notice
 
 
 DEFAULT_POINTER = Path.home() / ".synthesis" / "active-project.json"
@@ -152,6 +160,17 @@ def plugin_identity() -> tuple[str | None, str]:
         if version:
             return str(version), str(root)
     return None, str(root)
+
+
+def append_currency_notice(message: str, payload: dict[str, object]) -> str:
+    """Prepend the lifecycle notice to genuine SessionStart output."""
+    if payload.get("hook_event_name") != "SessionStart":
+        return message
+    try:
+        notice = sessionstart_notice(plugin_identity()[1])
+    except Exception as exc:
+        notice = f"Synthesis plugin currency could not be verified: {exc}."
+    return notice + "\n" + message if notice else message
 
 
 def client_provenance(
@@ -468,6 +487,7 @@ def main() -> int:
     except Exception as exc:
         print(f"synthesis project context failed closed: {exc}", file=sys.stderr)
         return 2
+    message = append_currency_notice(message, payload)
     try:
         record_live_receipt(payload, args.live_receipt.expanduser())
     except Exception as exc:

--- a/skills/synthesis-agent-conformance/scripts/test_session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/test_session_context.py
@@ -70,6 +70,29 @@ def test_build_includes_active_coordination(tmp_path: Path) -> None:
     assert "verify claims before writes" in message
 
 
+def test_sessionstart_prepends_plugin_update_notice(monkeypatch) -> None:
+    monkeypatch.setattr(
+        MODULE,
+        "sessionstart_notice",
+        lambda root: "Synthesis update available: installed plugin 4.73.0; stable channel is 4.74.0.",
+    )
+
+    message = MODULE.append_currency_notice(
+        "Context integrity: OK.", {"hook_event_name": "SessionStart"}
+    )
+
+    assert message.startswith("Synthesis update available:")
+    assert message.endswith("Context integrity: OK.")
+
+
+def test_non_sessionstart_output_has_no_plugin_currency_probe(monkeypatch) -> None:
+    def fail(_root):
+        raise AssertionError("currency probe should not run")
+
+    monkeypatch.setattr(MODULE, "sessionstart_notice", fail)
+    assert MODULE.append_currency_notice("context", {}) == "context"
+
+
 def test_build_displays_compact_v3_session_identity(tmp_path: Path) -> None:
     board = tmp_path / "active-sessions.md"
     identity = identity_from_uuid(

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,25 +1,45 @@
-# AGENT HEURISTIC: authored for the 4.73.0 cited-script-directory release.
+# AGENT HEURISTIC: authored for the 4.74.0 onboarding-lifecycle release.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff, proved by the runner before release.py consumes
 # the receipt.
 schema: 2
-suite: synthesis-cited-script-directory-release
+suite: synthesis-onboarding-lifecycle-release
 membership: closed
-production_entry_point: skills/synthesis-context-lifecycle/scripts/context_doctor.py --json
-enforcing_boundary: the corpus health signal consumed at SessionStart and at day-start Step 1
+production_entry_point: skills/synthesis-onboarding/scripts/onboard.py update
+enforcing_boundary: SessionStart update notice, onboarding doctor currency result, and the acceptance-bound release publisher
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the check establishes that a cited target was preserved and nothing more — a directory holding files proves the scripts exist, never that they run, that they are the version the artifact described, or that they still do what the citation claims; the corpus instance that motivated this comes from a private corpus and cannot be reproduced in CI
+unverified_remainder: hermetic tests prove policy parsing, semantic comparison, bounded cache behavior, client command construction, doctor outcomes, SessionStart injection, and atomic Git ref publication; they do not make live marketplace mutations or prove remote network availability, while release.py deep verification remains the live installed-cache boundary after publication
 changed_surfaces:
-  - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
-    cases: [cited-directory-accepted, empty-directory-still-fails, missing-target-still-fails]
-  - path: skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
-    cases: [cited-directory-accepted, empty-directory-still-fails, missing-target-still-fails, v18-vocabulary-documented]
-  - path: skills/synthesis-context-lifecycle/SKILL.md
-    cases: [v18-vocabulary-documented]
+  - path: skills/synthesis-onboarding/scripts/plugin_currency.py
+    cases: [policy-ref-resolution, semantic-version-comparison, release-cache-evidence, sessionstart-cache-comparison]
+  - path: skills/synthesis-onboarding/scripts/test_plugin_currency.py
+    cases: [policy-ref-resolution, semantic-version-comparison, release-cache-evidence, sessionstart-cache-comparison]
+  - path: skills/synthesis-onboarding/scripts/onboard.py
+    cases: [manifest-policy-validation, marketplace-target-selection, doctor-plugin-currency]
+  - path: skills/synthesis-onboarding/scripts/test_onboard.py
+    cases: [manifest-policy-validation, marketplace-target-selection, doctor-plugin-currency, public-channel-docs]
+  - path: skills/synthesis-onboarding/SKILL.md
+    cases: [public-channel-docs]
+  - path: skills/synthesis-onboarding/references/org-manifest.md
+    cases: [public-channel-docs]
+  - path: onboard.sh
+    cases: [bootstrap-channel-selection, public-channel-docs]
+  - path: README.md
+    cases: [public-channel-docs, release-changelog-parity]
+  - path: skills/synthesis-agent-conformance/scripts/session_context.py
+    cases: [sessionstart-lifecycle-notice]
+  - path: skills/synthesis-agent-conformance/scripts/test_session_context.py
+    cases: [sessionstart-lifecycle-notice]
+  - path: skills/synthesis-skills-manager/scripts/release.py
+    cases: [atomic-channel-publication]
+  - path: skills/synthesis-skills-manager/scripts/test_release.py
+    cases: [atomic-channel-publication, release-manager-doc-contract]
+  - path: skills/synthesis-skills-manager/SKILL.md
+    cases: [release-manager-doc-contract]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -28,25 +48,55 @@ changed_surfaces:
     cases: [release-manifest-parity]
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
-  - path: README.md
-    cases: [release-changelog-parity]
 cases:
-  - id: cited-directory-accepted
+  - id: policy-ref-resolution
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::CitedScriptTargetTests::test_a_directory_of_scripts_is_a_valid_citation
-    motivating_defect: referencing-a-multi-file-tool-by-its-directory-is-the-ordinary-way-to-do-it-and-requiring-a-regular-file-reported-preserved-work-as-a-missing-target
-  - id: empty-directory-still-fails
+    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_stable_edge_and_pin_resolve_to_distinct_git_refs
+    motivating_defect: stable-edge-and-exact-pins-are-only-real-when-they-resolve-to-distinct-enforceable-git-targets
+  - id: semantic-version-comparison
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_version_comparison_is_semantic_not_lexical
+    motivating_defect: lexical-ordering-reports-4-10-as-older-than-4-9-and-inverts-the-update-notice
+  - id: release-cache-evidence
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_live_resolution_is_cached_and_stale_cache_remains_labeled
+    motivating_defect: a-sessionstart-network-check-without-bounded-cache-evidence-either-blocks-startup-or-turns-an-outage-into-an-uncited-current-claim
+  - id: sessionstart-cache-comparison
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_sessionstart_notice_compares_executing_cache_to_stable
+    motivating_defect: the-notice-must-compare-the-executing-cache-manifest-not-a-source-checkout-or-client-self-report
+  - id: manifest-policy-validation
     control_class: enforced-gate
-    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::CitedScriptTargetTests::test_an_empty_directory_is_still_a_missing_target
-    motivating_defect: accepting-any-directory-would-let-an-empty-folder-stand-in-for-the-executable-nobody-preserved-which-is-the-exact-failure-the-check-exists-to-catch
-  - id: missing-target-still-fails
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::ParserTests::test_manifest_rejects_unknown_channel_and_non_exact_pin
+    motivating_defect: accepting-an-unknown-channel-or-non-exact-pin-converts-org-policy-into-guesswork
+  - id: marketplace-target-selection
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::CitedScriptTargetTests::test_a_missing_target_still_fires
-    motivating_defect: widening-a-check-must-not-cost-the-case-it-was-written-for
-  - id: v18-vocabulary-documented
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_marketplace_add_targets_stable_edge_and_version_pin
+    motivating_defect: a-manifest-label-without-client-marketplace-ref-selection-is-not-channel-support
+  - id: doctor-plugin-currency
+    control_class: enforced-gate
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_doctor_reports_current_behind_and_unverifiable_currency
+    motivating_defect: doctor-must-not-collapse-behind-and-unverifiable-release-state-into-the-same-green-presence-check
+  - id: bootstrap-channel-selection
     control_class: acceptance-test
-    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SkillDocContractTests::test_the_v18_vocabulary_is_documented_by_name
-    motivating_defect: a-report-names-the-check-that-fired-so-a-name-absent-from-the-skill-hands-the-operator-a-string-instead-of-a-remedy
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_bootstrap_defaults_to_stable_and_maps_edge_to_main
+    motivating_defect: a-stable-engine-default-is-bypassed-if-the-public-bootstrap-still-clones-main
+  - id: public-channel-docs
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_public_docs_expose_stable_edge_and_org_pin_contract
+    motivating_defect: an-engine-capability-hidden-behind-the-old-main-bootstrap-or-an-undocumented-pin-field-cannot-be-used-correctly
+  - id: sessionstart-lifecycle-notice
+    control_class: acceptance-test
+    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_sessionstart_prepends_plugin_update_notice
+    motivating_defect: an-update-check-that-never-enters-the-real-sessionstart-envelope-is-dead-code-not-a-lifecycle-notice
+  - id: atomic-channel-publication
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_publish_atomically_creates_edge_stable_and_version_pin_refs
+    motivating_defect: publishing-main-stable-and-the-pin-separately-can-leave-users-on-three-different-releases-after-one-failed-push
+  - id: release-manager-doc-contract
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_release_manager_documents_channel_ref_contract
+    motivating_defect: maintainers-need-the-same-channel-boundary-the-publisher-enforces-or-a-later-release-can-regress-to-main-only
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.2.0"
+  version: "1.3.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -36,7 +36,7 @@ Three ideas carry the whole design:
 **Terminal (works with nothing pre-installed except macOS):**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/synthesisengineering/synthesis-skills/main/onboard.sh | sh
+curl -fsSL https://raw.githubusercontent.com/synthesisengineering/synthesis-skills/stable/onboard.sh | sh
 ```
 
 **Agent (when Claude Code or Codex already has this plugin):** ask the
@@ -53,7 +53,7 @@ manifest. See `references/org-manifest.md`.
 ## Commands
 
 ```bash
-onboard.py install [--manifest PATH] [--dry-run] [--json]
+onboard.py install [--manifest PATH] [--channel stable|edge] [--dry-run] [--json]
                    [--clients claude,codex] [--no-plugin-cli]
                    [--with-personal-workspace NAME]
 onboard.py update          # explicit native-plugin refresh + install convergence
@@ -71,7 +71,7 @@ engine could not establish ground truth (no git, invalid manifest).
 | Phase | Behavior |
 |-------|----------|
 | preflight | Verify git (guides through `xcode-select --install` if missing); detect clients via `SYNTHESIS_CLAUDE_BIN`/`SYNTHESIS_CODEX_BIN` → PATH → well-known locations (incl. the ChatGPT app's bundled codex). Absent clients are skipped, not fatal. |
-| ecosystem | `install` adds a missing native plugin and checks an existing one without replacing its live cache. `update` explicitly refreshes existing native plugins, verifies the resulting version when running from a source checkout, and states the client-restart and receipt-verification boundary. A first installation may use the repo's direct-copy fallback when a client lacks the plugin CLI; an installed native plugin is never replaced by duplicate copies. |
+| ecosystem | `install` adds a missing native plugin from the selected lifecycle target and checks an existing one without replacing its live cache. Stable is the default, edge is opt-in, and an org manifest's exact `version_pin` takes precedence over its channel. `update` explicitly refreshes or reconfigures existing native plugins, verifies the resulting version, and states the client-restart and receipt-verification boundary. A first installation may use the repo's direct-copy fallback when a client lacks the plugin CLI; an installed native plugin is never replaced by duplicate copies. |
 | org-skills | For each manifest `skills_repos` entry: SSH-first clone/refresh into the engine cache, then delegate to that repo's own installer with its source pinned to the fresh cache. A cache that cannot refresh stops the step (`SYNTHESIS_ONBOARD_ALLOW_STALE=1` overrides, loudly). |
 | knowledge-bases | Clone to `~/workspaces/<org-workspace>/<name>`, or **adopt** an existing clone found by matching remotes (never moved). Superseded remotes are repointed to the manifest primary (`git remote set-url`). Fast-forward pull when clean. When the repo ships `.githooks` and no global hooks engine is active, wire repo-local `core.hooksPath` so protective hooks run on fresh clones. Auth failures print the manifest's `auth_help` and mark the step "needs you" — the run continues and the re-run completes it. |
 | workspace | Generate `~/workspaces/<org-workspace>/AGENTS.md` (+ `CLAUDE.md` = `@AGENTS.md`): the welcome, what-you-can-ask list, KB contract pointers. |
@@ -87,6 +87,25 @@ current content matches its receipt is engine-owned and may be updated
 person edited is **never overwritten** — the engine warns and moves on.
 `uninstall` removes only receipt-owned files (archived first) and never
 touches knowledge-base clones or plugins.
+
+The receipt also stores the effective plugin policy. SessionStart reads that
+policy and the executing plugin-cache manifest, then compares it with a
+six-hour cached release-manifest check. It emits a notice when the installed
+cache is behind or mismatched and preserves an explicit unverifiable state
+when neither live nor cached release evidence is available. `doctor` applies
+the same comparison and exit-code contract.
+
+## Release channels
+
+- `stable` (default) follows the release-gated `stable` branch.
+- `edge` follows `main` and is opt-in through `--channel edge` or
+  `SYNTHESIS_ONBOARD_CHANNEL=edge`.
+- Organization manifests may set an exact `version_pin`; the engine resolves
+  it to the immutable `vX.Y.Z` release tag and the pin overrides the channel.
+
+The gated release publisher advances `main`, `stable`, and the version tag in
+one atomic push per remote. A pull request reaching `main` is available to
+edge; stable moves only when the release gate succeeds.
 
 ## Safe plugin upgrades
 
@@ -121,6 +140,7 @@ this scaffolds the container so day one needs no hand-wiring.
 | `SYNTHESIS_WORKSPACES_ROOT` | `~/workspaces` | Where workspaces and KBs live |
 | `SYNTHESIS_ONBOARD_CACHE_DIR` | XDG cache | Org repo caches |
 | `SYNTHESIS_ONBOARD_SOURCE_DIR` | this repo | synthesis-skills checkout to install from |
+| `SYNTHESIS_ONBOARD_CHANNEL` | `stable` | Engine/plugin channel (`stable` or opt-in `edge`) |
 | `SYNTHESIS_CLAUDE_BIN` / `SYNTHESIS_CODEX_BIN` | auto | Client binary override; set-but-empty means "treat as absent" |
 | `SYNTHESIS_ONBOARD_ALLOW_STALE` | unset | Accept an unrefreshable cache (loud) |
 | `SYNTHESIS_ONBOARD_NO_PLUGIN_CLI` | unset | Force file-copy fallback |

--- a/skills/synthesis-onboarding/references/org-manifest.md
+++ b/skills/synthesis-onboarding/references/org-manifest.md
@@ -20,6 +20,8 @@ org:
 ecosystem:
   plugin: true                 # install the public synthesis-skills plugin
   clients: [claude, codex]     # attempted only where the client is present
+  channel: stable              # stable (default) or edge
+  version_pin: "4.74.0"        # optional exact org pin; overrides channel
 
 skills_repos:                  # org shared skills (optional)
   - name: example-shared-skills
@@ -72,7 +74,7 @@ workspace_instructions: true   # generate ~/workspaces/<workspace>/AGENTS.md
 |-----|----------|---------|
 | `version` | yes | Manifest schema version; currently `1`. Unknown keys anywhere are hard errors — the engine fails closed rather than guessing. |
 | `org.id`, `org.workspace` | yes | Slug and workspace directory name. `org.name` optional display name. |
-| `ecosystem` | no | `plugin` (default true) and `clients` list. |
+| `ecosystem` | no | `plugin` (default true), `clients` list, `channel` (`stable` default or `edge`), and optional exact `version_pin` (`X.Y.Z`). A pin overrides the channel and resolves to the immutable `vX.Y.Z` release tag. |
 | `skills_repos[]` | no | `name` + `primary` required. `installer` is invoked as `sh <installer> install <installer_args...>` from the engine's cache clone; `source_env` names the env var your installer honors to skip its own network fetch; `status_args` enables `doctor` verification. |
 | `knowledge_bases[]` | no | `name` + `primary` required. `superseded_remotes` powers remote migrations (e.g., moving from a personal mirror to the canonical host). `local_hooks` wires `.githooks` on machines without a global hooks engine. |
 | `auth_help` | no | Printed verbatim when a repo is unreachable — write it for a non-engineer, with the exact clicks. |
@@ -95,11 +97,11 @@ if ! command -v git >/dev/null 2>&1; then
   echo "git is required. On macOS run:  xcode-select --install  (then re-run)"; exit 2
 fi
 if [ -e "$SRC/.git" ]; then
-  git -C "$SRC" pull --ff-only || {
+  git -C "$SRC" fetch origin stable && git -C "$SRC" checkout --detach FETCH_HEAD || {
     [ "${SYNTHESIS_ONBOARD_ALLOW_STALE:-}" = "1" ] || {
       echo "Could not refresh $SRC and refusing to run stale."; exit 1; }; }
 else
-  git clone https://github.com/synthesisengineering/synthesis-skills.git "$SRC"
+  git clone --branch stable --single-branch https://github.com/synthesisengineering/synthesis-skills.git "$SRC"
 fi
 CMD="install"
 case "${1:-}" in

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -32,7 +32,16 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-ENGINE_VERSION = "1.1.0"
+from plugin_currency import (
+    compare_versions,
+    normalize_policy,
+    policy_from_manifest,
+    policy_label,
+    policy_ref,
+    resolve_target_version,
+)
+
+ENGINE_VERSION = "1.3.0"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"
@@ -250,6 +259,7 @@ def parse_subset_yaml(text, source="manifest"):
 TOP_KEYS = {"version", "org", "ecosystem", "skills_repos", "knowledge_bases",
             "auth_help", "welcome", "migrations", "workspace_instructions"}
 ORG_KEYS = {"id", "name", "workspace"}
+ECOSYSTEM_KEYS = {"plugin", "clients", "channel", "version_pin"}
 SKILLS_REPO_KEYS = {"name", "primary", "fallbacks", "installer", "installer_args",
                     "source_env", "status_args"}
 KB_KEYS = {"name", "primary", "superseded_remotes", "local_hooks", "default_branch"}
@@ -270,6 +280,25 @@ def validate_manifest(data, path):
     org = data.get("org") or {}
     _require(isinstance(org, dict) and not set(org) - ORG_KEYS, "org block has unknown keys")
     _require(org.get("id") and org.get("workspace"), "org.id and org.workspace are required")
+    ecosystem = data.get("ecosystem") or {}
+    _require(
+        isinstance(ecosystem, dict) and not set(ecosystem) - ECOSYSTEM_KEYS,
+        "ecosystem block has unknown keys",
+    )
+    clients = ecosystem.get("clients", ["claude", "codex"])
+    _require(
+        isinstance(ecosystem.get("plugin", True), bool),
+        "ecosystem.plugin must be true or false",
+    )
+    _require(
+        isinstance(clients, list)
+        and all(client in ("claude", "codex") for client in clients),
+        "ecosystem.clients must be a list containing only claude and codex",
+    )
+    try:
+        normalize_policy(ecosystem.get("channel"), ecosystem.get("version_pin"))
+    except ValueError as exc:
+        raise ValueError("manifest: ecosystem.%s" % exc)
     for repo in data.get("skills_repos") or []:
         _require(isinstance(repo, dict) and not set(repo) - SKILLS_REPO_KEYS,
                  "skills_repos entry has unknown keys: %r" % repo)
@@ -300,6 +329,19 @@ def load_manifest(path):
     except ImportError:
         data = parse_subset_yaml(text, source=str(path))
     return validate_manifest(data, path)
+
+
+def effective_clients(cli_value, manifest):
+    if cli_value is not None:
+        clients = [client.strip() for client in cli_value.split(",") if client.strip()]
+    else:
+        clients = list(((manifest or {}).get("ecosystem") or {}).get(
+            "clients", ["claude", "codex"]
+        ))
+    unknown = set(clients) - {"claude", "codex"}
+    if unknown:
+        raise ValueError("clients must contain only claude and codex")
+    return clients
 
 
 # ---------------------------------------------------------------------------
@@ -459,16 +501,46 @@ def expected_source_plugin_version():
     return None
 
 
-def refresh_plugin(client, binary):
-    """Refresh an installed native plugin without replacing it with copies."""
+def expected_policy_version(policy):
+    """Resolve the exact desired version without accepting stale evidence."""
+    if policy.get("version_pin"):
+        return policy["version_pin"], "exact version pin"
+    source_version = expected_source_plugin_version()
+    if source_version:
+        return source_version, "selected source checkout"
+    version, detail = resolve_target_version(policy, ttl_seconds=0)
+    if "stale" in detail:
+        return None, detail
+    return version, detail
+
+
+def marketplace_add_command(client, binary, policy):
+    ref = policy_ref(policy)
     if client == "claude":
+        return [binary, "plugin", "marketplace", "add", "%s@%s" % (PUBLIC_MARKETPLACE_REF, ref)]
+    return [binary, "plugin", "marketplace", "add", PUBLIC_MARKETPLACE_REF, "--ref", ref, "--json"]
+
+
+def refresh_plugin(client, binary, policy, reconfigure=False):
+    """Refresh an installed native plugin on the selected release target."""
+    if reconfigure:
+        commands = [
+            [binary, "plugin", "marketplace", "remove", MARKETPLACE_NAME],
+            marketplace_add_command(client, binary, policy),
+        ]
+        verb = "install" if client == "claude" else "add"
+        commands.append(
+            [binary, "plugin", verb, "%s@%s" % (PLUGIN_NAME, MARKETPLACE_NAME)]
+        )
+    elif client == "claude":
         commands = [
             [binary, "plugin", "marketplace", "update", MARKETPLACE_NAME],
             [binary, "plugin", "update", "%s@%s" % (PLUGIN_NAME, MARKETPLACE_NAME)],
         ]
     else:
         commands = [
-            [binary, "plugin", "marketplace", "upgrade", MARKETPLACE_NAME, "--json"]
+            [binary, "plugin", "marketplace", "upgrade", MARKETPLACE_NAME, "--json"],
+            [binary, "plugin", "add", "%s@%s" % (PLUGIN_NAME, MARKETPLACE_NAME)],
         ]
     for command in commands:
         rc, out, err = run(command, timeout=300)
@@ -477,11 +549,19 @@ def refresh_plugin(client, binary):
     return True, "marketplace and installed plugin refreshed"
 
 
-def install_plugin(client, binary):
+def install_plugin(client, binary, policy):
     """Best-effort native plugin install. Returns (success, detail)."""
-    add_cmd = [binary, "plugin", "marketplace", "add", PUBLIC_MARKETPLACE_REF]
+    add_cmd = marketplace_add_command(client, binary, policy)
     rc, out, err = run(add_cmd, timeout=180)
-    if rc != 0 and "already" not in (out + err).lower():
+    if "already" in (out + err).lower():
+        remove = [binary, "plugin", "marketplace", "remove", MARKETPLACE_NAME]
+        remove_rc, remove_out, remove_err = run(remove, timeout=180)
+        if remove_rc != 0:
+            return False, "marketplace reconfiguration failed: %s" % (
+                remove_err.strip() or remove_out.strip()
+            )
+        rc, out, err = run(add_cmd, timeout=180)
+    if rc != 0:
         return False, "marketplace add failed: %s" % (err.strip() or out.strip())
     verb = "install" if client == "claude" else "add"
     rc, out, err = run([binary, "plugin", verb, "%s@%s" % (PLUGIN_NAME, MARKETPLACE_NAME)], timeout=300)
@@ -568,7 +648,12 @@ def phase_preflight(report, clients_wanted):
 
 
 def phase_ecosystem(
-    report, clients, dry_run, no_plugin_cli, refresh_native_plugins=False
+    report,
+    clients,
+    dry_run,
+    no_plugin_cli,
+    policy,
+    refresh_native_plugins=False,
 ):
     """Public synthesis-skills into each present client; fallback to install.sh."""
     need_fallback = False
@@ -584,7 +669,7 @@ def phase_ecosystem(
                     (PLUGIN_NAME, name, before_version or "unknown version"),
                 )
                 continue
-            expected = expected_source_plugin_version()
+            expected, expectation_detail = expected_policy_version(policy)
             if not refresh_native_plugins:
                 if expected and before_version != expected:
                     report.add(
@@ -609,7 +694,12 @@ def phase_ecosystem(
                     "would refresh %s plugin for %s" % (PLUGIN_NAME, name),
                 )
                 continue
-            success, detail = refresh_plugin(name, binary)
+            success, detail = refresh_plugin(
+                name,
+                binary,
+                policy,
+                reconfigure=True,
+            )
             if not success:
                 report.add(
                     "ecosystem", ERROR,
@@ -626,6 +716,14 @@ def phase_ecosystem(
                     "ecosystem", ERROR,
                     "%s plugin for %s is %s after refresh; expected %s" %
                     (PLUGIN_NAME, name, after_version, expected),
+                )
+            elif expected is None:
+                report.add(
+                    "ecosystem",
+                    ERROR,
+                    "%s plugin refreshed for %s at %s, but %s could not be verified" %
+                    (PLUGIN_NAME, name, after_version or "unknown", policy_label(policy)),
+                    hint=expectation_detail,
                 )
             elif after_version != before_version:
                 restart = "restart Claude Code" if name == "claude" else "restart Codex"
@@ -648,8 +746,25 @@ def phase_ecosystem(
         if dry_run:
             report.add("ecosystem", CHANGED, "would install %s plugin via %s CLI" % (PLUGIN_NAME, name))
             continue
-        success, detail = install_plugin(name, binary)
-        if success and plugin_enabled(name, binary):
+        success, detail = install_plugin(name, binary, policy)
+        after_state, after_version = plugin_record(name, binary)
+        expected, expectation_detail = expected_policy_version(policy)
+        if success and after_state is True and expected and after_version != expected:
+            report.add(
+                "ecosystem",
+                ERROR,
+                "%s installed for %s at %s; %s resolves to %s" %
+                (PLUGIN_NAME, name, after_version or "unknown", policy_label(policy), expected),
+            )
+        elif success and after_state is True and expected is None:
+            report.add(
+                "ecosystem",
+                ERROR,
+                "%s installed for %s at %s, but %s could not be verified" %
+                (PLUGIN_NAME, name, after_version or "unknown", policy_label(policy)),
+                hint=expectation_detail,
+            )
+        elif success and after_state is True:
             restart = "restart Claude Code" if name == "claude" else "restart Codex"
             report.add(
                 "ecosystem", CHANGED,
@@ -991,23 +1106,78 @@ def init_workspace(report, receipts, workspace, dry_run, remote=None):
 # doctor
 # ---------------------------------------------------------------------------
 
-def doctor(report, manifest, clients_wanted):
+def doctor(report, manifest, clients_wanted, policy):
     rc, _, _ = run(["git", "--version"], timeout=15)
     if rc != 0:
         report.add("doctor", ERROR, "git unavailable — cannot verify anything else")
         return 2
     verified_any = False
+    currency_unverifiable = False
+    target_checked = False
+    target_version = None
+    target_detail = "not checked"
     for name in clients_wanted:
         binary = resolve_client(name)
         if not binary:
             report.add("doctor", SKIP, "%s not installed" % name)
             continue
-        state = plugin_enabled(name, binary)
+        state, installed_version = plugin_record(name, binary)
         fallback = (HOME / (".claude" if name == "claude" else ".agents") / "skills")
         copies = sorted(p.name for p in fallback.glob("synthesis-*")) if fallback.exists() else []
         if state is True:
             verified_any = True
-            report.add("doctor", OK, "%s: %s plugin enabled" % (name, PLUGIN_NAME))
+            if not target_checked:
+                target_version, target_detail = resolve_target_version(
+                    policy, ttl_seconds=0
+                )
+                target_checked = True
+            if target_version is None:
+                currency_unverifiable = True
+                report.add(
+                    "doctor",
+                    WARN,
+                    "%s: %s plugin enabled at %s; %s is unverifiable" %
+                    (name, PLUGIN_NAME, installed_version or "unknown", policy_label(policy)),
+                    hint=target_detail,
+                )
+            elif "stale" in target_detail:
+                currency_unverifiable = True
+                report.add(
+                    "doctor",
+                    WARN,
+                    "%s: %s plugin %s; %s could not be confirmed live" %
+                    (name, PLUGIN_NAME, installed_version or "unknown", policy_label(policy)),
+                    hint=target_detail,
+                )
+            else:
+                currency = compare_versions(installed_version, target_version)
+                if currency == "current":
+                    report.add(
+                        "doctor",
+                        OK,
+                        "%s: %s plugin %s matches %s (%s)" %
+                        (name, PLUGIN_NAME, installed_version, policy_label(policy), target_detail),
+                    )
+                elif currency in ("behind", "ahead"):
+                    report.add(
+                        "doctor",
+                        ACTION,
+                        "%s: %s plugin %s is %s; %s resolves to %s" %
+                        (name, PLUGIN_NAME, installed_version, currency,
+                         policy_label(policy), target_version),
+                        hint=(
+                            "Close other Claude Code and Codex sessions, then run "
+                            "onboard.py update as the invoking session's last action."
+                        ),
+                    )
+                else:
+                    currency_unverifiable = True
+                    report.add(
+                        "doctor",
+                        WARN,
+                        "%s: %s plugin version is unreadable; %s resolves to %s" %
+                        (name, PLUGIN_NAME, policy_label(policy), target_version),
+                    )
         elif copies:
             verified_any = True
             report.add("doctor", OK, "%s: %d fallback skill copies present" % (name, len(copies)))
@@ -1055,6 +1225,10 @@ def doctor(report, manifest, clients_wanted):
     counts = report.counts()
     if counts.get(ERROR):
         return 1
+    if counts.get(ACTION):
+        return 1
+    if currency_unverifiable:
+        return 2
     if not verified_any and not manifest:
         return 2
     return 0
@@ -1101,8 +1275,14 @@ def build_parser():
     parser.add_argument("command", nargs="?", default="install",
                         choices=["install", "update", "doctor", "init-workspace", "uninstall"])
     parser.add_argument("--manifest", type=Path, help="org onboarding manifest (.agents/onboarding.yaml)")
-    parser.add_argument("--clients", default="claude,codex",
-                        help="comma-separated clients to target (default: claude,codex)")
+    parser.add_argument("--clients",
+                        help="comma-separated clients to target (default: manifest or claude,codex)")
+    parser.add_argument(
+        "--channel",
+        choices=["stable", "edge"],
+        default=os.environ.get("SYNTHESIS_ONBOARD_CHANNEL"),
+        help="public plugin channel (default: stable; org version_pin takes precedence)",
+    )
     parser.add_argument("--workspace", help="workspace name for init-workspace")
     parser.add_argument("--remote", help="optional git remote URL for init-workspace")
     parser.add_argument("--with-personal-workspace", metavar="NAME",
@@ -1117,7 +1297,6 @@ def build_parser():
 def main(argv=None):
     args = build_parser().parse_args(argv)
     report = Report(dry_run=args.dry_run, as_json=args.json)
-    clients_wanted = [c.strip() for c in args.clients.split(",") if c.strip()]
     manifest = None
     if args.manifest:
         try:
@@ -1126,8 +1305,18 @@ def main(argv=None):
             report.add("manifest", ERROR, str(exc))
             return finish(report, args, 2)
 
+    try:
+        policy = policy_from_manifest(manifest, channel_override=args.channel)
+        clients_wanted = effective_clients(args.clients, manifest)
+    except ValueError as exc:
+        report.add("manifest", ERROR, str(exc))
+        return finish(report, args, 2)
+    plugin_requested = ((manifest or {}).get("ecosystem") or {}).get("plugin", True)
+
     if args.command == "doctor":
-        code = doctor(report, manifest, clients_wanted)
+        code = doctor(
+            report, manifest, clients_wanted if plugin_requested else [], policy
+        )
         return finish(report, args, code)
 
     if args.command == "init-workspace":
@@ -1147,16 +1336,20 @@ def main(argv=None):
     # install / update
     receipts = Receipts()
     no_plugin_cli = args.no_plugin_cli or os.environ.get("SYNTHESIS_ONBOARD_NO_PLUGIN_CLI") == "1"
-    clients = phase_preflight(report, clients_wanted)
+    clients = phase_preflight(report, clients_wanted if plugin_requested else [])
     if clients is None:
         return finish(report, args, 2)
-    phase_ecosystem(
-        report,
-        clients,
-        args.dry_run,
-        no_plugin_cli,
-        refresh_native_plugins=args.command == "update",
-    )
+    if plugin_requested:
+        phase_ecosystem(
+            report,
+            clients,
+            args.dry_run,
+            no_plugin_cli,
+            policy,
+            refresh_native_plugins=args.command == "update",
+        )
+    else:
+        report.add("ecosystem", SKIP, "public plugin disabled by manifest")
     if manifest:
         phase_org_skills(report, manifest, args.dry_run)
         phase_kbs(report, manifest, receipts, args.dry_run)
@@ -1165,6 +1358,7 @@ def main(argv=None):
     if args.with_personal_workspace:
         init_workspace(report, receipts, args.with_personal_workspace, args.dry_run)
     if not args.dry_run:
+        receipts.data["plugin_policy"] = policy
         receipts.data.setdefault("runs", []).append(
             {"at": utcnow(), "command": args.command, "manifest": str(args.manifest) if args.manifest else None,
              "engine": ENGINE_VERSION})

--- a/skills/synthesis-onboarding/scripts/plugin_currency.py
+++ b/skills/synthesis-onboarding/scripts/plugin_currency.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Release-channel and installed-plugin currency helpers.
+
+The public repository exposes three lifecycle targets:
+
+* ``stable`` branch — default, release-gated channel;
+* ``main`` branch — opt-in edge channel;
+* ``vX.Y.Z`` tags — immutable organization pins.
+
+SessionStart and the onboarding doctor share this module so they cannot drift
+on policy parsing, target discovery, or version comparison. Network discovery
+is cached. An unavailable target remains explicitly unverifiable; it is never
+silently treated as current.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+CHANNEL_REFS = {"stable": "stable", "edge": "main"}
+DEFAULT_CHANNEL = "stable"
+DEFAULT_TTL_SECONDS = 6 * 60 * 60
+RAW_MANIFEST_TEMPLATE = (
+    "https://raw.githubusercontent.com/synthesisengineering/"
+    "synthesis-skills/{ref}/.codex-plugin/plugin.json"
+)
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+def normalize_policy(channel=None, version_pin=None):
+    """Return a validated policy dictionary."""
+    channel = channel or DEFAULT_CHANNEL
+    if channel not in CHANNEL_REFS:
+        raise ValueError("release channel must be stable or edge")
+    if version_pin is not None:
+        version_pin = str(version_pin).strip()
+        if not VERSION_RE.fullmatch(version_pin):
+            raise ValueError("version_pin must be an exact X.Y.Z version")
+    return {"channel": channel, "version_pin": version_pin}
+
+
+def policy_from_manifest(manifest, channel_override=None):
+    ecosystem = (manifest or {}).get("ecosystem") or {}
+    return normalize_policy(
+        channel_override or ecosystem.get("channel"),
+        ecosystem.get("version_pin"),
+    )
+
+
+def policy_ref(policy):
+    normalized = normalize_policy(
+        policy.get("channel"), policy.get("version_pin")
+    )
+    if normalized["version_pin"]:
+        return "v%s" % normalized["version_pin"]
+    return CHANNEL_REFS[normalized["channel"]]
+
+
+def policy_label(policy):
+    normalized = normalize_policy(
+        policy.get("channel"), policy.get("version_pin")
+    )
+    if normalized["version_pin"]:
+        return "pinned release %s" % normalized["version_pin"]
+    return "%s channel" % normalized["channel"]
+
+
+def version_tuple(version):
+    if not isinstance(version, str) or not VERSION_RE.fullmatch(version):
+        return None
+    return tuple(int(part) for part in version.split("."))
+
+
+def compare_versions(installed, target):
+    """Return behind/current/ahead, or unverifiable for invalid versions."""
+    installed_parts = version_tuple(installed)
+    target_parts = version_tuple(target)
+    if installed_parts is None or target_parts is None:
+        return "unverifiable"
+    if installed_parts < target_parts:
+        return "behind"
+    if installed_parts > target_parts:
+        return "ahead"
+    return "current"
+
+
+def default_cache_path():
+    state_dir = Path(
+        os.environ.get(
+            "SYNTHESIS_ONBOARD_STATE_DIR",
+            str(Path.home() / ".synthesis" / "onboarding"),
+        )
+    )
+    return state_dir / "plugin-currency.json"
+
+
+def _read_cache(path):
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"version": 1, "targets": {}}
+    if not isinstance(data, dict) or not isinstance(data.get("targets"), dict):
+        return {"version": 1, "targets": {}}
+    return data
+
+
+def _write_cache(path, data):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=path.name + ".",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_name = temporary.name
+            temporary.write(json.dumps(data, indent=2, sort_keys=True) + "\n")
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_name, path)
+    finally:
+        if temporary_name and os.path.exists(temporary_name):
+            os.unlink(temporary_name)
+
+
+def resolve_target_version(
+    policy,
+    cache_path=None,
+    ttl_seconds=DEFAULT_TTL_SECONDS,
+    timeout=2,
+    opener=urllib.request.urlopen,
+    now=None,
+):
+    """Resolve the desired plugin version, using fresh or stale cache evidence.
+
+    Returns ``(version, detail)``. A stale cached version is usable evidence and
+    is labeled as such. With neither live nor cached evidence, version is None.
+    """
+    ref = policy_ref(policy)
+    cache_path = Path(cache_path or default_cache_path())
+    cache = _read_cache(cache_path)
+    cached = cache["targets"].get(ref) or {}
+    now = time.time() if now is None else now
+    cached_version = cached.get("version")
+    checked_at = cached.get("checked_at")
+    if (
+        version_tuple(cached_version) is not None
+        and isinstance(checked_at, (int, float))
+        and 0 <= now - checked_at <= ttl_seconds
+    ):
+        return cached_version, "cached %s ref (fresh)" % ref
+
+    url = RAW_MANIFEST_TEMPLATE.format(ref=ref)
+    try:
+        response = opener(url, timeout=timeout)
+        try:
+            payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            close = getattr(response, "close", None)
+            if close:
+                close()
+        version = str(payload.get("version") or "")
+        if version_tuple(version) is None:
+            raise ValueError("release manifest has no exact X.Y.Z version")
+        cache["targets"][ref] = {"version": version, "checked_at": now}
+        try:
+            _write_cache(cache_path, cache)
+        except OSError:
+            pass
+        return version, "live %s ref" % ref
+    except (OSError, UnicodeError, ValueError, urllib.error.URLError) as exc:
+        if version_tuple(cached_version) is not None:
+            return cached_version, "cached %s ref (stale; live check failed)" % ref
+        return None, "%s ref unavailable: %s" % (ref, str(exc))
+
+
+def read_persisted_policy(receipts_path=None):
+    path = Path(
+        receipts_path
+        or os.environ.get(
+            "SYNTHESIS_ONBOARD_RECEIPTS",
+            str(
+                Path(
+                    os.environ.get(
+                        "SYNTHESIS_ONBOARD_STATE_DIR",
+                        str(Path.home() / ".synthesis" / "onboarding"),
+                    )
+                )
+                / "receipts.json"
+            ),
+        )
+    )
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        policy = data.get("plugin_policy") or {}
+        return normalize_policy(policy.get("channel"), policy.get("version_pin"))
+    except (OSError, ValueError, AttributeError):
+        return normalize_policy()
+
+
+def installed_version_from_root(plugin_root):
+    versions = []
+    root = Path(plugin_root)
+    for relative in (".claude-plugin/plugin.json", ".codex-plugin/plugin.json"):
+        try:
+            payload = json.loads((root / relative).read_text(encoding="utf-8"))
+            version = str(payload.get("version") or "")
+            if version_tuple(version) is not None:
+                versions.append(version)
+        except (OSError, ValueError, AttributeError):
+            continue
+    return versions[0] if versions and len(set(versions)) == 1 else None
+
+
+def sessionstart_notice(plugin_root, receipts_path=None, resolver=resolve_target_version):
+    """Return a truthful one-line lifecycle notice for an executing cache."""
+    installed = installed_version_from_root(plugin_root)
+    if installed is None:
+        return ""
+    policy = read_persisted_policy(receipts_path)
+    target, detail = resolver(policy)
+    label = policy_label(policy)
+    if target is None:
+        return (
+            "Synthesis plugin currency: installed %s; %s could not be verified (%s)."
+            % (installed, label, detail)
+        )
+    status = compare_versions(installed, target)
+    if status == "current":
+        return ""
+    if status == "behind":
+        return (
+            "Synthesis update available: installed plugin %s; %s is %s. "
+            "Run the synthesis-onboarding update flow as this session's last action."
+            % (installed, label, target)
+        )
+    return (
+        "Synthesis plugin policy mismatch: installed %s; %s resolves to %s. "
+        "Run the synthesis-onboarding update flow as this session's last action."
+        % (installed, label, target)
+    )

--- a/skills/synthesis-onboarding/scripts/test_onboard.py
+++ b/skills/synthesis-onboarding/scripts/test_onboard.py
@@ -213,8 +213,65 @@ class ParserTests(unittest.TestCase):
             onboard.validate_manifest(
                 {"version": 1, "org": {"id": "x", "workspace": "x"}, "bogus": 1}, "t")
 
+    def test_manifest_accepts_release_channel_and_exact_org_pin(self):
+        data = onboard.validate_manifest(
+            {
+                "version": 1,
+                "org": {"id": "x", "workspace": "x"},
+                "ecosystem": {
+                    "plugin": True,
+                    "clients": ["claude", "codex"],
+                    "channel": "stable",
+                    "version_pin": "4.74.0",
+                },
+            },
+            "t",
+        )
+        self.assertEqual(data["ecosystem"]["version_pin"], "4.74.0")
+
+    def test_manifest_rejects_unknown_channel_and_non_exact_pin(self):
+        for ecosystem in (
+            {"channel": "preview"},
+            {"channel": "stable", "version_pin": "4.74"},
+        ):
+            with self.assertRaises(ValueError):
+                onboard.validate_manifest(
+                    {
+                        "version": 1,
+                        "org": {"id": "x", "workspace": "x"},
+                        "ecosystem": ecosystem,
+                    },
+                    "t",
+                )
+
+    def test_manifest_clients_and_plugin_switch_are_enforced(self):
+        manifest = onboard.validate_manifest(
+            {
+                "version": 1,
+                "org": {"id": "x", "workspace": "x"},
+                "ecosystem": {"plugin": False, "clients": ["codex"]},
+            },
+            "t",
+        )
+        self.assertEqual(onboard.effective_clients(None, manifest), ["codex"])
+        self.assertEqual(
+            onboard.effective_clients("claude,codex", manifest),
+            ["claude", "codex"],
+        )
+        with self.assertRaises(ValueError):
+            onboard.validate_manifest(
+                {
+                    "version": 1,
+                    "org": {"id": "x", "workspace": "x"},
+                    "ecosystem": {"plugin": "yes"},
+                },
+                "t",
+            )
+
 
 class PluginTests(unittest.TestCase):
+    policy = {"channel": "stable", "version_pin": None}
+
     def test_plugin_record_reads_codex_and_claude_versions(self):
         codex = {"installed": [{
             "pluginId": "synthesis-skills@synthesis-engineering",
@@ -234,13 +291,17 @@ class PluginTests(unittest.TestCase):
 
     def test_refresh_plugin_uses_each_clients_native_update_contract(self):
         with patch.object(onboard, "run", return_value=(0, "", "")) as runner:
-            self.assertTrue(onboard.refresh_plugin("codex", "codex")[0])
+            self.assertTrue(onboard.refresh_plugin("codex", "codex", self.policy)[0])
             self.assertEqual(
                 runner.call_args_list[0].args[0],
                 ["codex", "plugin", "marketplace", "upgrade", "synthesis-engineering", "--json"],
             )
+            self.assertEqual(
+                runner.call_args_list[1].args[0],
+                ["codex", "plugin", "add", "synthesis-skills@synthesis-engineering"],
+            )
         with patch.object(onboard, "run", return_value=(0, "", "")) as runner:
-            self.assertTrue(onboard.refresh_plugin("claude", "claude")[0])
+            self.assertTrue(onboard.refresh_plugin("claude", "claude", self.policy)[0])
             self.assertEqual(runner.call_count, 2)
             self.assertEqual(
                 runner.call_args_list[1].args[0],
@@ -257,6 +318,7 @@ class PluginTests(unittest.TestCase):
                 {"codex": "codex"},
                 dry_run=False,
                 no_plugin_cli=False,
+                policy=self.policy,
                 refresh_native_plugins=False,
             )
         refresh.assert_not_called()
@@ -272,6 +334,8 @@ class PluginTests(unittest.TestCase):
         ), patch.object(
             onboard, "expected_source_plugin_version", return_value=None
         ), patch.object(
+            onboard, "resolve_target_version", return_value=("4.24.0", "fixture")
+        ), patch.object(
             onboard, "refresh_plugin", return_value=(True, "refreshed")
         ) as refresh:
             onboard.phase_ecosystem(
@@ -279,9 +343,12 @@ class PluginTests(unittest.TestCase):
                 {"codex": "codex"},
                 dry_run=False,
                 no_plugin_cli=False,
+                policy=self.policy,
                 refresh_native_plugins=True,
             )
-        refresh.assert_called_once_with("codex", "codex")
+        refresh.assert_called_once_with(
+            "codex", "codex", self.policy, reconfigure=True
+        )
         self.assertEqual(report.steps[0]["status"], onboard.CHANGED)
         self.assertIn("4.23.0 -> 4.24.0", report.steps[0]["detail"])
 
@@ -299,6 +366,106 @@ class PluginTests(unittest.TestCase):
 
             with patch.object(onboard, "source_root", return_value=cache):
                 self.assertIsNone(onboard.expected_source_plugin_version())
+
+    def test_marketplace_add_targets_stable_edge_and_version_pin(self):
+        self.assertEqual(
+            onboard.marketplace_add_command("claude", "claude", self.policy),
+            [
+                "claude", "plugin", "marketplace", "add",
+                "synthesisengineering/synthesis-skills@stable",
+            ],
+        )
+        self.assertEqual(
+            onboard.marketplace_add_command(
+                "codex", "codex", {"channel": "edge", "version_pin": None}
+            ),
+            [
+                "codex", "plugin", "marketplace", "add",
+                "synthesisengineering/synthesis-skills", "--ref", "main", "--json",
+            ],
+        )
+        self.assertIn(
+            "synthesisengineering/synthesis-skills@v4.74.0",
+            onboard.marketplace_add_command(
+                "claude",
+                "claude",
+                {"channel": "stable", "version_pin": "4.74.0"},
+            ),
+        )
+
+    def test_existing_marketplace_is_reconfigured_before_fresh_install(self):
+        calls = [
+            (1, "", "already configured"),
+            (0, "", ""),
+            (0, "", ""),
+            (0, "", ""),
+        ]
+        with patch.object(onboard, "run", side_effect=calls) as runner:
+            success, _ = onboard.install_plugin("codex", "codex", self.policy)
+        self.assertTrue(success)
+        self.assertEqual(
+            runner.call_args_list[1].args[0],
+            ["codex", "plugin", "marketplace", "remove", "synthesis-engineering"],
+        )
+        self.assertIn("--ref", runner.call_args_list[2].args[0])
+
+    def test_exact_pin_is_the_version_expectation_even_from_newer_source(self):
+        policy = {"channel": "stable", "version_pin": "4.73.0"}
+        with patch.object(
+            onboard, "expected_source_plugin_version", return_value="4.74.0"
+        ), patch.object(onboard, "resolve_target_version") as resolver:
+            self.assertEqual(
+                onboard.expected_policy_version(policy),
+                ("4.73.0", "exact version pin"),
+            )
+        resolver.assert_not_called()
+
+    def test_bootstrap_defaults_to_stable_and_maps_edge_to_main(self):
+        bootstrap = (REPO_ROOT / "onboard.sh").read_text(encoding="utf-8")
+        self.assertIn('CHANNEL="${SYNTHESIS_ONBOARD_CHANNEL:-stable}"', bootstrap)
+        self.assertIn('stable) SOURCE_REF="stable"', bootstrap)
+        self.assertIn('edge) SOURCE_REF="main"', bootstrap)
+        self.assertIn('git clone --branch "$SOURCE_REF" --single-branch', bootstrap)
+
+    def test_public_docs_expose_stable_edge_and_org_pin_contract(self):
+        skill = (REPO_ROOT / "skills/synthesis-onboarding/SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        manifest = (
+            REPO_ROOT / "skills/synthesis-onboarding/references/org-manifest.md"
+        ).read_text(encoding="utf-8")
+        readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+        for text in (skill, manifest, readme):
+            self.assertIn("stable", text)
+            self.assertIn("edge", text)
+        self.assertIn("version_pin", manifest)
+        self.assertIn("/stable/onboard.sh", skill)
+        self.assertIn("/stable/onboard.sh", readme)
+
+    def test_doctor_reports_current_behind_and_unverifiable_currency(self):
+        with patch.object(onboard, "run", return_value=(0, "", "")), \
+             patch.object(onboard, "resolve_client", return_value="codex"), \
+             patch.object(onboard, "plugin_record", return_value=(True, "4.74.0")), \
+             patch.object(onboard, "resolve_target_version", return_value=("4.74.0", "fixture")):
+            report = onboard.Report(as_json=True)
+            self.assertEqual(onboard.doctor(report, None, ["codex"], self.policy), 0)
+            self.assertEqual(report.steps[-1]["status"], onboard.OK)
+
+        with patch.object(onboard, "run", return_value=(0, "", "")), \
+             patch.object(onboard, "resolve_client", return_value="codex"), \
+             patch.object(onboard, "plugin_record", return_value=(True, "4.73.0")), \
+             patch.object(onboard, "resolve_target_version", return_value=("4.74.0", "fixture")):
+            report = onboard.Report(as_json=True)
+            self.assertEqual(onboard.doctor(report, None, ["codex"], self.policy), 1)
+            self.assertEqual(report.steps[-1]["status"], onboard.ACTION)
+
+        with patch.object(onboard, "run", return_value=(0, "", "")), \
+             patch.object(onboard, "resolve_client", return_value="codex"), \
+             patch.object(onboard, "plugin_record", return_value=(True, "4.74.0")), \
+             patch.object(onboard, "resolve_target_version", return_value=(None, "offline")):
+            report = onboard.Report(as_json=True)
+            self.assertEqual(onboard.doctor(report, None, ["codex"], self.policy), 2)
+            self.assertEqual(report.steps[-1]["status"], onboard.WARN)
 
 
 class EngineTests(unittest.TestCase):

--- a/skills/synthesis-onboarding/scripts/test_plugin_currency.py
+++ b/skills/synthesis-onboarding/scripts/test_plugin_currency.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Hermetic lifecycle-policy and plugin-currency tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import plugin_currency
+
+
+class Response:
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self.payload
+
+    def close(self):
+        pass
+
+
+def write_plugin_root(root: Path, version: str) -> None:
+    for directory in (".claude-plugin", ".codex-plugin"):
+        target = root / directory
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "plugin.json").write_text(
+            json.dumps({"version": version}), encoding="utf-8"
+        )
+
+
+def test_stable_edge_and_pin_resolve_to_distinct_git_refs() -> None:
+    assert plugin_currency.policy_ref({"channel": "stable", "version_pin": None}) == "stable"
+    assert plugin_currency.policy_ref({"channel": "edge", "version_pin": None}) == "main"
+    assert plugin_currency.policy_ref(
+        {"channel": "stable", "version_pin": "4.74.0"}
+    ) == "v4.74.0"
+
+
+def test_policy_rejects_unknown_channel_and_non_exact_pin() -> None:
+    for channel, pin in (("preview", None), ("stable", "4.74"), ("stable", "latest")):
+        try:
+            plugin_currency.normalize_policy(channel, pin)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError((channel, pin))
+
+
+def test_version_comparison_is_semantic_not_lexical() -> None:
+    assert plugin_currency.compare_versions("4.9.0", "4.10.0") == "behind"
+    assert plugin_currency.compare_versions("4.10.0", "4.10.0") == "current"
+    assert plugin_currency.compare_versions("5.0.0", "4.99.0") == "ahead"
+
+
+def test_live_resolution_is_cached_and_stale_cache_remains_labeled(tmp_path: Path) -> None:
+    cache = tmp_path / "currency.json"
+    policy = {"channel": "stable", "version_pin": None}
+    calls = []
+
+    def live(url, timeout):
+        calls.append((url, timeout))
+        return Response({"version": "4.74.0"})
+
+    assert plugin_currency.resolve_target_version(
+        policy, cache_path=cache, opener=live, now=100
+    ) == ("4.74.0", "live stable ref")
+    assert plugin_currency.resolve_target_version(
+        policy, cache_path=cache, opener=lambda *_args, **_kwargs: None, now=101
+    ) == ("4.74.0", "cached stable ref (fresh)")
+    assert len(calls) == 1
+
+    def offline(*_args, **_kwargs):
+        raise OSError("offline")
+
+    version, detail = plugin_currency.resolve_target_version(
+        policy, cache_path=cache, ttl_seconds=1, opener=offline, now=200
+    )
+    assert version == "4.74.0"
+    assert "stale" in detail
+
+
+def test_sessionstart_notice_compares_executing_cache_to_stable(tmp_path: Path) -> None:
+    root = tmp_path / "plugin"
+    write_plugin_root(root, "4.73.0")
+    receipts = tmp_path / "receipts.json"
+    receipts.write_text(
+        json.dumps({"plugin_policy": {"channel": "stable", "version_pin": None}}),
+        encoding="utf-8",
+    )
+
+    notice = plugin_currency.sessionstart_notice(
+        root,
+        receipts,
+        resolver=lambda policy: ("4.74.0", "fixture"),
+    )
+    assert "update available" in notice.lower()
+    assert "installed plugin 4.73.0" in notice
+    assert "stable channel is 4.74.0" in notice
+
+
+def test_sessionstart_notice_is_quiet_when_current(tmp_path: Path) -> None:
+    root = tmp_path / "plugin"
+    write_plugin_root(root, "4.74.0")
+    assert plugin_currency.sessionstart_notice(
+        root,
+        resolver=lambda policy: ("4.74.0", "fixture"),
+    ) == ""
+
+
+def test_sessionstart_notice_preserves_unverifiable_state(tmp_path: Path) -> None:
+    root = tmp_path / "plugin"
+    write_plugin_root(root, "4.74.0")
+    notice = plugin_currency.sessionstart_notice(
+        root,
+        resolver=lambda policy: (None, "offline"),
+    )
+    assert "could not be verified" in notice
+    assert "installed 4.74.0" in notice

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -270,9 +270,12 @@ The sequence, each stage gating the next:
   changes. CI invokes the same consumer with the pull request base supplied by
   its event record.
 - **Publish** revalidates the accepted state immediately before every remote
-  mutation and pushes the immutable accepted commit SHA to `refs/heads/main`,
-  never a mutable local branch name. This is the PRINCIPAL RULE D4 repair for
-  `R5-REV-002`.
+  mutation and atomically pushes the immutable accepted commit SHA to three
+  lifecycle refs: `refs/heads/main` (edge), `refs/heads/stable` (default), and
+  `refs/tags/vX.Y.Z` (exact org pins). It never publishes a mutable local
+  branch name. A per-remote atomic push prevents a channel or pin from moving
+  without the others. This is the PRINCIPAL RULE D4 repair for `R5-REV-002`
+  extended to the release-channel contract.
 - **Install** uses each client's own commands, in the order each client
   requires. For Codex that means `plugin marketplace upgrade` **before**
   `plugin add`, because Codex installs *from* its git marketplace snapshot —

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -42,6 +42,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import secrets
 import subprocess
 import sys
@@ -79,6 +80,7 @@ ACCEPTANCE_RUNNER = Path(
 ACCEPTANCE_CONSUMER_ID = (
     "synthesis-skills-manager.release.consume-acceptance.v1"
 )
+RELEASE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 
 # The required checks, mirroring the repository's own verification contract.
 # Kept as data so a reader can see exactly what a release runs.
@@ -615,8 +617,9 @@ def publish(
     result: Result,
     dry_run: bool,
     authority: AcceptanceAuthority,
+    version: str,
 ) -> bool:
-    """Push the exact receipt-bound commit to every configured push remote."""
+    """Atomically publish edge, stable, and immutable pin refs per remote."""
     branch = run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo).stdout.strip()
     if not result.add("publish.on-main", branch == "main", f"branch={branch or 'unknown'}"):
         return False
@@ -628,6 +631,15 @@ def publish(
         return result.add(
             "publish.accepted-head", False, "receipt-bound head is unavailable"
         )
+    if not RELEASE_VERSION_RE.fullmatch(version):
+        return result.add(
+            "publish.version-tag", False, f"invalid release version: {version}"
+        )
+    refspecs = [
+        f"{accepted_head}:refs/heads/main",
+        f"{accepted_head}:refs/heads/stable",
+        f"{accepted_head}:refs/tags/v{version}",
+    ]
     remotes = sorted(
         {
             line.split()[0]
@@ -641,20 +653,25 @@ def publish(
         valid, detail = revalidate_acceptance_authority(repo, authority)
         if not result.add(f"publish.acceptance.{remote}", valid, detail):
             return False
-        refspec = f"{accepted_head}:refs/heads/main"
         if dry_run:
-            result.add(f"publish.push.{remote}", True, f"dry-run: {refspec}")
+            result.add(
+                f"publish.push.{remote}", True, "dry-run atomic: " + " ".join(refspecs)
+            )
             continue
         # PRINCIPAL RULE (controlling plan D4): the pushed object is immutable.
         # A concurrent branch movement cannot substitute a different commit
         # after the final authority check.
         completed = run(
-            ["git", "push", remote, refspec], cwd=repo, timeout=600
+            ["git", "push", "--atomic", remote] + refspecs,
+            cwd=repo,
+            timeout=600,
         )
         if completed.returncode != 0:
             tail = (completed.stderr or completed.stdout).strip().splitlines()
             return result.add(f"publish.push.{remote}", False, tail[-1] if tail else "push failed")
-        result.add(f"publish.push.{remote}", True, f"pushed {refspec}")
+        result.add(
+            f"publish.push.{remote}", True, "atomically pushed " + " ".join(refspecs)
+        )
     return True
 
 
@@ -723,7 +740,7 @@ def main(argv: list[str] | None = None) -> int:
         if args.check_only:
             print(f"\nCHECKS PASSED for {version}. Nothing published (--check-only).")
             return 0
-        if not publish(repo, result, args.dry_run, authority):
+        if not publish(repo, result, args.dry_run, authority, version):
             print("\nRELEASE ABORTED: publish failed. Clients left untouched.")
             return 1
 

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -321,13 +321,15 @@ def test_publish_refuses_when_receipt_bound_head_changes(tmp_path: Path) -> None
     )
 
     result = release.Result()
-    assert release.publish(repository, result, True, authority) is False
+    assert release.publish(repository, result, True, authority, "9.9.9") is False
     assert any(
         step.name == "publish.acceptance" and not step.ok for step in result.steps
     )
 
 
-def test_publish_dry_run_names_exact_receipt_bound_ref(tmp_path: Path) -> None:
+def test_publish_dry_run_names_exact_receipt_bound_channel_and_pin_refs(
+    tmp_path: Path,
+) -> None:
     repository, authority = accepted_publish_fixture(tmp_path)
     bare = tmp_path / "origin.git"
     subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True)
@@ -337,12 +339,60 @@ def test_publish_dry_run_names_exact_receipt_bound_ref(tmp_path: Path) -> None:
     )
 
     result = release.Result()
-    assert release.publish(repository, result, True, authority) is True
-    expected_ref = f"{authority.expected['change_head']}:refs/heads/main"
-    assert any(
-        step.name == "publish.push.origin" and expected_ref in step.detail
-        for step in result.steps
+    assert release.publish(repository, result, True, authority, "9.9.9") is True
+    detail = next(
+        step.detail for step in result.steps if step.name == "publish.push.origin"
     )
+    accepted = authority.expected["change_head"]
+    assert "atomic" in detail
+    assert f"{accepted}:refs/heads/main" in detail
+    assert f"{accepted}:refs/heads/stable" in detail
+    assert f"{accepted}:refs/tags/v9.9.9" in detail
+
+
+def test_publish_atomically_creates_edge_stable_and_version_pin_refs(
+    tmp_path: Path,
+) -> None:
+    repository, authority = accepted_publish_fixture(tmp_path)
+    bare = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repository), "remote", "add", "origin", str(bare)],
+        check=True,
+    )
+
+    result = release.Result()
+    assert release.publish(repository, result, False, authority, "9.9.9") is True
+    accepted = authority.expected["change_head"]
+    for ref in ("refs/heads/main", "refs/heads/stable", "refs/tags/v9.9.9"):
+        actual = subprocess.run(
+            ["git", "-C", str(bare), "rev-parse", ref],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert actual == accepted
+
+
+def test_publish_rejects_non_exact_version_tag(tmp_path: Path) -> None:
+    repository, authority = accepted_publish_fixture(tmp_path)
+    result = release.Result()
+
+    assert release.publish(repository, result, True, authority, "latest") is False
+    assert any(
+        step.name == "publish.version-tag" and not step.ok for step in result.steps
+    )
+
+
+def test_release_manager_documents_channel_ref_contract() -> None:
+    repository = Path(__file__).resolve().parents[3]
+    text = (repository / "skills/synthesis-skills-manager/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert "refs/heads/main" in text
+    assert "refs/heads/stable" in text
+    assert "refs/tags/vX.Y.Z" in text
+    assert "atomic" in text
 
 
 def test_main_carries_acceptance_authority_to_publish_boundary(
@@ -361,15 +411,16 @@ def test_main_carries_acceptance_authority_to_publish_boundary(
         result: release.Result,
         dry_run: bool,
         accepted: object,
+        version: str,
     ) -> bool:
-        received.append(accepted)
+        received.append((accepted, version))
         return result.add("publish.fixture", True)
 
     monkeypatch.setattr(release, "publish", publish)
     monkeypatch.setattr(release, "refresh_client", lambda *_args: True)
 
     assert release.main(["--repo-root", str(repo), "--dry-run"]) == 0
-    assert received == [authority]
+    assert received == [(authority, "9.9.9")]
 
 
 # --- client reporting, fail-closed -----------------------------------------


### PR DESCRIPTION
## Why

Plugin installations need a release policy that is visible at SessionStart, enforceable by the onboarding engine, and independently checked by doctor.

## What changed

- make stable the default channel, keep main as opt-in edge, and add exact version pins to organization manifests
- compare the executing plugin cache with the selected release target at SessionStart and in doctor
- reconfigure native marketplace sources to the selected Git ref during updates
- atomically publish main, stable, and the immutable version tag from the acceptance-bound commit
- update the bootstrap and public documentation to use stable by default

## Verification

- full gated release preflight with fresh transaction-bound acceptance receipt
- 117 focused lifecycle, conformance, release, and acceptance-validator tests
- source conformance: 204 checks passed
- shell syntax, Python compilation, and diff checks passed