### PR TITLE
Resolve peer sessions through the coordination board

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.74.1",
+  "version": "4.75.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.74.1",
+  "version": "4.75.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.75.0] - 2026-09-01
+
+**Peer-session messages now resolve through the board instead of guesswork.**
+Messages between agent sessions too often reached the wrong chat session, or
+an unsure sender broadcast to several — three naming layers (board identities,
+client chat handles, harness display labels) covered one population with no
+join between them, and the 2026-08-19 "labels are not seat identity" lesson
+was doctrine without a mechanism.
+
+Coordination board schema v4 adds the join: a `client session ref` column
+carrying each session's client-native delivery handle (`ccd:local_<uuid>`,
+`codex:<uuid>`), registered automatically at claim time from the session's own
+environment (`CLAUDE_CODE_HOST_SESSION_ID`, or `SYNTHESIS_CLIENT_SESSION_REF`
+for any client). A new `coordination.py resolve --to <project|session|ref>`
+returns the exact deliverable target with its delivery lane, refusing
+ambiguity (exit 20) and absence (exit 21) instead of guessing or
+broadcasting; chat titles and display labels are deliberately not selectors.
+`message --to` now refuses addressees that match no session or registered
+project unless `--free-address` records the exception. A claim with no
+`--session` whose detected ref matches its own active row updates that row
+in place — one client seat, one row — and duplicate active refs refuse with
+the stale rows named.
+
+Migration is staged for shared boards: the engine reads schemas v1–v4 but
+writes each board's declared schema, so live sessions on older plugin
+versions keep working until an explicit `migrate` flips the board to v4.
+The doctor and `conformance coordination` accept a declared v3 board with a
+migrate note during the transition.
+
+synthesis-message-guard v1.4.0 adds the fail-closed backstop: adopting
+`peer_send_resolution` in patterns.json gates direct peer-session sends —
+the target session id must be an active client ref on the board, or the
+send blocks with resolve/board-bus guidance. The peer lane runs before the
+exempt list and replaces the correspondence ledger lane for those tools;
+unadopted instances keep the previous exempt posture, and the doctor reports
+which posture is live plus the required hook wiring.
+
 ## [4.74.1] - 2026-09-01
 
 **The lifecycle now survives the release that advances it.** The first 4.74.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A peer session is addressed by what it owns, never by what a client calls
