### PR TITLE
Keep plugin lifecycle checks live across updates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.74.0",
+  "version": "4.74.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.74.0",
+  "version": "4.74.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.74.1] - 2026-09-01
+
+**The lifecycle now survives the release that advances it.** The first 4.74.0
+SessionStart exposed two defects that hermetic policy tests could not: the
+python.org macOS runtime had no configured OpenSSL CA path and therefore could
+not verify the stable manifest, while Codex's native plugin refresh deleted the
+old versioned cache before the running task's Stop hook had finished using it.
+
+Release discovery keeps urllib and verified TLS, but on a certificate-path
+failure it retries known operating-system CA bundles through
+`ssl.create_default_context(cafile=...)`; certificate-chain and hostname checks
+stay enabled. The release publisher snapshots every real Codex version root
+before refresh, restores any root the client removes, and verifies the complete
+tree digest before declaring installation successful. Symlink recovery artifacts
+are deliberately excluded. A failed snapshot blocks the client mutation; a
+failed restore leaves its recovery copy in place and fails the release loudly.
+
 ## [4.74.0] - 2026-09-01
 
 **`synthesis-onboarding` v1.3.0 — plugin upgrades now have a lifecycle instead

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A plugin update must not break the task applying it (September 2026).**
+Release **4.74.1** repairs both failure surfaces found by the first 4.74.0
+SessionStart: the stock python.org macOS runtime now resolves the stable release
+through an existing operating-system CA bundle while retaining full TLS and
+hostname verification, and the gated publisher preserves real Codex cache roots
+across the client's destructive refresh so running tasks keep their loaded hook
+code. See the [4.74.1 release notes](CHANGELOG.md).
+
 **A captured directive is not a routed one (August 2026).** Release
 **4.73.0** accepts a cited directory of scripts as a preserved target (an empty one still fails). Previously: **4.72.0** matches the open-items review horizon to what an item is — a backlog of intentions is not work owed by a date, and a recorded decision under an open-items heading needs moving rather than a longer horizon. Previously: **4.71.0** fixes five defects found by using 4.70.0 the day it shipped: a disposition finding that re-created itself, a suppression that shipped without its paired check, checks reporting their coverage so the next such gap is visible, the lifecycle rule extended to the tier and budget checks, and a status header that went unread when it was not first on its line. Previously: **4.70.0** makes the context health signal lifecycle-aware (a check that cannot apply no longer fires, and the check that *does* apply to a finished project takes its place) and gives the semantic tier a `reference/` shard so standing projects stop hitting a ceiling built for bounded ones. Previously: **4.69.0** makes persona-signature wire forms mechanically enforced at the send gate (HTML-path email, no visible-URL fallback on link-capable channels). Previously: **4.68.0** upgrades synthesis-autopilot for genuinely unattended runs: a verified continuation mechanism is now part of the delegation contract, enforced by a Stop-hook gate, with budget/runaway control and cycle ledgers. Previously: **4.67.0** adds the byte-faithful send-path rule (a provider-composed email path can rewrite your links; raw MIME stores your bytes). Previously: **4.66.0** makes persona signature links render as native hyperlinks per channel (HTML anchors in email, mrkdwn in Slack, plain fallback only where links are impossible). Previously: **4.65.0** makes the release gate verify installed bytes against source (version parity is not content parity), makes the currency audit refuse a zero scan, and adds dead-pattern and canonical-clean controls to the message-guard doctor. Previously: **4.64.0** teaches the context doctor to catch the failure that happens by
 default: an intake artifact that records a directive, reads as handled, and

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,45 +1,32 @@
-# AGENT HEURISTIC: authored for the 4.74.0 onboarding-lifecycle release.
+# AGENT HEURISTIC: authored for the 4.74.1 lifecycle-survival hotfix.
 # Fresh per transaction: changed_surfaces must equal the authoritative
-# base-to-head Git diff, proved by the runner before release.py consumes
-# the receipt.
+# base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: synthesis-onboarding-lifecycle-release
+suite: synthesis-onboarding-lifecycle-survival-hotfix
 membership: closed
