### PR TITLE
Diagnose engine/board version skew; stop the Active-sessions padding leak (4.78.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.77.1",
+  "version": "4.78.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.77.1",
+  "version": "4.78.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.78.0] - 2026-09-01
+
+**A coordination engine older than the board it reads now says so, and
+names the engine to run.** After the 4.75.0 schema migration, a session
+still on an older plugin cache read the shared board and reported the board
+itself as corrupt: its parser raised a bare column-count error, and the
+operator on that side spent the incident hunting a phantom second table.
+Version skew between a shared board and the engines reading it is permanent
+— a plugin release reaches sessions at different times — so the engine now
+refuses fail-closed with a diagnosis instead of a symptom: a board whose
+declared `Schema:` is newer than the engine, or a row wider than the
+engine's newest column set, raises a message naming the newest installed
+engine to invoke (resolved numerically from the plugin cache the script runs
+from, or the plugin refresh when none is newer), and `doctor` reports the
+same line. A stale engine still never rewrites a newer board.
+
+Also fixed: every rewrite of the Active sessions table grew the blank run
+between the heading and the table by one line — the section pattern
+swallowed the existing padding into the heading group and re-emitted it plus
+a newline — so a long-lived board carried over a thousand empty lines, which
+is what the "second table" reading was. Rewrites now emit a fixed-shape
+section (one blank line, table, one blank line) and are idempotent, so the
+next mutation on any board collapses the accumulated padding. Regression
+tests pin the refusal, the wider-row diagnosis, the remedy's newest-version
+resolution, the padding collapse, and the public documentation; the
+board-template reference now shows the v4 header.
+
 ## [4.77.1] - 2026-09-01
 
 **Historical Codex roots now survive cache generations created after the

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A stale engine now diagnoses itself instead of blaming the board
+(September 2026).** Release **4.78.0** makes the coordination engine refuse
+a board newer than itself with a message naming the engine to run, reports
+rows wider than it knows the same way, and stops every table rewrite from
+growing the board by a blank line. See the [4.78.0 release
+notes](CHANGELOG.md).
+
 **Historical tasks now survive cache replacement after the release command
 returns (September 2026).** Release **4.77.1** installs a durable, supervised
 Codex cache guardian outside the client-owned version tree. It restores only

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,28 +1,30 @@
-# AGENT HEURISTIC: authored for the 4.77.1 delayed-cache-generation hotfix.
+# AGENT HEURISTIC: authored for the 4.78.0 coordination-engine hardening.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: delayed-codex-cache-generation-survival
+suite: coordination-engine-version-skew-and-section-hygiene
 membership: closed
-production_entry_point: skills/synthesis-skills-manager/scripts/release.py
-enforcing_boundary: the gated publisher installs and verifies a durable user supervisor outside the client-owned cache before reporting the release complete
+production_entry_point: skills/synthesis-project-management/scripts/coordination.py
+enforcing_boundary: the coordination engine refuses to parse or rewrite a board newer than itself and names the engine to run, and every Active-sessions rewrite emits a fixed-shape section
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: hermetic tests cover archive validation, delayed parent replacement, newest-version noninterference, existing-content refusal, lock contention, and macOS and Linux supervisor definitions; the release receipt must additionally prove the macOS supervisor is live and a real post-command historical-root deletion is repaired, while a live Linux systemd-user acceptance remains platform-specific
+unverified_remainder: engines released before 4.78.0 keep their bare column-count message on a newer board and cannot be repaired retroactively; the live collapse of a real board's accumulated padding is proven in the release record rather than by a hermetic case
 changed_surfaces:
-  - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [release-installs-guardian]
-  - path: skills/synthesis-skills-manager/scripts/cache_guardian.py
-    cases: [delayed-generation-recovery, current-version-noninterference, guardian-fails-closed, shared-transition-lock, persistent-supervisors]
-  - path: skills/synthesis-skills-manager/scripts/test_cache_guardian.py
-    cases: [delayed-generation-recovery, current-version-noninterference, guardian-fails-closed, shared-transition-lock, persistent-supervisors]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [release-installs-guardian, guardian-doc-contract]
-  - path: skills/synthesis-skills-manager/SKILL.md
-    cases: [guardian-doc-contract]
+  - path: skills/synthesis-project-management/scripts/coordination.py
+    cases: [newer-board-refused-with-remedy, wider-row-names-newer-engine, section-padding-collapses]
+  - path: skills/synthesis-project-management/scripts/coordination_schema.py
+    cases: [remedy-names-newest-cached-engine, wider-row-names-newer-engine]
+  - path: skills/synthesis-project-management/scripts/test_coordination.py
+    cases: [newer-board-refused-with-remedy, wider-row-names-newer-engine, section-padding-collapses, remedy-names-newest-cached-engine, skew-doc-contract]
+  - path: skills/synthesis-project-management/references/session-identity.md
+    cases: [skew-doc-contract]
+  - path: skills/synthesis-project-management/references/active-sessions-template.md
+    cases: [skew-doc-contract]
+  - path: skills/synthesis-project-management/SKILL.md
+    cases: [skill-budget]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -30,38 +32,34 @@ changed_surfaces:
   - path: .codex-plugin/plugin.json
     cases: [release-manifest-parity]
   - path: CHANGELOG.md
-    cases: [release-changelog-parity, guardian-doc-contract]
+    cases: [release-changelog-parity, skew-doc-contract]
   - path: README.md
-    cases: [guardian-doc-contract]
+    cases: [release-changelog-parity]
 cases:
-  - id: delayed-generation-recovery
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_later_parent_generation_is_repaired_without_touching_current
-    motivating_defect: codex-replaced-the-live-cache-parent-thirteen-minutes-after-the-release-verified-a-ten-second-quiet-window
-  - id: current-version-noninterference
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_restore_protects_history_but_never_installs_current
-    motivating_defect: a-guardian-that-races-the-client-for-its-current-version-would-trade-a-missing-history-defect-for-cache-corruption
-  - id: guardian-fails-closed
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_differing_existing_history_fails_closed_without_overwrite
-    motivating_defect: silently-overlaying-a-differing-live-root-would-erase-the-evidence-needed-to-diagnose-content-drift
-  - id: shared-transition-lock
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_release_lock_defers_guardian_without_writing
-    motivating_defect: a-background-healer-writing-during-the-gated-release-transition-would-create-a-second-cache-writer
-  - id: persistent-supervisors
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_macos_supervisor_is_loaded_and_verified
-    motivating_defect: a-one-shot-repair-still-ends-before-the-later-client-owned-cache-generation-that-caused-the-incident
-  - id: release-installs-guardian
+  - id: newer-board-refused-with-remedy
     control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_guardian_install_uses_source_checkout_and_surfaces_receipt
-    motivating_defect: guardian-code-that-the-publisher-never-installs-cannot-protect-any-running-task
-  - id: guardian-doc-contract
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_rows_refuses_a_board_newer_than_the_engine
+    motivating_defect: a-stale-engine-reported-the-freshly-migrated-shared-board-as-corrupt-with-a-bare-column-count
+  - id: wider-row-names-newer-engine
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_delayed_cache_guardian_release_contract_is_public_and_coherent
-    motivating_defect: documentation-that-still-promises-a-bounded-quiet-window-as-enduring-proof-misstates-the-runtime-contract
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_wider_rows_than_the_engine_knows_name_the_newer_engine
+    motivating_defect: a-row-wider-than-the-engine-knows-has-one-cause-and-the-message-did-not-say-it
+  - id: section-padding-collapses
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_replace_table_collapses_padding_and_stays_fixed
+    motivating_defect: every-table-rewrite-grew-the-board-by-one-blank-line-until-a-thousand-read-as-a-second-table
+  - id: remedy-names-newest-cached-engine
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_engine_remedy_names_the_newest_cached_engine
+    motivating_defect: a-remedy-that-says-update-without-naming-the-path-sends-the-operator-back-to-guessing
+  - id: skew-doc-contract
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_version_skew_documented_on_public_surfaces
+    motivating_defect: a-refusal-nobody-is-told-about-reads-as-a-new-corruption
+  - id: skill-budget
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget
+    motivating_defect: a-version-bump-must-not-be-an-excuse-for-the-main-document-to-regrow
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.9.0"
+  version: "2.10.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-project-management/references/active-sessions-template.md
+++ b/skills/synthesis-project-management/references/active-sessions-template.md
@@ -3,12 +3,12 @@
 Shared advisory-lock and message board for independent agent sessions operating
 on the same ecosystem.
 
-Schema: v3
+Schema: v4
 
 ## Active sessions
 
-| session uuid | compact id | speakable id v1 | legacy id | agent | machine | project | started | heartbeat | mode | workspace(s) / branch | goal | claimed areas (advisory lock) | context role | status |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| session uuid | compact id | speakable id v1 | legacy id | agent | machine | client session ref | project | started | heartbeat | mode | workspace(s) / branch | goal | claimed areas (advisory lock) | context role | status |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 
 ## Messages
 

--- a/skills/synthesis-project-management/references/session-identity.md
+++ b/skills/synthesis-project-management/references/session-identity.md
@@ -80,6 +80,21 @@ each historical row a UUIDv7 and both aliases, and preserves its old letter in
 `legacy id`. Messages and history are left intact. Once migrated, canonical
 machine references use the UUID even when a human supplied a legacy selector.
 
+## Engine older than board
+
+A board is shared by every session on every machine that mounts it, and a
+plugin release reaches those sessions at different times, so version skew
+between the board and the engines reading it is a permanent condition rather
+than a transition. `rows()` refuses a board whose declared `Schema:` is newer
+than the running engine, and a row wider than the engine's newest column set
+is refused the same way; both messages name the newest installed engine to
+invoke — resolved from the plugin cache the running script lives in — or the
+plugin refresh when none is newer. The refusal is fail-closed by design: a
+stale engine must never rewrite a newer board, and the remedy is always the
+same, run the current engine's `coordination.py`. `doctor` reports the same
+line. Origin (2026-09-01): a session on an older cache read the freshly
+migrated v4 board and reported the board itself as corrupt.
+
 ## Collision boundary
 
 The UUID remains authoritative even if a human alias collision were ever

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -32,7 +32,9 @@ from coordination_schema import (
     V3_COLUMNS,
     V4_COLUMNS,
     SessionIdentity,
+    column_count_error,
     display_id,
+    engine_remedy,
     identity_lookup_keys,
     new_identity,
     selector_keys,
@@ -684,11 +686,7 @@ def session_from_cells(cells: list[str]) -> Session:
             context_role="none",
             status=plain(cells[6]).lower(),
         )
-    raise ValueError(
-        f"active-session row has {len(cells)} columns; expected "
-        f"{len(V4_COLUMNS)}, {len(V3_COLUMNS)}, {len(V2_COLUMNS)}, or "
-        f"{len(V1_COLUMNS)}"
-    )
+    raise column_count_error(cells, __file__)
 
 
 def with_identity(session: Session, identity: SessionIdentity) -> Session:
@@ -736,6 +734,16 @@ def find_session(sessions: list[Session], selector: str) -> Session | None:
 
 
 def rows(text: str) -> list[Session]:
+    declared = board_schema(text)
+    if declared is not None and declared > SCHEMA_VERSION:
+        # Version skew between a shared board and the engines reading it is
+        # permanent, not a transition: a release reaches sessions at different
+        # times. A stale engine must never rewrite a newer board, and the one
+        # useful thing it can say is which engine to run instead.
+        raise ValueError(
+            f"board declares schema v{declared}, newer than this engine's "
+            f"v{SCHEMA_VERSION}; {engine_remedy(__file__)}"
+        )
     result: list[Session] = []
     in_table = False
     for line in text.splitlines():
@@ -800,7 +808,10 @@ def replace_table(
         for session in sessions
     )
     block = "\n".join(rendered)
-    pattern = re.compile(r"(?ms)(^## Active sessions\s*\n).*?(?=^## Messages\s*$)")
+    # The heading group must not swallow blank lines: with `\s*` it captured
+    # every existing padding line and re-emitted it plus one more, so each
+    # rewrite grew the board by a line (over a thousand on a long-lived board).
+    pattern = re.compile(r"(?ms)(^## Active sessions[ \t]*\n).*?(?=^## Messages\s*$)")
     if not pattern.search(text):
         raise ValueError("board lacks Active sessions and Messages sections")
     updated = pattern.sub(lambda match: match.group(1) + "\n" + block + "\n\n", text)
@@ -2290,30 +2301,31 @@ def parser() -> argparse.ArgumentParser:
     return result
 
 
+COMMANDS = {
+    "status": command_status,
+    "check-staged": command_check_staged,
+    "claim": command_claim,
+    "heartbeat": command_heartbeat,
+    "release": command_release,
+    "message": command_message,
+    "resolve": command_resolve,
+    "migrate": command_migrate,
+    "lease-disable": command_lease_disable,
+    "stale": command_stale,
+}
+
+
 def main() -> int:
     args = parser().parse_args()
     args.board = args.board.expanduser()
-    if args.command == "status":
-        return command_status(args)
-    if args.command == "check-staged":
-        return command_check_staged(args)
-    if args.command == "claim":
-        return command_claim(args)
-    if args.command == "heartbeat":
-        return command_heartbeat(args)
-    if args.command == "release":
-        return command_release(args)
-    if args.command == "message":
-        return command_message(args)
-    if args.command == "resolve":
-        return command_resolve(args)
-    if args.command == "migrate":
-        return command_migrate(args)
-    if args.command == "lease-disable":
-        return command_lease_disable(args)
-    if args.command == "stale":
-        return command_stale(args)
-    return command_doctor(args)
+    command = COMMANDS.get(args.command, command_doctor)
+    try:
+        return command(args)
+    except ValueError as exc:
+        # A refusal is a diagnosis, not a crash: one line the operator can act
+        # on, never a traceback whose last line gets quoted as the problem.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/skills/synthesis-project-management/scripts/coordination_schema.py
+++ b/skills/synthesis-project-management/scripts/coordination_schema.py
@@ -303,6 +303,80 @@ def validate_identity(identity: SessionIdentity) -> list[str]:
     return issues
 
 
+_VERSION_DIR = re.compile(r"^\d+(?:\.\d+)+$")
+
+
+def _version_key(name: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in name.split("."))
+
+
+def engine_remedy(script_path: Path | str) -> str:
+    """Name the engine a stale script should hand off to.
+
+    A board written by a newer plugin than the one a session runs is the one
+    parse failure no change to the running engine can repair; the remedy is
+    always to invoke the current engine. When the running script lives in a
+    versioned plugin cache (``<plugin>/<version>/skills/...``) the newest
+    sibling version's copy of the same script is named outright — compared
+    numerically, so 4.78.0 outranks 4.9.0 — otherwise the caller is told to
+    refresh the installed plugin.
+    """
+    script = Path(script_path).resolve()
+    version_dir = next(
+        (
+            parent
+            for parent in script.parents
+            if _VERSION_DIR.match(parent.name) and (parent / "skills").is_dir()
+        ),
+        None,
+    )
+    if version_dir is None:
+        return (
+            f"this engine ({script}) is not from a versioned plugin cache; "
+            "update it to the current plugin release and rerun"
+        )
+    relative = script.relative_to(version_dir)
+    siblings = [
+        candidate
+        for candidate in version_dir.parent.iterdir()
+        if _VERSION_DIR.match(candidate.name) and (candidate / relative).is_file()
+    ]
+    newest = max(siblings, key=lambda candidate: _version_key(candidate.name))
+    if _version_key(newest.name) > _version_key(version_dir.name):
+        return (
+            f"this engine is {version_dir.name} but {newest.name} is installed; "
+            f"run {newest / relative}"
+        )
+    return (
+        f"this engine ({version_dir.name}) is the newest installed; refresh the "
+        "plugin (release.py --install-only, or the client's plugin update) "
+        "and rerun"
+    )
+
+
+def column_count_error(cells: list[str], script_path: Path | str) -> ValueError:
+    """The row-width failure, diagnosed instead of merely reported.
+
+    A row wider than the newest column set this engine knows can only have
+    been written by a newer engine, so the message names the engine to run;
+    a narrower unknown width is a malformed row and says so.
+    """
+    head = (
+        f"active-session row has {len(cells)} columns; expected "
+        f"{len(V4_COLUMNS)}, {len(V3_COLUMNS)}, {len(V2_COLUMNS)}, or "
+        f"{len(V1_COLUMNS)}"
+    )
+    if len(cells) > len(V4_COLUMNS):
+        return ValueError(
+            f"{head}. A wider row than this engine knows means the board was "
+            f"written by a newer engine: {engine_remedy(script_path)}"
+        )
+    return ValueError(
+        f"{head}. A narrower unknown width is a malformed row (hand edit?): "
+        "repair it or restore the board from its lease remote"
+    )
+
+
 def parse_table_rows(text: str) -> list[dict[str, str]]:
     """Parse v1-v3 active-session rows without mutating legacy boards."""
     result: list[dict[str, str]] = []
@@ -330,10 +404,8 @@ def parse_table_rows(text: str) -> list[dict[str, str]]:
         elif len(cells) == len(V1_COLUMNS):
             result.append(dict(zip(V1_COLUMNS, cells)))
         else:
-            raise ValueError(
-                f"active-session row has {len(cells)} columns; expected "
-                f"{len(V4_COLUMNS)}, {len(V3_COLUMNS)}, {len(V2_COLUMNS)}, "
-                f"or {len(V1_COLUMNS)}"
+            raise column_count_error(
+                cells, Path(__file__).with_name("coordination.py")
             )
     return result
 

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -4,6 +4,7 @@ import importlib.util
 import ast
 import json
 import platform
+import re
 import subprocess
 import sys
 import threading
@@ -1821,3 +1822,130 @@ def test_skill_document_stays_within_repo_budget() -> None:
         if reference.name == "session-words-v1.LICENSE.md":
             continue
         assert reference.name in skill, f"unlinked reference: {reference.name}"
+
+
+# --- engine/board version skew and section hygiene (4.78.0) ------------------
+
+
+def _claimed_board(tmp_path, *, schema=None, padding=0):
+    board = tmp_path / "board.md"
+    assert (
+        MODULE.command_claim(
+            seatless_claim(board, "project-a", "/tmp/wt-a @ feature/a", "repo-a/**")
+        )
+        == 0
+    )
+    text = board.read_text(encoding="utf-8")
+    if schema is not None:
+        text = re.sub(r"(?m)^Schema: v\d+$", f"Schema: v{schema}", text, count=1)
+    if padding:
+        text = text.replace(
+            "## Active sessions\n", "## Active sessions\n" + "\n" * padding, 1
+        )
+    board.write_text(text, encoding="utf-8")
+    return board
+
+
+def test_rows_refuses_a_board_newer_than_the_engine(tmp_path, capsys):
+    """The 2026-09-01 incident inverted: a stale engine must diagnose itself
+    instead of reporting the shared board as corrupt, and must never rewrite
+    a board written by a newer engine."""
+    newer = MODULE.SCHEMA_VERSION + 1
+    board = _claimed_board(tmp_path, schema=newer)
+    text = board.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError) as caught:
+        MODULE.rows(text)
+    message = str(caught.value)
+    assert f"schema v{newer}" in message
+    assert f"newer than this engine's v{MODULE.SCHEMA_VERSION}" in message
+    assert "coordination.py" in message  # the remedy names an engine path
+
+    assert MODULE.command_doctor(args(board)) == 1
+    assert "newer than this engine" in capsys.readouterr().err
+    assert board.read_text(encoding="utf-8") == text  # untouched
+
+
+def test_wider_rows_than_the_engine_knows_name_the_newer_engine(tmp_path):
+    board = _claimed_board(tmp_path)
+    text = board.read_text(encoding="utf-8")
+    row_uuid = MODULE.rows(text)[0].session_uuid
+    lines = text.splitlines()
+    index = next(i for i, line in enumerate(lines) if row_uuid in line)
+    lines[index] = lines[index] + " future-column |"
+
+    with pytest.raises(ValueError) as caught:
+        MODULE.rows("\n".join(lines))
+    message = str(caught.value)
+    assert f"{len(MODULE.V4_COLUMNS) + 1} columns" in message
+    assert "written by a newer engine" in message
+
+    lines[index] = "| " + " | ".join(["x"] * (len(MODULE.V1_COLUMNS) + 1)) + " |"
+    with pytest.raises(ValueError) as narrower:
+        MODULE.rows("\n".join(lines))
+    assert "malformed row" in str(narrower.value)
+
+
+def test_replace_table_collapses_padding_and_stays_fixed(tmp_path):
+    """Every rewrite used to grow the blank run under the heading by one line;
+    a rewrite now emits a fixed-shape section and is idempotent."""
+    board = _claimed_board(tmp_path, padding=500)
+    text = board.read_text(encoding="utf-8")
+
+    once = MODULE.replace_table(text, MODULE.rows(text))
+    section = once.split("## Active sessions\n", 1)[1].split("## Messages", 1)[0]
+    assert section.startswith("\n| session uuid |")
+    assert section.endswith("|\n\n")
+    assert len(once.splitlines()) == len(text.splitlines()) - 500
+
+    twice = MODULE.replace_table(once, MODULE.rows(once))
+    assert twice == once
+
+
+def test_engine_remedy_names_the_newest_cached_engine(tmp_path):
+    cache = tmp_path / "plugins" / "synthesis-skills"
+    relative = Path("skills") / "synthesis-project-management" / "scripts" / "coordination.py"
+    for version in ("4.74.1", "4.78.0", "4.9.0"):
+        script = cache / version / relative
+        script.parent.mkdir(parents=True)
+        script.write_text("#\n", encoding="utf-8")
+
+    stale = MODULE.engine_remedy(cache / "4.74.1" / relative)
+    assert str(cache / "4.78.0" / relative) in stale
+    assert "4.9.0" not in stale  # numeric ordering, not lexical
+
+    newest = MODULE.engine_remedy(cache / "4.78.0" / relative)
+    assert "newest installed" in newest and "refresh the plugin" in newest
+
+    outside = MODULE.engine_remedy(tmp_path / "src" / "coordination.py")
+    assert "not from a versioned plugin cache" in outside
+
+
+def test_version_skew_documented_on_public_surfaces():
+    skill_root = MODULE_PATH.parents[1]
+    repo_root = MODULE_PATH.parents[3]
+    identity = (skill_root / "references" / "session-identity.md").read_text(
+        encoding="utf-8"
+    )
+    assert "## Engine older than board" in identity
+    assert "than the running engine" in identity
+    template = (skill_root / "references" / "active-sessions-template.md").read_text(
+        encoding="utf-8"
+    )
+    assert "Schema: v4" in template
+    assert "| client session ref |" in template
+    changelog = (repo_root / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "## [4.78.0]" in changelog
+    assert "names the engine to run" in changelog
+
+
+def test_cli_presents_a_refusal_as_one_error_line(tmp_path):
+    board = _claimed_board(tmp_path, schema=MODULE.SCHEMA_VERSION + 1)
+    done = subprocess.run(
+        [sys.executable, str(MODULE_PATH), "--board", str(board), "status"],
+        capture_output=True, text=True, check=False,
+    )
+    assert done.returncode == 1
+    assert done.stderr.startswith("error: board declares schema v")
+    assert "Traceback" not in done.stderr
+


### PR DESCRIPTION
## Summary

- **Version-skew diagnosis.** `rows()` refuses a board whose declared `Schema:` is newer than the engine, and a row wider than the engine's newest column set is refused the same way; both messages name the newest installed engine to run (resolved numerically from the plugin cache the script lives in) or the plugin refresh when none is newer. `doctor` reports the same line, and the CLI presents these refusals as one `error:` line instead of a traceback. Origin: after the 4.75.0 schema migration, a session on an older cache read the shared board and reported the board itself as corrupt.
- **Padding leak.** The Active-sessions section pattern swallowed existing blank lines into the heading group and re-emitted them plus one, so every rewrite grew the board by a line (over a thousand on a long-lived board, which is what read as a "second table"). Rewrites now emit a fixed-shape section and are idempotent; the next mutation collapses the accumulated padding.
- Board-template reference shows the v4 header; project-management skill 2.10.0; release surfaces at 4.78.0 with a fresh transaction-bound acceptance manifest.

## Verification

- `pytest skills/synthesis-project-management/scripts/` — 111 passed (six new tests: newer-board refusal incl. doctor line and untouched file, wider-row diagnosis, padding collapse + idempotence, remedy resolution with numeric ordering, CLI error line, public-surface doc contract)
- Full AGENTS.md verification list green locally; conformance source 204/204, instructions PASS
- Live controls on a copy of the real board: `Schema: v5` → refused with the remedy; one `replace_table` rewrite collapses 3,579 lines to 2,470, idempotent, 228 rows preserved
- Release train held by the authoring session; acceptance receipt consumed after commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