+it (September 2026).** Release **4.75.0** joins the coordination board to
+each client's native delivery handle: claims self-register a `client session
+ref` (board schema v4, staged migration), `coordination.py resolve` turns a
+project or any session identity into the one exact deliverable target —
+refusing ambiguity and absence instead of guessing or broadcasting — the
+board bus refuses unresolvable addressees, and message-guard v1.4.0 can
+block any direct peer send whose target is not a registered active ref. See
+the [4.75.0 release notes](CHANGELOG.md).
+
 **A plugin update must not break the task applying it (September 2026).**
 Release **4.74.1** repairs both failure surfaces found by the first 4.74.0
 SessionStart: the stock python.org macOS runtime now resolves the stable release

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -1388,10 +1388,16 @@ def coordination_checks(board: Path, *, required: bool = True) -> list[Check]:
             heading,
             required=required,
         )
-    table_ok = all(
+    # v3 remains a valid declared schema during the staged v4 migration: the
+    # board upgrades only via an explicit `coordination.py migrate`, after
+    # every machine's client is current.
+    schema_ok = any(
+        f"Schema: v{version}" in text
+        for version in (COORDINATION_SCHEMA_VERSION, 3)
+    )
+    table_ok = schema_ok and all(
         column in text
         for column in (
-            f"Schema: v{COORDINATION_SCHEMA_VERSION}",
             "| session uuid |",
             "| compact id |",
             "| speakable id v1 |",

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,32 +1,38 @@
-# AGENT HEURISTIC: authored for the 4.74.1 lifecycle-survival hotfix.
+# AGENT HEURISTIC: authored for the 4.75.0 peer-session-resolution release.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: synthesis-onboarding-lifecycle-survival-hotfix
+suite: peer-session-resolution
 membership: closed
-production_entry_point: skills/synthesis-skills-manager/scripts/release.py
-enforcing_boundary: verified release lookup and active-session-safe plugin refresh
+production_entry_point: skills/synthesis-project-management/scripts/coordination.py
+enforcing_boundary: board-registered peer resolution, strict bus addressing, and staged v4 migration
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: hermetic tests prove certificate-path retries, refusal to mask unrelated network errors, verifying SSL context properties, exact Codex cache restoration, corruption detection, pre-mutation snapshot failure, documentation, manifest parity, and changelog parity; the live stock-Python stable lookup is checked outside the suite, while release.py deep verification remains the installed-cache boundary after publication
+unverified_remainder: hermetic tests prove ref registration and seat idempotency, resolve's fail-closed ambiguity and absence exits, strict bus addressing with the recorded exception, staged v3-write preservation, the guard's peer lane in all three outcomes, schema-tolerant conformance, and documentation on every public surface; live cross-session delivery, migration of the real lease-backed board, private guard adoption and hook wiring, and Codex-side ref export remain boundary work outside this suite
 changed_surfaces:
-  - path: skills/synthesis-onboarding/scripts/plugin_currency.py
-    cases: [verified-system-ca-retry, non-certificate-error-propagation, verifying-context]
-  - path: skills/synthesis-onboarding/scripts/test_plugin_currency.py
-    cases: [verified-system-ca-retry, non-certificate-error-propagation, verifying-context]
-  - path: skills/synthesis-onboarding/SKILL.md
-    cases: [lifecycle-hotfix-doc-contract]
-  - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [active-cache-restoration, cache-corruption-refusal, snapshot-failure-precedes-mutation]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [active-cache-restoration, cache-corruption-refusal, snapshot-failure-precedes-mutation, lifecycle-hotfix-doc-contract, release-manifest-parity, release-changelog-parity]
-  - path: skills/synthesis-skills-manager/SKILL.md
-    cases: [lifecycle-hotfix-doc-contract]
-  - path: README.md
-    cases: [lifecycle-hotfix-doc-contract]
+  - path: skills/synthesis-project-management/scripts/coordination.py
+    cases: [client-ref-registration, seat-idempotency, duplicate-seat-refusal, resolve-refuses-ambiguity, resolve-refuses-absence, resolve-by-client-ref, bus-strict-addressing, staged-migration-preserves-v3]
+  - path: skills/synthesis-project-management/scripts/coordination_schema.py
+    cases: [client-ref-registration, staged-migration-preserves-v3]
+  - path: skills/synthesis-project-management/scripts/test_coordination.py
+    cases: [client-ref-registration, seat-idempotency, duplicate-seat-refusal, resolve-refuses-ambiguity, resolve-refuses-absence, resolve-by-client-ref, bus-strict-addressing, staged-migration-preserves-v3, peer-doc-contract, conformance-accepts-declared-v3]
+  - path: skills/synthesis-project-management/SKILL.md
+    cases: [peer-doc-contract]
+  - path: skills/synthesis-project-management/references/parallel-agent-protocol.md
+    cases: [peer-doc-contract]
+  - path: skills/synthesis-project-management/references/session-identity.md
+    cases: [peer-doc-contract]
+  - path: skills/synthesis-message-guard/scripts/message_guard.py
+    cases: [peer-send-registered-target-passes, peer-send-unregistered-target-blocks, peer-send-missing-board-fails-closed]
+  - path: skills/synthesis-message-guard/scripts/test_message_guard.py
+    cases: [peer-send-registered-target-passes, peer-send-unregistered-target-blocks, peer-send-missing-board-fails-closed]
+  - path: skills/synthesis-message-guard/SKILL.md
+    cases: [peer-doc-contract]
+  - path: skills/synthesis-agent-conformance/scripts/conformance.py
+    cases: [conformance-accepts-declared-v3]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -34,36 +40,62 @@ changed_surfaces:
   - path: .codex-plugin/plugin.json
     cases: [release-manifest-parity]
   - path: CHANGELOG.md
-    cases: [release-changelog-parity]
+    cases: [release-changelog-parity, peer-doc-contract]
+  - path: README.md
+    cases: [peer-doc-contract]
 cases:
-  - id: verified-system-ca-retry
+  - id: client-ref-registration
     control_class: enforced-gate
-    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_verified_open_retries_cert_failure_with_system_ca_bundle
-    motivating_defect: python-org-macos-can-have-no-openssl-ca-path-even-though-the-operating-system-ships-a-valid-ca-bundle
-  - id: non-certificate-error-propagation
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_claim_registers_detected_client_ref
+    motivating_defect: three-naming-layers-covered-one-session-population-with-no-join-so-senders-guessed-targets-by-chat-title
+  - id: seat-idempotency
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_verified_open_does_not_mask_non_certificate_network_error
-    motivating_defect: retrying-every-network-error-as-a-ca-problem-hides-the-real-unverifiable-state-and-wastes-sessionstart-time
-  - id: verifying-context
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_claim_reuses_active_row_for_same_client_seat
+    motivating_defect: one-client-session-allocated-a-fresh-board-identity-per-claim-scattering-one-seat-across-many-rows
+  - id: duplicate-seat-refusal
     control_class: enforced-gate
-    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_system_ca_context_keeps_peer_and_hostname_verification_enabled
-    motivating_defect: fixing-ca-discovery-by-disabling-peer-or-hostname-verification-turns-an-update-notice-into-a-network-injection-surface
-  - id: active-cache-restoration
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_second_seat_with_same_ref_and_selector_is_refused
+    motivating_defect: a-zombie-row-sharing-a-live-seat-ref-would-make-the-delivery-lookup-silently-ambiguous
+  - id: resolve-refuses-ambiguity
     control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_restores_real_version_root_deleted_by_client
-    motivating_defect: codex-plugin-refresh-deletes-the-version-root-that-an-already-running-task-still-needs-for-its-stop-hook
-  - id: cache-corruption-refusal
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_resolve_ambiguity_refuses_instead_of_broadcasting
+    motivating_defect: an-unsure-sender-broadcast-to-several-sessions-and-a-wrong-session-may-comply-with-a-dispatch
+  - id: resolve-refuses-absence
     control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_fails_if_existing_preserved_root_changes
-    motivating_defect: presence-alone-cannot-prove-an-active-session-cache-still-contains-the-code-that-session-loaded
-  - id: snapshot-failure-precedes-mutation
-    control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_does_not_run_when_cache_snapshot_fails
-    motivating_defect: a-publisher-that-refreshes-after-its-preservation-copy-fails-can-strand-the-running-task-without-recovery-bytes
-  - id: lifecycle-hotfix-doc-contract
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_resolve_unknown_target_points_to_board_bus
+    motivating_defect: an-unregistered-peer-invited-title-guessing-instead-of-the-durable-self-selecting-bus
+  - id: resolve-by-client-ref
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_lifecycle_hotfix_is_documented_on_every_public_maintenance_surface
-    motivating_defect: future-maintainers-can-regress-a-runtime-lifecycle-invariant-that-only-lives-in-an-incident-log
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_resolve_by_bare_local_ref
+    motivating_defect: a-known-chat-handle-could-not-be-mapped-back-to-board-identity-for-verification
+  - id: bus-strict-addressing
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_message_to_registered_project_renders_sessions_address
+    motivating_defect: free-text-bus-addressees-accepted-typos-and-unregistered-recipients-without-any-refusal
+  - id: staged-migration-preserves-v3
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_v3_board_keeps_schema_until_explicit_migrate
+    motivating_defect: an-implicit-schema-rewrite-on-first-write-would-fail-live-older-parsers-mid-flight-on-a-shared-board
+  - id: peer-send-registered-target-passes
+    control_class: acceptance-test
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_peer_registered_active_target_passes
+    motivating_defect: a-guard-that-blocks-legitimate-resolved-traffic-gets-bypassed-rather-than-obeyed
+  - id: peer-send-unregistered-target-blocks
+    control_class: enforced-gate
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_peer_unregistered_target_blocks_with_resolve_guidance
+    motivating_defect: the-2026-08-19-lesson-stayed-doctrine-without-a-mechanism-and-misdelivery-kept-happening
+  - id: peer-send-missing-board-fails-closed
+    control_class: enforced-gate
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_peer_missing_board_blocks
+    motivating_defect: a-guard-that-cannot-read-its-authority-source-must-block-not-warn-and-pass
+  - id: peer-doc-contract
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_peer_resolution_documented_on_public_surfaces
+    motivating_defect: a-protocol-that-lives-only-in-code-gets-rediscovered-as-folklore-and-then-violated
+  - id: conformance-accepts-declared-v3
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_conformance_board_check_accepts_declared_v3_and_v4
+    motivating_defect: a-parity-checker-pinned-to-the-new-schema-would-fail-every-machine-during-the-staged-window
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
@@ -71,7 +103,7 @@ cases:
   - id: release-manifest-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
-    motivating_defect: a-hotfix-version-that-reaches-only-one-client-manifest-cannot-be-reliably-installed-or-audited
+    motivating_defect: a-version-that-reaches-only-one-client-manifest-cannot-be-reliably-installed-or-audited
   - id: release-changelog-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed

--- a/skills/synthesis-message-guard/SKILL.md
+++ b/skills/synthesis-message-guard/SKILL.md
@@ -75,6 +75,31 @@ composing agent                      engine (stdlib python, fail closed)
   the send/draft tool family across all MCP servers by name pattern. The doctor
   requires every installed client to carry the guard.
 
+## Peer-session sends (config-adopted)
+
+Agent-to-agent session messaging has a different failure mode from
+correspondence: not register drift but **misdelivery** — a target chat
+session chosen by guessing a title or display label. Adopting
+`peer_send_resolution` in `patterns.json` gives those tools their own lane,
+which runs before the exempt list and replaces the ledger lane for matching
+calls:
+
+```json
+"peer_send_resolution": {
+  "tool_pattern": "ccd_session_mgmt__send_message$",
+  "target_field": "session_id",
+  "board": "~/.synthesis/coordination/active-sessions.md"
+}
+```
+
+The target session id must appear as an **active client session ref** on the
+coordination board (schema v4, registered at claim time) — otherwise the send
+blocks with instructions to run `coordination.py resolve` or use the board
+message bus. An unreadable board blocks (fail closed). Unadopted instances
+keep the old posture — inter-session tools stay in `exempt_tool_patterns` —
+and the doctor says which posture is live. Requires the tool's PreToolUse
+wiring to route these calls to the guard; the doctor checks that too.
+
 ## The ledger contract
 
 `--ledger-template` prints the skeleton. Fields the engine enforces:

--- a/skills/synthesis-message-guard/scripts/message_guard.py
+++ b/skills/synthesis-message-guard/scripts/message_guard.py
@@ -51,7 +51,7 @@ import tempfile
 import time
 from datetime import datetime, timezone
 
-ENGINE_VERSION = "1.3.0"
+ENGINE_VERSION = "1.4.0"
 
 
 def config_path():
@@ -305,6 +305,86 @@ def validate_ledger(ledger, text, cfg, tool_name):
 
 
 # --------------------------------------------------------------------------
+# Peer-session sends (config-adopted, 2026-09-01)
+# --------------------------------------------------------------------------
+#
+# Correspondence tools carry Rajiv-register text to humans and take the full
+# ledger lane below. Peer-session tools carry agent-to-agent traffic; their
+# failure mode is not register drift but MISDELIVERY — a target chosen by
+# guessing a chat title or display label. The mechanical fix: the target
+# session id must be registered as an ACTIVE client ref on the coordination
+# board (schema v4), which only happens when that session claimed its seat.
+# The lesson this makes mechanical: the board id is the identity; the client
+# label is a display string.
+
+def _board_has_active_ref(content, ref):
+    """Self-contained active-row scan; no cross-skill import at hook time."""
+    terminal = {"released", "complete", "completed", "closed"}
+    in_table = False
+    for line in content.splitlines():
+        if line.strip() == "## Active sessions":
+            in_table = True
+            continue
+        if in_table and line.startswith("## "):
+            break
+        if not in_table or not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.split("|")[1:-1]]
+        if not cells or cells[0] in {"id", "session uuid"}:
+            continue
+        if set(cells[0]) <= {"-"}:
+            continue
+        if ref in cells and cells[-1].lower() not in terminal:
+            return True
+    return False
+
+
+def peer_send_resolution_failures(tool_name, tool_input, cfg):
+    """Return (handled, failures) for the peer-session send lane.
+
+    handled is True when the tool matches the configured peer pattern; the
+    peer lane then replaces the correspondence lane for this call. Absent
+    config means not handled — adoption is deliberate, per instance.
+    """
+    peer = cfg.get("peer_send_resolution")
+    if not isinstance(peer, dict):
+        return False, []
+    pattern = peer.get("tool_pattern")
+    if not pattern or not re.search(pattern, tool_name):
+        return False, []
+    field = peer.get("target_field", "session_id")
+    target = tool_input.get(field)
+    if not isinstance(target, str) or not target.strip():
+        return True, [
+            "peer send carries no %r target; unknown shape fails closed" % field
+        ]
+    target = target.strip()
+    board = os.path.expanduser(
+        peer.get("board", "~/.synthesis/coordination/active-sessions.md")
+    )
+    try:
+        with open(board, "r", encoding="utf-8") as fh:
+            content = fh.read()
+    except OSError as exc:
+        return True, [
+            "coordination board unreadable (%s) so the target cannot be "
+            "verified: %s" % (board, exc)
+        ]
+    if _board_has_active_ref(content, "ccd:" + target) or _board_has_active_ref(
+        content, target
+    ):
+        return True, []
+    return True, [
+        "target session id %r is not a registered active client ref on the "
+        "coordination board (%s). Run coordination.py resolve "
+        "--to <project-or-session> and address the exact ref it returns; if "
+        "the peer has not claimed a seat, deliver via the board message bus "
+        "and let it self-select — never guess a chat session by title or "
+        "broadcast" % (target, board)
+    ]
+
+
+# --------------------------------------------------------------------------
 # Gate
 # --------------------------------------------------------------------------
 
@@ -320,6 +400,25 @@ def run_gate():
         tool_input = payload.get("tool_input") or {}
 
         cfg, cblock, cwarn, gated, exempt = load_config()
+
+        # Peer-session lane runs BEFORE the exempt list: while unadopted,
+        # instances may exempt inter-session tools; once adopted, the peer
+        # pattern owns those tools and the exemption no longer bypasses it.
+        peer_handled, peer_fails = peer_send_resolution_failures(
+            tool_name, tool_input, cfg
+        )
+        if peer_handled:
+            if peer_fails:
+                block("peer-session resolution — " + " | ".join(peer_fails))
+            os.makedirs(state_dir(), exist_ok=True)
+            with open(log_path(), "a", encoding="utf-8") as fh:
+                fh.write(json.dumps({
+                    "at": datetime.now(timezone.utc).isoformat(),
+                    "kind": "peer-send",
+                    "tool": tool_name,
+                    "engine": ENGINE_VERSION,
+                }) + "\n")
+            sys.exit(0)
 
         if any(rx.search(tool_name) for rx in exempt):
             sys.exit(0)
@@ -513,8 +612,26 @@ def run_doctor():
     missed = [t for t in sample_tools if not any(rx.search(t) for rx in gated)]
     report(not missed, "gated patterns cover the send/draft tool family",
            "missed: %s" % ", ".join(missed) if missed else "all covered")
-    report(any(rx.search("mcp__ccd_session_mgmt__send_message") for rx in exempt),
-           "inter-session messaging is exempted")
+    peer_sample = "mcp__ccd_session_mgmt__send_message"
+    peer_cfg = cfg.get("peer_send_resolution")
+    if isinstance(peer_cfg, dict):
+        try:
+            peer_rx = re.compile(peer_cfg.get("tool_pattern") or "")
+            report(bool(peer_cfg.get("tool_pattern"))
+                   and bool(peer_rx.search(peer_sample)),
+                   "peer-session pattern covers inter-session sends",
+                   peer_cfg.get("tool_pattern", ""))
+        except re.error as exc:
+            report(False, "peer-session tool pattern compiles", str(exc))
+        peer_board = os.path.expanduser(peer_cfg.get(
+            "board", "~/.synthesis/coordination/active-sessions.md"))
+        report(os.path.isfile(peer_board),
+               "coordination board readable for peer resolution", peer_board)
+    else:
+        report(any(rx.search(peer_sample) for rx in exempt),
+               "inter-session messaging is exempted (peer_send_resolution "
+               "not adopted; adopt it to gate peer sends on board "
+               "registration)")
 
     client_configs = [
         (
@@ -550,6 +667,12 @@ def run_doctor():
                 "%s PreToolUse wiring covers the tool family" % label,
                 config_file,
             )
+            if isinstance(peer_cfg, dict) and label == "Claude Code":
+                report(
+                    hook_config_covers(config_file, [peer_sample]),
+                    "%s PreToolUse wiring routes peer-session sends" % label,
+                    config_file,
+                )
         except Exception as exc:
             report(False, "%s hook config readable" % label, str(exc))
     report(active_clients > 0, "at least one supported agent client is active")

--- a/skills/synthesis-message-guard/scripts/test_message_guard.py
+++ b/skills/synthesis-message-guard/scripts/test_message_guard.py
@@ -185,3 +185,112 @@ def test_wire_absent_config_is_off() -> None:
         "mcp__workspace-mcp__send_gmail_message", {"body_format": "plain"},
         RAGENIE_PLAIN, {})
     assert fails == []
+
+
+# --- peer-session send resolution (2026-09-01) ------------------------------
+#
+# Misdelivery, not register drift, is the peer-lane failure mode: a target
+# chosen by chat-title guesswork. The check requires the target session id to
+# be a registered ACTIVE client ref on the coordination board.
+
+PEER_BOARD = (
+    "# Coordination\n\nSchema: v4\n\n## Active sessions\n\n"
+    "| session uuid | compact id | speakable id v1 | legacy id | agent | "
+    "machine | client session ref | project | started | heartbeat | mode | "
+    "workspace(s) / branch | goal | claimed areas (advisory lock) | "
+    "context role | status |\n"
+    "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n"
+    "| u1 | s-aaaa-aaaa-aaaa | a-b-c-d-00001 |  | Claude Code | m1 | "
+    "ccd:local_good | proj-a | t | t | interactive | w | g | a/** | owner | "
+    "active |\n"
+    "| u2 | s-bbbb-bbbb-bbbb | a-b-c-d-00002 |  | Claude Code | m1 | "
+    "ccd:local_gone | proj-b | t | t | interactive | w | g | b/** | owner | "
+    "released |\n"
+    "\n## Messages\n\n---\n\n## Protocol\n"
+)
+
+
+def peer_cfg(board_path) -> dict:
+    return {
+        "peer_send_resolution": {
+            "tool_pattern": "ccd_session_mgmt__send_message$",
+            "target_field": "session_id",
+            "board": str(board_path),
+        }
+    }
+
+
+def test_peer_registered_active_target_passes(tmp_path: Path) -> None:
+    board = tmp_path / "board.md"
+    board.write_text(PEER_BOARD, encoding="utf-8")
+    handled, fails = MODULE.peer_send_resolution_failures(
+        "mcp__ccd_session_mgmt__send_message",
+        {"session_id": "local_good", "message": "hello"},
+        peer_cfg(board),
+    )
+    assert handled and fails == []
+
+
+def test_peer_unregistered_target_blocks_with_resolve_guidance(
+    tmp_path: Path,
+) -> None:
+    board = tmp_path / "board.md"
+    board.write_text(PEER_BOARD, encoding="utf-8")
+    handled, fails = MODULE.peer_send_resolution_failures(
+        "mcp__ccd_session_mgmt__send_message",
+        {"session_id": "local_guessed", "message": "hello"},
+        peer_cfg(board),
+    )
+    assert handled
+    joined = " ".join(fails)
+    assert "resolve" in joined
+    assert "never guess" in joined
+
+
+def test_peer_released_target_blocks(tmp_path: Path) -> None:
+    board = tmp_path / "board.md"
+    board.write_text(PEER_BOARD, encoding="utf-8")
+    handled, fails = MODULE.peer_send_resolution_failures(
+        "mcp__ccd_session_mgmt__send_message",
+        {"session_id": "local_gone"},
+        peer_cfg(board),
+    )
+    assert handled and fails
+
+
+def test_peer_missing_board_blocks(tmp_path: Path) -> None:
+    handled, fails = MODULE.peer_send_resolution_failures(
+        "mcp__ccd_session_mgmt__send_message",
+        {"session_id": "local_good"},
+        peer_cfg(tmp_path / "absent.md"),
+    )
+    assert handled and any("unreadable" in f for f in fails)
+
+
+def test_peer_missing_target_field_blocks(tmp_path: Path) -> None:
+    board = tmp_path / "board.md"
+    board.write_text(PEER_BOARD, encoding="utf-8")
+    handled, fails = MODULE.peer_send_resolution_failures(
+        "mcp__ccd_session_mgmt__send_message",
+        {"message": "hello"},
+        peer_cfg(board),
+    )
+    assert handled and any("fails closed" in f for f in fails)
+
+
+def test_peer_absent_config_is_not_handled() -> None:
+    handled, fails = MODULE.peer_send_resolution_failures(
+        "mcp__ccd_session_mgmt__send_message", {"session_id": "x"}, {}
+    )
+    assert (handled, fails) == (False, [])
+
+
+def test_peer_other_tools_stay_in_correspondence_lane(tmp_path: Path) -> None:
+    board = tmp_path / "board.md"
+    board.write_text(PEER_BOARD, encoding="utf-8")
+    handled, fails = MODULE.peer_send_resolution_failures(
+        "mcp__abc__slack_send_message",
+        {"session_id": "local_good"},
+        peer_cfg(board),
+    )
+    assert (handled, fails) == (False, [])

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.7.0"
+  version: "2.8.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -14,21 +14,24 @@ metadata:
 
 A lightweight project management system designed for human-agent collaboration. Optimized for context preservation across conversation sessions and context compaction events.
 
-## v2.5.0 — Staged paths enforced against coordination claims
+## v2.8.0 — Peer-session resolution: the board is the address book
 
-`coordination.py check-staged` compares both sides of every staged rename and
-all other staged paths with the selected active session's source-area claims.
-The exact Git worktree and branch must also appear on that session's board row.
-The authority snapshot is taken under the board lock; a lease-backed board
-passes through a compare-and-swap fence so a concurrent release is read before
-the check can issue a receipt. Equivalent filesystem spellings resolve before
-claim matching.
-An outside path refuses by default; an explicit override succeeds only after
-its reason, staged tree, repository, branch, and outside paths are appended
-atomically to `## Messages`. Every result separates its authority label from
-its enforcement outcome and names the unverified remainder. The receipt binds
-that outcome and its outside-path list alongside the staged tree. The board
-remains schema v3; this release adds no columns or sidecar state.
+Board schema v4 adds one column, `client session ref` — the client-native
+delivery handle (`ccd:local_<uuid>` for a Claude Code chat session,
+`codex:<uuid>` for Codex), registered automatically at claim time from the
+session's own environment. `coordination.py resolve --to <project|session|ref>`
+turns any board identity or registered project into the exact deliverable
+target, refusing ambiguity (exit 20) and absence (exit 21) instead of
+guessing or broadcasting; `message --to` now refuses an addressee that
+matches no session or registered project unless `--free-address` is passed.
+A claim with no `--session` whose detected ref matches its own active row
+updates that row instead of allocating a new identity. Migration is staged:
+the engine reads v1–v4 but writes each board's declared schema, so a shared
+board upgrades only via an explicit `migrate` after every machine's client
+is current. Doctrine source: the 2026-08-19 lesson — the board id is the
+identity; the client label is a display string. Full protocol:
+[references/parallel-agent-protocol.md](references/parallel-agent-protocol.md)
+("Addressing a peer session").
 
 ## Configuration
 