-production_entry_point: skills/synthesis-onboarding/scripts/onboard.py update
-enforcing_boundary: SessionStart update notice, onboarding doctor currency result, and the acceptance-bound release publisher
+production_entry_point: skills/synthesis-skills-manager/scripts/release.py
+enforcing_boundary: verified release lookup and active-session-safe plugin refresh
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: hermetic tests prove policy parsing, semantic comparison, bounded cache behavior, client command construction, doctor outcomes, SessionStart injection, and atomic Git ref publication; they do not make live marketplace mutations or prove remote network availability, while release.py deep verification remains the live installed-cache boundary after publication
+unverified_remainder: hermetic tests prove certificate-path retries, refusal to mask unrelated network errors, verifying SSL context properties, exact Codex cache restoration, corruption detection, pre-mutation snapshot failure, documentation, manifest parity, and changelog parity; the live stock-Python stable lookup is checked outside the suite, while release.py deep verification remains the installed-cache boundary after publication
 changed_surfaces:
   - path: skills/synthesis-onboarding/scripts/plugin_currency.py
-    cases: [policy-ref-resolution, semantic-version-comparison, release-cache-evidence, sessionstart-cache-comparison]
+    cases: [verified-system-ca-retry, non-certificate-error-propagation, verifying-context]
   - path: skills/synthesis-onboarding/scripts/test_plugin_currency.py
-    cases: [policy-ref-resolution, semantic-version-comparison, release-cache-evidence, sessionstart-cache-comparison]
-  - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [manifest-policy-validation, marketplace-target-selection, doctor-plugin-currency]
-  - path: skills/synthesis-onboarding/scripts/test_onboard.py
-    cases: [manifest-policy-validation, marketplace-target-selection, doctor-plugin-currency, public-channel-docs]
+    cases: [verified-system-ca-retry, non-certificate-error-propagation, verifying-context]
   - path: skills/synthesis-onboarding/SKILL.md
-    cases: [public-channel-docs]
-  - path: skills/synthesis-onboarding/references/org-manifest.md
-    cases: [public-channel-docs]
-  - path: onboard.sh
-    cases: [bootstrap-channel-selection, public-channel-docs]
-  - path: README.md
-    cases: [public-channel-docs, release-changelog-parity]
-  - path: skills/synthesis-agent-conformance/scripts/session_context.py
-    cases: [sessionstart-lifecycle-notice]
-  - path: skills/synthesis-agent-conformance/scripts/test_session_context.py
-    cases: [sessionstart-lifecycle-notice]
+    cases: [lifecycle-hotfix-doc-contract]
   - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [atomic-channel-publication]
+    cases: [active-cache-restoration, cache-corruption-refusal, snapshot-failure-precedes-mutation]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [atomic-channel-publication, release-manager-doc-contract]
+    cases: [active-cache-restoration, cache-corruption-refusal, snapshot-failure-precedes-mutation, lifecycle-hotfix-doc-contract, release-manifest-parity, release-changelog-parity]
   - path: skills/synthesis-skills-manager/SKILL.md
-    cases: [release-manager-doc-contract]
+    cases: [lifecycle-hotfix-doc-contract]
+  - path: README.md
+    cases: [lifecycle-hotfix-doc-contract]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -49,62 +36,42 @@ changed_surfaces:
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
 cases:
