### PR TITLE
Preserve complete Codex cache roots across refreshes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.76.2",
+  "version": "4.76.3",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.76.2",
+  "version": "4.76.3",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.76.3] - 2026-09-01
+
+**A Codex plugin refresh no longer strands tasks that started on an older
+cache root.** The gated publisher now constructs a complete recovery set from
+the real version roots retained by both supported clients. Immutable release
+tags supply authoritative tracked bytes. For versions that predate release
+tags, the publisher accepts a peer or prior archive root only after its plugin
+manifest, hook commands, hook targets, skill tree, and symlinks validate.
+
+The Codex transition is single-writer, repairs missing and partial roots, keeps
+only known client metadata, and rechecks the restored trees through a bounded
+post-command quiet window. The recovery archive has a 512 MiB hard limit and
+never silently deletes historical versions. Failures leave the transition copy
+in place and stop the release. Regression coverage includes delayed deletion,
+pre-tag recovery, partial roots, changed bytes, unsafe symlinks, concurrent
+writers, unknown extras, and archive-budget exhaustion.
+
 ## [4.76.2] - 2026-09-01
 
 **The project-management skill document is back inside its own budget.**
@@ -20,19 +37,6 @@ retirement internals). A pinned test now enforces the budget, keeps the
 load-bearing rules in the main document, verifies each moved block exists
 in its reference, and refuses orphaned references — so the next growth
 lands in `references/` instead of silently rebreaking the rule.
-
-**A truly empty home now reaches a committed personal workspace without a
-manual repair step.** The 4.76.0 live-stable acceptance run found that a new
-user with no configured Git author could receive every scaffold but stop at
-the first repository commit. Guided `init` now detects that condition before
-mutation and asks for the author name and email it needs. Reviewed
-non-interactive answers can provide the same values as `git_name` and
-`git_email`.
-
-The engine applies those values only to the new personal repository, retries
-the initial commit when repairing a half-finished 4.76.0 run, and leaves global
-Git configuration untouched. Acceptance tests prove both the pre-mutation
-validation boundary and a successful repository-local first commit.
 
 ## [4.76.1] - 2026-09-01
 

--- a/README.md
+++ b/README.md
@@ -11,20 +11,20 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Codex refreshes preserve running tasks (September 2026).** Release
+**4.76.3** reconstructs every historical plugin root retained by either
+supported client before a Codex refresh. Tagged source is authoritative;
+pre-tag roots must prove complete manifests, hooks, targets, skills, and safe
+links. A single-writer transition lock, bounded recovery archive, partial-root
+repair, and post-command quiet-window verification keep already-running tasks'
+absolute hook paths valid. See the [4.76.3 release notes](CHANGELOG.md).
+
 **A rule about document budgets now enforces itself (September 2026).**
 Release **4.76.2** restructures the project-management skill back under the
 repository's 500-line SKILL.md rule — every operating rule stays in the main
 document; formats, rationale, and mechanics moved to `references/` — and
 pins the budget with a test so regrowth fails CI instead of accumulating.
 See the [4.76.2 release notes](CHANGELOG.md).
-
-**An empty home no longer stops at Git identity (September 2026).** Release
-**4.76.1** makes guided whole-system onboarding collect the personal
-repository's author name and email before mutation when Git has no configured
-identity. Non-interactive runs accept `git_name` and `git_email`; both paths
-configure only the new repository and complete its initial commit. A rerun also
-repairs the half-finished repository produced by 4.76.0. See the [4.76.1
-release notes](CHANGELOG.md).
 
 **An empty home no longer stops at Git identity (September 2026).** Release
 **4.76.1** makes guided whole-system onboarding collect the personal

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,63 +1,63 @@
-# AGENT HEURISTIC: authored for the 4.76.2 skill-document-budget release.
+# AGENT HEURISTIC: authored for the 4.76.3 Codex cache-survival release.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: pm-skill-document-budget
+suite: codex-cache-post-refresh-survival
 membership: closed
-production_entry_point: skills/synthesis-project-management/SKILL.md
-enforcing_boundary: repository 500-line SKILL.md budget with pinned load-bearing rules and reference linkage
+production_entry_point: skills/synthesis-skills-manager/scripts/release.py
+enforcing_boundary: single-writer snapshot, refresh, repair, and post-command verification before gated release completion
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: hermetic tests prove the line budget, the survival of load-bearing rules in the main document, the presence of every moved block in its reference, no orphaned references, the peer-resolution doc contract across public surfaces, version-neutral release fixtures, and manifest/changelog parity; whether the restructured summary reads well to a human, and how in-context agent behavior shifts with the shorter document, remain editorial judgments outside the suite
+unverified_remainder: hermetic cases and a read-only real-cache probe prove reconstruction and failure behavior before publication; the state-changing client refresh, both installed-tree comparisons, and delayed live-root survival are verified by release.py only after the accepted commit is published
 changed_surfaces:
-  - path: skills/synthesis-project-management/SKILL.md
-    cases: [skill-doc-budget, peer-doc-contract]
-  - path: skills/synthesis-project-management/references/parallel-agent-protocol.md
-    cases: [skill-doc-budget, peer-doc-contract]
-  - path: skills/synthesis-project-management/references/records-and-conventions.md
-    cases: [skill-doc-budget]
-  - path: skills/synthesis-project-management/references/codex-dispatch.md
-    cases: [skill-doc-budget]
-  - path: skills/synthesis-project-management/scripts/test_coordination.py
-    cases: [skill-doc-budget]
-  - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
-    cases: [shipped-manifest-self-consumption]
-  - path: skills/synthesis-onboarding/scripts/test_onboard.py
-    cases: [onboarding-fixture-version-neutrality]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [release-contract-version-neutrality]
   - path: .claude-plugin/plugin.json
     cases: [release-manifest-parity]
   - path: .codex-plugin/plugin.json
     cases: [release-manifest-parity]
   - path: CHANGELOG.md
-    cases: [release-changelog-parity, peer-doc-contract]
+    cases: [release-changelog-parity, public-contract]
   - path: README.md
-    cases: [peer-doc-contract]
+    cases: [public-contract]
+  - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
+    cases: [shipped-manifest-self-consumption]
+  - path: skills/synthesis-skills-manager/SKILL.md
+    cases: [public-contract]
+  - path: skills/synthesis-skills-manager/scripts/release.py
+    cases: [tag-backed-repair, pre-tag-peer-recovery, post-command-deletion, single-writer-transition, unsafe-symlink-refusal, unknown-extra-refusal, archive-budget-refusal]
+  - path: skills/synthesis-skills-manager/scripts/test_release.py
+    cases: [tag-backed-repair, pre-tag-peer-recovery, post-command-deletion, single-writer-transition, unsafe-symlink-refusal, unknown-extra-refusal, archive-budget-refusal, release-manifest-parity, release-changelog-parity, public-contract]
 cases:
-  - id: skill-doc-budget
+  - id: tag-backed-repair
     control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget
-    motivating_defect: a-length-rule-nobody-measures-drifted-160-lines-past-its-budget-while-every-release-stayed-green
-  - id: peer-doc-contract
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots
+    motivating_defect: a-version-directory-can-exist-with-only-one-recreated-hook-file-while-the-rest-of-its-tagged-tree-is-missing
+  - id: pre-tag-peer-recovery
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_snapshot_imports_complete_untagged_peer_root_missing_from_codex
+    motivating_defect: an-active-task-can-reference-a-version-that-codex-already-removed-and-that-predates-immutable-release-tags
+  - id: post-command-deletion
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_restore_repeats_after_post_command_cache_deletion
+    motivating_defect: an-immediate-restore-receipt-can-pass-before-the-client-finishes-reconciling-and-removes-the-root-again
+  - id: single-writer-transition
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_cache_transition_lock_refuses_a_second_writer
+    motivating_defect: two-release-processes-mutating-the-same-cache-and-recovery-archive-can-invalidate-each-others-verification
+  - id: unsafe-symlink-refusal
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_peer_resolution_documented_on_public_surfaces
-    motivating_defect: a-restructure-that-moves-prose-can-silently-drop-the-documentation-contract-a-prior-release-pinned
-  - id: onboarding-fixture-version-neutrality
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_untagged_peer_root_rejects_unsafe_symlink
+    motivating_defect: a-peer-root-with-an-escaping-symlink-must-not-be-promoted-into-durable-recovery-state
+  - id: unknown-extra-refusal
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_full_init_converges_every_layer_and_reruns_cleanly
-    motivating_defect: a-fixture-pinned-to-the-shipping-release-version-was-hand-repinned-in-two-consecutive-releases
-  - id: release-contract-version-neutrality
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_whole_system_onboarding_release_contract_is_public_and_coherent
-    motivating_defect: a-release-contract-test-asserting-the-shipping-version-literal-fails-every-future-version-bump
-  - id: shipped-manifest-self-consumption
-    control_class: acceptance-test
-    fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: an-acceptance-manifest-that-its-own-runner-cannot-consume-issues-authority-it-never-earned
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_fails_if_unowned_extra_survives_repair
+    motivating_defect: overlay-copy-cannot-prove-repair-when-an-unowned-extra-remains-in-the-destination-tree
+  - id: archive-budget-refusal
+    control_class: enforced-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_tag_backed_snapshot_refuses_archive_budget_overflow
+    motivating_defect: unbounded-historical-cache-retention-can-turn-lifecycle-safety-into-unbounded-disk-growth
   - id: release-manifest-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