@@ -342,7 +345,12 @@ python3 <synthesis-project-management-root>/scripts/coordination.py heartbeat \
 python3 <synthesis-project-management-root>/scripts/coordination.py \
   check-staged --session s-6adk-06yc-yqb2 --repository /path/to/worktree
 
-# Leave an asynchronous handoff
+# Resolve a peer to its exact deliverable target before messaging it
+python3 <synthesis-project-management-root>/scripts/coordination.py resolve \
+  --to example-project --role owner
+
+# Leave an asynchronous handoff (--to must resolve to a session or a
+# registered project; --free-address records a deliberate exception)
 printf '%s\n' "Source checks pass; live install awaits authorization." |
   python3 <synthesis-project-management-root>/scripts/coordination.py message \
     --from s-6adk-06yc-yqb2 --to crater-sunset-alone-okay-23907
@@ -392,8 +400,12 @@ Rules:
 6. **Autonomous claim keeps priority.** When an autonomous and interactive
    session overlap, the autonomous session keeps its existing claim; the
    interactive session yields unless the user explicitly reorders them.
-7. **Messages are asynchronous.** Address the other session in the message log;
-   the recipient reads it at its next checkpoint.
+7. **Messages are asynchronous, and addresses are resolved, never guessed.**
+   Address the other session in the message log; the recipient reads it at
+   its next checkpoint. Before any direct client-channel send to a peer
+   session, run `resolve` and address the exact ref it returns; a client's
+   display labels and chat titles are not identities, and an unresolvable
+   peer gets a board message, not a broadcast.
 8. **Heartbeat and release explicitly.** Refresh the heartbeat at checkpoints.
    A paused or completed session releases or narrows its claims. Stale `active`
    rows remain blocking until explicitly resolved; time alone never transfers