-  - id: policy-ref-resolution
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_stable_edge_and_pin_resolve_to_distinct_git_refs
-    motivating_defect: stable-edge-and-exact-pins-are-only-real-when-they-resolve-to-distinct-enforceable-git-targets
-  - id: semantic-version-comparison
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_version_comparison_is_semantic_not_lexical
-    motivating_defect: lexical-ordering-reports-4-10-as-older-than-4-9-and-inverts-the-update-notice
-  - id: release-cache-evidence
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_live_resolution_is_cached_and_stale_cache_remains_labeled
-    motivating_defect: a-sessionstart-network-check-without-bounded-cache-evidence-either-blocks-startup-or-turns-an-outage-into-an-uncited-current-claim
-  - id: sessionstart-cache-comparison
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_sessionstart_notice_compares_executing_cache_to_stable
-    motivating_defect: the-notice-must-compare-the-executing-cache-manifest-not-a-source-checkout-or-client-self-report
-  - id: manifest-policy-validation
+  - id: verified-system-ca-retry
     control_class: enforced-gate
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::ParserTests::test_manifest_rejects_unknown_channel_and_non_exact_pin
-    motivating_defect: accepting-an-unknown-channel-or-non-exact-pin-converts-org-policy-into-guesswork
-  - id: marketplace-target-selection
+    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_verified_open_retries_cert_failure_with_system_ca_bundle
+    motivating_defect: python-org-macos-can-have-no-openssl-ca-path-even-though-the-operating-system-ships-a-valid-ca-bundle
+  - id: non-certificate-error-propagation
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_marketplace_add_targets_stable_edge_and_version_pin
-    motivating_defect: a-manifest-label-without-client-marketplace-ref-selection-is-not-channel-support
-  - id: doctor-plugin-currency
+    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_verified_open_does_not_mask_non_certificate_network_error
+    motivating_defect: retrying-every-network-error-as-a-ca-problem-hides-the-real-unverifiable-state-and-wastes-sessionstart-time
+  - id: verifying-context
     control_class: enforced-gate
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_doctor_reports_current_behind_and_unverifiable_currency
-    motivating_defect: doctor-must-not-collapse-behind-and-unverifiable-release-state-into-the-same-green-presence-check
-  - id: bootstrap-channel-selection
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_bootstrap_defaults_to_stable_and_maps_edge_to_main
-    motivating_defect: a-stable-engine-default-is-bypassed-if-the-public-bootstrap-still-clones-main
-  - id: public-channel-docs
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_public_docs_expose_stable_edge_and_org_pin_contract
-    motivating_defect: an-engine-capability-hidden-behind-the-old-main-bootstrap-or-an-undocumented-pin-field-cannot-be-used-correctly
-  - id: sessionstart-lifecycle-notice
-    control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_sessionstart_prepends_plugin_update_notice
-    motivating_defect: an-update-check-that-never-enters-the-real-sessionstart-envelope-is-dead-code-not-a-lifecycle-notice
-  - id: atomic-channel-publication
+    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_system_ca_context_keeps_peer_and_hostname_verification_enabled
+    motivating_defect: fixing-ca-discovery-by-disabling-peer-or-hostname-verification-turns-an-update-notice-into-a-network-injection-surface
+  - id: active-cache-restoration
     control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_publish_atomically_creates_edge_stable_and_version_pin_refs
-    motivating_defect: publishing-main-stable-and-the-pin-separately-can-leave-users-on-three-different-releases-after-one-failed-push
-  - id: release-manager-doc-contract
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_restores_real_version_root_deleted_by_client
+    motivating_defect: codex-plugin-refresh-deletes-the-version-root-that-an-already-running-task-still-needs-for-its-stop-hook
+  - id: cache-corruption-refusal
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_fails_if_existing_preserved_root_changes
+    motivating_defect: presence-alone-cannot-prove-an-active-session-cache-still-contains-the-code-that-session-loaded
+  - id: snapshot-failure-precedes-mutation
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_does_not_run_when_cache_snapshot_fails
+    motivating_defect: a-publisher-that-refreshes-after-its-preservation-copy-fails-can-strand-the-running-task-without-recovery-bytes
+  - id: lifecycle-hotfix-doc-contract
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_release_manager_documents_channel_ref_contract
-    motivating_defect: maintainers-need-the-same-channel-boundary-the-publisher-enforces-or-a-later-release-can-regress-to-main-only
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_lifecycle_hotfix_is_documented_on_every_public_maintenance_surface
+    motivating_defect: future-maintainers-can-regress-a-runtime-lifecycle-invariant-that-only-lives-in-an-incident-log
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: a-manifest-that-cannot-be-consumed-by-its-own-runner-issues-authority-it-never-earned
+    motivating_defect: an-acceptance-manifest-that-its-own-runner-cannot-consume-issues-authority-it-never-earned
   - id: release-manifest-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