@@ -66,3 +66,11 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed
     motivating_defect: a-release-whose-changelog-disagrees-with-its-manifests-cannot-be-audited-later
+  - id: public-contract
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_cache_survival_release_contract_is_public_and_coherent
+    motivating_defect: a-cache-survival-mechanism-without-an-accurate-public-contract-cannot-be-operated-or-reviewed
+  - id: shipped-manifest-self-consumption
+    control_class: acceptance-test
+    fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
+    motivating_defect: an-acceptance-manifest-that-its-own-runner-cannot-consume-issues-authority-it-never-earned

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -5,17 +5,19 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.3.0"
+  version: "2.4.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
 
 # Synthesis Skills Manager
 
-**Version 2.3.0** (2026-09-01) makes the whole-system onboarding suite and
-its scaffold/component catalog audit required release checks. A release cannot
-publish an onboarding change that passed repository CI but was omitted from the
-publisher's own transaction.
+**Version 2.4.0** (2026-09-01) makes Codex cache survival tag-backed and
+post-command verified. Historical roots are reconstructed from immutable
+release tags, retained in a budgeted recovery archive, repaired when partial,
+and required to remain unchanged through a bounded quiet window after the
+client command returns. The whole-system onboarding suite and its
+scaffold/component catalog audit remain required release checks.
 
 Manage synthesis skills across a three-repo architecture. Skills are executable
 methodology. Public skills are also packaged as a native plugin for clients that
@@ -285,10 +287,17 @@ The sequence, each stage gating the next:
   requires. For Codex that means `plugin marketplace upgrade` **before**
   `plugin add`, because Codex installs *from* its git marketplace snapshot —
   skipping the upgrade installs the previous release while appearing to
-  succeed. Before that destructive Codex refresh, the publisher snapshots
-  every real versioned cache root and afterwards restores and byte-verifies
-  any root the client removed. An already-running task keeps the exact hook
-  code its SessionStart loaded. Symlink recovery artifacts are not preserved.
+  succeed. Before that destructive Codex refresh, the publisher snapshots each
+  real versioned cache root into a durable recovery archive, reconstructs all
+  tracked bytes from immutable release tags, and retains client-only metadata.
+  It restores missing roots, repairs partial ones, and repeats the check until
+  the tree has remained unchanged for ten seconds after the client command
+  returned. An already-running task therefore keeps the complete skill and
+  hook tree its SessionStart loaded, not merely whichever files happened to
+  survive the last transition. The archive has a 512 MiB hard budget and never
+  deletes a historical root automatically when that budget is reached;
+  unverifiable cleanup fails the release closed. Symlink recovery artifacts are
+  not preserved.
 - **Verify** is the point of the whole script, and it checks each client
   **twice**: what the CLI reports, and the plugin manifest at the path the CLI
   says it loads. Agreement of both with the source version is the only pass.

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -12,10 +12,11 @@ metadata:
 
 # Synthesis Skills Manager
 
-**Version 2.4.0** (2026-09-01) makes Codex cache survival tag-backed and
-post-command verified. Historical roots are reconstructed from immutable
-release tags, retained in a budgeted recovery archive, repaired when partial,
-and required to remain unchanged through a bounded quiet window after the
+**Version 2.4.0** (2026-09-01) makes Codex cache survival source-backed and
+post-command verified. Every version retained by either client is preserved.
+Immutable release tags supply authoritative tracked bytes; complete peer roots
+cover releases that predate tags. The budgeted archive repairs missing or
+partial Codex roots and verifies them through a bounded quiet window after the
 client command returns. The whole-system onboarding suite and its
 scaffold/component catalog audit remain required release checks.
 

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -291,7 +291,9 @@ The sequence, each stage gating the next:
   real versioned cache root retained by either client into a durable recovery archive.
   Immutable release tags supply authoritative tracked bytes. For releases that
   predate immutable tags, a peer-client or prior archive root is accepted only
-  after its manifests, complete hook target set, and skill tree validate. The
+  after its manifests, complete hook target set, and skill tree validate. Known
+  Codex installation metadata is retained; arbitrary untracked cache files are
+  not promoted into recovery state. The
   publisher holds a single-writer transition lock, restores missing Codex roots,
   repairs partial ones, and repeats the check until the tree has remained
   unchanged for ten seconds after the client command returned. An already-running

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -287,17 +287,20 @@ The sequence, each stage gating the next:
   requires. For Codex that means `plugin marketplace upgrade` **before**
   `plugin add`, because Codex installs *from* its git marketplace snapshot —
   skipping the upgrade installs the previous release while appearing to
-  succeed. Before that destructive Codex refresh, the publisher snapshots each
-  real versioned cache root into a durable recovery archive, reconstructs all
-  tracked bytes from immutable release tags, and retains client-only metadata.
-  It restores missing roots, repairs partial ones, and repeats the check until
-  the tree has remained unchanged for ten seconds after the client command
-  returned. An already-running task therefore keeps the complete skill and
-  hook tree its SessionStart loaded, not merely whichever files happened to
-  survive the last transition. The archive has a 512 MiB hard budget and never
-  deletes a historical root automatically when that budget is reached;
-  unverifiable cleanup fails the release closed. Symlink recovery artifacts are
-  not preserved.
+  succeed. Before that destructive Codex refresh, the publisher snapshots every
+  real versioned cache root retained by either client into a durable recovery archive.
+  Immutable release tags supply authoritative tracked bytes. For releases that
+  predate immutable tags, a peer-client or prior archive root is accepted only
+  after its manifests, complete hook target set, and skill tree validate. The
+  publisher holds a single-writer transition lock, restores missing Codex roots,
+  repairs partial ones, and repeats the check until the tree has remained
+  unchanged for ten seconds after the client command returned. An already-running
+  task therefore keeps the complete skill and hook tree its SessionStart loaded
+  even when Codex had already removed that version before this release began.
+  The archive has a 512 MiB hard budget and never deletes a historical root
+  automatically when that budget is reached; unverifiable cleanup fails the
+  release closed. Symlink recovery artifacts and client liveness markers are not
+  preserved.
 - **Verify** is the point of the whole script, and it checks each client
   **twice**: what the CLI reports, and the plugin manifest at the path the CLI
   says it loads. Agreement of both with the source version is the only pass.

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -628,14 +628,14 @@ def _export_release_tag(
 
 
 def _copy_cache_extras(source: Path, destination: Path, tracked: set[str]) -> None:
-    """Retain client metadata while immutable tag bytes win every collision."""
+    """Retain known client metadata while immutable tag bytes win collisions."""
     if not source.is_dir() or source.is_symlink():
         return
     for path in sorted(source.rglob("*"), key=lambda item: str(item.relative_to(source))):
         relative = path.relative_to(source)
         relative_text = relative.as_posix()
         target = destination / relative
-        if relative.parts and relative.parts[0] in {".git", ".in_use"}:
+        if not relative.parts or relative.parts[0] != ".codex-marketplace-install.json":
             continue
         if relative_text in tracked:
             continue

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import io
 import json
 import os
 import re
@@ -47,9 +48,11 @@ import secrets
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
+import time
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR.parents[1] / "synthesis-agent-conformance" / "scripts"))
@@ -83,6 +86,10 @@ ACCEPTANCE_CONSUMER_ID = (
     "synthesis-skills-manager.release.consume-acceptance.v1"
 )
 RELEASE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+CODEX_CACHE_ARCHIVE_BUDGET_BYTES = 512 * 1024 * 1024
+CODEX_CACHE_QUIET_SECONDS = 10.0
+CODEX_CACHE_SETTLE_TIMEOUT_SECONDS = 60.0
+CODEX_CACHE_POLL_SECONDS = 0.1
 
 # The required checks, mirroring the repository's own verification contract.
 # Kept as data so a reader can see exactly what a release runs.
@@ -135,6 +142,15 @@ class AcceptanceAuthority:
     change_base: str
     expected: dict[str, object]
     receipt: dict[str, object]
+
+
+@dataclass(frozen=True)
+class CodexCacheSnapshot:
+    """Complete recovery trees retained across Codex's cache transition."""
+
+    backup: Path
+    versions: tuple[str, ...]
+    archive: Path | None = None
 
 
 def run(cmd: list[str], cwd: Path | None = None, timeout: int = 900) -> subprocess.CompletedProcess:
@@ -491,43 +507,234 @@ def _tree_digest(root: Path) -> str:
     return digest.hexdigest()
 
 