--- a/skills/synthesis-project-management/references/parallel-agent-protocol.md
+++ b/skills/synthesis-project-management/references/parallel-agent-protocol.md
@@ -30,6 +30,52 @@ machine:
    with `retire_worktree.py`, never by hand. Publish the attributed batch
    only for explicit remote handoff or day-end.
 
+## Addressing a peer session — resolve, never guess
+
+Three naming systems cover one population of sessions: the board's
+identities (UUIDv7 with compact and speakable aliases), each client's chat
+handles (Claude Code's `local_<uuid>` session ids with free-text titles),
+and the harness's display labels (directory-plus-recency strings that
+duplicate freely). Only the board answers "what does this session own," and
+since schema v4 it also carries the join: each row's **client session ref**,
+the client-native delivery handle registered automatically at claim time
+(`ccd:local_<uuid>` from `CLAUDE_CODE_HOST_SESSION_ID`, or any scheme-prefixed
+value exported as `SYNTHESIS_CLIENT_SESSION_REF`, e.g. `codex:<uuid>`).
+
+The addressing protocol:
+
+1. **Resolve first.** `coordination.py resolve --to <project|session|ref>`
+   returns the exact target with its delivery lane. Exactly one match exits
+   0; several exit 20 and are printed — narrow with `--role owner` or
+   address one exact id; none exits 21. Titles and display labels are
+   deliberately not selectors.
+2. **Deliver on the returned lane.** A `ccd:` ref is a direct-push target
+   for Claude Code's session-messaging tool on that machine. A Codex session
+   or an unregistered peer is reached through the board message bus
+   (`message --to`), which now also refuses addressees that match no
+   session or registered project (`--free-address` records a deliberate
+   exception). Substance belongs on the durable bus either way; the direct
+   channel is the pointer (the 2026-08-19 rule).
+3. **Never assign work to a guess.** An unresolvable peer means broadcast
+   informationally on the bus and let sessions self-select — a dispatch to
+   the wrong session starts work in a context with the wrong claims, and
+   the receiving session cannot tell it was a guess.
+4. **One seat, one row.** A claim with no `--session` whose detected ref
+   matches its own active row updates that row in place; two active rows
+   with one ref refuse until the stale one is released. Sub-agents spawned
+   by a session inherit its environment and therefore its seat — they must
+   not claim as independent sessions.
+5. **Enforcement.** Instances that adopt `peer_send_resolution` in
+   synthesis-message-guard get the fail-closed backstop: a direct
+   peer-session send whose target id is not an active board ref is blocked
+   at the PreToolUse boundary with resolve/bus guidance.
+
+Migration is staged: the engine reads schemas v1–v4 and writes each board's
+declared schema; a shared board flips to v4 only via an explicit `migrate`
+run after every machine's client is current, so older parsers mid-flight
+fail closed on nothing. Until migration, refs print a notice at claim time
+and drop harmlessly; resolve says the board is pre-v4.
+
 ## Digests — what survives a crash
 
 Semantic continuity does not come from copying chat transcripts. The durable

--- a/skills/synthesis-project-management/references/session-identity.md
+++ b/skills/synthesis-project-management/references/session-identity.md
@@ -13,6 +13,13 @@ remain the source-area paths attached to the session.
 | Speakable v1 | `crater-sunset-alone-okay-23906` | 60 | Dictation, reading, and short-term recall |
 | Legacy | `AX` | historical | Explicit lookup mapping for migrated v1/v2 boards |
 