-    motivating_defect: a-version-bump-that-reaches-one-client-and-not-the-other-stays-invisible-until-something-breaks
+    motivating_defect: a-hotfix-version-that-reaches-only-one-client-manifest-cannot-be-reliably-installed-or-audited
   - id: release-changelog-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.3.0"
+  version: "1.3.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -92,7 +92,10 @@ The receipt also stores the effective plugin policy. SessionStart reads that
 policy and the executing plugin-cache manifest, then compares it with a
 six-hour cached release-manifest check. It emits a notice when the installed
 cache is behind or mismatched and preserves an explicit unverifiable state
-when neither live nor cached release evidence is available. `doctor` applies
+when neither live nor cached release evidence is available. On python.org's
+macOS runtime, where OpenSSL can have no configured CA path, the live check
+retries with an existing operating-system CA bundle through a fully verifying
+TLS context; it never disables certificate or hostname verification. `doctor` applies
 the same comparison and exit-code contract.
 
 ## Release channels

--- a/skills/synthesis-onboarding/scripts/plugin_currency.py
+++ b/skills/synthesis-onboarding/scripts/plugin_currency.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import ssl
 import tempfile
 import time
 import urllib.error
@@ -33,6 +34,13 @@ RAW_MANIFEST_TEMPLATE = (
     "synthesis-skills/{ref}/.codex-plugin/plugin.json"
 )
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+SYSTEM_CA_FILES = (
+    "/etc/ssl/cert.pem",  # macOS and several BSDs
+    "/etc/ssl/certs/ca-certificates.crt",  # Debian, Ubuntu, and WSL
+    "/etc/pki/tls/certs/ca-bundle.crt",  # Fedora and RHEL
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+    "/etc/ssl/ca-bundle.pem",  # openSUSE
+)
 
 
 def normalize_policy(channel=None, version_pin=None):
@@ -135,12 +143,83 @@ def _write_cache(path, data):
             os.unlink(temporary_name)
 
 
