### PR TITLE
Exclude client metadata from cache recovery digests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.76.3",
+  "version": "4.76.4",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.76.3",
+  "version": "4.76.4",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.76.4] - 2026-09-01
+
+**Recovery verification now distinguishes client-owned metadata from the
+plugin tree it protects.** Codex creates its own `.git` checkout and install
+record in the newly installed current-version root; Claude maintains liveness
+markers in retained roots. These paths are outside the immutable recovery-tree
+digest, while every source file, hook, skill, symlink, and unknown extra remains
+covered.
+
+The 4.76.3 publisher installed byte-current source in both clients but refused
+its final preservation receipt when the new Codex root contained that expected
+client metadata. A regression fixture now proves the three client-owned paths
+do not change the recovery digest and that an arbitrary extra still does. The
+publisher therefore keeps the strict unknown-content boundary without treating
+the client's own administrative files as source drift.
+
 ## [4.76.3] - 2026-09-01
 
 **A Codex plugin refresh no longer strands tasks that started on an older

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Recovery checks separate plugin content from client metadata (September
+2026).** Release **4.76.4** keeps source files, hooks, skills, links, and
+unknown extras inside the strict recovery digest while excluding the clients'
+own checkout, liveness, and install-record paths. This lets the 4.76.3
+historical-root repair verify a newly installed Codex root without weakening
+its fail-closed content boundary. See the [4.76.4 release notes](CHANGELOG.md).
+
 **Codex refreshes preserve running tasks (September 2026).** Release
 **4.76.3** reconstructs every historical plugin root retained by either
 supported client before a Codex refresh. Tagged source is authoritative;

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,17 +1,17 @@
-# AGENT HEURISTIC: authored for the 4.76.3 Codex cache-survival release.
+# AGENT HEURISTIC: authored for the 4.76.4 client-metadata digest repair.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: codex-cache-post-refresh-survival
+suite: codex-cache-client-metadata-boundary
 membership: closed
 production_entry_point: skills/synthesis-skills-manager/scripts/release.py
-enforcing_boundary: single-writer snapshot, refresh, repair, and post-command verification before gated release completion
+enforcing_boundary: recovery-tree digest before the gated Codex refresh can receive a preservation receipt
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: hermetic cases and a read-only real-cache probe prove reconstruction and failure behavior before publication; the state-changing client refresh, both installed-tree comparisons, and delayed live-root survival are verified by release.py only after the accepted commit is published
+unverified_remainder: hermetic tests prove that declared client metadata is outside the recovery digest while unknown extras remain inside it; the state-changing Codex refresh and delayed live-root survival are verified by release.py only after the accepted commit is published
 changed_surfaces:
   - path: .claude-plugin/plugin.json
     cases: [release-manifest-parity]
@@ -26,38 +26,14 @@ changed_surfaces:
   - path: skills/synthesis-skills-manager/SKILL.md
     cases: [public-contract]
   - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [tag-backed-repair, pre-tag-peer-recovery, post-command-deletion, single-writer-transition, unsafe-symlink-refusal, unknown-extra-refusal, archive-budget-refusal]
+    cases: [client-metadata-digest-boundary]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [tag-backed-repair, pre-tag-peer-recovery, post-command-deletion, single-writer-transition, unsafe-symlink-refusal, unknown-extra-refusal, archive-budget-refusal, release-manifest-parity, release-changelog-parity, public-contract]
+    cases: [client-metadata-digest-boundary, release-manifest-parity, release-changelog-parity, public-contract]
 cases:
-  - id: tag-backed-repair
+  - id: client-metadata-digest-boundary
     control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots
-    motivating_defect: a-version-directory-can-exist-with-only-one-recreated-hook-file-while-the-rest-of-its-tagged-tree-is-missing
-  - id: pre-tag-peer-recovery
-    control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_snapshot_imports_complete_untagged_peer_root_missing_from_codex
-    motivating_defect: an-active-task-can-reference-a-version-that-codex-already-removed-and-that-predates-immutable-release-tags
-  - id: post-command-deletion
-    control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_restore_repeats_after_post_command_cache_deletion
-    motivating_defect: an-immediate-restore-receipt-can-pass-before-the-client-finishes-reconciling-and-removes-the-root-again
-  - id: single-writer-transition
-    control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_cache_transition_lock_refuses_a_second_writer
-    motivating_defect: two-release-processes-mutating-the-same-cache-and-recovery-archive-can-invalidate-each-others-verification
-  - id: unsafe-symlink-refusal
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_untagged_peer_root_rejects_unsafe_symlink
-    motivating_defect: a-peer-root-with-an-escaping-symlink-must-not-be-promoted-into-durable-recovery-state
-  - id: unknown-extra-refusal
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_fails_if_unowned_extra_survives_repair
-    motivating_defect: overlay-copy-cannot-prove-repair-when-an-unowned-extra-remains-in-the-destination-tree
-  - id: archive-budget-refusal
-    control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_tag_backed_snapshot_refuses_archive_budget_overflow
-    motivating_defect: unbounded-historical-cache-retention-can-turn-lifecycle-safety-into-unbounded-disk-growth
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_recovery_digest_ignores_client_metadata_but_rejects_unknown_extras
+    motivating_defect: a-new-current-root-is-source-complete-but-the-client-adds-administrative-paths-that-are-not-part-of-the-recovery-tree
   - id: release-manifest-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
