### PR TITLE
Keep historical Codex roots available after delayed cache refreshes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.77.0",
+  "version": "4.77.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.77.0",
+  "version": "4.77.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.77.1] - 2026-09-01
+
+**Historical Codex roots now survive cache generations created after the
+publisher exits.** The earlier recovery boundary reconstructed and verified
+every historical root, then watched for a ten-second quiet window. A later
+client-owned reconciliation could still replace the entire live cache minutes
+after that receipt and strand running tasks whose hooks retained an older
+absolute path.
+
+The gated publisher now installs a standard-library cache guardian outside the
+client-owned tree and verifies its user-level supervisor before reporting a
+release complete. The guardian shares the release transition lock, validates
+the durable archive, protects every archived version except the newest
+client-owned version, and restores missing historical roots after any later
+cache replacement. It never deletes a cache path or overwrites differing
+existing content. macOS uses launchd; Linux uses a systemd user service.
+Hermetic coverage pins delayed parent replacement, current-version
+noninterference, unsafe archives, differing-content refusal, lock contention,
+and both supervisor definitions.
+
 ## [4.77.0] - 2026-09-01
 
 **Releases now serialize mechanically: one train, one holder.** Five

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Historical tasks now survive cache replacement after the release command
+returns (September 2026).** Release **4.77.1** installs a durable, supervised
+Codex cache guardian outside the client-owned version tree. It restores only
+verified historical roots from the bounded recovery archive, never races the
+newest client-owned version, shares the publisher's transition lock, and fails
+closed on unsafe or differing content. See the [4.77.1 release
+notes](CHANGELOG.md).
+
 **Two release trains on one track now queue instead of colliding (September
 2026).** Release **4.77.0** makes release serialization mechanical: a
 virtual `release-train:synthesis-skills` claim on the coordination board is

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,28 +1,28 @@
-# AGENT HEURISTIC: authored for the 4.77.0 release-train-serialization release.
+# AGENT HEURISTIC: authored for the 4.77.1 delayed-cache-generation hotfix.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: release-train-serialization
+suite: delayed-codex-cache-generation-survival
 membership: closed
 production_entry_point: skills/synthesis-skills-manager/scripts/release.py
-enforcing_boundary: preflight possession of the virtual release-train claim on board-carrying machines
+enforcing_boundary: the gated publisher installs and verifies a durable user supervisor outside the client-owned cache before reporting the release complete
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: hermetic tests prove the not-adopted pass, the held-by-me pass, and the peer-held, unheld, released-holder, and identity-less refusals, plus that the virtual token conflicts with itself and never with path claims; the cross-machine lease serialization of the claim itself is the coordination engine's own tested contract, and the first live two-train queueing necessarily occurs after both sessions run 4.77.0
+unverified_remainder: hermetic tests cover archive validation, delayed parent replacement, newest-version noninterference, existing-content refusal, lock contention, and macOS and Linux supervisor definitions; the release receipt must additionally prove the macOS supervisor is live and a real post-command historical-root deletion is repaired, while a live Linux systemd-user acceptance remains platform-specific
 changed_surfaces:
   - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [train-possession-gate, train-token-lock-semantics]
+    cases: [release-installs-guardian]
+  - path: skills/synthesis-skills-manager/scripts/cache_guardian.py
+    cases: [delayed-generation-recovery, current-version-noninterference, guardian-fails-closed, shared-transition-lock, persistent-supervisors]
+  - path: skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+    cases: [delayed-generation-recovery, current-version-noninterference, guardian-fails-closed, shared-transition-lock, persistent-supervisors]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [train-possession-gate, train-token-lock-semantics]
+    cases: [release-installs-guardian, guardian-doc-contract]
   - path: skills/synthesis-skills-manager/SKILL.md
-    cases: [train-doc-contract]
-  - path: skills/synthesis-project-management/references/parallel-agent-protocol.md
-    cases: [train-doc-contract]
-  - path: AGENTS.md
-    cases: [train-doc-contract]
+    cases: [guardian-doc-contract]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -30,22 +30,38 @@ changed_surfaces:
   - path: .codex-plugin/plugin.json
     cases: [release-manifest-parity]
   - path: CHANGELOG.md
-    cases: [release-changelog-parity, train-doc-contract]
+    cases: [release-changelog-parity, guardian-doc-contract]
   - path: README.md
-    cases: [train-doc-contract]
+    cases: [guardian-doc-contract]
 cases:
-  - id: train-possession-gate
+  - id: delayed-generation-recovery
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_later_parent_generation_is_repaired_without_touching_current
+    motivating_defect: codex-replaced-the-live-cache-parent-thirteen-minutes-after-the-release-verified-a-ten-second-quiet-window
+  - id: current-version-noninterference
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_restore_protects_history_but_never_installs_current
+    motivating_defect: a-guardian-that-races-the-client-for-its-current-version-would-trade-a-missing-history-defect-for-cache-corruption
+  - id: guardian-fails-closed
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_differing_existing_history_fails_closed_without_overwrite
+    motivating_defect: silently-overlaying-a-differing-live-root-would-erase-the-evidence-needed-to-diagnose-content-drift
+  - id: shared-transition-lock
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_release_lock_defers_guardian_without_writing
+    motivating_defect: a-background-healer-writing-during-the-gated-release-transition-would-create-a-second-cache-writer
+  - id: persistent-supervisors
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_macos_supervisor_is_loaded_and_verified
+    motivating_defect: a-one-shot-repair-still-ends-before-the-later-client-owned-cache-generation-that-caused-the-incident
+  - id: release-installs-guardian
     control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_train_held_by_peer_refuses
-    motivating_defect: five-same-day-overtakes-and-a-version-collision-because-nothing-mechanical-serialized-parallel-releases
-  - id: train-token-lock-semantics
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_guardian_install_uses_source_checkout_and_surfaces_receipt
+    motivating_defect: guardian-code-that-the-publisher-never-installs-cannot-protect-any-running-task
+  - id: guardian-doc-contract
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_train_token_conflicts_with_itself_but_not_with_paths
-    motivating_defect: a-virtual-lock-that-collides-with-ordinary-path-claims-would-deny-unrelated-work-instead-of-serializing-releases
-  - id: train-doc-contract
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_train_unheld_refuses_with_claim_guidance
-    motivating_defect: a-lock-whose-refusal-does-not-teach-the-claim-command-turns-serialization-into-a-mystery-outage
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_delayed_cache_guardian_release_contract_is_public_and_coherent
+    motivating_defect: documentation-that-still-promises-a-bounded-quiet-window-as-enduring-proof-misstates-the-runtime-contract
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -5,23 +5,23 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.4.0"
+  version: "2.5.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
 
 # Synthesis Skills Manager
 
-**Version 2.4.0** (2026-09-01) makes Codex cache survival source-backed and
-post-command verified. Every version retained by either client is preserved.
-Immutable release tags supply authoritative tracked bytes; complete peer roots
-cover releases that predate tags. The budgeted archive repairs missing or
-partial Codex roots and verifies them through a bounded quiet window after the
-client command. Recovery digests exclude only client-owned metadata: checkout,
-liveness, and install-record paths. Every other unexpected path still fails
-verification.
-client command returns. The whole-system onboarding suite and its
-scaffold/component catalog audit remain required release checks.
+**Version 2.5.0** (2026-09-01) makes Codex cache survival durable beyond the
+release command. The budgeted, tag-backed archive remains authoritative, and a
+standard-library guardian installed outside the client-owned cache restores
+historical roots whenever Codex creates a later cache generation. The newest
+version remains exclusively client-owned; the guardian shares the transition
+lock, refuses unsafe links or differing existing content, runs under the user
+supervisor, and is installed and verified by the gated publisher before it
+returns. Recovery digests still exclude only client-owned metadata. The
+whole-system onboarding suite and its scaffold/component catalog audit remain
+required release checks.
 
 Manage synthesis skills across a three-repo architecture. Skills are executable
 methodology. Public skills are also packaged as a native plugin for clients that
@@ -300,9 +300,17 @@ The sequence, each stage gating the next:
   not promoted into recovery state. The
   publisher holds a single-writer transition lock, restores missing Codex roots,
   repairs partial ones, and repeats the check until the tree has remained
-  unchanged for ten seconds after the client command returned. An already-running
-  task therefore keeps the complete skill and hook tree its SessionStart loaded
-  even when Codex had already removed that version before this release began.
+  unchanged for ten seconds after the client command returned. That synchronous
+  receipt covers the release transaction; it cannot prove that the client will
+  not create another cache generation minutes later. The publisher therefore
+  installs `cache_guardian.py` under the durable recovery root and verifies its
+  user-level launchd or systemd supervisor before returning. The guardian shares
+  the release lock, protects every archived version except the newest
+  client-owned version, and rehydrates missing historical roots after any later
+  cache replacement. It never deletes a cache path or overwrites differing
+  existing content. An already-running task therefore keeps the complete skill
+  and hook tree its SessionStart loaded even when reconciliation occurs after
+  the publisher has exited.
   The archive has a 512 MiB hard budget and never deletes a historical root
   automatically when that budget is reached; unverifiable cleanup fails the
   release closed. Symlink recovery artifacts and client liveness markers are not