-def snapshot_codex_caches(result: Result) -> tuple[Path, list[str]] | None:
-    """Copy real version roots before Codex's destructive plugin refresh.
+def codex_cache_archive() -> Path:
+    """Durable recovery source for cache roots retained by running tasks."""
+    return (
+        Path.home()
+        / ".synthesis"
+        / "plugin-cache-recovery"
+        / MARKETPLACE
+        / PLUGIN_NAME
+    )
 
-    A running Codex task retains the absolute plugin root from its SessionStart
-    hook definition. Codex's plugin add currently replaces the cache and removes
-    that root, which strands the task's later Stop hook. Claude already retains
-    historical roots. The release publisher therefore preserves every real
-    Codex version directory that exists at the transition boundary. Symlinks are
-    deliberately excluded: they are recovery artifacts, not installed versions.
+
+def _version_key(version: str) -> tuple[int, int, int]:
+    return tuple(int(part) for part in version.split("."))  # type: ignore[return-value]
+
+
+def _real_version_roots(parent: Path) -> dict[str, Path]:
+    if not parent.is_dir():
+        return {}
+    return {
+        source.name: source
+        for source in sorted(parent.iterdir(), key=lambda path: path.name)
+        if not source.is_symlink()
+        and source.is_dir()
+        and RELEASE_VERSION_RE.fullmatch(source.name) is not None
+    }
+
+
+def _release_tags(repo: Path) -> list[str]:
+    completed = run(["git", "tag", "--list", "v*"], cwd=repo)
+    if completed.returncode != 0:
+        raise OSError(completed.stderr.strip() or "could not list release tags")
+    return sorted(
+        {
+            tag[1:]
+            for tag in completed.stdout.splitlines()
+            if tag.startswith("v") and RELEASE_VERSION_RE.fullmatch(tag[1:])
+        },
+        key=_version_key,
+    )
+
+
+def _export_release_tag(
+    repo: Path,
+    version: str,
+    destination: Path,
+    *,
+    current_version: str,
+) -> set[str]:
+    """Export one immutable release tree without trusting tar member paths."""
+    reference = "HEAD" if version == current_version else f"v{version}"
+    completed = subprocess.run(
+        ["git", "archive", "--format=tar", reference],
+        cwd=str(repo),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=120,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise OSError(detail or f"could not export v{version}")
+    tracked: set[str] = set()
+    destination.mkdir(parents=True, exist_ok=False)
+    with tarfile.open(fileobj=io.BytesIO(completed.stdout), mode="r:") as archive:
+        for member in archive.getmembers():
+            relative = PurePosixPath(member.name)
+            if relative.is_absolute() or ".." in relative.parts:
+                raise OSError(f"unsafe path in v{version}: {member.name}")
+            target = destination.joinpath(*relative.parts)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                target.chmod(member.mode & 0o777)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if member.isfile():
+                source = archive.extractfile(member)
+                if source is None:
+                    raise OSError(f"unreadable file in v{version}: {member.name}")
+                target.write_bytes(source.read())
+                target.chmod(member.mode & 0o777)
+            elif member.issym():
+                link = PurePosixPath(member.linkname)
+                if link.is_absolute() or ".." in link.parts:
+                    raise OSError(
+                        f"unsafe symlink in v{version}: {member.name} -> {member.linkname}"
+                    )
+                target.symlink_to(member.linkname)
+            else:
+                raise OSError(f"unsupported archive entry in v{version}: {member.name}")
+            tracked.add(relative.as_posix())
+    return tracked
+
+
+def _copy_cache_extras(source: Path, destination: Path, tracked: set[str]) -> None:
+    """Retain client metadata while immutable tag bytes win every collision."""
+    if not source.is_dir() or source.is_symlink():
+        return
+    for path in sorted(source.rglob("*"), key=lambda item: str(item.relative_to(source))):
+        relative = path.relative_to(source)
+        relative_text = relative.as_posix()
+        target = destination / relative
+        if relative_text in tracked:
+            continue
+        if path.is_symlink():
+            link = PurePosixPath(os.readlink(path))
+            if link.is_absolute() or ".." in link.parts:
+                raise OSError(f"unsafe cache symlink: {path}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists() or target.is_symlink():
+                target.unlink()
+            target.symlink_to(os.readlink(path))
+        elif path.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+        elif path.is_file():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, target)
+
+
+def _tree_bytes(root: Path) -> int:
+    return sum(path.stat().st_size for path in root.rglob("*") if path.is_file())
+
+
+def _persist_codex_archive(
+    backup: Path, versions: list[str], archive: Path
+) -> None:
+    archive.mkdir(parents=True, exist_ok=True)
+    for version in versions:
+        source = backup / version
+        destination = archive / version
+        if destination.is_symlink():
+            raise OSError(f"recovery archive root is a symlink: {destination}")
+        shutil.copytree(source, destination, dirs_exist_ok=True, symlinks=True)
+        if _tree_digest(source) != _tree_digest(destination):
+            raise OSError(f"recovery archive differs after write: {destination}")
+
+
+def snapshot_codex_caches(
+    result: Result, repo: Path | None = None
+) -> CodexCacheSnapshot | None:
+    """Build complete tag-backed snapshots before Codex's destructive refresh.
+
+    Existing cache roots alone are not proof of completeness: a prior refresh
+    can leave only the one file a stranded Stop hook needed. When a source
+    checkout is supplied, immutable release tags provide every tracked byte;
+    cache-only metadata is layered on top. A durable, budgeted archive lets a
+    later release recover roots that a previous client transition removed.
     """
     parent = plugin_cache_parent("codex")
+    archive = codex_cache_archive() if repo is not None else None
     backup = Path(tempfile.mkdtemp(prefix="synthesis-codex-cache-"))
-    versions = []
     try:
-        if parent.is_dir():
-            for source in sorted(parent.iterdir(), key=lambda path: path.name):
-                if (
-                    source.is_symlink()
-                    or not source.is_dir()
-                    or RELEASE_VERSION_RE.fullmatch(source.name) is None
-                ):
-                    continue
-                shutil.copytree(source, backup / source.name, symlinks=True)
-                versions.append(source.name)
-    except OSError as exc:
+        cache_roots = _real_version_roots(parent)
+        archive_roots = _real_version_roots(archive) if archive is not None else {}
+        boundary_versions = set(cache_roots) | set(archive_roots)
+        preserved_versions = set(boundary_versions)
+        seed_versions = set(boundary_versions)
+        tags: list[str] = []
+        current_version: str | None = None
+        if repo is not None:
+            tags = _release_tags(repo)
+            current_version, detail = source_version(repo)
+            if current_version is None:
+                raise OSError(detail)
+            if current_version not in tags:
+                tags.append(current_version)
+                tags.sort(key=_version_key)
+            if boundary_versions:
+                low = min(boundary_versions, key=_version_key)
+                high = max(boundary_versions, key=_version_key)
+                preserved_versions.update(
+                    version
+                    for version in tags
+                    if _version_key(low) <= _version_key(version) <= _version_key(high)
+                )
+            seed_versions.update(preserved_versions)
+            seed_versions.add(current_version)
+
+        for version in sorted(seed_versions, key=_version_key):
+            destination = backup / version
+            if repo is None:
+                source = cache_roots.get(version) or archive_roots.get(version)
+                if source is None:
+                    raise OSError(f"no recovery source for cache version {version}")
+                shutil.copytree(source, destination, symlinks=True)
+                continue
+            if version not in tags:
+                raise OSError(f"immutable tag v{version} is unavailable")
+            tracked = _export_release_tag(
+                repo,
+                version,
+                destination,
+                current_version=current_version or "",
+            )
+            if version in archive_roots:
+                _copy_cache_extras(archive_roots[version], destination, tracked)
+            if version in cache_roots:
+                _copy_cache_extras(cache_roots[version], destination, tracked)
+
+        if archive is not None:
+            projected_bytes = _tree_bytes(backup)
+            if projected_bytes > CODEX_CACHE_ARCHIVE_BUDGET_BYTES:
+                raise OSError(
+                    "recovery archive would exceed the 512 MiB hard budget; "
+                    "no historical root was deleted automatically"
+                )
+            _persist_codex_archive(
+                backup, sorted(seed_versions, key=_version_key), archive
+            )
+            if _tree_bytes(archive) > CODEX_CACHE_ARCHIVE_BUDGET_BYTES:
+                raise OSError("recovery archive exceeds the 512 MiB hard budget")
+            result.add(
+                "install.codex.cache-archive",
+                True,
+                f"verified {len(seed_versions)} immutable recovery root(s)",
+            )
+    except (OSError, subprocess.SubprocessError, tarfile.TarError) as exc:
         result.add(
             "install.codex.cache-snapshot",
             False,
-            f"could not preserve active-session cache roots; recovery copy kept at {backup}: {exc}",
+            f"could not preserve complete active-session cache roots; recovery copy kept at {backup}: {exc}",
         )
         return None
+    versions = tuple(sorted(preserved_versions, key=_version_key))
     result.add(
         "install.codex.cache-snapshot",
         True,
-        f"preserved {len(versions)} real version root(s) before refresh",
+        f"preserved {len(versions)} complete version root(s) before refresh",
     )
-    return backup, versions
+    return CodexCacheSnapshot(backup=backup, versions=versions, archive=archive)
 
 
 def _remove_transition_backup(backup: Path) -> None:
@@ -543,37 +750,72 @@ def _remove_transition_backup(backup: Path) -> None:
     shutil.rmtree(resolved)
 
 
-def restore_codex_caches(
-    backup: Path, versions: list[str], result: Result
-) -> bool:
-    """Restore missing version roots and prove every preserved tree is exact."""
+def _restore_codex_caches_once(
+    snapshot: CodexCacheSnapshot,
+) -> tuple[set[str], set[str]]:
+    """Restore or repair one observed generation of the cache tree."""
     parent = plugin_cache_parent("codex")
-    restored = []
+    restored: set[str] = set()
+    repaired: set[str] = set()
+    parent.mkdir(parents=True, exist_ok=True)
+    for version in snapshot.versions:
+        source = snapshot.backup / version
+        destination = parent / version
+        if destination.is_symlink():
+            raise OSError(f"version root became a symlink: {destination}")
+        if not destination.exists():
+            shutil.copytree(source, destination, symlinks=True)
+            restored.add(version)
+        elif not destination.is_dir():
+            raise OSError(f"version root is not a directory: {destination}")
+        elif _tree_digest(source) != _tree_digest(destination):
+            shutil.copytree(source, destination, dirs_exist_ok=True, symlinks=True)
+            repaired.add(version)
+        if _tree_digest(source) != _tree_digest(destination):
+            raise OSError(f"version root changed during refresh: {destination}")
+    return restored, repaired
+
+
+def restore_codex_caches(
+    snapshot: CodexCacheSnapshot,
+    result: Result,
+    *,
+    clock=time.monotonic,
+    sleeper=time.sleep,
+) -> bool:
+    """Restore complete roots and require a quiet post-command cache window."""
+    restored: set[str] = set()
+    repaired: set[str] = set()
+    started = clock()
+    quiet_since = started
     try:
-        parent.mkdir(parents=True, exist_ok=True)
-        for version in versions:
-            source = backup / version
-            destination = parent / version
-            if destination.is_symlink():
-                raise OSError(f"version root became a symlink: {destination}")
-            if not destination.exists():
-                shutil.copytree(source, destination, symlinks=True)
-                restored.append(version)
-            if not destination.is_dir():
-                raise OSError(f"version root is not a directory: {destination}")
-            if _tree_digest(source) != _tree_digest(destination):
-                raise OSError(f"version root changed during refresh: {destination}")
-        _remove_transition_backup(backup)
+        while True:
+            new_restored, new_repaired = _restore_codex_caches_once(snapshot)
+            now = clock()
+            if new_restored or new_repaired:
+                restored.update(new_restored)
+                repaired.update(new_repaired)
+                quiet_since = now
+            if now - quiet_since >= CODEX_CACHE_QUIET_SECONDS:
+                _remove_transition_backup(snapshot.backup)
+                break
+            if now - started >= CODEX_CACHE_SETTLE_TIMEOUT_SECONDS:
+                raise OSError(
+                    "Codex cache did not remain unchanged for the required quiet window"
+                )
+            sleeper(CODEX_CACHE_POLL_SECONDS)
     except OSError as exc:
         return result.add(
             "install.codex.cache-restore",
             False,
-            f"active-session cache preservation failed; recovery copy kept at {backup}: {exc}",
+            f"active-session cache preservation failed; recovery copy kept at {snapshot.backup}: {exc}",
         )
     return result.add(
         "install.codex.cache-restore",
         True,
-        f"verified {len(versions)} preserved root(s); restored {len(restored)}",
+        f"verified {len(snapshot.versions)} complete root(s) after a "
+        f"{CODEX_CACHE_QUIET_SECONDS:g}s quiet window; restored {len(restored)}, "
+        f"repaired {len(repaired)}",
     )
 
 
@@ -668,7 +910,9 @@ def deep_verify(client: str, expected: str, result: Result,
     return ok_reported and ok_disk and ok_content
 
 
-def refresh_client(client: str, result: Result, dry_run: bool) -> bool:
+def refresh_client(
+    client: str, result: Result, dry_run: bool, repo: Path | None = None
+) -> bool:
     """Refresh one client's marketplace snapshot and installed plugin."""
     binary = resolve_client_binary(client)
     if not binary:
@@ -688,7 +932,7 @@ def refresh_client(client: str, result: Result, dry_run: bool) -> bool:
         ]
     cache_snapshot = None
     if client == "codex" and not dry_run:
-        cache_snapshot = snapshot_codex_caches(result)
+        cache_snapshot = snapshot_codex_caches(result, repo=repo)
         if cache_snapshot is None:
             return False
 
@@ -707,7 +951,7 @@ def refresh_client(client: str, result: Result, dry_run: bool) -> bool:
         result.add(label, True, " ".join(command[1:]))
     caches_ok = True
     if cache_snapshot is not None:
-        caches_ok = restore_codex_caches(*cache_snapshot, result)
+        caches_ok = restore_codex_caches(cache_snapshot, result)
     return commands_ok and caches_ok
 
 
@@ -866,7 +1110,7 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
     for client in ("claude", "codex"):
-        refresh_client(client, result, args.dry_run)
+        refresh_client(client, result, args.dry_run, repo=repo)
 
     if args.dry_run:
         print(f"\nDRY RUN complete for {version}. No state changed.")

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -658,6 +658,12 @@ def _cache_root_completeness(root: Path, version: str) -> tuple[bool, str]:
     """Validate an untagged peer/archive root before trusting it as recovery source."""
     if not root.is_dir() or root.is_symlink():
         return False, "root is absent, not a directory, or a symlink"
+    for path in root.rglob("*"):
+        if not path.is_symlink():
+            continue
+        link = PurePosixPath(os.readlink(path))
+        if link.is_absolute() or ".." in link.parts:
+            return False, f"unsafe symlink is present: {path.relative_to(root)}"
     manifest_versions = {
         read_manifest_version(root / manifest)
         for manifest in MANIFESTS
@@ -727,8 +733,17 @@ def snapshot_codex_caches(
     archive = codex_cache_archive() if repo is not None else None
     backup = Path(tempfile.mkdtemp(prefix="synthesis-codex-cache-"))
     try:
+        peers = {
+            "Codex cache": parent,
+            "Claude cache": plugin_cache_parent("claude"),
+        }
+        if archive is not None:
+            peers["recovery archive"] = archive
+        for label, root in peers.items():
+            if root.is_symlink():
+                raise OSError(f"{label} root is a symlink: {root}")
         cache_roots = _real_version_roots(parent)
-        peer_roots = _real_version_roots(plugin_cache_parent("claude"))
+        peer_roots = _real_version_roots(peers["Claude cache"])
         archive_roots = _real_version_roots(archive) if archive is not None else {}
         boundary_versions = set(cache_roots) | set(peer_roots) | set(archive_roots)
         preserved_versions = set(boundary_versions)

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -39,6 +39,7 @@ Exit codes: 0 released/verified, 1 a step failed, 2 preconditions unverifiable.
 from __future__ import annotations
 
 import argparse
+import fcntl
 import hashlib
 import io
 import json
@@ -86,6 +87,7 @@ ACCEPTANCE_CONSUMER_ID = (
     "synthesis-skills-manager.release.consume-acceptance.v1"
 )
 RELEASE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+HOOK_PLUGIN_PATH_RE = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\s\"']+)")
 CODEX_CACHE_ARCHIVE_BUDGET_BYTES = 512 * 1024 * 1024
 CODEX_CACHE_QUIET_SECONDS = 10.0
 CODEX_CACHE_SETTLE_TIMEOUT_SECONDS = 60.0
@@ -518,6 +520,32 @@ def codex_cache_archive() -> Path:
     )
 
 
+def _acquire_codex_cache_lock():
+    """Acquire the single-writer lock for the Codex cache transition."""
+    lock_path = codex_cache_archive().parent / f".{PLUGIN_NAME}.release.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(lock_path, flags, 0o600)
+    handle = os.fdopen(descriptor, "a+")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        handle.close()
+        raise OSError(
+            "another release process owns the Codex cache transition lock"
+        ) from None
+    return handle
+
+
+def _release_codex_cache_lock(handle) -> None:
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    handle.close()
+
+
 def _version_key(version: str) -> tuple[int, int, int]:
     return tuple(int(part) for part in version.split("."))  # type: ignore[return-value]
 
@@ -607,6 +635,8 @@ def _copy_cache_extras(source: Path, destination: Path, tracked: set[str]) -> No
         relative = path.relative_to(source)
         relative_text = relative.as_posix()
         target = destination / relative
+        if relative.parts and relative.parts[0] in {".git", ".in_use"}:
+            continue
         if relative_text in tracked:
             continue
         if path.is_symlink():
@@ -622,6 +652,46 @@ def _copy_cache_extras(source: Path, destination: Path, tracked: set[str]) -> No
         elif path.is_file():
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(path, target)
+
+
+def _cache_root_completeness(root: Path, version: str) -> tuple[bool, str]:
+    """Validate an untagged peer/archive root before trusting it as recovery source."""
+    if not root.is_dir() or root.is_symlink():
+        return False, "root is absent, not a directory, or a symlink"
+    manifest_versions = {
+        read_manifest_version(root / manifest)
+        for manifest in MANIFESTS
+        if (root / manifest).is_file()
+    }
+    if version not in manifest_versions:
+        return False, f"no plugin manifest reports {version}"
+    hooks = root / "hooks" / "hooks.json"
+    if not hooks.is_file():
+        return False, "hooks/hooks.json is missing"
+    try:
+        hook_text = hooks.read_text(encoding="utf-8")
+        json.loads(hook_text)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return False, f"hooks/hooks.json is unreadable: {exc}"
+    hook_targets = sorted(set(HOOK_PLUGIN_PATH_RE.findall(hook_text)))
+    if not hook_targets:
+        return False, "hooks/hooks.json declares no plugin-root command target"
+    missing_targets = [target for target in hook_targets if not (root / target).is_file()]
+    if missing_targets:
+        return False, f"missing hook target(s): {', '.join(missing_targets[:3])}"
+    if not any(root.glob("skills/*/SKILL.md")):
+        return False, "no skill entry point is present"
+    return True, f"{len(hook_targets)} hook target(s) and skill tree present"
+
+
+def _copy_legacy_cache_root(source: Path, destination: Path) -> None:
+    """Copy a complete pre-tag cache tree without client liveness markers."""
+    shutil.copytree(
+        source,
+        destination,
+        symlinks=True,
+        ignore=shutil.ignore_patterns(".git", ".in_use"),
+    )
 
 
 def _tree_bytes(root: Path) -> int:
@@ -658,8 +728,9 @@ def snapshot_codex_caches(
     backup = Path(tempfile.mkdtemp(prefix="synthesis-codex-cache-"))
     try:
         cache_roots = _real_version_roots(parent)
+        peer_roots = _real_version_roots(plugin_cache_parent("claude"))
         archive_roots = _real_version_roots(archive) if archive is not None else {}
-        boundary_versions = set(cache_roots) | set(archive_roots)
+        boundary_versions = set(cache_roots) | set(peer_roots) | set(archive_roots)
         preserved_versions = set(boundary_versions)
         seed_versions = set(boundary_versions)
         tags: list[str] = []
@@ -692,7 +763,29 @@ def snapshot_codex_caches(
                 shutil.copytree(source, destination, symlinks=True)
                 continue
             if version not in tags:
-                raise OSError(f"immutable tag v{version} is unavailable")
+                candidates = [
+                    ("recovery archive", archive_roots.get(version)),
+                    ("Claude cache", peer_roots.get(version)),
+                    ("Codex cache", cache_roots.get(version)),
+                ]
+                rejected: list[str] = []
+                for label, source in candidates:
+                    if source is None:
+                        continue
+                    complete, completeness_detail = _cache_root_completeness(
+                        source, version
+                    )
+                    if complete:
+                        _copy_legacy_cache_root(source, destination)
+                        break
+                    rejected.append(f"{label}: {completeness_detail}")
+                else:
+                    detail = "; ".join(rejected) or "no peer or archive root exists"
+                    raise OSError(
+                        f"immutable tag v{version} is unavailable and no complete "
+                        f"legacy recovery root was found ({detail})"
+                    )
+                continue
             tracked = _export_release_tag(
                 repo,
                 version,
@@ -701,6 +794,8 @@ def snapshot_codex_caches(
             )
             if version in archive_roots:
                 _copy_cache_extras(archive_roots[version], destination, tracked)
+            if version in peer_roots:
+                _copy_cache_extras(peer_roots[version], destination, tracked)
             if version in cache_roots:
                 _copy_cache_extras(cache_roots[version], destination, tracked)
 
@@ -719,7 +814,7 @@ def snapshot_codex_caches(
             result.add(
                 "install.codex.cache-archive",
                 True,
-                f"verified {len(seed_versions)} immutable recovery root(s)",
+                f"verified {len(seed_versions)} complete recovery root(s)",
             )
     except (OSError, subprocess.SubprocessError, tarfile.TarError) as exc:
         result.add(
@@ -930,29 +1025,40 @@ def refresh_client(
             [binary, "plugin", "marketplace", "upgrade", MARKETPLACE],
             [binary, "plugin", "add", f"{PLUGIN_NAME}@{MARKETPLACE}"],
         ]
-    cache_snapshot = None
-    if client == "codex" and not dry_run:
-        cache_snapshot = snapshot_codex_caches(result, repo=repo)
-        if cache_snapshot is None:
-            return False
+    cache_lock = None
+    if client == "codex" and not dry_run and repo is not None:
+        try:
+            cache_lock = _acquire_codex_cache_lock()
+        except OSError as exc:
+            return result.add("install.codex.cache-lock", False, str(exc))
+        result.add("install.codex.cache-lock", True, "single writer acquired")
+    try:
+        cache_snapshot = None
+        if client == "codex" and not dry_run:
+            cache_snapshot = snapshot_codex_caches(result, repo=repo)
+            if cache_snapshot is None:
+                return False
 
-    commands_ok = True
-    for command in commands:
-        label = f"install.{client}.{command[2] if len(command) > 2 else 'run'}"
-        if dry_run:
-            result.add(label, True, "dry-run: " + " ".join(command[1:]))
-            continue
-        completed = run(command, timeout=600)
-        if completed.returncode != 0:
-            tail = (completed.stderr or completed.stdout).strip().splitlines()
-            result.add(label, False, tail[-1] if tail else "command failed")
-            commands_ok = False
-            break
-        result.add(label, True, " ".join(command[1:]))
-    caches_ok = True
-    if cache_snapshot is not None:
-        caches_ok = restore_codex_caches(cache_snapshot, result)
-    return commands_ok and caches_ok
+        commands_ok = True
+        for command in commands:
+            label = f"install.{client}.{command[2] if len(command) > 2 else 'run'}"
+            if dry_run:
+                result.add(label, True, "dry-run: " + " ".join(command[1:]))
+                continue
+            completed = run(command, timeout=600)
+            if completed.returncode != 0:
+                tail = (completed.stderr or completed.stdout).strip().splitlines()
+                result.add(label, False, tail[-1] if tail else "command failed")
+                commands_ok = False
+                break
+            result.add(label, True, " ".join(command[1:]))
+        caches_ok = True
+        if cache_snapshot is not None:
+            caches_ok = restore_codex_caches(cache_snapshot, result)
+        return commands_ok and caches_ok
+    finally:
+        if cache_lock is not None:
+            _release_codex_cache_lock(cache_lock)
 
 
 def preflight(repo: Path, result: Result, install_only: bool) -> str | None:

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -669,6 +669,41 @@ def commit_release(repo: Path, version: str, marker: str) -> None:
     )
 
 
+def seed_complete_cache_root(root: Path, version: str) -> None:
+    write_manifests(root, version, version)
+    target = root / "skills" / "synthesis-autopilot" / "scripts" / "autopilot_gate.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("print('gate')\n", encoding="utf-8")
+    (target.parents[1] / "SKILL.md").write_text(
+        f"---\nname: synthesis-autopilot\nversion: {version}\n---\n",
+        encoding="utf-8",
+    )
+    hooks = root / "hooks" / "hooks.json"
+    hooks.parent.mkdir(parents=True, exist_ok=True)
+    hooks.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": (
+                                        "python3 ${CLAUDE_PLUGIN_ROOT}/skills/"
+                                        "synthesis-autopilot/scripts/autopilot_gate.py --gate"
+                                    ),
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -710,6 +745,73 @@ def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
     assert next(
         step for step in result.steps if step.name == "install.codex.cache-archive"
     ).ok
+
+
+def test_snapshot_imports_complete_untagged_peer_root_missing_from_codex(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    commit_release(source, "4.74.0", "tagged")
+    codex_cache = tmp_path / "codex-cache"
+    (codex_cache / "4.74.0").mkdir(parents=True)
+    claude_cache = tmp_path / "claude-cache"
+    peer = claude_cache / "4.73.0"
+    seed_complete_cache_root(peer, "4.73.0")
+    (peer / ".in_use").mkdir()
+    (peer / ".in_use" / "123").touch()
+    recovery = tmp_path / "recovery"
+
+    monkeypatch.setattr(
+        release,
+        "plugin_cache_parent",
+        lambda client: claude_cache if client == "claude" else codex_cache,
+    )
+    monkeypatch.setattr(release, "codex_cache_archive", lambda: recovery)
+
+    result = release.Result()
+    snapshot = release.snapshot_codex_caches(result, repo=source)
+
+    assert snapshot is not None
+    assert snapshot.versions == ("4.73.0", "4.74.0")
+    recovered = snapshot.backup / "4.73.0"
+    assert (recovered / "skills/synthesis-autopilot/scripts/autopilot_gate.py").is_file()
+    assert not (recovered / ".in_use").exists()
+    assert release.restore_codex_caches(snapshot, result)
+    assert (
+        codex_cache / "4.73.0/skills/synthesis-autopilot/scripts/autopilot_gate.py"
+    ).is_file()
+
+
+def test_snapshot_rejects_incomplete_untagged_peer_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    commit_release(source, "4.74.0", "tagged")
+    codex_cache = tmp_path / "codex-cache"
+    (codex_cache / "4.74.0").mkdir(parents=True)
+    claude_cache = tmp_path / "claude-cache"
+    peer = claude_cache / "4.73.0"
+    seed_complete_cache_root(peer, "4.73.0")
+    (peer / "skills/synthesis-autopilot/scripts/autopilot_gate.py").unlink()
+
+    monkeypatch.setattr(
+        release,
+        "plugin_cache_parent",
+        lambda client: claude_cache if client == "claude" else codex_cache,
+    )
+    monkeypatch.setattr(
+        release, "codex_cache_archive", lambda: tmp_path / "recovery"
+    )
+
+    result = release.Result()
+    assert release.snapshot_codex_caches(result, repo=source) is None
+    failure = next(
+        step for step in result.steps if step.name == "install.codex.cache-snapshot"
+    )
+    assert failure.ok is False
+    assert "missing hook target" in failure.detail
 
 
 def test_restore_repeats_after_post_command_cache_deletion(
@@ -808,6 +910,20 @@ def test_refresh_fails_closed_without_binary(monkeypatch: pytest.MonkeyPatch) ->
     result = release.Result()
     assert release.refresh_client("codex", result, dry_run=True) is False
     assert result.failed
+
+
+def test_codex_cache_transition_lock_refuses_a_second_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        release, "codex_cache_archive", lambda: tmp_path / "recovery" / "plugin"
+    )
+    first = release._acquire_codex_cache_lock()
+    try:
+        with pytest.raises(OSError, match="another release process"):
+            release._acquire_codex_cache_lock()
+    finally:
+        release._release_codex_cache_lock(first)
 
 
 def test_codex_refresh_restores_real_version_root_deleted_by_client(

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -809,6 +809,17 @@ def test_snapshot_rejects_incomplete_untagged_peer_root(
     assert "missing hook target" in failure.detail
 
 
+def test_untagged_peer_root_rejects_unsafe_symlink(tmp_path: Path) -> None:
+    root = tmp_path / "4.73.0"
+    seed_complete_cache_root(root, "4.73.0")
+    (root / "unsafe").symlink_to("../../outside")
+
+    complete, detail = release._cache_root_completeness(root, "4.73.0")
+
+    assert complete is False
+    assert "unsafe symlink" in detail
+
+
 def test_restore_repeats_after_post_command_cache_deletion(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -664,6 +664,41 @@ def commit_release(repo: Path, version: str, marker: str) -> None:
     )
 
 
+def seed_complete_cache_root(root: Path, version: str) -> None:
+    write_manifests(root, version, version)
+    target = root / "skills" / "synthesis-autopilot" / "scripts" / "autopilot_gate.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("print('gate')\n", encoding="utf-8")
+    (target.parents[1] / "SKILL.md").write_text(
+        f"---\nname: synthesis-autopilot\nversion: {version}\n---\n",
+        encoding="utf-8",
+    )
+    hooks = root / "hooks" / "hooks.json"
+    hooks.parent.mkdir(parents=True, exist_ok=True)
+    hooks.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": (
+                                        "python3 ${CLAUDE_PLUGIN_ROOT}/skills/"
+                                        "synthesis-autopilot/scripts/autopilot_gate.py --gate"
+                                    ),
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -705,6 +740,73 @@ def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
     assert next(
         step for step in result.steps if step.name == "install.codex.cache-archive"
     ).ok
+
+
+def test_snapshot_imports_complete_untagged_peer_root_missing_from_codex(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    commit_release(source, "4.74.0", "tagged")
+    codex_cache = tmp_path / "codex-cache"
+    (codex_cache / "4.74.0").mkdir(parents=True)
+    claude_cache = tmp_path / "claude-cache"
+    peer = claude_cache / "4.73.0"
+    seed_complete_cache_root(peer, "4.73.0")
+    (peer / ".in_use").mkdir()
+    (peer / ".in_use" / "123").touch()
+    recovery = tmp_path / "recovery"
+
+    monkeypatch.setattr(
+        release,
+        "plugin_cache_parent",
+        lambda client: claude_cache if client == "claude" else codex_cache,
+    )
+    monkeypatch.setattr(release, "codex_cache_archive", lambda: recovery)
+
+    result = release.Result()
+    snapshot = release.snapshot_codex_caches(result, repo=source)
+
+    assert snapshot is not None
+    assert snapshot.versions == ("4.73.0", "4.74.0")
+    recovered = snapshot.backup / "4.73.0"
+    assert (recovered / "skills/synthesis-autopilot/scripts/autopilot_gate.py").is_file()
+    assert not (recovered / ".in_use").exists()
+    assert release.restore_codex_caches(snapshot, result)
+    assert (
+        codex_cache / "4.73.0/skills/synthesis-autopilot/scripts/autopilot_gate.py"
+    ).is_file()
+
+
+def test_snapshot_rejects_incomplete_untagged_peer_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    commit_release(source, "4.74.0", "tagged")
+    codex_cache = tmp_path / "codex-cache"
+    (codex_cache / "4.74.0").mkdir(parents=True)
+    claude_cache = tmp_path / "claude-cache"
+    peer = claude_cache / "4.73.0"
+    seed_complete_cache_root(peer, "4.73.0")
+    (peer / "skills/synthesis-autopilot/scripts/autopilot_gate.py").unlink()
+
+    monkeypatch.setattr(
+        release,
+        "plugin_cache_parent",
+        lambda client: claude_cache if client == "claude" else codex_cache,
+    )
+    monkeypatch.setattr(
+        release, "codex_cache_archive", lambda: tmp_path / "recovery"
+    )
+
+    result = release.Result()
+    assert release.snapshot_codex_caches(result, repo=source) is None
+    failure = next(
+        step for step in result.steps if step.name == "install.codex.cache-snapshot"
+    )
+    assert failure.ok is False
+    assert "missing hook target" in failure.detail
 
 
 def test_restore_repeats_after_post_command_cache_deletion(
@@ -803,6 +905,20 @@ def test_refresh_fails_closed_without_binary(monkeypatch: pytest.MonkeyPatch) ->
     result = release.Result()
     assert release.refresh_client("codex", result, dry_run=True) is False
     assert result.failed
+
+
+def test_codex_cache_transition_lock_refuses_a_second_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        release, "codex_cache_archive", lambda: tmp_path / "recovery" / "plugin"
+    )
+    first = release._acquire_codex_cache_lock()
+    try:
+        with pytest.raises(OSError, match="another release process"):
+            release._acquire_codex_cache_lock()
+    finally:
+        release._release_codex_cache_lock(first)
 
 
 def test_codex_refresh_restores_real_version_root_deleted_by_client(

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -45,6 +45,11 @@ def repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture(autouse=True)
+def no_real_cache_settle_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(release, "CODEX_CACHE_QUIET_SECONDS", 0.0)
+
+
 # --- source of truth -------------------------------------------------------
 
 
@@ -485,7 +490,7 @@ def test_main_carries_acceptance_authority_to_publish_boundary(
         return result.add("publish.fixture", True)
 
     monkeypatch.setattr(release, "publish", publish)
-    monkeypatch.setattr(release, "refresh_client", lambda *_args: True)
+    monkeypatch.setattr(release, "refresh_client", lambda *_args, **_kwargs: True)
 
     assert release.main(["--repo-root", str(repo), "--dry-run"]) == 0
     assert received == [(authority, "9.9.9")]
@@ -598,6 +603,181 @@ def test_deep_verify_fails_when_client_silent(
 # --- install sequencing ----------------------------------------------------
 
 
+def commit_release(repo: Path, version: str, marker: str) -> None:
+    write_manifests(repo, version, version)
+    skill = repo / "skills" / "example" / "SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text(f"version: {version}\n{marker}\n", encoding="utf-8")
+    if not (repo / ".git").is_dir():
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    tree = subprocess.run(
+        ["git", "write-tree"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    parent = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    commit_command = [
+        "git",
+        "-c",
+        "user.name=Release Test",
+        "-c",
+        "user.email=release-test@example.invalid",
+        "commit-tree",
+        tree,
+    ]
+    if parent.returncode == 0:
+        commit_command.extend(["-p", parent.stdout.strip()])
+    commit = subprocess.run(
+        commit_command,
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        input=f"Release {version}\n",
+        text=True,
+    ).stdout.strip()
+    branch = subprocess.run(
+        ["git", "symbolic-ref", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        [
+            "git",
+            "update-ref",
+            branch,
+            commit,
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", f"refs/tags/v{version}", commit],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    commit_release(source, "4.74.0", "first")
+    commit_release(source, "4.74.1", "middle")
+    commit_release(source, "4.75.0", "current")
+    subprocess.run(
+        ["git", "update-ref", "-d", "refs/tags/v4.75.0"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+    )
+
+    cache_parent = tmp_path / "codex-cache"
+    partial = cache_parent / "4.74.0"
+    partial.mkdir(parents=True)
+    (partial / "cache-only.json").write_text("{}\n", encoding="utf-8")
+    newest = cache_parent / "4.75.0"
+    newest.mkdir(parents=True)
+    recovery = tmp_path / "recovery"
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "codex_cache_archive", lambda: recovery)
+
+    result = release.Result()
+    snapshot = release.snapshot_codex_caches(result, repo=source)
+
+    assert snapshot is not None
+    assert snapshot.versions == ("4.74.0", "4.74.1", "4.75.0")
+    assert (snapshot.backup / "4.74.0" / ".codex-plugin/plugin.json").is_file()
+    assert (snapshot.backup / "4.74.0" / "cache-only.json").is_file()
+    assert (
+        snapshot.backup / "4.74.1" / "skills/example/SKILL.md"
+    ).read_text(encoding="utf-8") == "version: 4.74.1\nmiddle\n"
+    assert release._tree_digest(snapshot.backup / "4.74.1") == release._tree_digest(
+        recovery / "4.74.1"
+    )
+    assert next(
+        step for step in result.steps if step.name == "install.codex.cache-archive"
+    ).ok
+
+
+def test_restore_repeats_after_post_command_cache_deletion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_parent = tmp_path / "codex-cache"
+    old_root = cache_parent / "4.74.0"
+    old_root.mkdir(parents=True)
+    (old_root / "marker").write_text("complete\n", encoding="utf-8")
+    backup = tmp_path / "synthesis-codex-cache-fixture"
+    shutil.copytree(old_root, backup / "4.74.0")
+    snapshot = release.CodexCacheSnapshot(backup, ("4.74.0",))
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "CODEX_CACHE_QUIET_SECONDS", 2.0)
+    monkeypatch.setattr(release, "CODEX_CACHE_SETTLE_TIMEOUT_SECONDS", 10.0)
+    monkeypatch.setattr(release, "CODEX_CACHE_POLL_SECONDS", 1.0)
+    monkeypatch.setattr(
+        release, "_remove_transition_backup", lambda path: shutil.rmtree(path)
+    )
+
+    class Clock:
+        now = 0.0
+        deleted = False
+
+        def read(self) -> float:
+            return self.now
+
+        def sleep(self, seconds: float) -> None:
+            self.now += seconds
+            if not self.deleted:
+                shutil.rmtree(old_root)
+                self.deleted = True
+
+    clock = Clock()
+    result = release.Result()
+    assert release.restore_codex_caches(
+        snapshot, result, clock=clock.read, sleeper=clock.sleep
+    )
+    assert (old_root / "marker").read_text(encoding="utf-8") == "complete\n"
+    detail = next(
+        step.detail
+        for step in result.steps
+        if step.name == "install.codex.cache-restore"
+    )
+    assert "restored 1" in detail
+
+
+def test_tag_backed_snapshot_refuses_archive_budget_overflow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    commit_release(source, "4.74.0", "content larger than one byte")
+    cache_parent = tmp_path / "codex-cache"
+    (cache_parent / "4.74.0").mkdir(parents=True)
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "codex_cache_archive", lambda: tmp_path / "recovery")
+    monkeypatch.setattr(release, "CODEX_CACHE_ARCHIVE_BUDGET_BYTES", 1)
+
+    result = release.Result()
+    assert release.snapshot_codex_caches(result, repo=source) is None
+    failure = next(
+        step for step in result.steps if step.name == "install.codex.cache-snapshot"
+    )
+    assert failure.ok is False
+    assert "hard budget" in failure.detail
+
+
 def test_codex_refresh_upgrades_marketplace_before_installing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -656,12 +836,12 @@ def test_codex_refresh_restores_real_version_root_deleted_by_client(
     assert not recovery_link.exists()
     steps = {step.name: step for step in result.steps}
     assert steps["install.codex.cache-snapshot"].ok is True
-    assert "1 real version" in steps["install.codex.cache-snapshot"].detail
+    assert "1 complete version" in steps["install.codex.cache-snapshot"].detail
     assert steps["install.codex.cache-restore"].ok is True
     assert "restored 1" in steps["install.codex.cache-restore"].detail
 
 
-def test_codex_refresh_fails_if_existing_preserved_root_changes(
+def test_codex_refresh_repairs_if_existing_preserved_root_changes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cache_parent = tmp_path / "codex-cache"
@@ -675,6 +855,33 @@ def test_codex_refresh_fails_if_existing_preserved_root_changes(
     def run(command, **_kwargs):
         if command[1:3] == ["plugin", "add"]:
             old_file.write_text("modified\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(release, "run", run)
+    result = release.Result()
+    assert release.refresh_client("codex", result, dry_run=False) is True
+    assert old_file.read_text(encoding="utf-8") == "before\n"
+    restore = next(
+        step for step in result.steps if step.name == "install.codex.cache-restore"
+    )
+    assert restore.ok is True
+    assert "repaired 1" in restore.detail
+
+
+def test_codex_refresh_fails_if_unowned_extra_survives_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_parent = tmp_path / "codex-cache"
+    old_root = cache_parent / "4.74.0"
+    old_root.mkdir(parents=True)
+    (old_root / "owned").write_text("before\n", encoding="utf-8")
+
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "resolve_client_binary", lambda name: "/fake/codex")
+
+    def run(command, **_kwargs):
+        if command[1:3] == ["plugin", "add"]:
+            (old_root / "unexpected").write_text("late\n", encoding="utf-8")
         return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
     monkeypatch.setattr(release, "run", run)

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -435,6 +435,23 @@ def test_lifecycle_hotfix_is_documented_on_every_public_maintenance_surface() ->
     assert "full TLS and" in readme
 
 
+def test_cache_survival_release_contract_is_public_and_coherent() -> None:
+    repository = Path(__file__).resolve().parents[3]
+    manager = (repository / "skills/synthesis-skills-manager/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    readme = (repository / "README.md").read_text(encoding="utf-8")
+    changelog = (repository / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert "Every version retained by either client" in manager
+    assert "single-writer transition lock" in readme
+    assert "pre-tag" in readme
+    assert "## [4.76.3]" in changelog
+    assert "512 MiB hard limit" in changelog
+    assert readme.count("**4.76.1**") == 1
+    assert changelog.count("## [4.76.1]") == 1
+
+
 def test_whole_system_onboarding_release_contract_is_public_and_coherent() -> None:
     repository = Path(__file__).resolve().parents[3]
     onboarding = (repository / "skills/synthesis-onboarding/SKILL.md").read_text(

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -722,7 +722,10 @@ def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
     cache_parent = tmp_path / "codex-cache"
     partial = cache_parent / "4.74.0"
     partial.mkdir(parents=True)
-    (partial / "cache-only.json").write_text("{}\n", encoding="utf-8")
+    (partial / ".codex-marketplace-install.json").write_text(
+        "{}\n", encoding="utf-8"
+    )
+    (partial / "unowned-cache-file").write_text("discard\n", encoding="utf-8")
     newest = cache_parent / "4.75.0"
     newest.mkdir(parents=True)
     recovery = tmp_path / "recovery"
@@ -735,7 +738,10 @@ def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
     assert snapshot is not None
     assert snapshot.versions == ("4.74.0", "4.74.1", "4.75.0")
     assert (snapshot.backup / "4.74.0" / ".codex-plugin/plugin.json").is_file()
-    assert (snapshot.backup / "4.74.0" / "cache-only.json").is_file()
+    assert (
+        snapshot.backup / "4.74.0" / ".codex-marketplace-install.json"
+    ).is_file()
+    assert not (snapshot.backup / "4.74.0" / "unowned-cache-file").exists()
     assert (
         snapshot.backup / "4.74.1" / "skills/example/SKILL.md"
     ).read_text(encoding="utf-8") == "version: 4.74.1\nmiddle\n"

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -814,6 +814,17 @@ def test_snapshot_rejects_incomplete_untagged_peer_root(
     assert "missing hook target" in failure.detail
 
 
+def test_untagged_peer_root_rejects_unsafe_symlink(tmp_path: Path) -> None:
+    root = tmp_path / "4.73.0"
+    seed_complete_cache_root(root, "4.73.0")
+    (root / "unsafe").symlink_to("../../outside")
+
+    complete, detail = release._cache_root_completeness(root, "4.73.0")
+
+    assert complete is False
+    assert "unsafe symlink" in detail
+
+
 def test_restore_repeats_after_post_command_cache_deletion(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -45,6 +45,11 @@ def repo(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@pytest.fixture(autouse=True)
+def no_real_cache_settle_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(release, "CODEX_CACHE_QUIET_SECONDS", 0.0)
+
+
 # --- source of truth -------------------------------------------------------
 
 
@@ -480,7 +485,7 @@ def test_main_carries_acceptance_authority_to_publish_boundary(
         return result.add("publish.fixture", True)
 
     monkeypatch.setattr(release, "publish", publish)
-    monkeypatch.setattr(release, "refresh_client", lambda *_args: True)
+    monkeypatch.setattr(release, "refresh_client", lambda *_args, **_kwargs: True)
 
     assert release.main(["--repo-root", str(repo), "--dry-run"]) == 0
     assert received == [(authority, "9.9.9")]
@@ -593,6 +598,181 @@ def test_deep_verify_fails_when_client_silent(
 # --- install sequencing ----------------------------------------------------
 
 
+def commit_release(repo: Path, version: str, marker: str) -> None:
+    write_manifests(repo, version, version)
+    skill = repo / "skills" / "example" / "SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text(f"version: {version}\n{marker}\n", encoding="utf-8")
+    if not (repo / ".git").is_dir():
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+    tree = subprocess.run(
+        ["git", "write-tree"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    parent = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    commit_command = [
+        "git",
+        "-c",
+        "user.name=Release Test",
+        "-c",
+        "user.email=release-test@example.invalid",
+        "commit-tree",
+        tree,
+    ]
+    if parent.returncode == 0:
+        commit_command.extend(["-p", parent.stdout.strip()])
+    commit = subprocess.run(
+        commit_command,
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        input=f"Release {version}\n",
+        text=True,
+    ).stdout.strip()
+    branch = subprocess.run(
+        ["git", "symbolic-ref", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        [
+            "git",
+            "update-ref",
+            branch,
+            commit,
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", f"refs/tags/v{version}", commit],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    commit_release(source, "4.74.0", "first")
+    commit_release(source, "4.74.1", "middle")
+    commit_release(source, "4.75.0", "current")
+    subprocess.run(
+        ["git", "update-ref", "-d", "refs/tags/v4.75.0"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+    )
+
+    cache_parent = tmp_path / "codex-cache"
+    partial = cache_parent / "4.74.0"
+    partial.mkdir(parents=True)
+    (partial / "cache-only.json").write_text("{}\n", encoding="utf-8")
+    newest = cache_parent / "4.75.0"
+    newest.mkdir(parents=True)
+    recovery = tmp_path / "recovery"
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "codex_cache_archive", lambda: recovery)
+
+    result = release.Result()
+    snapshot = release.snapshot_codex_caches(result, repo=source)
+
+    assert snapshot is not None
+    assert snapshot.versions == ("4.74.0", "4.74.1", "4.75.0")
+    assert (snapshot.backup / "4.74.0" / ".codex-plugin/plugin.json").is_file()
+    assert (snapshot.backup / "4.74.0" / "cache-only.json").is_file()
+    assert (
+        snapshot.backup / "4.74.1" / "skills/example/SKILL.md"
+    ).read_text(encoding="utf-8") == "version: 4.74.1\nmiddle\n"
+    assert release._tree_digest(snapshot.backup / "4.74.1") == release._tree_digest(
+        recovery / "4.74.1"
+    )
+    assert next(
+        step for step in result.steps if step.name == "install.codex.cache-archive"
+    ).ok
+
+
+def test_restore_repeats_after_post_command_cache_deletion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_parent = tmp_path / "codex-cache"
+    old_root = cache_parent / "4.74.0"
+    old_root.mkdir(parents=True)
+    (old_root / "marker").write_text("complete\n", encoding="utf-8")
+    backup = tmp_path / "synthesis-codex-cache-fixture"
+    shutil.copytree(old_root, backup / "4.74.0")
+    snapshot = release.CodexCacheSnapshot(backup, ("4.74.0",))
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "CODEX_CACHE_QUIET_SECONDS", 2.0)
+    monkeypatch.setattr(release, "CODEX_CACHE_SETTLE_TIMEOUT_SECONDS", 10.0)
+    monkeypatch.setattr(release, "CODEX_CACHE_POLL_SECONDS", 1.0)
+    monkeypatch.setattr(
+        release, "_remove_transition_backup", lambda path: shutil.rmtree(path)
+    )
+
+    class Clock:
+        now = 0.0
+        deleted = False
+
+        def read(self) -> float:
+            return self.now
+
+        def sleep(self, seconds: float) -> None:
+            self.now += seconds
+            if not self.deleted:
+                shutil.rmtree(old_root)
+                self.deleted = True
+
+    clock = Clock()
+    result = release.Result()
+    assert release.restore_codex_caches(
+        snapshot, result, clock=clock.read, sleeper=clock.sleep
+    )
+    assert (old_root / "marker").read_text(encoding="utf-8") == "complete\n"
+    detail = next(
+        step.detail
+        for step in result.steps
+        if step.name == "install.codex.cache-restore"
+    )
+    assert "restored 1" in detail
+
+
+def test_tag_backed_snapshot_refuses_archive_budget_overflow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    commit_release(source, "4.74.0", "content larger than one byte")
+    cache_parent = tmp_path / "codex-cache"
+    (cache_parent / "4.74.0").mkdir(parents=True)
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "codex_cache_archive", lambda: tmp_path / "recovery")
+    monkeypatch.setattr(release, "CODEX_CACHE_ARCHIVE_BUDGET_BYTES", 1)
+
+    result = release.Result()
+    assert release.snapshot_codex_caches(result, repo=source) is None
+    failure = next(
+        step for step in result.steps if step.name == "install.codex.cache-snapshot"
+    )
+    assert failure.ok is False
+    assert "hard budget" in failure.detail
+
+
 def test_codex_refresh_upgrades_marketplace_before_installing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -651,12 +831,12 @@ def test_codex_refresh_restores_real_version_root_deleted_by_client(
     assert not recovery_link.exists()
     steps = {step.name: step for step in result.steps}
     assert steps["install.codex.cache-snapshot"].ok is True
-    assert "1 real version" in steps["install.codex.cache-snapshot"].detail
+    assert "1 complete version" in steps["install.codex.cache-snapshot"].detail
     assert steps["install.codex.cache-restore"].ok is True
     assert "restored 1" in steps["install.codex.cache-restore"].detail
 
 
-def test_codex_refresh_fails_if_existing_preserved_root_changes(
+def test_codex_refresh_repairs_if_existing_preserved_root_changes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cache_parent = tmp_path / "codex-cache"
@@ -670,6 +850,33 @@ def test_codex_refresh_fails_if_existing_preserved_root_changes(
     def run(command, **_kwargs):
         if command[1:3] == ["plugin", "add"]:
             old_file.write_text("modified\n", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(release, "run", run)
+    result = release.Result()
+    assert release.refresh_client("codex", result, dry_run=False) is True
+    assert old_file.read_text(encoding="utf-8") == "before\n"
+    restore = next(
+        step for step in result.steps if step.name == "install.codex.cache-restore"
+    )
+    assert restore.ok is True
+    assert "repaired 1" in restore.detail
+
+
+def test_codex_refresh_fails_if_unowned_extra_survives_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_parent = tmp_path / "codex-cache"
+    old_root = cache_parent / "4.74.0"
+    old_root.mkdir(parents=True)
+    (old_root / "owned").write_text("before\n", encoding="utf-8")
+
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "resolve_client_binary", lambda name: "/fake/codex")
+
+    def run(command, **_kwargs):
+        if command[1:3] == ["plugin", "add"]:
+            (old_root / "unexpected").write_text("late\n", encoding="utf-8")
         return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
     monkeypatch.setattr(release, "run", run)

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -717,7 +717,10 @@ def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
     cache_parent = tmp_path / "codex-cache"
     partial = cache_parent / "4.74.0"
     partial.mkdir(parents=True)
-    (partial / "cache-only.json").write_text("{}\n", encoding="utf-8")
+    (partial / ".codex-marketplace-install.json").write_text(
+        "{}\n", encoding="utf-8"
+    )
+    (partial / "unowned-cache-file").write_text("discard\n", encoding="utf-8")
     newest = cache_parent / "4.75.0"
     newest.mkdir(parents=True)
     recovery = tmp_path / "recovery"
@@ -730,7 +733,10 @@ def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
     assert snapshot is not None
     assert snapshot.versions == ("4.74.0", "4.74.1", "4.75.0")
     assert (snapshot.backup / "4.74.0" / ".codex-plugin/plugin.json").is_file()
-    assert (snapshot.backup / "4.74.0" / "cache-only.json").is_file()
+    assert (
+        snapshot.backup / "4.74.0" / ".codex-marketplace-install.json"
+    ).is_file()
+    assert not (snapshot.backup / "4.74.0" / "unowned-cache-file").exists()
     assert (
         snapshot.backup / "4.74.1" / "skills/example/SKILL.md"
     ).read_text(encoding="utf-8") == "version: 4.74.1\nmiddle\n"


### PR DESCRIPTION
## User outcome

Codex lifecycle hooks and historical skill paths remain available after a plugin refresh, including when the client removed a cache root before the release began or removes it after the refresh command has returned.

## Change

- Build complete recovery snapshots from every real version retained by either supported client.
- Use release tags as the authority for tracked bytes.
- Validate manifests, hook targets, skill entry points, and symlinks before accepting a pre-tag legacy root.
- Reconstruct missing versions, repair partial roots, and retain only known client metadata.
- Serialize Codex cache transitions with a single-writer lock.
- Recheck restored roots through a bounded post-refresh quiet window.
- Fail closed if recovery storage exceeds its fixed safety budget or verification differs.
- Publish the repair as 4.76.3 with a closed transaction-bound acceptance manifest.

## Runtime impact

- Claude Code: retained historical roots can supply validated recovery material for pre-tag releases; its cache is not modified.
- ChatGPT Codex desktop/CLI: historical roots can be reconstructed and reverified after delayed cache reconciliation.
- Other clients: no behavior change.

## Evidence

- [x] Source conformance passes: full release.py check-only gate
- [x] Relevant unit and integration tests pass: 52 release-manager tests plus the complete repository release battery
- [x] Installed evidence supplied: a read-only real-cache probe reconstructed 57 versions from 4.21.0 through 4.76.1 in temporary storage; the previously missing 4.73.0 Stop-hook target was present
- [ ] Live evidence supplied for runtime behavior, or the exact human/runtime gate is named: gated 4.76.3 release verification pending
- [x] Destructive and failure paths were tested, including post-command deletion, missing pre-tag versions, partial roots, invalid hook targets, unsafe symlinks, concurrent writers, unexpected extras, changed bytes, and archive-budget exhaustion

## Public boundary

- [x] No personal, client, or organization-specific names, paths, data, or configuration
- [x] No installed cache was edited as source
- [x] Documentation and release notes match the behavior

## Contributor credit

Implementation and validation are contained in this change; no additional attribution is requested.

This PR replaces #90 so the transaction-bound CI receipt is created against the published 4.76.2 base.