+Since schema v4 a row also carries a **client session ref** (for example
+`ccd:local_<uuid>`), which is not an identity: it is the client-native
+delivery address registered at claim time, resolvable through
+`coordination.py resolve` but never a substitute for the UUID in pointers,
+leases, or receipts. See the parallel-agent protocol's "Addressing a peer
+session."
+
 UUIDv7 follows RFC 9562: 48 milliseconds-of-Unix-time bits, required version
 and variant fields, and 74 random bits. The alias token uses only the low 60
 bits of `rand_b`; no timestamp, version, or variant bit enters either

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -30,6 +30,7 @@ from coordination_schema import (
     V1_COLUMNS,
     V2_COLUMNS,
     V3_COLUMNS,
+    V4_COLUMNS,
     SessionIdentity,
     display_id,
     identity_lookup_keys,
@@ -42,13 +43,55 @@ from coordination_schema import (
 
 DEFAULT_BOARD = Path.home() / ".synthesis" / "coordination" / "active-sessions.md"
 DEFAULT_ACTIVE_PROJECT = Path.home() / ".synthesis" / "active-project.json"
-TABLE_COLUMNS = V3_COLUMNS
-TABLE_HEADER = (
-    "| " + " | ".join(TABLE_COLUMNS) + " |\n"
-    + "|"
-    + "|".join("---" for _ in TABLE_COLUMNS)
-    + "|"
-)
+TABLE_COLUMNS = V4_COLUMNS
+
+
+def table_header(columns: tuple[str, ...]) -> str:
+    return (
+        "| " + " | ".join(columns) + " |\n"
+        + "|"
+        + "|".join("---" for _ in columns)
+        + "|"
+    )
+
+
+TABLE_HEADER = table_header(TABLE_COLUMNS)
+
+# A client session ref is the client-native delivery handle for a session,
+# recorded as a scheme-prefixed URI so the delivery adapter stays at the edge:
+#   ccd:local_<uuid>   Claude Code chat session (ccd send_message target)
+#   codex:<uuid>       OpenAI Codex session (board bus is its delivery lane)
+# The scheme namespace is open (an a2a: adapter would slot in the same way).
+CLIENT_REF_PATTERN = re.compile(r"^[a-z][a-z0-9+.-]*:[A-Za-z0-9._:@-]+$")
+
+
+def normalize_client_ref(value: str) -> str:
+    candidate = (value or "").strip()
+    if candidate in {"", "-"}:
+        return ""
+    if not CLIENT_REF_PATTERN.match(candidate):
+        raise ValueError(
+            f"client session ref must be scheme-prefixed (like ccd:local_...): "
+            f"{candidate!r}"
+        )
+    return candidate
+
+
+def detect_client_ref() -> str:
+    """Best available self-identity for the running client session.
+
+    SYNTHESIS_CLIENT_SESSION_REF is the generic override any client (or its
+    SessionStart hook) can export. Claude Code exposes its chat-session id as
+    CLAUDE_CODE_HOST_SESSION_ID, which is exactly what ccd send_message
+    targets. An invalid value fails closed rather than registering garbage.
+    """
+    explicit = os.environ.get("SYNTHESIS_CLIENT_SESSION_REF", "").strip()
+    if explicit:
+        return normalize_client_ref(explicit)
+    host = os.environ.get("CLAUDE_CODE_HOST_SESSION_ID", "").strip()
+    if host:
+        return normalize_client_ref(f"ccd:{host}")
+    return ""
 TERMINAL_STATUSES = {"released", "complete", "completed", "closed"}
 CONTEXT_RESERVED_PATTERNS = (
     "context.md",
@@ -77,6 +120,7 @@ class Session:
     claims: list[str]
     context_role: str
     status: str
+    client_ref: str = ""
 
     @property
     def identity(self) -> SessionIdentity:
@@ -96,14 +140,15 @@ class Session:
     def label(self) -> str:
         return display_id(self.identity)
 
-    def cells(self) -> list[str]:
-        return [
+    def cells(self, columns: tuple[str, ...] = TABLE_COLUMNS) -> list[str]:
+        values = [
             self.session_uuid,
             self.compact_id,
             self.speakable_id,
             self.legacy_id,
             self.agent,
             self.machine,
+            self.client_ref or "-",
             self.project,
             self.started,
             self.heartbeat,
@@ -114,6 +159,9 @@ class Session:
             self.context_role,
             self.status,
         ]
+        if "client session ref" not in columns:
+            del values[6]
+        return values
 
 
 def timestamp() -> str:
@@ -136,6 +184,8 @@ def template() -> str:
         "4. One session owns project context; contributors write separate handoff artifacts.\n"
         "5. Existing autonomous claims keep priority over interactive sessions.\n"
         "6. Heartbeat at checkpoints; release or narrow claims at pause and session end.\n"
+        "7. Address peers through resolve — board identity, never client labels; "
+        "an unresolvable peer gets a board message, not a broadcast.\n"
     )
 
 
@@ -559,7 +609,27 @@ def parse_cells(line: str) -> list[str] | None:
 
 
 def session_from_cells(cells: list[str]) -> Session:
-    if len(cells) == len(TABLE_COLUMNS):
+    if len(cells) == len(V4_COLUMNS):
+        raw_ref = plain(cells[6])
+        return Session(
+            session_uuid=plain(cells[0]),
+            compact_id=plain(cells[1]),
+            speakable_id=plain(cells[2]),
+            legacy_id=plain(cells[3]),
+            agent=plain(cells[4]),
+            machine=plain(cells[5]),
+            client_ref="" if raw_ref == "-" else raw_ref,
+            project=plain(cells[7]),
+            started=plain(cells[8]),
+            heartbeat=plain(cells[9]),
+            mode=plain(cells[10]),
+            workspaces=split_values(cells[11]),
+            goal=plain(cells[12]),
+            claims=split_values(cells[13]),
+            context_role=plain(cells[14]).lower(),
+            status=plain(cells[15]).lower(),
+        )
+    if len(cells) == len(V3_COLUMNS):
         return Session(
             session_uuid=plain(cells[0]),
             compact_id=plain(cells[1]),
@@ -616,7 +686,8 @@ def session_from_cells(cells: list[str]) -> Session:
         )
     raise ValueError(
         f"active-session row has {len(cells)} columns; expected "
-        f"{len(TABLE_COLUMNS)}, {len(V2_COLUMNS)}, or {len(V1_COLUMNS)}"
+        f"{len(V4_COLUMNS)}, {len(V3_COLUMNS)}, {len(V2_COLUMNS)}, or "
+        f"{len(V1_COLUMNS)}"
     )
 
 
@@ -628,6 +699,7 @@ def with_identity(session: Session, identity: SessionIdentity) -> Session:
         legacy_id=identity.legacy_id,
         agent=session.agent,
         machine=session.machine,
+        client_ref=session.client_ref,
         project=session.project,
         started=session.started,
         heartbeat=session.heartbeat,
@@ -701,11 +773,30 @@ def stale(session: Session, minutes: int) -> bool:
     return now - heartbeat > timedelta(minutes=minutes)
 
 
-def replace_table(text: str, sessions: list[Session]) -> str:
+def board_schema(text: str) -> int | None:
+    """The schema version a board declares in its header, or None."""
+    match = re.search(r"(?m)^Schema:\s*v(\d+)\s*$", text)
+    return int(match.group(1)) if match else None
+
+
+def replace_table(
+    text: str, sessions: list[Session], *, force_schema: int | None = None
+) -> str:
+    """Rewrite the Active sessions table, honoring the board's declared schema.
+
+    A board keeps its declared schema until an explicit `migrate` passes
+    force_schema — older clients on other machines parse the shared board, so
+    an implicit rewrite here would fail them closed mid-flight. Client refs
+    are dropped on a v3 emission and re-registered on the next claim after
+    migration.
+    """
     sessions = ensure_identities(sessions)
-    rendered = [TABLE_HEADER]
+    declared = board_schema(text)
+    effective = force_schema or declared or SCHEMA_VERSION
+    columns = TABLE_COLUMNS if effective >= 4 else V3_COLUMNS
+    rendered = [table_header(columns)]
     rendered.extend(
-        "| " + " | ".join(sanitize(value) for value in session.cells()) + " |"
+        "| " + " | ".join(sanitize(value) for value in session.cells(columns)) + " |"
         for session in sessions
     )
     block = "\n".join(rendered)
@@ -716,7 +807,7 @@ def replace_table(text: str, sessions: list[Session]) -> str:
     if re.search(r"(?m)^Schema:\s*v\d+\s*$", updated):
         return re.sub(
             r"(?m)^Schema:\s*v\d+\s*$",
-            f"Schema: v{SCHEMA_VERSION}",
+            f"Schema: v{effective}",
             updated,
             count=1,
         )
@@ -725,7 +816,7 @@ def replace_table(text: str, sessions: list[Session]) -> str:
         raise ValueError("board lacks Active sessions heading")
     return (
         updated[: marker.start()]
-        + f"Schema: v{SCHEMA_VERSION}\n\n"
+        + f"Schema: v{effective}\n\n"
         + updated[marker.start() :]
     )
 
@@ -1058,6 +1149,19 @@ def validate_sessions(sessions: list[Session]) -> list[str]:
                 f"{session.context_role}"
             )
     live = [session for session in sessions if active(session)]
+    seen_refs: dict[str, str] = {}
+    for session in live:
+        if not session.client_ref:
+            continue
+        previous = seen_refs.get(session.client_ref)
+        if previous is not None:
+            problems.append(
+                f"duplicate active client session ref {session.client_ref} "
+                f"({previous}, {session.label}); release the stale row or "
+                "re-claim with --session to update the existing one"
+            )
+        else:
+            seen_refs[session.client_ref] = session.label
     for index, left in enumerate(live):
         if left.context_role == "contributor":
             for claim in left.claims:
@@ -1111,6 +1215,7 @@ def command_status(args) -> int:
         )
     payload = {
         "schema_version": SCHEMA_VERSION,
+        "board_schema": board_schema(content),
         "board": str(args.board),
         "lease": lease,
         "sessions": [
@@ -1396,7 +1501,17 @@ def command_claim(args) -> int:
             )
             return 10
 
-    claimed: dict[str, SessionIdentity] = {}
+    try:
+        requested_ref = (
+            normalize_client_ref(args.client_ref)
+            if getattr(args, "client_ref", None)
+            else detect_client_ref()
+        )
+    except ValueError as exc:
+        print(f"coordination claim refused: {exc}", file=sys.stderr)
+        return 10
+
+    claimed: dict[str, object] = {}
 
     def operation(content: str) -> str:
         current = ensure_identities(rows(content))
@@ -1412,6 +1527,24 @@ def command_claim(args) -> int:
                 "strong session selector was not found; omit --session to "
                 "allocate a new identity or use an unused legacy label"
             )
+        if existing_self is None and not selector and requested_ref:
+            # The same client session re-claiming without a selector updates
+            # its own row instead of allocating another identity.
+            same_seat = [
+                session
+                for session in current
+                if active(session) and session.client_ref == requested_ref
+            ]
+            if len(same_seat) > 1:
+                raise RuntimeError(
+                    f"client session ref {requested_ref} has "
+                    f"{len(same_seat)} active rows ("
+                    + ", ".join(session.label for session in same_seat)
+                    + "); release the stale ones before claiming"
+                )
+            if same_seat:
+                existing_self = same_seat[0]
+                claimed["reused"] = existing_self.identity.compact_id
         identity = (
             existing_self.identity
             if existing_self is not None
@@ -1421,6 +1554,7 @@ def command_claim(args) -> int:
             )
         )
         claimed["identity"] = identity