@@ -69,7 +45,7 @@ cases:
   - id: public-contract
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_cache_survival_release_contract_is_public_and_coherent
-    motivating_defect: a-cache-survival-mechanism-without-an-accurate-public-contract-cannot-be-operated-or-reviewed
+    motivating_defect: a-recovery-digest-boundary-without-an-accurate-public-contract-cannot-be-operated-or-reviewed
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -17,6 +17,9 @@ post-command verified. Every version retained by either client is preserved.
 Immutable release tags supply authoritative tracked bytes; complete peer roots
 cover releases that predate tags. The budgeted archive repairs missing or
 partial Codex roots and verifies them through a bounded quiet window after the
+client command. Recovery digests exclude only client-owned metadata: checkout,
+liveness, and install-record paths. Every other unexpected path still fails
+verification.
 client command returns. The whole-system onboarding suite and its
 scaffold/component catalog audit remain required release checks.
 

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -88,6 +88,9 @@ ACCEPTANCE_CONSUMER_ID = (
 )
 RELEASE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 HOOK_PLUGIN_PATH_RE = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\s\"']+)")
+RECOVERY_DIGEST_IGNORED_ROOTS = frozenset(
+    {".git", ".in_use", ".codex-marketplace-install.json"}
+)
 CODEX_CACHE_ARCHIVE_BUDGET_BYTES = 512 * 1024 * 1024
 CODEX_CACHE_QUIET_SECONDS = 10.0
 CODEX_CACHE_SETTLE_TIMEOUT_SECONDS = 60.0
@@ -496,10 +499,16 @@ def plugin_cache_parent(client: str) -> Path:
 
 
 def _tree_digest(root: Path) -> str:
-    """Hash paths, entry types, symlink targets, and file bytes deterministically."""
+    """Hash recovery-owned paths and bytes, excluding client-managed metadata."""
     digest = hashlib.sha256()
     for path in sorted(root.rglob("*"), key=lambda item: str(item.relative_to(root))):
-        relative = str(path.relative_to(root)).encode("utf-8")
+        relative_path = path.relative_to(root)
+        if (
+            relative_path.parts
+            and relative_path.parts[0] in RECOVERY_DIGEST_IGNORED_ROOTS
+        ):
+            continue
+        relative = str(relative_path).encode("utf-8")
         if path.is_symlink():
             digest.update(b"L\0" + relative + b"\0" + os.readlink(path).encode("utf-8"))
         elif path.is_dir():

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -446,7 +446,8 @@ def test_cache_survival_release_contract_is_public_and_coherent() -> None:
     assert "Every version retained by either client" in manager
     assert "single-writer transition lock" in readme
     assert "pre-tag" in readme
-    assert "## [4.76.3]" in changelog
+    assert "## [4.76.4]" in changelog
+    assert "client-owned metadata" in manager
     assert "512 MiB hard limit" in changelog
     assert readme.count("**4.76.1**") == 1
     assert changelog.count("## [4.76.1]") == 1
@@ -615,6 +616,30 @@ def test_deep_verify_fails_when_client_silent(
     monkeypatch.setattr(release, "installed_root", lambda client, version: tmp_path / "nope")
     result = release.Result()
     assert release.deep_verify("claude", "4.30.1", result) is False
+
+
+def test_recovery_digest_ignores_client_metadata_but_rejects_unknown_extras(
+    tmp_path: Path,
+) -> None:
+    expected = tmp_path / "expected"
+    installed = tmp_path / "installed"
+    (expected / "skills/example").mkdir(parents=True)
+    (expected / "skills/example/SKILL.md").write_text(
+        "name: example\n", encoding="utf-8"
+    )
+    shutil.copytree(expected, installed)
+    (installed / ".git").mkdir()
+    (installed / ".git/config").write_text("[core]\n", encoding="utf-8")
+    (installed / ".in_use").mkdir()
+    (installed / ".in_use/123").touch()
+    (installed / ".codex-marketplace-install.json").write_text(
+        '{"revision":"fixture"}\n', encoding="utf-8"
+    )
+
+    assert release._tree_digest(expected) == release._tree_digest(installed)
+
+    (installed / "unexpected").write_text("unowned\n", encoding="utf-8")
+    assert release._tree_digest(expected) != release._tree_digest(installed)
 
 
 # --- install sequencing ----------------------------------------------------


### PR DESCRIPTION
## User outcome

The gated Codex refresh can verify a newly installed current-version root without mistaking the client’s own administrative files for plugin-source drift.

## Change

- Exclude only the three client-owned root paths from the recovery digest: the Codex checkout, Claude liveness markers, and the Codex install record.
- Keep every source file, hook, skill, symlink, and unknown extra inside the strict digest.
- Add a regression fixture proving both halves of that boundary.
- Publish the correction as 4.76.4 with a fresh closed acceptance manifest.

## Runtime impact

- Claude Code: liveness markers no longer affect cross-client recovery comparison.
- ChatGPT Codex desktop/CLI: checkout and install metadata no longer create a false preservation failure after a source-complete install.
- Other clients: no behavior change.

## Evidence

- [x] Source conformance passes: full release.py check-only gate
- [x] Relevant unit and integration tests pass: 53 release-manager tests plus the complete repository release battery
- [x] Installed evidence supplied: the 4.76.3 publisher installed 369 source-equal files in both clients and reproduced the metadata-only digest mismatch at the live cache boundary
- [ ] Live evidence supplied for corrected runtime behavior, or the exact human/runtime gate is named: gated 4.76.4 release verification pending
- [x] Failure polarity is pinned: declared client metadata compares equal; an arbitrary extra still changes the digest

## Public boundary

- [x] No personal, client, or organization-specific names, paths, data, or configuration
- [x] No installed cache was edited as source
- [x] Documentation and release notes match the behavior

## Contributor credit

Implementation and validation are contained in this change; no additional attribution is requested.