+def _certificate_verification_failed(exc):
+    """Recognize verification failures even when urllib wraps the SSL error."""
+    seen = set()
+    current = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, ssl.SSLCertVerificationError):
+            return True
+        reason = getattr(current, "reason", None)
+        if reason is not None and reason is not current:
+            current = reason
+            continue
+        current = getattr(current, "__cause__", None)
+    return "CERTIFICATE_VERIFY_FAILED" in str(exc)
+
+
+def _candidate_ca_files():
+    """Return existing platform CA bundles not already resolved by OpenSSL.
+
+    Python.org's macOS runtime can have no resolved OpenSSL CA path even while
+    the operating system ships ``/etc/ssl/cert.pem``. Linux distributions use
+    a small set of other conventional bundle locations. Passing any candidate
+    to ``ssl.create_default_context`` keeps chain and hostname verification
+    enabled; this function never manufactures or downloads a trust root.
+    """
+    defaults = ssl.get_default_verify_paths()
+    candidates = [defaults.cafile, *SYSTEM_CA_FILES]
+    resolved = []
+    seen = set()
+    for candidate in candidates:
+        if not candidate:
+            continue
+        path = Path(candidate)
+        try:
+            identity = str(path.resolve())
+        except OSError:
+            identity = str(path)
+        if identity in seen or not path.is_file():
+            continue
+        seen.add(identity)
+        resolved.append(path)
+    return resolved
+
+
+def _verified_urlopen(url, timeout):
+    """Open HTTPS with verified TLS across stock Python distributions.
+
+    The default urllib path remains first. Only a certificate-verification
+    failure triggers retries with an existing operating-system CA bundle.
+    Network, HTTP, decoding, and other TLS failures remain failures instead of
+    being masked by a second transport.
+    """
+    try:
+        return urllib.request.urlopen(url, timeout=timeout)
+    except (OSError, urllib.error.URLError) as first_error:
+        if not _certificate_verification_failed(first_error):
+            raise
+
+    attempts = []
+    for ca_file in _candidate_ca_files():
+        try:
+            context = ssl.create_default_context(cafile=str(ca_file))
+            return urllib.request.urlopen(url, timeout=timeout, context=context)
+        except (OSError, urllib.error.URLError) as retry_error:
+            attempts.append("%s: %s" % (ca_file, retry_error))
+    detail = "; ".join(attempts) or "no operating-system CA bundle found"
+    raise urllib.error.URLError(
+        "certificate verification failed with default trust; %s" % detail
+    )
+
+
 def resolve_target_version(
     policy,
     cache_path=None,
     ttl_seconds=DEFAULT_TTL_SECONDS,
     timeout=2,
-    opener=urllib.request.urlopen,
+    opener=None,
     now=None,
 ):
     """Resolve the desired plugin version, using fresh or stale cache evidence.
@@ -164,7 +243,7 @@ def resolve_target_version(
 
     url = RAW_MANIFEST_TEMPLATE.format(ref=ref)
     try:
-        response = opener(url, timeout=timeout)
+        response = (opener or _verified_urlopen)(url, timeout=timeout)
         try:
             payload = json.loads(response.read().decode("utf-8"))
         finally:

--- a/skills/synthesis-onboarding/scripts/test_plugin_currency.py
+++ b/skills/synthesis-onboarding/scripts/test_plugin_currency.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import ssl
+import urllib.error
 from pathlib import Path
 
 import plugin_currency
@@ -78,6 +80,68 @@ def test_live_resolution_is_cached_and_stale_cache_remains_labeled(tmp_path: Pat
     )
     assert version == "4.74.0"
     assert "stale" in detail
+
+
+def test_verified_open_retries_cert_failure_with_system_ca_bundle(
+    tmp_path: Path, monkeypatch
+) -> None:
+    ca_file = tmp_path / "system-ca.pem"
+    ca_file.write_text("fixture", encoding="utf-8")
+    contexts = []
+    calls = []
+    sentinel_context = object()
+
+    def open_url(url, timeout, context=None):
+        calls.append((url, timeout, context))
+        if context is None:
+            verification_error = ssl.SSLCertVerificationError(
+                1, "certificate verify failed"
+            )
+            raise urllib.error.URLError(verification_error)
+        return Response({"version": "4.74.0"})
+
+    def create_context(*, cafile):
+        contexts.append(cafile)
+        return sentinel_context
+
+    monkeypatch.setattr(plugin_currency.urllib.request, "urlopen", open_url)
+    monkeypatch.setattr(plugin_currency, "_candidate_ca_files", lambda: [ca_file])
+    monkeypatch.setattr(plugin_currency.ssl, "create_default_context", create_context)
+
+    response = plugin_currency._verified_urlopen("https://example.test", timeout=2)
+    assert json.loads(response.read()) == {"version": "4.74.0"}
+    assert contexts == [str(ca_file)]
+    assert calls == [
+        ("https://example.test", 2, None),
+        ("https://example.test", 2, sentinel_context),
+    ]
+
+
+def test_verified_open_does_not_mask_non_certificate_network_error(monkeypatch) -> None:
+    def offline(*_args, **_kwargs):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr(plugin_currency.urllib.request, "urlopen", offline)
+    monkeypatch.setattr(
+        plugin_currency,
+        "_candidate_ca_files",
+        lambda: (_ for _ in ()).throw(AssertionError("must not retry CA files")),
+    )
+    try:
+        plugin_currency._verified_urlopen("https://example.test", timeout=2)
+    except urllib.error.URLError as exc:
+        assert "offline" in str(exc)
+    else:
+        raise AssertionError("offline lookup should fail")
+
+
+def test_system_ca_context_keeps_peer_and_hostname_verification_enabled() -> None:
+    candidates = plugin_currency._candidate_ca_files()
+    if not candidates:
+        return
+    context = ssl.create_default_context(cafile=str(candidates[0]))
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True
 
 
 def test_sessionstart_notice_compares_executing_cache_to_stable(tmp_path: Path) -> None:

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.2.0"
+  version: "2.2.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -280,7 +280,10 @@ The sequence, each stage gating the next:
   requires. For Codex that means `plugin marketplace upgrade` **before**
   `plugin add`, because Codex installs *from* its git marketplace snapshot —
   skipping the upgrade installs the previous release while appearing to
-  succeed.
+  succeed. Before that destructive Codex refresh, the publisher snapshots
+  every real versioned cache root and afterwards restores and byte-verifies
+  any root the client removed. An already-running task keeps the exact hook
+  code its SessionStart loaded. Symlink recovery artifacts are not preserved.
 - **Verify** is the point of the whole script, and it checks each client
   **twice**: what the CLI reports, and the plugin manifest at the path the CLI
   says it loads. Agreement of both with the source version is the only pass.

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -44,8 +44,10 @@ import json
 import os
 import re
 import secrets
+import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -468,6 +470,111 @@ def installed_root(client: str, version: str) -> Path:
     return base / "plugins" / "cache" / MARKETPLACE / PLUGIN_NAME / version
 
 
+def plugin_cache_parent(client: str) -> Path:
+    """Return the directory containing this plugin's versioned cache roots."""
+    return installed_root(client, "0.0.0").parent
+
+
+def _tree_digest(root: Path) -> str:
+    """Hash paths, entry types, symlink targets, and file bytes deterministically."""
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*"), key=lambda item: str(item.relative_to(root))):
+        relative = str(path.relative_to(root)).encode("utf-8")
+        if path.is_symlink():
+            digest.update(b"L\0" + relative + b"\0" + os.readlink(path).encode("utf-8"))
+        elif path.is_dir():
+            digest.update(b"D\0" + relative)
+        elif path.is_file():
+            digest.update(b"F\0" + relative + b"\0" + path.read_bytes())
+    return digest.hexdigest()
+
+
+def snapshot_codex_caches(result: Result) -> tuple[Path, list[str]] | None:
+    """Copy real version roots before Codex's destructive plugin refresh.
+
+    A running Codex task retains the absolute plugin root from its SessionStart
+    hook definition. Codex's plugin add currently replaces the cache and removes
+    that root, which strands the task's later Stop hook. Claude already retains
+    historical roots. The release publisher therefore preserves every real
+    Codex version directory that exists at the transition boundary. Symlinks are
+    deliberately excluded: they are recovery artifacts, not installed versions.
+    """
+    parent = plugin_cache_parent("codex")
+    backup = Path(tempfile.mkdtemp(prefix="synthesis-codex-cache-"))
+    versions = []
+    try:
+        if parent.is_dir():
+            for source in sorted(parent.iterdir(), key=lambda path: path.name):
+                if (
+                    source.is_symlink()
+                    or not source.is_dir()
+                    or RELEASE_VERSION_RE.fullmatch(source.name) is None
+                ):
+                    continue
+                shutil.copytree(source, backup / source.name, symlinks=True)
+                versions.append(source.name)
+    except OSError as exc:
+        result.add(
+            "install.codex.cache-snapshot",
+            False,
+            f"could not preserve active-session cache roots; recovery copy kept at {backup}: {exc}",
+        )
+        return None
+    result.add(
+        "install.codex.cache-snapshot",
+        True,
+        f"preserved {len(versions)} real version root(s) before refresh",
+    )
+    return backup, versions
+
+
+def _remove_transition_backup(backup: Path) -> None:
+    """Remove only a validated mkdtemp directory created by this module."""
+    resolved = backup.resolve()
+    temporary_root = Path(tempfile.gettempdir()).resolve()
+    if (
+        resolved.parent != temporary_root
+        or not resolved.name.startswith("synthesis-codex-cache-")
+        or resolved.is_symlink()
+    ):
+        raise OSError(f"refusing unsafe transition-backup cleanup target: {backup}")
+    shutil.rmtree(resolved)
+
+
+def restore_codex_caches(
+    backup: Path, versions: list[str], result: Result
+) -> bool:
+    """Restore missing version roots and prove every preserved tree is exact."""
+    parent = plugin_cache_parent("codex")
+    restored = []
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+        for version in versions:
+            source = backup / version
+            destination = parent / version
+            if destination.is_symlink():
+                raise OSError(f"version root became a symlink: {destination}")
+            if not destination.exists():
+                shutil.copytree(source, destination, symlinks=True)
+                restored.append(version)
+            if not destination.is_dir():
+                raise OSError(f"version root is not a directory: {destination}")
+            if _tree_digest(source) != _tree_digest(destination):
+                raise OSError(f"version root changed during refresh: {destination}")
+        _remove_transition_backup(backup)
+    except OSError as exc:
+        return result.add(
+            "install.codex.cache-restore",
+            False,
+            f"active-session cache preservation failed; recovery copy kept at {backup}: {exc}",
+        )
+    return result.add(
+        "install.codex.cache-restore",
+        True,
+        f"verified {len(versions)} preserved root(s); restored {len(restored)}",
+    )
+
+
 def content_digest_report(source_repo: Path, installed: Path) -> tuple[bool, str]:
     """Compare every source skills/ file against the installed tree by bytes.
 
@@ -577,6 +684,13 @@ def refresh_client(client: str, result: Result, dry_run: bool) -> bool:
             [binary, "plugin", "marketplace", "upgrade", MARKETPLACE],
             [binary, "plugin", "add", f"{PLUGIN_NAME}@{MARKETPLACE}"],
         ]
+    cache_snapshot = None
+    if client == "codex" and not dry_run:
+        cache_snapshot = snapshot_codex_caches(result)
+        if cache_snapshot is None:
+            return False
+
+    commands_ok = True
     for command in commands:
         label = f"install.{client}.{command[2] if len(command) > 2 else 'run'}"
         if dry_run:
@@ -585,9 +699,14 @@ def refresh_client(client: str, result: Result, dry_run: bool) -> bool:
         completed = run(command, timeout=600)
         if completed.returncode != 0:
             tail = (completed.stderr or completed.stdout).strip().splitlines()
-            return result.add(label, False, tail[-1] if tail else "command failed")
+            result.add(label, False, tail[-1] if tail else "command failed")
+            commands_ok = False
+            break
         result.add(label, True, " ".join(command[1:]))
-    return True
+    caches_ok = True
+    if cache_snapshot is not None:
+        caches_ok = restore_codex_caches(*cache_snapshot, result)
+    return commands_ok and caches_ok
 
 
 def preflight(repo: Path, result: Result, install_only: bool) -> str | None:

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -13,6 +13,7 @@ converts an unknown into a false assurance.
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -395,6 +396,21 @@ def test_release_manager_documents_channel_ref_contract() -> None:
     assert "atomic" in text
 
 
+def test_lifecycle_hotfix_is_documented_on_every_public_maintenance_surface() -> None:
+    repository = Path(__file__).resolve().parents[3]
+    manager = (repository / "skills/synthesis-skills-manager/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    onboarding = (repository / "skills/synthesis-onboarding/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    readme = (repository / "README.md").read_text(encoding="utf-8")
+    assert "snapshots" in manager and "versioned cache root" in manager
+    assert "operating-system CA bundle" in onboarding
+    assert "4.74.1" in readme
+    assert "full TLS and" in readme
+
+
 def test_main_carries_acceptance_authority_to_publish_boundary(
     repo: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -560,6 +576,90 @@ def test_refresh_fails_closed_without_binary(monkeypatch: pytest.MonkeyPatch) ->
     result = release.Result()
     assert release.refresh_client("codex", result, dry_run=True) is False
     assert result.failed
+
+
+def test_codex_refresh_restores_real_version_root_deleted_by_client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_parent = tmp_path / "codex-cache"
+    old_root = cache_parent / "4.74.0"
+    (old_root / "hooks").mkdir(parents=True)
+    (old_root / "hooks" / "hooks.json").write_text("old hook bytes\n", encoding="utf-8")
+    recovery_link = cache_parent / "4.73.0"
+    recovery_link.symlink_to(old_root)
+
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "resolve_client_binary", lambda name: "/fake/codex")
+
+    def run(command, **_kwargs):
+        if command[1:3] == ["plugin", "add"]:
+            shutil.rmtree(old_root)
+            recovery_link.unlink()
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(release, "run", run)
+    result = release.Result()
+    assert release.refresh_client("codex", result, dry_run=False) is True
+    assert (old_root / "hooks" / "hooks.json").read_text(encoding="utf-8") == "old hook bytes\n"
+    assert not recovery_link.exists()
+    steps = {step.name: step for step in result.steps}
+    assert steps["install.codex.cache-snapshot"].ok is True
+    assert "1 real version" in steps["install.codex.cache-snapshot"].detail
+    assert steps["install.codex.cache-restore"].ok is True
+    assert "restored 1" in steps["install.codex.cache-restore"].detail
+
+
+def test_codex_refresh_fails_if_existing_preserved_root_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_parent = tmp_path / "codex-cache"
+    old_file = cache_parent / "4.74.0" / "hooks" / "hooks.json"
+    old_file.parent.mkdir(parents=True)
+    old_file.write_text("before\n", encoding="utf-8")
+
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "resolve_client_binary", lambda name: "/fake/codex")
+
+    def run(command, **_kwargs):
+        if command[1:3] == ["plugin", "add"]:
+            old_file.write_text("modified\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(release, "run", run)
+    result = release.Result()
+    assert release.refresh_client("codex", result, dry_run=False) is False
+    restore = next(
+        step for step in result.steps if step.name == "install.codex.cache-restore"
+    )
+    assert restore.ok is False
+    assert "recovery copy kept" in restore.detail
+
+
+def test_codex_refresh_does_not_run_when_cache_snapshot_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_parent = tmp_path / "codex-cache"
+    old_root = cache_parent / "4.74.0"
+    old_root.mkdir(parents=True)
+    calls = []
+
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "resolve_client_binary", lambda name: "/fake/codex")
+    monkeypatch.setattr(
+        release.shutil,
+        "copytree",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("disk full")),
+    )
+    monkeypatch.setattr(release, "run", lambda *args, **kwargs: calls.append(args))
+
+    result = release.Result()
+    assert release.refresh_client("codex", result, dry_run=False) is False
+    assert calls == []
+    snapshot = next(
+        step for step in result.steps if step.name == "install.codex.cache-snapshot"
+    )
+    assert snapshot.ok is False
+    assert "recovery copy kept" in snapshot.detail
 
 
 # --- entrypoint guards -----------------------------------------------------


### PR DESCRIPTION
Why

The first post-release SessionStart for 4.74.0 exposed two lifecycle failures: python.org Python on macOS could not find a CA path for the stable manifest, and the native plugin refresh removed the versioned cache that an already-running task still needed for its Stop hook.

What changed

- Retry certificate-path failures with existing operating-system CA bundles through a verifying SSL context. Certificate and hostname checks remain enabled.
- Snapshot every real versioned Codex cache before refresh, restore any removed root, and verify its full tree digest before the release can pass.
- Refuse client mutation when the preservation snapshot fails. Keep a recovery copy and fail loudly when restoration cannot be proved.
- Exclude symlink recovery artifacts from preserved installed versions.

Verification

- 65 focused and acceptance-runner tests passed.
- Source conformance passed 204 checks.
- Instruction conformance passed both checks.
- The live stable lookup succeeded under the same stock Python runtime that reproduced the certificate failure.