+        claimed["board_schema"] = board_schema(content)
         replacement = Session(
             session_uuid=identity.session_uuid,
             compact_id=identity.compact_id,
@@ -1428,6 +1562,8 @@ def command_claim(args) -> int:
             legacy_id=identity.legacy_id,
             agent=args.agent,
             machine=args.machine,
+            client_ref=requested_ref
+            or (existing_self.client_ref if existing_self else ""),
             project=args.project,
             started=existing_self.started if existing_self else now,
             heartbeat=now,
@@ -1463,6 +1599,22 @@ def command_claim(args) -> int:
         f"Claimed {', '.join(requested)} for session {identity.compact_id} "
         f"({identity.speakable_id}; uuid={identity.session_uuid}{legacy})."
     )
+    if claimed.get("reused"):
+        print(
+            "Reused this client session's existing active row "
+            f"({claimed['reused']}) instead of allocating a new identity."
+        )
+    if requested_ref:
+        declared = claimed.get("board_schema")
+        if declared is not None and declared < 4:
+            print(
+                f"Client session ref {requested_ref} was detected but the "
+                f"board declares schema v{declared}, which has no column for "
+                "it; run 'coordination.py migrate' once every machine's "
+                "client is current to enable peer-session resolution."
+            )
+        else:
+            print(f"Registered client session ref {requested_ref}.")
     return 0
 
 
@@ -1564,6 +1716,58 @@ def archive_owned_pointer(
         return destination
 
 
+def resolve_targets(
+    sessions: list[Session], selector: str
+) -> tuple[str, list[Session]]:
+    """Resolve a peer selector to board sessions, most exact form first.
+
+    Accepted forms: any identity selector (UUID, compact, speakable, legacy),
+    a client session ref (bare `local_...` is accepted as `ccd:local_...`),
+    or a registered project name (optionally suffixed " sessions"). Client
+    titles and display labels are deliberately not selectors — they are the
+    guessing vector this resolver exists to remove.
+    """
+    identity = [
+        session
+        for session in sessions
+        if selector_matches(session.identity, selector)
+    ]
+    if identity:
+        return "identity", identity
+    candidate = selector.strip()
+    ref_forms = {candidate}
+    if candidate.startswith("local_"):
+        ref_forms.add(f"ccd:{candidate}")
+    refs = [
+        session
+        for session in sessions
+        if session.client_ref and session.client_ref in ref_forms
+    ]
+    if refs:
+        return "client-ref", refs
+    base = candidate[: -len(" sessions")] if candidate.endswith(" sessions") else candidate
+    projects = [
+        session
+        for session in sessions
+        if session.project not in {"", "unknown", "none"}
+        and session.project.casefold() == base.casefold()
+    ]
+    if projects:
+        return "project", projects
+    return "none", []
+
+
+def delivery_lane(session: Session) -> str:
+    if session.client_ref.startswith("ccd:"):
+        return (
+            f"ccd send_message to session_id {session.client_ref[4:]} "
+            f"(valid on machine {session.machine})"
+        )
+    if session.client_ref.startswith("codex:") or "codex" in session.agent.lower():
+        return "board message bus (Codex sessions have no direct push channel)"
+    return "board message bus (session has no registered client ref)"
+
+
 def command_message(args) -> int:
     body = args.text if args.text is not None else sys.stdin.read().strip()
     if not body:
@@ -1573,11 +1777,26 @@ def command_message(args) -> int:
     def operation(content: str) -> str:
         current = rows(content)
         sender = find_session(current, args.sender)
-        recipient = find_session(current, args.to)
         sender_label = sender.label if sender is not None else sanitize(args.sender)
-        recipient_label = (
-            recipient.label if recipient is not None else sanitize(args.to)
-        )
+        kind, matches = resolve_targets(current, args.to)
+        if kind in {"identity", "client-ref"}:
+            if len(matches) > 1:
+                raise RuntimeError(
+                    f"recipient selector {args.to!r} is ambiguous: "
+                    + ", ".join(session.label for session in matches)
+                )
+            recipient_label = matches[0].label
+        elif kind == "project":
+            recipient_label = f"{matches[0].project} sessions"
+        elif getattr(args, "free_address", False):
+            recipient_label = sanitize(args.to)
+        else:
+            raise RuntimeError(
+                f"recipient {args.to!r} matches no session identity, client "
+                "ref, or registered project on this board; use 'resolve' to "
+                "find the target, or pass --free-address to record a "
+                "deliberately unregistered addressee"
+            )
         heading = (
             f"### → {recipient_label}, from {sender_label} — {timestamp()}"
         )
@@ -1599,13 +1818,105 @@ def command_message(args) -> int:
     return 0
 
 
+def command_resolve(args) -> int:
+    """Resolve a peer selector to an exact, deliverable session target.
+
+    Exit codes: 0 exactly one target; 20 several candidates (never broadcast —
+    narrow with --role or address one exact id, or use the board bus addressed
+    to the project); 21 no target (the peer is unregistered; use the board
+    bus). The lesson this mechanizes: the board id is the identity, the client
+    label is a display string.
+    """
+    lease_refresh(args.board)
+    if not args.board.is_file():
+        print(f"resolve: no coordination board at {args.board}", file=sys.stderr)
+        return 21
+    content = args.board.read_text(encoding="utf-8")
+    sessions = rows(content)
+    pool = (
+        sessions
+        if args.include_released
+        else [session for session in sessions if active(session)]
+    )
+    kind, matches = resolve_targets(pool, args.to)
+    if args.role:
+        matches = [
+            session for session in matches if session.context_role == args.role
+        ]
+    entries = [
+        {
+            "session": session.compact_id,
+            "uuid": session.session_uuid,
+            "speakable": session.speakable_id,
+            "agent": session.agent,
+            "machine": session.machine,
+            "project": session.project,
+            "context_role": session.context_role,
+            "status": session.status,
+            "heartbeat": session.heartbeat,
+            "stale": stale(session, args.stale_after_minutes),
+            "client_ref": session.client_ref,
+            "delivery": delivery_lane(session),
+        }
+        for session in matches
+    ]
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "selector": args.to,
+                    "matched_by": kind,
+                    "board_schema": board_schema(content),
+                    "matches": entries,
+                },
+                indent=2,
+            )
+        )
+    else:
+        for entry in entries:
+            marker = " STALE" if entry["stale"] else ""
+            print(
+                f"{entry['session']}  {entry['project']}  "
+                f"[{entry['context_role']}/{entry['status']}{marker}]  "
+                f"{entry['agent']} on {entry['machine']}"
+            )
+            print(f"  uuid: {entry['uuid']}")
+            print(f"  client ref: {entry['client_ref'] or '-'}")
+            print(f"  delivery: {entry['delivery']}")
+    if len(entries) == 1:
+        return 0
+    if len(entries) > 1:
+        print(
+            f"resolve: {len(entries)} candidates for {args.to!r} — do not "
+            "broadcast; narrow with --role, address one exact session id, or "
+            "post to the board bus addressed to the project",
+            file=sys.stderr,
+        )
+        return 20
+    hint = ""
+    if kind != "none":
+        hint = f" (matched {kind} rows, but none passed the filters)"
+    if board_schema(content) is not None and board_schema(content) < 4:
+        hint += (
+            "; note the board declares a pre-v4 schema, which carries no "
+            "client refs until 'migrate' runs"
+        )
+    print(
+        f"resolve: no active target for {args.to!r}{hint} — the peer has not "
+        "registered a claim, so deliver via the board message bus and let it "
+        "self-select; do not guess a chat session by title",
+        file=sys.stderr,
+    )
+    return 21
+
+
 def command_migrate(args) -> int:
     def operation(content: str) -> str:
         migrated = ensure_identities(rows(content))
         problems = validate_sessions(migrated)
         if problems:
             raise RuntimeError("; ".join(problems))
-        return replace_table(content, migrated)
+        return replace_table(content, migrated, force_schema=SCHEMA_VERSION)
 
     try:
         locked_update(args.board, operation)
@@ -1829,14 +2140,26 @@ def command_doctor(args) -> int:
     missing = [heading for heading in required if heading not in content]
     if missing:
         problems.extend(f"missing heading: {heading}" for heading in missing)
