### PR TITLE
Resolve cross-project controlling plans through a shared plan_reference module

### DIFF
--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -62,6 +62,7 @@ from live_receipt import (
     session_receipt_path,
     transcript_binds_session,
 )
+from plan_reference import locate_plan
 from project_context import next_actions, record_freshness
 from pointer_lock import locked_pointer
 from coordination_schema import SCHEMA_VERSION as COORDINATION_SCHEMA_VERSION
@@ -1458,14 +1459,14 @@ def project_summary(project: Path) -> tuple[dict[str, object], list[Check]]:
         for key in ("Phase", "Status", "Last session"):
             match = re.search(rf"^\*\*{re.escape(key)}:\*\*\s*(.+)$", text, re.MULTILINE)
             summary[key.lower().replace(" ", "_")] = match.group(1).strip() if match else "unknown"
-        plan_match = re.search(r"\((resources/artifacts/[^)]+plan[^)]*\.md)\)", text)
-        if plan_match:
-            plan = project / plan_match.group(1)
-            summary["plan"] = str(plan)
-            add(checks, "handoff.plan", plan.is_file(), str(plan))
+        # Shared with the stopped-task payload builders so the two
+        # derivations cannot drift (plan_reference.locate_plan).
+        plan_ref = locate_plan(project, text)
+        summary["plan"] = plan_ref.value
+        if plan_ref.declared is None:
+            add(checks, "handoff.plan", False, plan_ref.detail, required=False)
         else:
-            summary["plan"] = "unknown"
-            add(checks, "handoff.plan", False, "CONTEXT.md has no linked plan", required=False)
+            add(checks, "handoff.plan", plan_ref.resolved is not None, plan_ref.detail)
 
         summary["next"] = next_actions(text)
 

