### PR TITLE
Hold the documented verification list equal to the CI workflow

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.76.4",
+  "version": "4.76.5",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.76.4",
+  "version": "4.76.5",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
       - run: python skills/synthesis-agent-conformance/scripts/conformance.py source
       - run: python skills/synthesis-agent-conformance/scripts/conformance.py instructions --repo-root .
       - run: python -m pytest skills/synthesis-agent-conformance/scripts/test_*.py -q
-      - run: python -m pytest skills/synthesis-project-management/scripts/test_coordination.py -q
+      - run: python -m pytest skills/synthesis-project-management/scripts/ -q
       - run: python -m pytest skills/synthesis-promotion-gate/scripts/ -q
       - run: python -m pytest skills/synthesis-context-lifecycle/scripts/ skills/synthesis-implementation-integrity/scripts/ -q
       - name: Consume transaction-bound R5 acceptance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,11 +57,16 @@ Run the same checks required by CI:
 python3 skills/synthesis-agent-conformance/scripts/conformance.py source
 python3 skills/synthesis-agent-conformance/scripts/conformance.py instructions --repo-root .
 python3 -m pytest skills/synthesis-agent-conformance/scripts/test_*.py -q
-python3 -m pytest skills/synthesis-project-management/scripts/test_coordination.py -q
+python3 -m pytest skills/synthesis-project-management/scripts/ -q
+python3 -m pytest skills/synthesis-promotion-gate/scripts/ -q
+python3 -m pytest skills/synthesis-context-lifecycle/scripts/ skills/synthesis-implementation-integrity/scripts/ -q
 python3 -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
 python3 -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py -q
 python3 -m pytest skills/synthesis-onboarding/scripts/test_onboard.py -q
+python3 skills/synthesis-onboarding/scripts/check_scaffolds.py .
+python3 -m pytest skills/synthesis-skills-manager/scripts/test_release.py -q
 python3 skills/synthesis-meeting-transcripts/test_verify_transcripts.py
+python3 skills/synthesis-meeting-transcripts/test_transcript_primary.py
 sh -n install.sh onboard.sh tests/test_installer.sh
 ./tests/test_installer.sh
 python3 -m compileall -q skills