--- a/skills/synthesis-skills-manager/scripts/cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/cache_guardian.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Keep historical Codex plugin roots available after cache reconciliation.
+
+Codex owns its cache directory and may replace the complete directory well
+after an install command returns. Running tasks still execute hook commands
+bound to the absolute version root from their SessionStart. The release
+publisher therefore keeps an immutable, budgeted archive outside the client
+cache, while this guardian restores historical roots whenever a later cache
+generation removes them.
+
+The newest archived version is deliberately excluded: it is the version the
+client currently owns and may be installing. The guardian never deletes a
+cache path and never writes through a differing existing root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import plistlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Iterator
+
+
+MARKETPLACE = "synthesis-engineering"
+PLUGIN_NAME = "synthesis-skills"
+LABEL = "org.synthesisengineering.synthesis-skills-cache-guardian"
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+HOOK_PLUGIN_PATH_RE = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\s\"']+)")
+IGNORED_ROOTS = frozenset({".git", ".in_use", ".codex-marketplace-install.json"})
+DEFAULT_INTERVAL_SECONDS = 1.0
+ERROR_RETRY_SECONDS = 10.0
+EX_TEMPFAIL = 75
+
+
+class GuardianError(RuntimeError):
+    """The guardian could not establish or preserve a safe cache state."""
+
+
+class GuardianBusy(GuardianError):
+    """The release transition currently owns the shared cache lock."""
+
+
+def archive_root(home: Path) -> Path:
+    return home / ".synthesis" / "plugin-cache-recovery" / MARKETPLACE / PLUGIN_NAME
+
+
+def cache_parent(home: Path) -> Path:
+    return home / ".codex" / "plugins" / "cache" / MARKETPLACE / PLUGIN_NAME
+
+
+def runtime_path(home: Path) -> Path:
+    return archive_root(home).parent / f".{PLUGIN_NAME}-cache-guardian.py"
+
+
+def receipt_path(home: Path) -> Path:
+    return archive_root(home).parent / "cache-guardian-last.json"
+
+
+def lock_path(home: Path) -> Path:
+    return archive_root(home).parent / f".{PLUGIN_NAME}.release.lock"
+
+
+def _version_key(version: str) -> tuple[int, int, int]:
+    return tuple(int(part) for part in version.split("."))  # type: ignore[return-value]
+
+
+def _version_roots(parent: Path) -> dict[str, Path]:
+    if not parent.is_dir() or parent.is_symlink():
+        return {}
+    return {
+        child.name: child
+        for child in sorted(parent.iterdir(), key=lambda item: item.name)
+        if child.is_dir()
+        and not child.is_symlink()
+        and VERSION_RE.fullmatch(child.name) is not None
+    }
+
+
+def _tree_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(root.rglob("*"), key=lambda item: str(item.relative_to(root))):
+        relative_path = path.relative_to(root)
+        if relative_path.parts and relative_path.parts[0] in IGNORED_ROOTS:
+            continue
+        relative = str(relative_path).encode("utf-8")
+        if path.is_symlink():
+            digest.update(b"L\0" + relative + b"\0" + os.readlink(path).encode("utf-8"))
+        elif path.is_dir():
+            digest.update(b"D\0" + relative)
+        elif path.is_file():
+            digest.update(b"F\0" + relative + b"\0" + path.read_bytes())
+    return digest.hexdigest()
+
+
+def _validate_root(root: Path, version: str) -> None:
+    if not root.is_dir() or root.is_symlink():
+        raise GuardianError(f"archive root is absent, not a directory, or a symlink: {root}")
+    for path in root.rglob("*"):
+        if not path.is_symlink():
+            continue
+        link = PurePosixPath(os.readlink(path))
+        if link.is_absolute() or ".." in link.parts:
+            raise GuardianError(
+                f"unsafe archive symlink: {path.relative_to(root)} -> {link}"
+            )
+    versions: set[str] = set()
+    for manifest in (".claude-plugin/plugin.json", ".codex-plugin/plugin.json"):
+        candidate = root / manifest
+        if not candidate.is_file():
+            continue
+        try:
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise GuardianError(f"unreadable archive manifest {candidate}: {exc}") from exc
+        value = payload.get("version")
+        if isinstance(value, str):
+            versions.add(value)
+    if version not in versions:
+        raise GuardianError(f"no archive manifest reports {version}: {root}")
+    hooks = root / "hooks" / "hooks.json"
+    try:
+        hook_text = hooks.read_text(encoding="utf-8")
+        json.loads(hook_text)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GuardianError(f"unreadable archive hook definition {hooks}: {exc}") from exc
+    targets = sorted(set(HOOK_PLUGIN_PATH_RE.findall(hook_text)))
+    if not targets:
+        raise GuardianError(f"archive hook definition has no plugin-root target: {hooks}")
+    missing = [target for target in targets if not (root / target).is_file()]
+    if missing:
+        raise GuardianError(f"archive root {version} misses hook target(s): {', '.join(missing[:3])}")
+    if not any(root.glob("skills/*/SKILL.md")):
+        raise GuardianError(f"archive root has no skill entry point: {root}")
+
+
+def _refuse_symlinked_boundary(home: Path, path: Path) -> None:
+    if not home.is_absolute() or not path.is_absolute():
+        raise GuardianError("home and cache boundaries must be absolute")
+    try:
+        relative = path.relative_to(home)
+    except ValueError as exc:
+        raise GuardianError(f"path escapes home boundary: {path}") from exc
+    cursor = home
+    if cursor.is_symlink():
+        raise GuardianError(f"home boundary is a symlink: {cursor}")
+    for part in relative.parts:
+        cursor = cursor / part
+        if cursor.is_symlink():
+            raise GuardianError(f"refusing symlinked cache boundary: {cursor}")
+
+
+def _atomic_write(path: Path, payload: bytes, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        raise GuardianError(f"refusing to replace symlinked file: {path}")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.chmod(mode)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+@contextmanager
+def _cache_lock(home: Path, *, blocking: bool) -> Iterator[None]:
+    path = lock_path(home)
+    _refuse_symlinked_boundary(home, path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o600)
+    handle = os.fdopen(descriptor, "a+")
+    operation = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+    try:
+        try:
+            fcntl.flock(handle.fileno(), operation)
+        except (BlockingIOError, OSError) as exc:
+            raise GuardianBusy("release transition owns the cache lock") from exc
+        yield
+    finally:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
+
+
+def _remove_staging(path: Path, parent: Path) -> None:
+    if not path.exists():
+        return
+    if path.parent != parent or not path.name.startswith(".guardian-") or path.is_symlink():
+        raise GuardianError(f"refusing unsafe staging cleanup target: {path}")
+    shutil.rmtree(path)
+
+
+def _restore_missing(source: Path, destination: Path, parent: Path) -> bool:
+    staging = parent / f".guardian-{destination.name}-{os.getpid()}-{time.time_ns()}"
+    try:
+        shutil.copytree(source, staging, symlinks=True)
+        if _tree_digest(source) != _tree_digest(staging):
+            raise GuardianError(f"staged recovery differs from archive: {source.name}")
+        if destination.exists() or destination.is_symlink():
+            if destination.is_symlink() or not destination.is_dir():
+                raise GuardianError(f"cache root appeared with an unsafe type: {destination}")
+            if _tree_digest(source) != _tree_digest(destination):
+                raise GuardianError(f"cache root appeared with differing content: {destination}")
+            return False
+        os.rename(staging, destination)
+        if _tree_digest(source) != _tree_digest(destination):
+            raise GuardianError(f"restored cache root differs from archive: {destination}")
+        return True
+    finally:
+        _remove_staging(staging, parent)
+
+
+def restore_once(home: Path | None = None, *, blocking: bool = False) -> dict[str, object]:
+    home = (home or Path.home()).absolute()
+    archive = archive_root(home)
+    cache = cache_parent(home)
+    _refuse_symlinked_boundary(home, archive)
+    _refuse_symlinked_boundary(home, cache)
+    if not archive.is_dir():
+        raise GuardianError(f"recovery archive is unavailable: {archive}")
+    archived = _version_roots(archive)
+    if not archived:
+        raise GuardianError(f"recovery archive has no version roots: {archive}")
+    ordered = sorted(archived, key=_version_key)
+    current = ordered[-1]
+    protected = ordered[:-1]
+    restored: list[str] = []
+    verified: list[str] = []
+    with _cache_lock(home, blocking=blocking):
+        cache.mkdir(parents=True, exist_ok=True)
+        if cache.is_symlink():
+            raise GuardianError(f"cache parent is a symlink: {cache}")
+        for version in protected:
+            source = archived[version]
+            _validate_root(source, version)
+            destination = cache / version
+            if destination.is_symlink() or (destination.exists() and not destination.is_dir()):
+                raise GuardianError(f"historical cache root has an unsafe type: {destination}")
+            if not destination.exists():
+                if _restore_missing(source, destination, cache):
+                    restored.append(version)
+            elif _tree_digest(source) != _tree_digest(destination):
+                raise GuardianError(f"historical cache root differs from archive: {destination}")
+            verified.append(version)
+    record: dict[str, object] = {
+        "schema": 1,
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+        "archive": str(archive),
+        "cache": str(cache),
+        "current_excluded": current,
+        "protected_versions": protected,
+        "verified": len(verified),
+        "restored": restored,
+    }
+    _atomic_write(receipt_path(home), (json.dumps(record, indent=2, sort_keys=True) + "\n").encode(), 0o600)
+    return record
+
+
+def _cache_signature(home: Path) -> tuple[object, ...]:
+    parent = cache_parent(home)
+    if not parent.is_dir() or parent.is_symlink():
+        return ("absent",)
+    stat = parent.stat()
+    return (stat.st_ino, stat.st_mtime_ns, tuple(sorted(_version_roots(parent))))
+
+
+def watch(home: Path | None = None, interval: float = DEFAULT_INTERVAL_SECONDS) -> None:
+    home = (home or Path.home()).absolute()
+    previous: tuple[object, ...] | None = None
+    while True:
+        signature = _cache_signature(home)
+        if signature != previous:
+            try:
+                restore_once(home)
+                previous = _cache_signature(home)
+            except GuardianBusy:
+                previous = None
+            except GuardianError as exc:
+                print(f"cache guardian retrying after error: {exc}", file=sys.stderr, flush=True)
+                previous = None
+                time.sleep(ERROR_RETRY_SECONDS)
+                continue
+        time.sleep(interval)
+
+
+def _launchd_payload(home: Path, runtime: Path) -> bytes:
+    logs = archive_root(home).parent / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    return plistlib.dumps(
+        {
+            "Label": LABEL,
+            "ProgramArguments": [sys.executable, str(runtime), "--watch"],
+            "RunAtLoad": True,
+            "KeepAlive": True,
+            "ThrottleInterval": 10,
+            "ProcessType": "Background",
+            "StandardOutPath": str(logs / "cache-guardian.out.log"),
+            "StandardErrorPath": str(logs / "cache-guardian.err.log"),
+        },
+        sort_keys=False,
+    )
+
+
+def _systemd_quote(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _systemd_payload(runtime: Path) -> bytes:
+    command = " ".join(_systemd_quote(value) for value in (sys.executable, str(runtime), "--watch"))
+    return (
+        "[Unit]\nDescription=Synthesis Skills historical Codex cache guardian\n\n"
+        "[Service]\nType=simple\n"
+        f"ExecStart={command}\n"
+        "Restart=always\nRestartSec=10\n\n"
+        "[Install]\nWantedBy=default.target\n"
+    ).encode()
+
+
+def _completed_detail(completed: subprocess.CompletedProcess[str]) -> str:
+    return (completed.stderr or completed.stdout or "").strip()
+
+
+def install_supervisor(
+    home: Path,
+    runtime: Path,
+    *,
+    platform: str | None = None,
+    runner=subprocess.run,
+) -> str:
+    platform = platform or sys.platform
+    if platform == "darwin":
+        launchctl = shutil.which("launchctl")
+        if launchctl is None:
+            raise GuardianError("launchctl is required for the macOS cache guardian")
+        plist = home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+        _refuse_symlinked_boundary(home, plist)
+        _atomic_write(plist, _launchd_payload(home, runtime), 0o644)
+        domain = f"gui/{os.getuid()}"
+        runner([launchctl, "bootout", domain, str(plist)], capture_output=True, text=True, check=False)
+        boot = runner([launchctl, "bootstrap", domain, str(plist)], capture_output=True, text=True, check=False)
+        if boot.returncode:
+            raise GuardianError(f"launchctl bootstrap failed: {_completed_detail(boot)}")
+        kick = runner([launchctl, "kickstart", "-k", f"{domain}/{LABEL}"], capture_output=True, text=True, check=False)
+        if kick.returncode:
+            raise GuardianError(f"launchctl kickstart failed: {_completed_detail(kick)}")
+        probe = runner([launchctl, "print", f"{domain}/{LABEL}"], capture_output=True, text=True, check=False)
+        if probe.returncode:
+            raise GuardianError(f"launchctl could not verify the guardian: {_completed_detail(probe)}")
+        return str(plist)
+    if platform.startswith("linux"):
+        systemctl = shutil.which("systemctl")
+        if systemctl is None:
+            raise GuardianError("systemctl is required for the Linux cache guardian")
+        unit = home / ".config" / "systemd" / "user" / f"{LABEL}.service"
+        _refuse_symlinked_boundary(home, unit)
+        _atomic_write(unit, _systemd_payload(runtime), 0o644)
+        for command in (
+            [systemctl, "--user", "daemon-reload"],
+            [systemctl, "--user", "enable", "--now", unit.name],
+            [systemctl, "--user", "restart", unit.name],
+            [systemctl, "--user", "is-active", unit.name],
+        ):
+            completed = runner(command, capture_output=True, text=True, check=False)
+            if completed.returncode:
+                raise GuardianError(f"systemd guardian command failed: {_completed_detail(completed)}")
+        return str(unit)
+    raise GuardianError(f"no supported user supervisor on platform {platform}")
+
+
+def install(home: Path | None = None) -> dict[str, object]:
+    home = (home or Path.home()).absolute()
+    runtime = runtime_path(home)
+    _refuse_symlinked_boundary(home, runtime)
+    source = Path(__file__).resolve()
+    _atomic_write(runtime, source.read_bytes(), 0o755)
+    if runtime.read_bytes() != source.read_bytes():
+        raise GuardianError(f"installed guardian differs from source: {runtime}")
+    record = restore_once(home, blocking=True)
+    supervisor = install_supervisor(home, runtime)
+    record["runtime"] = str(runtime)
+    record["supervisor"] = supervisor
+    return record
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    modes = parser.add_mutually_exclusive_group(required=True)
+    modes.add_argument("--once", action="store_true", help="restore and verify historical roots once")
+    modes.add_argument("--watch", action="store_true", help="continuously guard later cache generations")
+    modes.add_argument("--install", action="store_true", help="install and start the durable user supervisor")
+    modes.add_argument("--doctor", action="store_true", help="restore once and verify the durable runtime exists")
+    parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL_SECONDS)
+    args = parser.parse_args(argv)
+    try:
+        if args.watch:
+            watch(interval=max(args.interval, 0.1))
+            return 0
+        if args.install:
+            record = install()
+        else:
+            record = restore_once()
+            if args.doctor:
+                runtime = runtime_path(Path.home())
+                if not runtime.is_file() or runtime.is_symlink():
+                    raise GuardianError(f"durable guardian runtime is unavailable: {runtime}")
+        print(json.dumps(record, sort_keys=True))
+        return 0
+    except GuardianBusy as exc:
+        print(f"cache guardian busy: {exc}", file=sys.stderr)
+        return EX_TEMPFAIL
+    except (GuardianError, OSError, subprocess.SubprocessError) as exc:
+        print(f"cache guardian failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -83,6 +83,9 @@ ACCEPTANCE_MANIFEST = Path(
 ACCEPTANCE_RUNNER = Path(
     "skills/synthesis-implementation-integrity/scripts/acceptance_suite.py"
 )
+CACHE_GUARDIAN = Path(
+    "skills/synthesis-skills-manager/scripts/cache_guardian.py"
+)
 ACCEPTANCE_CONSUMER_ID = (
     "synthesis-skills-manager.release.consume-acceptance.v1"
 )
@@ -1098,6 +1101,32 @@ def refresh_client(
             _release_codex_cache_lock(cache_lock)
 
 
+def install_codex_cache_guardian(
+    repo: Path, result: Result, dry_run: bool
+) -> bool:
+    """Install the durable supervisor that repairs later Codex cache generations."""
+    source = repo / CACHE_GUARDIAN
+    if not source.is_file() or source.is_symlink():
+        return result.add(
+            "install.codex.cache-guardian",
+            False,
+            f"guardian source is unavailable or unsafe: {source}",
+        )
+    command = [sys.executable, str(source), "--install"]
+    if dry_run:
+        return result.add(
+            "install.codex.cache-guardian",
+            True,
+            "dry-run: " + " ".join(command[1:]),
+        )
+    completed = run(command, cwd=repo, timeout=120)
+    output = (completed.stdout or completed.stderr).strip().splitlines()
+    detail = output[-1] if output else "guardian command produced no receipt"
+    return result.add(
+        "install.codex.cache-guardian", completed.returncode == 0, detail
+    )
+
+
 def _coordination_board_path() -> Path:
     override = os.environ.get("SYNTHESIS_COORDINATION_BOARD", "").strip()
     return Path(override).expanduser() if override else DEFAULT_COORDINATION_BOARD
@@ -1366,6 +1395,8 @@ def main(argv: list[str] | None = None) -> int:
 
     for client in ("claude", "codex"):
         refresh_client(client, result, args.dry_run, repo=repo)
+
+    install_codex_cache_guardian(repo, result, args.dry_run)
 
     if args.dry_run:
         print(f"\nDRY RUN complete for {version}. No state changed.")

--- a/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import fcntl
+import importlib.util
+import json
+import os
+import plistlib
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).with_name("cache_guardian.py")
+SPEC = importlib.util.spec_from_file_location("cache_guardian", SCRIPT)
+assert SPEC and SPEC.loader
+guardian = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(guardian)
+
+
+def seed_root(root: Path, version: str, marker: str) -> None:
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".codex-plugin").mkdir(parents=True)
+    manifest = json.dumps({"version": version})
+    (root / ".claude-plugin" / "plugin.json").write_text(manifest, encoding="utf-8")
+    (root / ".codex-plugin" / "plugin.json").write_text(manifest, encoding="utf-8")
+    hook = root / "skills" / "synthesis-autopilot" / "scripts" / "autopilot_gate.py"
+    hook.parent.mkdir(parents=True)
+    hook.write_text(f"print({marker!r})\n", encoding="utf-8")
+    (hook.parents[1] / "SKILL.md").write_text("---\nname: synthesis-autopilot\n---\n", encoding="utf-8")
+    (root / "hooks").mkdir()
+    (root / "hooks" / "hooks.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-autopilot/scripts/autopilot_gate.py --gate",
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def seeded_home(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    archive = guardian.archive_root(home)
+    seed_root(archive / "4.73.0", "4.73.0", "old")
+    seed_root(archive / "4.77.1", "4.77.1", "current")
+    return home
+
+
+def test_restore_protects_history_but_never_installs_current(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+
+    record = guardian.restore_once(home)
+
+    cache = guardian.cache_parent(home)
+    assert (cache / "4.73.0" / "skills/synthesis-autopilot/scripts/autopilot_gate.py").is_file()
+    assert not (cache / "4.77.1").exists()
+    assert record["current_excluded"] == "4.77.1"
+    assert record["restored"] == ["4.73.0"]
+    assert json.loads(guardian.receipt_path(home).read_text(encoding="utf-8"))["verified"] == 1
+
+
+def test_later_parent_generation_is_repaired_without_touching_current(
+    tmp_path: Path,
+) -> None:
+    home = seeded_home(tmp_path)
+    guardian.restore_once(home)
+    cache = guardian.cache_parent(home)
+    first_signature = guardian._cache_signature(home)
+
+    shutil.rmtree(cache)
+    current = cache / "4.77.1"
+    current.mkdir(parents=True)
+    (current / "client-owned").write_text("new generation\n", encoding="utf-8")
+    replacement_signature = guardian._cache_signature(home)
+    assert replacement_signature != first_signature
+
+    record = guardian.restore_once(home)
+
+    assert (cache / "4.73.0" / "skills/synthesis-autopilot/scripts/autopilot_gate.py").is_file()
+    assert (current / "client-owned").read_text(encoding="utf-8") == "new generation\n"
+    assert record["restored"] == ["4.73.0"]
+
+
+def test_differing_existing_history_fails_closed_without_overwrite(
+    tmp_path: Path,
+) -> None:
+    home = seeded_home(tmp_path)
+    guardian.restore_once(home)
+    target = guardian.cache_parent(home) / "4.73.0" / "unexpected"
+    target.write_text("do not erase\n", encoding="utf-8")
+
+    with pytest.raises(guardian.GuardianError, match="differs from archive"):
+        guardian.restore_once(home)
+
+    assert target.read_text(encoding="utf-8") == "do not erase\n"
+
+
+def test_unsafe_archive_symlink_is_refused(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    (guardian.archive_root(home) / "4.73.0" / "escape").symlink_to("../../outside")
+
+    with pytest.raises(guardian.GuardianError, match="unsafe archive symlink"):
+        guardian.restore_once(home)
+
+
+def test_release_lock_defers_guardian_without_writing(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    path = guardian.lock_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+")
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        with pytest.raises(guardian.GuardianBusy):
+            guardian.restore_once(home)
+    finally:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+    assert not guardian.cache_parent(home).exists()
+
+
+def test_launchd_definition_is_persistent_and_runs_stable_runtime(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    runtime = guardian.runtime_path(home)
+
+    payload = plistlib.loads(guardian._launchd_payload(home, runtime))
+
+    assert payload["Label"] == guardian.LABEL
+    assert payload["ProgramArguments"] == [os.sys.executable, str(runtime), "--watch"]
+    assert payload["RunAtLoad"] is True
+    assert payload["KeepAlive"] is True
+    assert payload["ThrottleInterval"] == 10
+
+
+def test_macos_supervisor_is_loaded_and_verified(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    runtime = guardian.runtime_path(home)
+    runtime.parent.mkdir(parents=True)
+    runtime.write_text("guardian\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="ok\n", stderr="")
+
+    monkeypatch.setattr(guardian.shutil, "which", lambda name: "/bin/launchctl")
+
+    installed = guardian.install_supervisor(
+        home, runtime, platform="darwin", runner=fake_run
+    )
+
+    plist = home / "Library" / "LaunchAgents" / f"{guardian.LABEL}.plist"
+    assert installed == str(plist)
+    assert plist.is_file()
+    assert [command[1] for command in calls] == ["bootout", "bootstrap", "kickstart", "print"]
+
+
+def test_systemd_definition_restarts_and_uses_stable_runtime(tmp_path: Path) -> None:
+    runtime = guardian.runtime_path(tmp_path / "home with spaces")
+
+    payload = guardian._systemd_payload(runtime).decode("utf-8")
+
+    assert "Restart=always" in payload
+    assert str(runtime) in payload
+    assert "--watch" in payload
+
+
+def test_linux_supervisor_restarts_changed_runtime_and_verifies_active(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    runtime = guardian.runtime_path(home)
+    runtime.parent.mkdir(parents=True)
+    runtime.write_text("guardian\n", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="active\n", stderr="")
+
+    monkeypatch.setattr(guardian.shutil, "which", lambda name: "/bin/systemctl")
+
+    guardian.install_supervisor(home, runtime, platform="linux", runner=fake_run)
+
+    assert [command[2] for command in calls] == [
+        "daemon-reload",
+        "enable",
+        "restart",
+        "is-active",
+    ]

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -620,7 +620,7 @@ def test_cache_survival_release_contract_is_public_and_coherent() -> None:
     readme = (repository / "README.md").read_text(encoding="utf-8")
     changelog = (repository / "CHANGELOG.md").read_text(encoding="utf-8")
 
-    assert "Every version retained by either client" in manager
+    assert "every archived version except the newest" in manager
     assert "single-writer transition lock" in readme
     assert "pre-tag" in readme
     assert "## [4.76.4]" in changelog
@@ -628,6 +628,23 @@ def test_cache_survival_release_contract_is_public_and_coherent() -> None:
     assert "512 MiB hard limit" in changelog
     assert readme.count("**4.76.1**") == 1
     assert changelog.count("## [4.76.1]") == 1
+
+
+def test_delayed_cache_guardian_release_contract_is_public_and_coherent() -> None:
+    repository = Path(__file__).resolve().parents[3]
+    manager = (repository / "skills/synthesis-skills-manager/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    guardian = (repository / release.CACHE_GUARDIAN).read_text(encoding="utf-8")
+    readme = (repository / "README.md").read_text(encoding="utf-8")
+    changelog = (repository / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert "Version 2.5.0" in manager
+    assert "outside the client-owned cache" in manager
+    assert "current_excluded" in guardian
+    assert "KeepAlive" in guardian and "Restart=always" in guardian
+    assert "4.77.1" in readme
+    assert "## [4.77.1]" in changelog
 
 
 def test_whole_system_onboarding_release_contract_is_public_and_coherent() -> None:
@@ -1160,6 +1177,41 @@ def test_codex_cache_transition_lock_refuses_a_second_writer(
             release._acquire_codex_cache_lock()
     finally:
         release._release_codex_cache_lock(first)
+
+
+def test_guardian_install_uses_source_checkout_and_surfaces_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / release.CACHE_GUARDIAN
+    source.parent.mkdir(parents=True)
+    source.write_text("print('guardian')\n", encoding="utf-8")
+    calls: list[tuple[list[str], Path | None, int]] = []
+
+    def fake_run(command, cwd=None, timeout=900):
+        calls.append((command, cwd, timeout))
+        return subprocess.CompletedProcess(
+            command, 0, stdout='{"verified": 61}\n', stderr=""
+        )
+
+    monkeypatch.setattr(release, "run", fake_run)
+    result = release.Result()
+
+    assert release.install_codex_cache_guardian(tmp_path, result, False)
+    assert calls == [
+        ([sys.executable, str(source), "--install"], tmp_path, 120)
+    ]
+    step = next(
+        step for step in result.steps if step.name == "install.codex.cache-guardian"
+    )
+    assert step.ok is True
+    assert step.detail == '{"verified": 61}'
+
+
+def test_guardian_install_fails_closed_without_source(tmp_path: Path) -> None:
+    result = release.Result()
+
+    assert release.install_codex_cache_guardian(tmp_path, result, False) is False
+    assert result.failed[0].name == "install.codex.cache-guardian"
 
 
 def test_codex_refresh_restores_real_version_root_deleted_by_client(


### PR DESCRIPTION
## Why

Codex can replace its plugin-cache tree after a release command exits. That delayed refresh can remove historical version roots that active sessions still reference.

## What changed

- Add a supervised cache guardian installed outside the client-owned cache.
- Restore only missing historical roots from the durable release archive; the newest current root remains client-owned.
- Share the release lock and fail closed on unsafe archives or differing existing content.
- Install and verify the guardian through the gated release manager, with receipts and closed-suite coverage.

## Verification

- 73 focused release-manager tests passed.
- The full gated `release.py --check-only` path passed, including a fresh transaction-bound R5 receipt.
- Source conformance passed 204 checks with zero required failures.