### PR TITLE
Serialize releases on a claimable train resource

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.76.5",
+  "version": "4.77.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.76.5",
+  "version": "4.77.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,10 @@ python3 skills/synthesis-agent-conformance/scripts/conformance.py coordination
 - Update the concise release note in `README.md`.
 - Use a feature branch and a review request for non-trivial changes.
 - Merge only after every required check passes.
+- On a machine with a synthesis coordination board, hold the release train
+  (`coordination.py claim ... --area release-train:synthesis-skills`) from
+  version authoring through the gated release; `release.py` preflight
+  refuses otherwise. Release the claim right after shipping.
 - **Ship with the gated release script**, which runs the required checks,
   publishes to every push remote, installs into both clients using each
   client's own commands, and verifies each client twice — its CLI report and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.77.0] - 2026-09-01
+
+**Releases now serialize mechanically: one train, one holder.** Five
+same-day overtakes between two parallel releasing agent sessions — each
+merge invalidating the other's open PR, once colliding on the version
+number itself — proved message-based sequencing fails when an autonomous
+session mid-transaction does not re-read the board. The release train is
+now a virtual coordination-board resource (`release-train:synthesis-skills`)
+claimed through the unmodified claim machinery, whose overlap refusal is
+the mutual exclusion and whose lease compare-and-swap serializes it across
+machines. `release.py` preflight enforces possession fail-closed in every
+publish-capable mode on any machine carrying a coordination board: unheld
+refuses with the claim command, peer-held refuses naming the holder, a
+missing local identity refuses, and a stale board mirror refuses. Machines
+without a board — outside contributors — pass with a notice, so the public
+repository stays usable without the coordination system. Hold the train
+from version authoring through the gated release; a dead holder is freed
+only by the user via the stale-claim review.
+
 ## [4.76.5] - 2026-09-01
 
 **The documented check list and CI now move together or fail together.**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Two release trains on one track now queue instead of colliding (September
+2026).** Release **4.77.0** makes release serialization mechanical: a
+virtual `release-train:synthesis-skills` claim on the coordination board is
+the lock, and `release.py` preflight refuses to gate or publish on a
+board-carrying machine unless the running session holds it — while machines
+without a board pass with a notice. See the
+[4.77.0 release notes](CHANGELOG.md).
+
 **A documented check list that CI outgrew is now a test failure (September
 2026).** Release **4.76.5** syncs AGENTS.md's Verification list with the CI
 workflow and pins their equality with a test, and widens the

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,26 +1,28 @@
-# AGENT HEURISTIC: authored for the 4.76.5 ci-doc-parity release.
+# AGENT HEURISTIC: authored for the 4.77.0 release-train-serialization release.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: ci-doc-parity
+suite: release-train-serialization
 membership: closed
-production_entry_point: .github/workflows/validate.yml
-enforcing_boundary: documented verification list held equal to the CI conformance job, with the project-management suite widened at every boundary
+production_entry_point: skills/synthesis-skills-manager/scripts/release.py
+enforcing_boundary: preflight possession of the virtual release-train claim on board-carrying machines
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: hermetic tests prove the fence/workflow equality under its stated normalization, the widened project-management step at the CI and release-gate boundaries, and manifest/changelog parity; that the hosted runner executes the workflow as written is CI's own concern, and the equality test deliberately excludes the CI-only dependency install and the env-bound acceptance step
+unverified_remainder: hermetic tests prove the not-adopted pass, the held-by-me pass, and the peer-held, unheld, released-holder, and identity-less refusals, plus that the virtual token conflicts with itself and never with path claims; the cross-machine lease serialization of the claim itself is the coordination engine's own tested contract, and the first live two-train queueing necessarily occurs after both sessions run 4.77.0
 changed_surfaces:
-  - path: AGENTS.md
-    cases: [agents-ci-parity]
-  - path: .github/workflows/validate.yml
-    cases: [agents-ci-parity, pm-suite-widened]
   - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [pm-suite-widened]
+    cases: [train-possession-gate, train-token-lock-semantics]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [agents-ci-parity, pm-suite-widened]
+    cases: [train-possession-gate, train-token-lock-semantics]
+  - path: skills/synthesis-skills-manager/SKILL.md
+    cases: [train-doc-contract]
+  - path: skills/synthesis-project-management/references/parallel-agent-protocol.md
+    cases: [train-doc-contract]
+  - path: AGENTS.md
+    cases: [train-doc-contract]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -28,18 +30,22 @@ changed_surfaces:
   - path: .codex-plugin/plugin.json
     cases: [release-manifest-parity]
   - path: CHANGELOG.md