-    if f"Schema: v{SCHEMA_VERSION}" not in content:
-        problems.append(f"missing Schema: v{SCHEMA_VERSION}")
+    declared = board_schema(content)
+    schema_note = ""
+    if declared is None:
+        problems.append("missing Schema declaration")
+    elif declared > SCHEMA_VERSION:
+        problems.append(
+            f"board declares schema v{declared}, newer than this client "
+            f"(v{SCHEMA_VERSION}); update the installed plugin before mutating"
+        )
+    elif declared < SCHEMA_VERSION:
+        schema_note = (
+            f" (declared v{declared}; run migrate once every machine's "
+            "client is current to enable client session refs)"
+        )
     if problems:
         for problem in problems:
             print(f"FAIL coordination: {problem}", file=sys.stderr)
         return 1
     print(
-        f"PASS coordination: schema v{SCHEMA_VERSION}, "
+        f"PASS coordination: schema v{declared}{schema_note}, "
         f"{len(sessions)} session(s){lease_line}"
     )
     return 0
@@ -1904,6 +2227,15 @@ def parser() -> argparse.ArgumentParser:
         choices=("owner", "contributor", "none"),
         required=True,
     )
+    claim.add_argument(
+        "--client-ref",
+        help=(
+            "Client-native delivery handle for this session, scheme-prefixed "
+            "(ccd:local_..., codex:...). Auto-detected from "
+            "SYNTHESIS_CLIENT_SESSION_REF or CLAUDE_CODE_HOST_SESSION_ID "
+            "when omitted."
+        ),
+    )
     heartbeat = commands.add_parser("heartbeat")
     heartbeat.add_argument("--id", "--session", dest="id", required=True)
     release = commands.add_parser("release")
@@ -1915,6 +2247,27 @@ def parser() -> argparse.ArgumentParser:
     message.add_argument("--from", dest="sender", required=True)
     message.add_argument("--to", required=True)
     message.add_argument("--text")