@@ -69,6 +74,12 @@ python3 skills/synthesis-inbox-cleanup/tests/run_poisoned.py
 python3 skills/synthesis-inbox-cleanup/tests/run_resolver.py
 sh skills/synthesis-inbox-cleanup/tests/test_runtime_installer.sh
 ```
+
+This fenced list and the `conformance` job in
+`.github/workflows/validate.yml` are held equal (modulo the CI-only
+`pip install` and env-bound acceptance steps) by
+`test_release.py::test_agents_verification_list_matches_ci_workflow` —
+change them together, or CI fails.
 
 For a cross-client release, also run:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.76.5] - 2026-09-01
+
+**The documented check list and CI now move together or fail together.**
+On 2026-09-01 a locally-green branch failed CI because validate.yml had
+grown five steps beyond AGENTS.md's Verification list — test_release.py
+had never run locally. The fenced list is synced to the workflow's
+conformance job, and a parity test holds them equal from now on (modulo
+the CI-only dependency install and the env-bound acceptance step). The
+project-management test step widens from test_coordination.py to the whole
+scripts directory in CI, the release gate, and the docs, so the handoff
+and worktree-retirement suites finally run at both boundaries.
+
 ## [4.76.4] - 2026-09-01
 
 **Recovery verification now distinguishes client-owned metadata from the

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A documented check list that CI outgrew is now a test failure (September
+2026).** Release **4.76.5** syncs AGENTS.md's Verification list with the CI
+workflow and pins their equality with a test, and widens the
+project-management test step to the full scripts directory in CI, the
+release gate, and the docs. See the [4.76.5 release notes](CHANGELOG.md).
+
 **Recovery checks separate plugin content from client metadata (September
 2026).** Release **4.76.4** keeps source files, hooks, skills, links, and
 unknown extras inside the strict recovery digest while excluding the clients'

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,39 +1,49 @@
-# AGENT HEURISTIC: authored for the 4.76.4 client-metadata digest repair.
+# AGENT HEURISTIC: authored for the 4.76.5 ci-doc-parity release.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: codex-cache-client-metadata-boundary
+suite: ci-doc-parity
 membership: closed
-production_entry_point: skills/synthesis-skills-manager/scripts/release.py
-enforcing_boundary: recovery-tree digest before the gated Codex refresh can receive a preservation receipt
+production_entry_point: .github/workflows/validate.yml
+enforcing_boundary: documented verification list held equal to the CI conformance job, with the project-management suite widened at every boundary
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: hermetic tests prove that declared client metadata is outside the recovery digest while unknown extras remain inside it; the state-changing Codex refresh and delayed live-root survival are verified by release.py only after the accepted commit is published
+unverified_remainder: hermetic tests prove the fence/workflow equality under its stated normalization, the widened project-management step at the CI and release-gate boundaries, and manifest/changelog parity; that the hosted runner executes the workflow as written is CI's own concern, and the equality test deliberately excludes the CI-only dependency install and the env-bound acceptance step
 changed_surfaces:
+  - path: AGENTS.md
+    cases: [agents-ci-parity]
+  - path: .github/workflows/validate.yml
+    cases: [agents-ci-parity, pm-suite-widened]
+  - path: skills/synthesis-skills-manager/scripts/release.py
+    cases: [pm-suite-widened]
+  - path: skills/synthesis-skills-manager/scripts/test_release.py
+    cases: [agents-ci-parity, pm-suite-widened]
+  - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
+    cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
     cases: [release-manifest-parity]
   - path: .codex-plugin/plugin.json
     cases: [release-manifest-parity]
   - path: CHANGELOG.md
-    cases: [release-changelog-parity, public-contract]
+    cases: [release-changelog-parity]
   - path: README.md
-    cases: [public-contract]
-  - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
-    cases: [shipped-manifest-self-consumption]
-  - path: skills/synthesis-skills-manager/SKILL.md
-    cases: [public-contract]
-  - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [client-metadata-digest-boundary]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [client-metadata-digest-boundary, release-manifest-parity, release-changelog-parity, public-contract]
+    cases: [agents-ci-parity]
 cases:
-  - id: client-metadata-digest-boundary
+  - id: agents-ci-parity
     control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_recovery_digest_ignores_client_metadata_but_rejects_unknown_extras
-    motivating_defect: a-new-current-root-is-source-complete-but-the-client-adds-administrative-paths-that-are-not-part-of-the-recovery-tree
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_agents_verification_list_matches_ci_workflow
+    motivating_defect: a-locally-green-branch-failed-ci-because-the-workflow-grew-five-steps-beyond-the-documented-list
+  - id: pm-suite-widened
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_required_checks_execute_r5_integrity_suite
+    motivating_defect: the-handoff-and-worktree-retirement-suites-ran-at-no-boundary-while-looking-covered-by-the-skill-directory
+  - id: shipped-manifest-self-consumption
+    control_class: acceptance-test
+    fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
+    motivating_defect: an-acceptance-manifest-that-its-own-runner-cannot-consume-issues-authority-it-never-earned
   - id: release-manifest-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
@@ -42,11 +52,3 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed
     motivating_defect: a-release-whose-changelog-disagrees-with-its-manifests-cannot-be-audited-later
-  - id: public-contract
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_cache_survival_release_contract_is_public_and_coherent
-    motivating_defect: a-recovery-digest-boundary-without-an-accurate-public-contract-cannot-be-operated-or-reviewed
-  - id: shipped-manifest-self-consumption
-    control_class: acceptance-test
-    fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: an-acceptance-manifest-that-its-own-runner-cannot-consume-issues-authority-it-never-earned

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -102,7 +102,7 @@ REQUIRED_CHECKS: tuple[tuple[str, list[str]], ...] = (
     ("conformance.source", ["python3", "skills/synthesis-agent-conformance/scripts/conformance.py", "source"]),
     ("conformance.instructions", ["python3", "skills/synthesis-agent-conformance/scripts/conformance.py", "instructions", "--repo-root", "."]),
     ("pytest.conformance", ["python3", "-m", "pytest", "skills/synthesis-agent-conformance/scripts/", "-q"]),
-    ("pytest.coordination", ["python3", "-m", "pytest", "skills/synthesis-project-management/scripts/test_coordination.py", "-q"]),
+    ("pytest.coordination", ["python3", "-m", "pytest", "skills/synthesis-project-management/scripts/", "-q"]),
     ("pytest.promotion-gate", ["python3", "-m", "pytest", "skills/synthesis-promotion-gate/scripts/", "-q"]),
     ("pytest.context-lifecycle-integrity", ["python3", "-m", "pytest", "skills/synthesis-context-lifecycle/scripts/", "skills/synthesis-implementation-integrity/scripts/", "-q"]),
     ("pytest.onboarding", ["python3", "-m", "pytest", "skills/synthesis-onboarding/scripts/test_onboard.py", "-q"]),

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -13,6 +13,7 @@ converts an unknown into a false assurance.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -151,6 +152,44 @@ def test_required_checks_execute_whole_system_onboarding_contract() -> None:
         "skills/synthesis-onboarding/scripts/check_scaffolds.py",
         ".",
     ]
+
+
+def test_agents_verification_list_matches_ci_workflow() -> None:
+    """2026-09-01: a locally-green branch failed CI because validate.yml had
+    grown five steps beyond AGENTS.md's documented Verification list. The
+    fenced list and the conformance job now move together, or this fails.
+    Excluded by design: the CI-only dependency install and the env-bound
+    acceptance step (documented under Releases instead)."""
+    repository = Path(__file__).resolve().parents[3]
+    workflow = yaml.safe_load(
+        (repository / ".github" / "workflows" / "validate.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    ci_steps = [
+        step["run"].strip()
+        for step in workflow["jobs"]["conformance"]["steps"]
+        if "run" in step
+        and "pip install" not in step["run"]
+        and "--acceptance-only" not in step["run"]
+    ]
+    normalized_ci = [
+        "python3 " + command[len("python "):]
+        if command.startswith("python ")
+        else command
+        for command in ci_steps
+    ]
+    agents = (repository / "AGENTS.md").read_text(encoding="utf-8")
+    section = agents.split("## Verification", 1)[1].split(
+        "For a cross-client release", 1
+    )[0]
+    fence = re.search(r"```bash\n(.*?)```", section, re.S).group(1)
+    documented = [line.strip() for line in fence.splitlines() if line.strip()]
+    assert documented == normalized_ci, (
+        "AGENTS.md Verification fence and validate.yml conformance steps "
+        "drifted; change them together.\ndocumented=%r\nci=%r"
+        % (documented, normalized_ci)
+    )
 
 
 def test_repository_ci_executes_release_wiring_tests() -> None:


### PR DESCRIPTION
On 2026-09-01 a locally-green branch failed CI because validate.yml had grown five steps beyond AGENTS.md's Verification list. This syncs the fenced list to the conformance job and pins their equality with a test (excluding the CI-only dependency install and the env-bound acceptance step), and widens the project-management test step from test_coordination.py to the whole scripts directory in CI, the release gate, and the docs — so the handoff and worktree-retirement suites run at both boundaries.

Rebased onto 4.76.3; ships as 4.76.4. Verification: full synced list green locally end to end (including the parity test proving itself), R5 acceptance consumed at base 592acfb; bidirectional integration audit confirms all peer-session (4.76.0–4.76.3) and this session's (4.75.0, 4.76.2) work present together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)