-    cases: [release-changelog-parity]
+    cases: [release-changelog-parity, train-doc-contract]
   - path: README.md
-    cases: [agents-ci-parity]
+    cases: [train-doc-contract]
 cases:
-  - id: agents-ci-parity
+  - id: train-possession-gate
     control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_agents_verification_list_matches_ci_workflow
-    motivating_defect: a-locally-green-branch-failed-ci-because-the-workflow-grew-five-steps-beyond-the-documented-list
-  - id: pm-suite-widened
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_train_held_by_peer_refuses
+    motivating_defect: five-same-day-overtakes-and-a-version-collision-because-nothing-mechanical-serialized-parallel-releases
+  - id: train-token-lock-semantics
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_required_checks_execute_r5_integrity_suite
-    motivating_defect: the-handoff-and-worktree-retirement-suites-ran-at-no-boundary-while-looking-covered-by-the-skill-directory
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_train_token_conflicts_with_itself_but_not_with_paths
+    motivating_defect: a-virtual-lock-that-collides-with-ordinary-path-claims-would-deny-unrelated-work-instead-of-serializing-releases
+  - id: train-doc-contract
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_train_unheld_refuses_with_claim_guidance
+    motivating_defect: a-lock-whose-refusal-does-not-teach-the-claim-command-turns-serialization-into-a-mystery-outage
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-project-management/references/parallel-agent-protocol.md
+++ b/skills/synthesis-project-management/references/parallel-agent-protocol.md
@@ -76,6 +76,27 @@ run after every machine's client is current, so older parsers mid-flight
 fail closed on nothing. Until migration, refs print a notice at claim time
 and drop harmlessly; resolve says the board is pre-v4.
 
+## Release trains — serializing a shared publish surface
+
+Path claims keep concurrent sessions off each other's files, but some
+resources are not files: a repository's release identity (its `main`, its
+version number, its changelog top) is one shared slot that every releasing
+session mutates. Five same-day overtakes between two parallel release
+trains (2026-09-01) showed that message-based sequencing fails exactly when
+it matters — an autonomous session mid-transaction does not re-read the
+board between authoring a version and merging.
+
+The pattern: claim a **virtual resource** — a non-path token such as
+`release-train:<plugin>` — through the ordinary claim machinery. Identical
+tokens conflict under the same overlap refusal that guards paths (and the
+lease compare-and-swap serializes them across machines), so the claim is
+the lock; path claims never false-positive against it. The consuming
+boundary then enforces possession fail-closed: synthesis-skills'
+`release.py` preflight refuses every publish-capable mode on a
+board-carrying machine unless the running session holds the train. Hold it
+from version authoring through the gated release; release it immediately
+after. A dead holder is freed only by the user via the stale-claim review.
+
 ## Digests — what survives a crash
 
 Semantic continuity does not come from copying chat transcripts. The durable

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -324,6 +324,37 @@ The general rule this encodes, worth applying beyond releases: **when a
 verification asks a system to describe itself, verify the description against
 the artifact.** A self-report is a claim, not evidence.
 