--- a/skills/synthesis-agent-conformance/scripts/plan_reference.py
+++ b/skills/synthesis-agent-conformance/scripts/plan_reference.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Single source of truth for locating a project's controlling plan.
+
+CONTEXT.md can declare its controlling plan three ways, in precedence
+order:
+
+1. An explicit ``Controlling plan:`` line naming an absolute or
+   repo-relative path — optionally as a markdown link, optionally with a
+   trailing parenthetical annotation such as ``(item 2.1)``.
+2. A relative markdown link that climbs out of the project directory
+   (``../program/resources/artifacts/x-work-plan.md``): a bounded arc
+   governed by its parent program's work plan.
+3. The legacy project-local link form ``(resources/artifacts/...plan...md)``.
+
+Every consumer — conformance's project summary, the stopped-task payload
+builders — must derive the plan through :func:`locate_plan` so the
+derivations cannot drift; the two pre-existing per-site regexes had
+already drifted (case sensitivity) when this module replaced them.
+
+Declared-but-unresolvable plans fail closed: ``resolved`` stays ``None``
+and ``detail`` names the reason, including a relative target that
+resolves outside the repository.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+PLAN_LINE_PATTERN = re.compile(
+    r"^(?:\*\*)?Controlling plan:(?:\*\*)?\s*(.+)$", re.MULTILINE
+)
+PLAN_LINE_LINK_PATTERN = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+PLAN_LOCAL_LINK_PATTERN = re.compile(
+    r"\((resources/artifacts/[^)\n]*plan[^)\n]*\.md)\)", re.IGNORECASE
+)
+PLAN_RELATIVE_LINK_PATTERN = re.compile(
+    r"\(((?:\.\./)+[^)\s]*plan[^)\s]*\.md)\)", re.IGNORECASE
+)
+
+
+@dataclass
+class PlanReference:
+    """One project's controlling-plan derivation.
+
+    ``declared`` is the raw declared target (None when CONTEXT.md declares
+    nothing). ``resolved`` is the existing file the declaration resolves
+    to, or None when the declaration cannot be satisfied. ``value`` is the
+    string consumers publish (summary field, payload line): the resolved
+    path, the declared target when unresolvable, or ``"unknown"``. The
+    legacy project-local form keeps its historical unresolved
+    project-joined ``value`` so existing pointer comparisons stay stable.
+    """
+
+    declared: str | None
+    resolved: Path | None
+    value: str
+    detail: str
+    legacy_local: bool = False
+
+
+def _declared_target(remainder: str) -> str:
+    remainder = remainder.strip()
+    link = PLAN_LINE_LINK_PATTERN.search(remainder)
+    if link:
+        return link.group(1)
+    remainder = re.sub(r"\s*\([^)]*\)\s*$", "", remainder)
+    return remainder.rstrip(".").strip()
+
+
+def _repo_root(project: Path) -> Path | None:
+    result = subprocess.run(
+        ["git", "-C", str(project), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return Path(result.stdout.strip()).resolve()
+
+
+def _resolve_declared(project: Path, target: str) -> tuple[Path | None, str]:
+    expanded = Path(target).expanduser()
+    if expanded.is_absolute():
+        resolved = expanded.resolve()
+        if resolved.is_file():
+            return resolved, str(resolved)
+        return None, f"declared controlling plan is not a file: {target}"
+    repo_root = _repo_root(project)
+    bases = [project]
+    if repo_root is not None:
+        bases.append(repo_root)
+    for base in bases:
+        resolved = (base / expanded).resolve()
+        if not resolved.is_file():
+            continue
+        if repo_root is None:
+            return None, (
+                "cannot verify the declared controlling plan stays inside "
+                f"the repository: {target}"
+            )
+        if not resolved.is_relative_to(repo_root):
+            return None, (
+                f"declared controlling plan resolves outside the repository: {target}"
+            )
+        return resolved, str(resolved)
+    return None, f"declared controlling plan is not a file: {target}"
+
+
+def locate_plan(project: Path, context_text: str) -> PlanReference:
+    line = PLAN_LINE_PATTERN.search(context_text)
+    declared = _declared_target(line.group(1)) if line else None
+    if not declared:
+        relative = PLAN_RELATIVE_LINK_PATTERN.search(context_text)
+        if relative:
+            declared = relative.group(1)
+    if declared:
+        resolved, detail = _resolve_declared(project, declared)
+        value = str(resolved) if resolved is not None else declared
+        return PlanReference(declared, resolved, value, detail)
+    local = PLAN_LOCAL_LINK_PATTERN.search(context_text)
+    if local:
+        plan = project / local.group(1)
+        exists = plan.is_file()
+        return PlanReference(
+            declared=local.group(1),
+            resolved=plan if exists else None,
+            value=str(plan),
+            detail=str(plan) if exists else f"active plan is missing: {plan}",
+            legacy_local=True,
+        )
+    return PlanReference(None, None, "unknown", "CONTEXT.md has no linked plan")

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -2044,3 +2044,146 @@ def test_render_atomically_writes_the_same_structured_evidence(
     assert stdout == cached
     assert cached["checks"][0]["plane"] == "source"
     assert not list(report.parent.glob("last-report.json.*.tmp"))
+
+
+def _seed_plan_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Repo with a bounded arc and a sibling program that owns the work plan."""
+    repo = tmp_path / "repo"
+    arc = repo / "projects" / "arc"
+    program_plan = (
+        repo
+        / "projects"
+        / "program"
+        / "resources"
+        / "artifacts"
+        / "2026-01-01-work-plan.md"
+    )
+    program_plan.parent.mkdir(parents=True)
+    program_plan.write_text("# Plan\n", encoding="utf-8")
+    (arc / "sessions").mkdir(parents=True)
+    (arc / "REFERENCE.md").write_text("# Reference\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "init", "--quiet", "--initial-branch", "main", str(repo)],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "core.hooksPath", "/dev/null"],
+        check=True,
+    )
+    return repo, arc, program_plan
+
+
+def _write_arc_context(arc: Path, plan_reference: str) -> None:
+    (arc / "CONTEXT.md").write_text(
+        "**Phase:** Drafting\n"
+        "**Status:** Active\n\n"
+        f"{plan_reference}\n"
+        "## What's Next\n\n"
+        "1. [ ] Continue.\n",
+        encoding="utf-8",
+    )
+
+
+def _plan_check(checks: list) -> object:
+    return {check.name: check for check in checks}["handoff.plan"]
+
+
+def test_project_summary_accepts_cross_project_plan_link(tmp_path: Path) -> None:
+    _, arc, program_plan = _seed_plan_repo(tmp_path)
+    _write_arc_context(
+        arc, "[plan](../program/resources/artifacts/2026-01-01-work-plan.md)\n"
+    )
+
+    summary, checks = MODULE.project_summary(arc)
+
+    assert _plan_check(checks).ok
+    assert summary["plan"] == str(program_plan.resolve())
+
+
+def test_project_summary_accepts_controlling_plan_line_absolute(
+    tmp_path: Path,
+) -> None:
+    _, arc, program_plan = _seed_plan_repo(tmp_path)
+    _write_arc_context(arc, f"Controlling plan: {program_plan} (item 2.1)\n")
+
+    summary, checks = MODULE.project_summary(arc)
+
+    assert _plan_check(checks).ok
+    assert summary["plan"] == str(program_plan.resolve())
+
+
+def test_project_summary_accepts_controlling_plan_line_repo_relative(
+    tmp_path: Path,
+) -> None:
+    _, arc, program_plan = _seed_plan_repo(tmp_path)
+    _write_arc_context(
+        arc,
+        "Controlling plan: projects/program/resources/artifacts/2026-01-01-work-plan.md\n",
+    )
+
+    summary, checks = MODULE.project_summary(arc)
+
+    assert _plan_check(checks).ok
+    assert summary["plan"] == str(program_plan.resolve())
+
+
+def test_project_summary_fails_closed_on_missing_declared_plan(
+    tmp_path: Path,
+) -> None:
+    _, arc, _ = _seed_plan_repo(tmp_path)
+    _write_arc_context(
+        arc,
+        "Controlling plan: projects/program/resources/artifacts/absent-plan.md\n",
+    )
+
+    summary, checks = MODULE.project_summary(arc)
+
+    check = _plan_check(checks)
+    assert not check.ok
+    assert check.required
+    assert "not a file" in check.detail
+    assert summary["plan"] == "projects/program/resources/artifacts/absent-plan.md"
+
+
+def test_project_summary_refuses_plan_escaping_repository(tmp_path: Path) -> None:
+    _, arc, _ = _seed_plan_repo(tmp_path)
+    (tmp_path / "outside-plan.md").write_text("# Outside\n", encoding="utf-8")
+    _write_arc_context(arc, "[plan](../../../outside-plan.md)\n")
+
+    summary, checks = MODULE.project_summary(arc)
+
+    check = _plan_check(checks)
+    assert not check.ok
+    assert check.required
+    assert "outside the repository" in check.detail
+    assert summary["plan"] == "../../../outside-plan.md"
+
+
+def test_project_summary_keeps_local_plan_value_shape(tmp_path: Path) -> None:
+    project = write_stopped_project(tmp_path)
+
+    summary, checks = MODULE.project_summary(project)
+
+    assert _plan_check(checks).ok
+    assert summary["plan"] == str(project / "resources/artifacts/demo-plan.md")
+
+
+def test_project_summary_ignores_mid_line_controlling_plan(tmp_path: Path) -> None:
+    """A `Controlling plan:` fragment fused into another line is corrupted
+    record state, not a declaration; the anchored pattern must not match it."""
+    _, arc, program_plan = _seed_plan_repo(tmp_path)
+    _write_arc_context(
+        arc, f"(some other prose)Controlling plan: {program_plan}\n"
+    )
+
+    summary, checks = MODULE.project_summary(arc)
+
+    check = _plan_check(checks)
+    assert not check.ok
+    assert not check.required
+    assert summary["plan"] == "unknown"

--- a/skills/synthesis-agent-conformance/scripts/test_plan_reference.py
+++ b/skills/synthesis-agent-conformance/scripts/test_plan_reference.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("plan_reference.py")
+SPEC = importlib.util.spec_from_file_location("plan_reference", MODULE_PATH)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def _git_repo(root: Path) -> None:
+    subprocess.run(
+        ["git", "init", "--quiet", "--initial-branch", "main", str(root)],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(root), "config", "core.hooksPath", "/dev/null"],
+        check=True,
+    )
+
+
+def test_locate_plan_matches_links_case_insensitively(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    plan = project / "resources" / "artifacts" / "Master-PLAN.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Plan\n", encoding="utf-8")
+
+    ref = MODULE.locate_plan(project, "[plan](resources/artifacts/Master-PLAN.md)\n")
+
+    assert ref.legacy_local
+    assert ref.resolved is not None
+    assert ref.value == str(project / "resources/artifacts/Master-PLAN.md")
+
+
+def test_explicit_line_outranks_local_link(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    local = project / "resources" / "artifacts" / "local-plan.md"
+    local.parent.mkdir(parents=True)
+    local.write_text("# Local\n", encoding="utf-8")
+    outer = tmp_path / "outer-plan.md"
+    outer.write_text("# Outer\n", encoding="utf-8")
+
+    ref = MODULE.locate_plan(
+        project,
+        f"Controlling plan: {outer}\n[plan](resources/artifacts/local-plan.md)\n",
+    )
+
+    assert not ref.legacy_local
+    assert ref.value == str(outer.resolve())
+
+
+def test_legacy_missing_keeps_project_joined_value(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    ref = MODULE.locate_plan(project, "[plan](resources/artifacts/gone-plan.md)\n")
+
+    assert ref.legacy_local
+    assert ref.resolved is None
+    assert ref.value == str(project / "resources/artifacts/gone-plan.md")
+    assert ref.detail.startswith("active plan is missing:")
+
+
+def test_empty_declaration_falls_through_to_link_scan(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    plan = project / "resources" / "artifacts" / "demo-plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Plan\n", encoding="utf-8")
+
+    ref = MODULE.locate_plan(
+        project, "Controlling plan: .\n[plan](resources/artifacts/demo-plan.md)\n"
+    )
+
+    assert ref.legacy_local
+    assert ref.resolved is not None
+
+
+def test_markdown_link_on_declaration_line_resolves(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    project = repo / "projects" / "arc"
+    project.mkdir(parents=True)
+    plan = repo / "projects" / "program" / "resources" / "artifacts" / "p-plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Plan\n", encoding="utf-8")
+    _git_repo(repo)
+
+    ref = MODULE.locate_plan(
+        project,
+        "Controlling plan: [the plan](../program/resources/artifacts/p-plan.md)\n",
+    )
+
+    assert ref.resolved == plan.resolve()
+    assert ref.value == str(plan.resolve())
+
+
+def test_relative_target_without_repository_fails_closed(tmp_path: Path) -> None:
+    proj_parent = tmp_path / "outer" / "proj"
+    project = proj_parent / "arc"
+    project.mkdir(parents=True)
+    side = proj_parent / "side-plan.md"
+    side.write_text("# Plan\n", encoding="utf-8")
+
+    ref = MODULE.locate_plan(project, "Controlling plan: ../side-plan.md\n")
+
+    assert ref.resolved is None
+    assert "cannot verify" in ref.detail
+    assert ref.value == "../side-plan.md"


### PR DESCRIPTION
## Problem

`project_summary()` recognized a controlling plan only through a markdown link to a plan artifact inside the same project (`(resources/artifacts/...plan...md)`). A bounded arc governed by its parent program's work plan can never satisfy `handoff.plan`, and the stopped-task payload reports `Controlling plan: unknown` even when CONTEXT.md names the plan explicitly. Real case: a project whose controlling plan is one item of a sibling program's `post-decisions-work-plan.md`.

A second copy of the detection regex lives in `session_context.py` (`linked_plan()`), and the two had already drifted: one is case-insensitive, the other is not. That drift class is the deeper defect.

## Change

- New `scripts/plan_reference.py` — single source of truth (`locate_plan`) for deriving a project's controlling plan from CONTEXT.md, with three accepted forms in precedence order:
  1. an explicit `Controlling plan:` line naming an absolute or repo-relative path, optionally as a markdown link, optionally with a trailing annotation such as `(item 2.1)`;
  2. a parent-escaping relative markdown link (`../program/resources/artifacts/x-work-plan.md`);
  3. the legacy project-local link form, unchanged.
- Fail-closed: a declared-but-unresolvable plan is a required failure with a named reason; a relative target that resolves outside the repository is refused; a repository that cannot be established refuses relative targets rather than guessing.
- Compatibility: the legacy project-local form keeps its historical unresolved `str(project / link)` value so existing active-project pointer comparisons stay byte-stable. A `Controlling plan:` fragment fused mid-line into other text (corrupted record state, observed in production) deliberately does not match.
- `conformance.py` consumes `locate_plan`; its in-file regex is gone.

## Verification

- 157 tests pass (`test_conformance.py` +7, new `test_plan_reference.py` +6, all pre-existing green), `conformance.py source` 204 checks pass, `instructions` pass, `compileall` clean, plus the full AGENTS.md CI battery (coordination, kb-edit, okf, daily-rituals, message-guard, git-hooks, onboarding, meeting-transcripts, installer, inbox-cleanup fixtures).
- Real case re-run from source: `handoff.plan` now passes with the resolved sibling-program plan path.

## Draft until the companion lands

`session_context.py` (and its test) are held by another active session's coordination claim, so this PR does not touch them. Until its `linked_plan()` is swapped for `locate_plan`, a project using the new forms passes `handoff.plan` but fails `continuity.stopped-task-payload` (payload still says `unknown`) — so this PR stays draft until the companion is in, landing both halves in one release. The companion, handed to the claim holder:

```python
# imports (with the other sibling imports)
from plan_reference import locate_plan

# append_project_context(): replace the linked_plan() call and the raise
ref = locate_plan(project, context)
if ref.declared is not None and ref.resolved is None:
    raise FileNotFoundError(ref.detail)
...
f"Controlling plan: {ref.value}.",

# delete linked_plan() — append_project_context was its only caller
```

Legacy behavior is preserved exactly: same payload string for project-local plans, same `active plan is missing:` raise text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