+    message.add_argument(
+        "--free-address",
+        action="store_true",
+        help=(
+            "Record an addressee that matches no session or registered "
+            "project. Without it, an unresolvable --to refuses."
+        ),
+    )
+    resolve = commands.add_parser(
+        "resolve",
+        help=(
+            "Resolve a peer selector (identity, client ref, or project) to "
+            "an exact deliverable target; refuses ambiguity instead of "
+            "guessing or broadcasting."
+        ),
+    )
+    resolve.add_argument("--to", required=True)
+    resolve.add_argument("--role", choices=("owner", "contributor", "none"))
+    resolve.add_argument("--include-released", action="store_true")
+    resolve.add_argument("--stale-after-minutes", type=int, default=240)
+    resolve.add_argument("--json", action="store_true")
     commands.add_parser("migrate")
     commands.add_parser("doctor")
     stale = commands.add_parser(
@@ -1952,6 +2305,8 @@ def main() -> int:
         return command_release(args)
     if args.command == "message":
         return command_message(args)
+    if args.command == "resolve":
+        return command_resolve(args)
     if args.command == "migrate":
         return command_migrate(args)
     if args.command == "lease-disable":

--- a/skills/synthesis-project-management/scripts/coordination_schema.py
+++ b/skills/synthesis-project-management/scripts/coordination_schema.py
@@ -16,7 +16,25 @@ from pathlib import Path
 from typing import Iterable
 
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
+V4_COLUMNS = (
+    "session uuid",
+    "compact id",
+    "speakable id v1",
+    "legacy id",
+    "agent",
+    "machine",
+    "client session ref",
+    "project",
+    "started",
+    "heartbeat",
+    "mode",
+    "workspace(s) / branch",
+    "goal",
+    "claimed areas (advisory lock)",
+    "context role",
+    "status",
+)
 V3_COLUMNS = (
     "session uuid",
     "compact id",
@@ -303,7 +321,9 @@ def parse_table_rows(text: str) -> list[dict[str, str]]:
             "session uuid",
         }:
             continue
-        if len(cells) == len(V3_COLUMNS):
+        if len(cells) == len(V4_COLUMNS):
+            result.append(dict(zip(V4_COLUMNS, cells)))
+        elif len(cells) == len(V3_COLUMNS):
             result.append(dict(zip(V3_COLUMNS, cells)))
         elif len(cells) == len(V2_COLUMNS):
             result.append(dict(zip(V2_COLUMNS, cells)))
@@ -312,7 +332,8 @@ def parse_table_rows(text: str) -> list[dict[str, str]]:
         else:
             raise ValueError(
                 f"active-session row has {len(cells)} columns; expected "
-                f"{len(V3_COLUMNS)}, {len(V2_COLUMNS)}, or {len(V1_COLUMNS)}"
+                f"{len(V4_COLUMNS)}, {len(V3_COLUMNS)}, {len(V2_COLUMNS)}, "
+                f"or {len(V1_COLUMNS)}"
             )
     return result
 

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -1711,3 +1711,71 @@ def test_status_json_reports_client_ref_and_board_schema(
     payload = json.loads(capsys.readouterr().out)
     assert payload["board_schema"] == 4
     assert payload["sessions"][0]["client_ref"] == "ccd:local_feed-beef"
+
+
+def test_peer_resolution_documented_on_public_surfaces() -> None:
+    """The protocol must live on every public maintenance surface, not only
+    in code — undocumented mechanisms get rediscovered as folklore."""
+    repo = Path(__file__).resolve().parents[3]
+    skill_dir = repo / "skills" / "synthesis-project-management"
+    surfaces = {
+        repo / "README.md": "resolve",
+        repo / "CHANGELOG.md": "client session ref",
+        skill_dir / "SKILL.md": "client session ref",
+        skill_dir / "references" / "parallel-agent-protocol.md": (
+            "Addressing a peer session"
+        ),
+        skill_dir / "references" / "session-identity.md": "client session ref",
+        repo / "skills" / "synthesis-message-guard" / "SKILL.md": (
+            "peer_send_resolution"
+        ),
+    }
+    for path, marker in surfaces.items():
+        assert marker in path.read_text(encoding="utf-8"), (
+            f"{path.name} does not document {marker!r}"
+        )
+
+
+def test_conformance_board_check_accepts_declared_v3_and_v4(tmp_path) -> None:
+    """The parity checker must accept both declared schemas during the staged
+    migration window, and still reject anything older."""
+    conformance_path = (
+        Path(__file__).resolve().parents[2]
+        / "synthesis-agent-conformance"
+        / "scripts"
+        / "conformance.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "conformance_for_board_check", conformance_path
+    )
+    assert spec and spec.loader
+    conformance = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = conformance
+    spec.loader.exec_module(conformance)
+
+    def board_with(schema_line: str) -> Path:
+        board = tmp_path / f"board-{schema_line.split('v')[-1]}.md"
+        columns = (
+            MODULE.TABLE_COLUMNS
+            if schema_line.endswith("v4")
+            else MODULE.V3_COLUMNS
+        )
+        board.write_text(
+            f"# Coordination\n\n{schema_line}\n\n## Active sessions\n\n"
+            + MODULE.table_header(columns)
+            + "\n\n## Messages\n\n---\n\n## Protocol\n",
+            encoding="utf-8",
+        )
+        return board
+
+    def schema_check(board: Path) -> bool:
+        checks = conformance.coordination_checks(board, required=False)
+        return next(
+            check.ok
+            for check in checks
+            if check.name == "coordination.active-table-schema"
+        )
+
+    assert schema_check(board_with("Schema: v4"))
+    assert schema_check(board_with("Schema: v3"))
+    assert not schema_check(board_with("Schema: v2"))

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -23,6 +23,15 @@ sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
 
 
+@pytest.fixture(autouse=True)
+def _isolate_client_session_env(monkeypatch):
+    """Keep the suite hermetic: a developer shell inside a real client session
+    carries that session's ref, which would register one seat on every
+    simulated session and trip the duplicate-ref refusal."""
+    monkeypatch.delenv("SYNTHESIS_CLIENT_SESSION_REF", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_HOST_SESSION_ID", raising=False)
+
+
 def args(board: Path, **values):
     return type("Args", (), {"board": board, **values})()
 
@@ -502,7 +511,7 @@ def test_v1_board_migrates_without_losing_messages(tmp_path: Path) -> None:
     assert MODULE.command_migrate(args(board)) == 0
     text = board.read_text(encoding="utf-8")
     migrated = MODULE.rows(text)
-    assert "Schema: v3" in text
+    assert "Schema: v4" in text
     assert "Keep this handoff." in text
     assert uuid.UUID(migrated[0].session_uuid).version == 7
     assert migrated[0].legacy_id == "A"
@@ -588,7 +597,11 @@ def test_message_accepts_annotated_protocol_heading(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
-    message = args(board, sender="B", to="A", text="Sequencing update.")
+    strict = args(board, sender="B", to="A", text="Sequencing update.")
+    assert MODULE.command_message(strict) == 10
+    message = args(
+        board, sender="B", to="A", text="Sequencing update.", free_address=True
+    )
     assert MODULE.command_message(message) == 0
     text = board.read_text(encoding="utf-8")
     assert "Sequencing update." in text
@@ -1428,3 +1441,273 @@ def test_json_mode_is_machine_readable(tmp_path):
     data = json.loads(r.stdout)
     assert data["stale_total"] == 1
     assert data["shown"][0]["worktree_gone"] is True
+
+
+# --- peer-session resolution (schema v4 client refs) -----------------------
+#
+# The board is the only join between coordination identity and each client's
+# native delivery handle. These tests pin the whole contract: registration at
+# claim time, one row per client seat, fail-closed ambiguity in resolve, and
+# the staged v3→v4 migration that keeps older parsers alive on shared boards.
+
+
+def seatless_claim(board, project, workspace, area, agent="seat"):
+    return args(
+        board,
+        id=None,
+        agent=agent,
+        machine="machine-seat",
+        project=project,
+        mode="interactive",
+        goal=f"goal-{project}",
+        workspace=[workspace],
+        area=[area],
+        context_role="owner",
+    )
+
+
+def resolve_args(board, to, **overrides):
+    values = {
+        "to": to,
+        "role": None,
+        "include_released": False,
+        "stale_after_minutes": 240,
+        "json": False,
+    }
+    values.update(overrides)
+    return args(board, **values)
+
+
+def test_claim_registers_detected_client_ref(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local_feed-beef")
+    board = tmp_path / "board.md"
+    request = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/wt-a @ feature/a",
+        area="repo-a/**",
+    )
+    assert MODULE.command_claim(request) == 0
+    row = MODULE.rows(board.read_text(encoding="utf-8"))[0]
+    assert row.client_ref == "ccd:local_feed-beef"
+    assert "| ccd:local_feed-beef |" in board.read_text(encoding="utf-8")
+
+
+def test_generic_ref_env_overrides_client_specific(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local_feed-beef")
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:0a0a-1b1b")
+    board = tmp_path / "board.md"
+    assert (
+        MODULE.command_claim(
+            seatless_claim(board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**")
+        )
+        == 0
+    )
+    assert MODULE.rows(board.read_text(encoding="utf-8"))[0].client_ref == (
+        "codex:0a0a-1b1b"
+    )
+
+
+def test_claim_reuses_active_row_for_same_client_seat(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local_feed-beef")
+    board = tmp_path / "board.md"
+    assert (
+        MODULE.command_claim(
+            seatless_claim(board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**")
+        )
+        == 0
+    )
+    first = MODULE.rows(board.read_text(encoding="utf-8"))[0]
+    assert (
+        MODULE.command_claim(
+            seatless_claim(board, "project-b", "/tmp/wt-b @ feature/b", "repo-b/**")
+        )
+        == 0
+    )
+    table = MODULE.rows(board.read_text(encoding="utf-8"))
+    assert len(table) == 1
+    assert table[0].session_uuid == first.session_uuid
+    assert table[0].project == "project-b"
+
+
+def test_second_seat_with_same_ref_and_selector_is_refused(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local_feed-beef")
+    board = tmp_path / "board.md"
+    first = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/wt-a @ feature/a",
+        area="repo-a/**",
+    )
+    assert MODULE.command_claim(first) == 0
+    second = claim_args(
+        board,
+        session_id="B",
+        project="project-b",
+        workspace="/tmp/wt-b @ feature/b",
+        area="repo-b/**",
+    )
+    assert MODULE.command_claim(second) == 10
+
+
+def test_explicit_invalid_client_ref_refuses(tmp_path):
+    board = tmp_path / "board.md"
+    request = seatless_claim(
+        board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**"
+    )
+    request.client_ref = "not a scheme ref"
+    assert MODULE.command_claim(request) == 10
+    assert not board.exists()
+
+
+def _v3_board(tmp_path):
+    board = tmp_path / "board.md"
+    board.write_text(
+        "# Coordination\n\nSchema: v3\n\n## Active sessions\n\n"
+        + MODULE.table_header(MODULE.V3_COLUMNS)
+        + "\n\n## Messages\n\n---\n\n## Protocol\n",
+        encoding="utf-8",
+    )
+    return board
+
+
+def test_v3_board_keeps_schema_until_explicit_migrate(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local_feed-beef")
+    board = _v3_board(tmp_path)
+    assert (
+        MODULE.command_claim(
+            seatless_claim(board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**")
+        )
+        == 0
+    )
+    text = board.read_text(encoding="utf-8")
+    assert "Schema: v3" in text
+    assert "ccd:" not in text
+    row = MODULE.rows(text)[0]
+    assert row.client_ref == ""
+
+    assert MODULE.command_migrate(args(board)) == 0
+    migrated = board.read_text(encoding="utf-8")
+    assert "Schema: v4" in migrated
+    assert "| client session ref |" in migrated
+
+    request = seatless_claim(
+        board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**"
+    )
+    request.id = row.compact_id
+    assert MODULE.command_claim(request) == 0
+    assert "ccd:local_feed-beef" in board.read_text(encoding="utf-8")
+
+
+def test_resolve_unique_project_target(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local_feed-beef")
+    board = tmp_path / "board.md"
+    assert (
+        MODULE.command_claim(
+            seatless_claim(board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**")
+        )
+        == 0
+    )
+    assert MODULE.command_resolve(resolve_args(board, "project-a")) == 0
+    output = capsys.readouterr().out
+    assert "ccd send_message to session_id local_feed-beef" in output
+
+
+def test_resolve_by_bare_local_ref(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local_feed-beef")
+    board = tmp_path / "board.md"
+    assert (
+        MODULE.command_claim(
+            seatless_claim(board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**")
+        )
+        == 0
+    )
+    capsys.readouterr()
+    request = resolve_args(board, "local_feed-beef", json=True)
+    assert MODULE.command_resolve(request) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["matched_by"] == "client-ref"
+    assert payload["matches"][0]["client_ref"] == "ccd:local_feed-beef"
+
+
+def test_resolve_ambiguity_refuses_instead_of_broadcasting(tmp_path, capsys):
+    board = tmp_path / "board.md"
+    owner = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/wt-a @ feature/a",
+        area="repo-a/impl/**",
+    )
+    assert MODULE.command_claim(owner) == 0
+    helper = claim_args(
+        board,
+        session_id="B",
+        project="project-a",
+        workspace="/tmp/wt-b @ feature/b",
+        area="repo-a/docs/**",
+        context_role="contributor",
+    )
+    assert MODULE.command_claim(helper) == 0
+    assert MODULE.command_resolve(resolve_args(board, "project-a")) == 20
+    err = capsys.readouterr().err
+    assert "do not broadcast" in err
+    assert (
+        MODULE.command_resolve(resolve_args(board, "project-a", role="owner"))
+        == 0
+    )
+
+
+def test_resolve_unknown_target_points_to_board_bus(tmp_path, capsys):
+    board = tmp_path / "board.md"
+    assert (
+        MODULE.command_claim(
+            seatless_claim(board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**")
+        )
+        == 0
+    )
+    assert MODULE.command_resolve(resolve_args(board, "project-zz")) == 21
+    err = capsys.readouterr().err
+    assert "board message bus" in err
+    assert "do not guess" in err
+
+
+def test_message_to_registered_project_renders_sessions_address(tmp_path):
+    board = tmp_path / "board.md"
+    assert (
+        MODULE.command_claim(
+            seatless_claim(board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**")
+        )
+        == 0
+    )
+    message = args(board, sender="ops", to="project-a", text="Handoff ready.")
+    assert MODULE.command_message(message) == 0
+    text = board.read_text(encoding="utf-8")
+    assert "→ project-a sessions," in text
+    suffixed = args(
+        board, sender="ops", to="project-a sessions", text="Second note."
+    )
+    assert MODULE.command_message(suffixed) == 0
+
+
+def test_status_json_reports_client_ref_and_board_schema(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local_feed-beef")
+    board = tmp_path / "board.md"
+    assert (
+        MODULE.command_claim(
+            seatless_claim(board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**")
+        )
+        == 0
+    )
+    capsys.readouterr()
+    status = args(
+        board, json=True, strict=False, stale_after_minutes=240
+    )
+    assert MODULE.command_status(status) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["board_schema"] == 4
+    assert payload["sessions"][0]["client_ref"] == "ccd:local_feed-beef"


### PR DESCRIPTION
Board schema v4 adds a client-session-ref column (registered automatically at claim time from the session's own environment), a fail-closed `resolve` verb, strict board-bus addressing, idempotent per-seat claims, staged v3→v4 migration that keeps live older parsers working until an explicit `migrate`, and message-guard v1.4.0's config-adopted `peer_send_resolution` backstop for direct peer sends. Mechanizes the 2026-08-19 lesson: the board id is the identity; the client label is a display string.

Verification: full repo CI list run locally — conformance source (204) + instructions, coordination 72/72, guard 19 pytest + 12/12 behavioral, agent-conformance 146, rituals/guard/git-hooks 94, onboarding 31, handoff/retire 30, kb-edit/okf 8, transcripts 49 checks, installer + inbox suites, compileall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)