+## The release train — one publisher at a time
+
+On 2026-09-01, two agent sessions releasing this repository in parallel
+overtook each other five times — each merge to `main` turned the other's open
+PR CONFLICTING with checks never run — and once both authored the same
+version number. Coordination-board messages failed as a serializer because
+an autonomous session mid-transaction does not re-read the board between
+authoring a version and merging.
+
+Serialization is now mechanical. The train is a **virtual coordination-board
+resource**, `release-train:synthesis-skills`, claimed like any source area:
+
+```bash
+python3 <synthesis-project-management-root>/scripts/coordination.py claim \
+  ... --area release-train:synthesis-skills --area <your real areas>
+```
+
+The board's existing claim-overlap refusal is the mutual exclusion (two
+holders cannot coexist; the lease serializes it across machines), and
+`release.py`'s preflight enforces possession: on any machine that has a
+coordination board, every mode except `--install-only` refuses unless the
+running process's session — from `SYNTHESIS_COORDINATION_SESSION` or an
+owned active-project pointer — holds the train. Machines without a board
+(outside contributors) pass with a notice; adoption travels with the board.
+
+Protocol: claim the train **before authoring the version bump**, hold it
+through merge and `release.py`, and release or narrow the claim immediately
+after the gated release completes. A crashed holder blocks the train by
+design; the user — never another agent on its own initiative — frees it via
+the stale-claim review (`coordination.py stale`).
+
 ## Source Update Protocol (NON-NEGOTIABLE)
 
 When updating any skill — whether one file or several — follow this exact sequence. Do not deviate. **Manual file copies to install targets are NOT installation.** They create drift between what is committed, what is pushed, and what is locally active. The protocol below exists because that drift has happened before and must not happen again.

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -87,6 +87,19 @@ ACCEPTANCE_CONSUMER_ID = (
     "synthesis-skills-manager.release.consume-acceptance.v1"
 )
 RELEASE_VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+# One release train per plugin: a virtual coordination-board resource whose
+# claim overlap refusal is the mutual exclusion. On 2026-09-01 two agent
+# sessions releasing this repository in parallel overtook each other five
+# times and once collided on the announced version; message-based sequencing
+# failed because an autonomous session mid-transaction does not re-read the
+# board. Machines without a coordination board (outside contributors) are
+# exempt; where a board exists, preflight refuses to proceed unless this
+# process's session holds the train.
+TRAIN_RESOURCE = f"release-train:{PLUGIN_NAME}"
+DEFAULT_COORDINATION_BOARD = (
+    Path.home() / ".synthesis" / "coordination" / "active-sessions.md"
+)
+DEFAULT_ACTIVE_PROJECT_POINTER = Path.home() / ".synthesis" / "active-project.json"
 HOOK_PLUGIN_PATH_RE = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\s\"']+)")
 RECOVERY_DIGEST_IGNORED_ROOTS = frozenset(
     {".git", ".in_use", ".codex-marketplace-install.json"}
@@ -1085,6 +1098,117 @@ def refresh_client(
             _release_codex_cache_lock(cache_lock)
 
 
+def _coordination_board_path() -> Path:
+    override = os.environ.get("SYNTHESIS_COORDINATION_BOARD", "").strip()
+    return Path(override).expanduser() if override else DEFAULT_COORDINATION_BOARD
+
+
+def _train_session_selector() -> tuple[str | None, str]:
+    """This process's coordination identity: env first, then the pointer."""
+    explicit = os.environ.get("SYNTHESIS_COORDINATION_SESSION", "").strip()
+    if explicit:
+        return explicit, "environment"
+    override = os.environ.get("SYNTHESIS_ACTIVE_PROJECT_FILE", "").strip()
+    pointer = (
+        Path(override).expanduser() if override else DEFAULT_ACTIVE_PROJECT_POINTER
+    )
+    try:
+        payload = json.loads(pointer.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None, "unavailable"
+    owner = str(payload.get("owner_session") or "").strip()
+    return (owner, "active-project pointer") if owner else (None, "unavailable")
+
+
+def train_check(result: Result) -> bool:
+    """Fail closed unless this session holds the release train on the board.
+
+    A machine without a coordination board has not adopted train
+    serialization (public contributors); the check passes with a notice.
+    Where a board exists, an unheld or peer-held train refuses — waiting is
+    the point. A crashed holder is released by the user via the stale-claim
+    review, never by another agent on its own initiative.
+    """
+    board = _coordination_board_path()
+    if not board.is_file():
+        return result.add(
+            "preflight.release-train",
+            True,
+            f"no coordination board at {board}; train serialization not "
+            "adopted on this machine",
+        )
+    coordination_scripts = (
+        SCRIPT_DIR.parents[1] / "synthesis-project-management" / "scripts"
+    )
+    if str(coordination_scripts) not in sys.path:
+        sys.path.insert(0, str(coordination_scripts))
+    try:
+        import coordination
+    except Exception as exc:  # board present but engine missing: unverifiable
+        return result.add(
+            "preflight.release-train",
+            False,
+            f"board exists but the coordination engine is unavailable ({exc}); "
+            "the release train cannot be verified",
+        )
+    refresh = coordination.lease_refresh(board)
+    if refresh.get("error"):
+        return result.add(
+            "preflight.release-train",
+            False,
+            f"board lease refresh failed; the local mirror may be stale: "
+            f"{refresh['error']}",
+        )
+    try:
+        sessions = coordination.rows(board.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return result.add(
+            "preflight.release-train", False, f"board unreadable: {exc}"
+        )
+    holders = [
+        session
+        for session in sessions
+        if coordination.active(session)
+        and any(claim.strip() == TRAIN_RESOURCE for claim in session.claims)
+    ]
+    if not holders:
+        return result.add(
+            "preflight.release-train",
+            False,
+            f"nobody holds {TRAIN_RESOURCE}; claim it before authoring or "
+            "publishing a release: coordination.py claim ... --area "
+            f"{TRAIN_RESOURCE}",
+        )
+    selector, source = _train_session_selector()
+    if selector is None:
+        return result.add(
+            "preflight.release-train",
+            False,
+            f"{TRAIN_RESOURCE} is held by {holders[0].label} and this process "
+            "has no session identity; set SYNTHESIS_COORDINATION_SESSION or "
+            "run with an owned active-project pointer",
+        )
+    mine = [
+        session
+        for session in holders
+        if coordination.selector_matches(session.identity, selector)
+    ]
+    if mine:
+        return result.add(
+            "preflight.release-train",
+            True,
+            f"held by this session ({mine[0].label}, selector via {source})",
+        )
+    return result.add(
+        "preflight.release-train",
+        False,
+        f"{TRAIN_RESOURCE} is held by {holders[0].label}, not this session; "
+        "wait for its release, coordinate on the board message bus, or — for "
+        "a genuinely dead holder — ask the user to run the stale-claim "
+        "review (coordination.py stale)",
+    )
+
+
 def preflight(repo: Path, result: Result, install_only: bool) -> str | None:
     """Validate the release is coherent before anything is published."""
     version, detail = source_version(repo)
@@ -1104,6 +1228,7 @@ def preflight(repo: Path, result: Result, install_only: bool) -> str | None:
             not dirty,
             f"{len(dirty)} uncommitted path(s)" if dirty else "clean",
         )
+        train_check(result)
     return version
 
 

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -51,6 +51,21 @@ def no_real_cache_settle_delay(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(release, "CODEX_CACHE_QUIET_SECONDS", 0.0)
 
 
+@pytest.fixture(autouse=True)
+def hermetic_release_train(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Keep the suite off the developer's real coordination board and
+    session identity; train tests point at their own fixtures."""
+    monkeypatch.setenv(
+        "SYNTHESIS_COORDINATION_BOARD", str(tmp_path / "absent-board.md")
+    )
+    monkeypatch.delenv("SYNTHESIS_COORDINATION_SESSION", raising=False)
+    monkeypatch.setenv(
+        "SYNTHESIS_ACTIVE_PROJECT_FILE", str(tmp_path / "absent-pointer.json")
+    )
+
+
 # --- source of truth -------------------------------------------------------
 
 
@@ -152,6 +167,129 @@ def test_required_checks_execute_whole_system_onboarding_contract() -> None:
         "skills/synthesis-onboarding/scripts/check_scaffolds.py",
         ".",
     ]
+
+
+# --- release-train serialization (2026-09-01) -------------------------------
+#
+# Five same-day overtakes between two parallel releasing sessions, one
+# version-number collision. The train is a virtual coordination-board claim;
+# holding it is verified here, at the boundary both sessions already run.
+
+TRAIN_UUID = "01a05e00-0000-7000-8000-000000000001"
+OTHER_UUID = "01a05e00-0000-7000-8000-000000000002"
+
+
+def train_board(tmp_path: Path, rows: list[tuple[str, str, str]]) -> Path:
+    header = (
+        "| session uuid | compact id | speakable id v1 | legacy id | agent | "
+        "machine | client session ref | project | started | heartbeat | mode | "
+        "workspace(s) / branch | goal | claimed areas (advisory lock) | "
+        "context role | status |\n"
+        "|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|\n"
+    )
+    body = "".join(
+        f"| {uuid} | s-x | a-b-c-d-00001 |  | Agent | m1 | - | proj | t | t | "
+        f"interactive | w | g | {claims} | owner | {status} |\n"
+        for uuid, claims, status in rows
+    )
+    board = tmp_path / "board.md"
+    board.write_text(
+        "# Coordination\n\nSchema: v4\n\n## Active sessions\n\n"
+        + header + body + "\n## Messages\n\n---\n\n## Protocol\n",
+        encoding="utf-8",
+    )
+    return board
+
+
+def run_train_check(
+    monkeypatch: pytest.MonkeyPatch, board: Path | None, selector: str | None
+) -> release.Step:
+    if board is not None:
+        monkeypatch.setenv("SYNTHESIS_COORDINATION_BOARD", str(board))
+    if selector is not None:
+        monkeypatch.setenv("SYNTHESIS_COORDINATION_SESSION", selector)
+    result = release.Result()
+    release.train_check(result)
+    (step,) = [s for s in result.steps if s.name == "preflight.release-train"]
+    return step
+
+
+def test_train_not_adopted_without_a_board(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    step = run_train_check(monkeypatch, None, None)
+    assert step.ok and "not adopted" in step.detail
+
+
+def test_train_held_by_this_session_passes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    board = train_board(
+        tmp_path, [(TRAIN_UUID, release.TRAIN_RESOURCE, "active")]
+    )
+    step = run_train_check(monkeypatch, board, TRAIN_UUID)
+    assert step.ok and "held by this session" in step.detail
+
+
+def test_train_held_by_peer_refuses(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    board = train_board(
+        tmp_path, [(OTHER_UUID, release.TRAIN_RESOURCE, "active")]
+    )
+    step = run_train_check(monkeypatch, board, TRAIN_UUID)
+    assert not step.ok and "not this session" in step.detail
+
+
+def test_train_unheld_refuses_with_claim_guidance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    board = train_board(tmp_path, [(OTHER_UUID, "some/path/**", "active")])
+    step = run_train_check(monkeypatch, board, TRAIN_UUID)
+    assert not step.ok and "claim it before" in step.detail
+
+
+def test_train_released_holder_does_not_count(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    board = train_board(
+        tmp_path, [(OTHER_UUID, release.TRAIN_RESOURCE, "released")]
+    )
+    step = run_train_check(monkeypatch, board, TRAIN_UUID)
+    assert not step.ok and "claim it before" in step.detail
+
+
+def test_train_held_without_local_identity_refuses(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    board = train_board(
+        tmp_path, [(OTHER_UUID, release.TRAIN_RESOURCE, "active")]
+    )
+    step = run_train_check(monkeypatch, board, None)
+    assert not step.ok and "no session identity" in step.detail
+
+
+def test_train_token_conflicts_with_itself_but_not_with_paths() -> None:
+    """The virtual resource rides the unmodified claim-overlap machinery:
+    identical tokens conflict (the lock), ordinary path claims do not
+    (no false positives)."""
+    sys.path.insert(
+        0,
+        str(
+            Path(release.__file__).resolve().parents[2]
+            / "synthesis-project-management"
+            / "scripts"
+        ),
+    )
+    import coordination
+
+    assert coordination.overlaps(release.TRAIN_RESOURCE, release.TRAIN_RESOURCE)
+    assert not coordination.overlaps(
+        release.TRAIN_RESOURCE, "/repos/synthesis-skills/skills/**"
+    )
+    assert not coordination.overlaps(
+        "ai-knowledge-demo/projects/**", release.TRAIN_RESOURCE
+    )
 
 
 def test_agents_verification_list_matches_ci_workflow() -> None:


### PR DESCRIPTION
Five same-day overtakes between two parallel releasing sessions (and one version-number collision) proved message-based sequencing fails when an autonomous session mid-transaction does not re-read the board. The release train is now a virtual coordination-board claim — release-train:synthesis-skills — whose existing overlap refusal is the mutual exclusion (lease-CAS'd across machines). release.py preflight enforces possession fail-closed in every publish-capable mode on board-carrying machines: unheld teaches the claim command, peer-held names the holder, missing identity and stale mirrors refuse. Machines without a board pass with a notice, so outside contributors are unaffected. Ships as 4.77.0.

Verification: full synced list green; seven hermetic train tests plus token-lock semantics; live negative control (no identity → refused naming holder) and positive control (holder session → pass, acceptance consumed) run against the real board; this PR itself was authored under the train claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)