### PR TITLE
Sync watermarks carry a time and a target; a run proves its own coverage (4.79.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.78.0",
+  "version": "4.79.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.78.0",
+  "version": "4.79.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.79.0] - 2026-09-01
+
+**Sync watermarks now carry a time and a target, and a run proves its own
+coverage.** The v2.27.0 watermarks were day-granular, and a day cannot see
+the hours: on one day-start a Slack surface written at 09:15 counted as
+current for the rest of the day, the mid-day passes re-read only the targets
+the morning had skipped, and at 17:51 the agent reported a question still
+unanswered on the strength of the 09:15 read while the answer had gone out
+at 09:27. A first pass that morning had also hand-typed an `oldest` of 07:50
+*today* and reported five channels empty that were not.
+
+`sync_watermark.py` (synthesis-daily-rituals 2.30.0) now records ISO-8601
+moments — the last moment actually written, never the last attempted — and
+one watermark per declared read target within a surface; `begin` stamps a
+run and `status --since run` exits non-zero naming every declared surface
+or target this run did not re-read (with `--max-age` as the alternative
+bound, `--targets-from` for the declared target set, and per-target
+deferrals); `window` prints human-readable bounds beside the epoch `oldest`
+a read call takes, so a window parameter is computed and echoed rather than
+typed; a bare date means complete through the END of that day and is
+refused for today until the day is over. Schema-1 stores are read as what
+they meant and rewritten on the next write. synthesis-slack-sync 3.8.0
+takes every `oldest` from `window`, records every saved read with
+`advance --target`, re-reads every declared target every sync, and treats
+the user's own outbound as first-class sweep state: owed items it
+discharged are marked, and "unanswered" or "unsent" is never claimed on a
+read older than the current run. Thirty-seven tests pin the mechanism and
+the documented rules; contract and rationale live in the new
+`references/sync-watermarks.md`.
+
 ## [4.78.0] - 2026-09-01
 
 **A coordination engine older than the board it reads now says so, and

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A sync now proves what it re-read, to the minute (September 2026).**
+Release **4.79.0** replaces day-granular sync watermarks with timestamps
+per surface and per declared read target: `begin` stamps a run,
+`status --since run` names every target the run skipped, `window` prints
+the epoch bound a read call takes beside human-readable time, and the Slack
+protocol treats the user's own outbound as sweep state. See the [4.79.0
+release notes](CHANGELOG.md).
+
 **A stale engine now diagnoses itself instead of blaming the board
 (September 2026).** Release **4.78.0** makes the coordination engine refuse
 a board newer than itself with a message naming the engine to run, reports

--- a/skills/synthesis-daily-rituals/SKILL.md
+++ b/skills/synthesis-daily-rituals/SKILL.md
@@ -10,7 +10,7 @@ depends_on:
   - synthesis-checkpoint
 metadata:
   author: "Rajiv Pant"
-  version: "2.29.0"
+  version: "2.30.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -18,6 +18,23 @@ metadata:
 # Daily Rituals — Global Checklists
 
 Standard day-start and day-end rituals for synthesis engineering projects. These are the global (per-person) checklists. Each project may have a project-specific supplement that extends these with channel-specific sync, repo-specific checks, and stakeholder-specific communications.
+
+## v2.30.0 — Watermarks carry a time and a target, and a run proves its own coverage
+
+v2.30.0 (2026-09-01) fixes what a day-granular watermark could not see: a
+surface written at 09:15 counted as current for the rest of the day, so a
+mid-day pass that re-read only what the morning had skipped let the
+morning's own reads go stale — and an "unanswered" claim at 17:51 rested on
+a 09:15 read while the answer had gone out at 09:27. Four defects, one
+mechanism: watermarks are ISO-8601 timestamps (the last moment actually WRITTEN,
+never the last attempted); a surface carries one watermark per
+declared read target; `begin` stamps a run and
+`status --since run` exits non-zero on every declared surface or target not
+re-read during THIS run; and `window` echoes human-readable bounds beside
+the epoch `oldest` a read call takes — a window parameter is a claim about
+time and is computed, not typed. Every sync re-reads every declared target:
+"already read today" is a statement about the past. Contract, store, and
+rationale: [references/sync-watermarks.md](references/sync-watermarks.md).
 
 ## v2.27.0 — Sync windows follow the last write, and a recorded gap blocks
 
@@ -583,14 +600,19 @@ The set of remotes for each repo comes from `git remote -v` inside that repo. Th
 - [ ] **Email sync (v2.19.0)** — when the workspace routinely syncs email (established `transcripts/email/` practice or explicit config): sweep the window's inbound mail AND the user's own sent mail (sent items are correspondence records too — the user's outbound exec mail is often the day's most consequential artifact), using the workspace's designated email tooling and account. Save to the workspace convention (e.g., `transcripts/email/YYYY-MM-DD-<slug>.md`).
 - [ ] **Document-comment sync (v2.19.0)** — when the workspace has an established docs-sweep practice (`transcripts/docs/` or explicit config): Drive documents modified in the window, open comment threads where the newest reply is not the user's (ball in their court), and engagement on documents the user shared out.
 - [ ] **Name any surface not swept.** The declared surface set is the complete decision (v2.12.1 applied to channels); a sync that skips one must say so in its report rather than reporting as complete.
-- [ ] **Watermark gate (v2.28.0):** after the sweeps, run
-  `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s>` with
-  **every declared surface passed explicitly** — the store only knows surfaces
-  that have already been written, so a status that consults only the store
-  walks straight past a declared surface that has never been swept (the
-  command refuses an empty surface set for exactly that reason). Non-zero exit
-  means an unclosed gap: close it this run or defer it with an explicit
-  reason before the ritual proceeds.
+- [ ] **Watermark gate (v2.30.0):** the sweep opened with
+  `python3 <skill-root>/scripts/sync_watermark.py begin --workspace <W> --label day-start`,
+  every read target's `oldest` came from `sync_watermark.py window`, and every
+  saved read was recorded with `sync_watermark.py advance` (per target for
+  Slack and Chat). Now run
+  `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s> --since run`
+  with **every declared surface passed explicitly** and the declared read
+  targets via `--targets-from` — the store only knows what has already been
+  written, so a status that consults only the store walks straight past a
+  declared surface never swept (the command refuses an empty surface set for
+  exactly that reason). Non-zero exit names each surface or target this run
+  did not re-read: read it now or defer it with an explicit reason before the
+  ritual proceeds.
 - [ ] Run any project-specific sync steps (see project supplement).
 
 #### 3c. Meeting Transcripts
@@ -988,6 +1010,8 @@ The day-start checklist does a full sync. The user will ask for syncs repeatedly
 
 The key discipline encoded in that skill: **every sync must re-read ALL threads with replies from today**, not just fetch new channel-level messages. Thread replies don't appear as channel messages — skipping thread re-reads causes stale action plans and duplicate message sends.
 
+**Every sync re-reads every declared target (v2.30.0).** A DM or channel read at day-start is not current at mid-day: "already read today" is a statement about the past, not about now, and a twelve-minute-old reply is the normal case for a DM. Open each sync with `python3 <skill-root>/scripts/sync_watermark.py begin --workspace <W> --label mid-day`, take each target's `oldest` from `sync_watermark.py window --target <resolved id>`, record each saved read with `sync_watermark.py advance --target <resolved id>`, and close with `sync_watermark.py status --workspace <W> --surface <s> --since run --targets-from <declared.json>` — its BLOCKING list is exactly the set this sync skipped, and the sync is not complete while it is non-empty. The user's own outbound is first-class sweep state: list every owed item their messages discharged since the window opened, and never call anything "unanswered" or "unsent" on a read older than this run. Origin (2026-09-01): two mid-day syncs covered group DMs and channels only; a DM answered at 09:27 was reported unanswered at 17:51 on the strength of a 09:15 read.
+
 **Record after every sync.** Any sync that creates or updates transcripts, daily plans, or context files must leave session-attributed local state. Day-start and mid-day sync do not push merely to make same-machine client switching work; day-end and explicit remote handoff publish the batch.
 
 ---
@@ -1062,11 +1086,14 @@ The Weekly Loose-Ends Review (Step 10) attaches to whichever ritual runs first o
 - [ ] **Run `/synthesis-slack-sync`** for final capture of the day. The `synthesis-slack-sync` skill ensures all channels, threads, and DMs are captured.
 - [ ] **Google Chat final capture (v2.17.0)** — if the workspace declares `.agents/gchat-sync.yaml`, run the same Chat sweep as Day-Start Step 3b for the day's window (fresh space enumeration; raw sender IDs preserved).
 - [ ] **Email + document-comment final capture (v2.19.0)** — when the workspace syncs those surfaces (per Day-Start 3b's declared-set rule): the day's inbound and sent mail, meeting transcripts for any meeting that ended since the last sync, and document comments/engagement for the day's window. Name any surface not swept.
-- [ ] **Watermark gate (v2.28.0):** run
-  `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s>` with
-  every declared surface passed explicitly (same rule and same reason as
-  Day-Start Step 3b's gate). The day does not close over a blocking gap:
-  close it or defer it with a reason now.
+- [ ] **Watermark gate (v2.30.0):** the final capture opened with
+  `sync_watermark.py begin --workspace <W> --label day-end` and recorded each
+  saved read with `advance`; now run
+  `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s> --since run`
+  with every declared surface and read target passed explicitly (same rule
+  and same reason as Day-Start Step 3b's gate). The day does not close over a
+  surface or target this run did not re-read: read it or defer it with a
+  reason now.
 - [ ] Update CONTEXT.md to mark any items resolved by day's conversations (so tomorrow's day-start does not re-propose them).
 
 ### 2. Source-Code Sync

--- a/skills/synthesis-daily-rituals/references/sync-watermarks.md
+++ b/skills/synthesis-daily-rituals/references/sync-watermarks.md
@@ -1,0 +1,102 @@
+# Sync watermarks — contract and rationale
+
+`scripts/sync_watermark.py` keeps, per workspace, the last MOMENT each sync
+surface — and each declared read target within a surface — was actually
+written to the local mirror. Every sync computes its window from that
+record, and a run proves its own coverage before the ritual proceeds.
+
+## Why a moment and not a day (v2.30.0, 2026-09-01)
+
+v2.27.0 introduced per-surface watermarks so a skipped run's hole would be
+revisited automatically. They were day-granular, and a day cannot see the
+hours. On one day-start a Slack surface was written at 09:15 and counted as
+current for the rest of the day; the mid-day passes re-read only the targets
+the morning had skipped, on the assumption that a DM read once was still
+current; and at 17:51 the agent told the principal a question was still
+unanswered, citing the 09:15 read, when the answer had gone out at 09:27.
+Four defects were filed from that day and one mechanism closes them:
+
+1. **Day-granular watermarks** → watermarks are ISO-8601 timestamps with
+   offset, and `status` judges freshness against an explicit bound.
+2. **Mid-day passes not re-reading what the morning read** → a surface
+   carries one watermark per declared read target, and `status --since run`
+   lists every target this run did not re-read.
+3. **The principal's own outbound unmonitored** → the sweep's contract
+   (synthesis-slack-sync Step 5) treats the user's own messages as first-class
+   sweep state, and an "unanswered" or "unsent" claim must rest on a read
+   inside the current run — which the same gate proves.
+4. **Window parameters unverified** → `window` computes the epoch `oldest`
+   a read call takes and prints it beside human-readable bounds. A first pass
+   that morning had used an `oldest` of 07:50 *today* and reported five
+   channels empty that were not. A window parameter is a claim about time,
+   and it is computed, not typed.
+
+## The verbs
+
+```bash
+python3 <skill-root>/scripts/sync_watermark.py begin   --workspace <W> --label day-start
+python3 <skill-root>/scripts/sync_watermark.py window  --workspace <W> --surface slack --target <resolved id>
+python3 <skill-root>/scripts/sync_watermark.py advance --workspace <W> --surface slack --target <resolved id> --through <latest>
+python3 <skill-root>/scripts/sync_watermark.py defer   --workspace <W> --surface slack --target <resolved id> --reason "<why>"
+python3 <skill-root>/scripts/sync_watermark.py status  --workspace <W> --surface <s> ... --targets-from <declared.json> --since run
+```
+
+- **`begin`** stamps the run. Everything the run must re-read is judged
+  against this moment.
+- **`window`** prints `<surface>: <from> → <to> (<span>)` and
+  `oldest=<epoch> latest=<epoch>`. The `oldest` is what the read call takes;
+  copy it, never derive it. With `--target`, the window follows that target's
+  own watermark, falling back to the surface's and saying so. A bootstrap
+  window (nothing written yet) says to read to the workspace's backfill bound
+  and to state that bound.
+- **`advance`** records a successful write and moves only forward, never into
+  the future. `--through` is the read's `latest` — an ISO timestamp, `now`,
+  or a bare `YYYY-MM-DD`, which means complete through the **END of that day**
+  and is therefore refused for today until the day is over: a mid-day run
+  records the moment it read, not the date. With `--target` (repeatable)
+  each target's own watermark advances; without it the surface's does.
+- **`defer`** records a gap that genuinely cannot close this run, with a
+  reason, for one day. A stale deferral is re-surfaced as blocking.
+- **`status`** takes the declared set — every surface with `--surface`, every
+  read target with `--target surface:id` or `--targets-from` (a JSON object
+  `{"slack": ["C…", "D…"]}` or a list of `"surface:id"`) — and one freshness
+  bound: `--since run`, `--since <timestamp>`, or `--max-age <duration>`.
+  It exits non-zero while any declared surface or target is missing or older
+  than the bound and not deferred, and names the keys. The store only knows
+  what has been written, so a status without the declared set is refused.
+
+## Store
+
+`~/.synthesis/sync-watermarks/<workspace>.json`, schema 2:
+
+```json
+{
+  "schema": 2,
+  "run": {"started_at": "2026-09-01T11:39:02-04:00", "label": "mid-day"},
+  "surfaces": {
+    "slack": {
+      "through": "2026-09-01T09:15:00-04:00",
+      "updated_at": "2026-09-01T09:15:40-04:00",
+      "targets": {"C0123": {"through": "2026-09-01T11:45:12-04:00", "updated_at": "…"}}
+    }
+  },
+  "deferrals": {"slack:D0456": {"reason": "member left", "deferred_at": "…"}}
+}
+```
+
+A schema-1 store (bare dates) is read as what it meant — complete through
+the end of that day, capped by the moment the entry was written and never a
+moment in the future — and rewritten as schema 2 on the next write.
+
+## Where the ritual calls it
+
+- Day-Start Step 3b and Day-End Step 1 open with `begin`, take every read
+  window from `window`, record every saved read with `advance`, and close
+  with `status … --since run`.
+- The Mid-Day Sync Protocol does the same on every sync request: every
+  declared target is re-read every sync. "Already read today" is a statement
+  about the past, not about now.
+- `synthesis-slack-sync` Steps 1, 3, 3b take `oldest` from `window`; Step 4
+  records each saved read with `advance`; Step 5 cross-references the user's
+  own outbound against owed items and forbids "unanswered" on a read older
+  than the run.

--- a/skills/synthesis-daily-rituals/scripts/sync_watermark.py
+++ b/skills/synthesis-daily-rituals/scripts/sync_watermark.py
@@ -1,30 +1,40 @@
 #!/usr/bin/env python3
-"""Per-surface sync watermarks: the last date actually WRITTEN, not last run.
+"""Per-surface, per-target sync watermarks: the last MOMENT actually written.
 
 A sync window anchored on when the previous run executed cannot see its own
-holes. Skip a run and the hole is never revisited, because the next window
-starts at now-minus-a-bit rather than at the last day on disk. Nothing persists
-"the mirror is complete through date X", so no run can detect what it missed.
+holes, and a watermark that only knows the DAY cannot see the hours: a
+surface written at 09:15 counted as current for the rest of the day, so a
+mid-day pass that re-read only what the morning had skipped let the morning's
+own reads go stale while the agent kept speaking from them. The repair is
+structural rather than diligent:
 
-A watermark fixes that by construction rather than by diligence:
+* a watermark is an ISO-8601 timestamp — the last moment actually WRITTEN,
+  never the last attempted — so a window starts exactly where the mirror
+  stops, and `window` prints the bounds a human can check beside the epoch
+  `oldest` a read call takes (a window parameter is a claim about time and
+  is computed here, not typed);
+* a surface may carry one watermark per declared read target (a Slack
+  channel, a DM), so "20 of 60 targets read" is a list of forty keys and not
+  a sentence in a report;
+* `begin` stamps a run, and `status --since run` blocks on every declared
+  surface or target that this run did not re-read — "already read today" is
+  a statement about the past, and the gate says so mechanically;
+* the watermark advances only after a successful write, so a run that
+  fetches nothing, errors, or is interrupted cannot declare coverage;
+* a gap that genuinely cannot close is deferred WITH A REASON for one day,
+  and a stale deferral is re-surfaced rather than silently honored.
 
-* the window is computed from the watermark, so a hole is revisited
-  automatically on the next run — no one has to notice it;
-* the watermark advances only on a successful WRITE, so a run that fetches
-  nothing, errors, or is interrupted cannot silently declare the day covered;
-* `status` exits non-zero while any surface has an unclosed, undeferred gap,
-  which is what makes a recorded gap load-bearing instead of prose. A gap that
-  genuinely cannot close this run must be deferred WITH A REASON, and the
-  deferral is itself dated and re-surfaced.
+    sync_watermark.py begin    --workspace W [--label L]
+    sync_watermark.py window   --workspace W --surface S [--target T]
+    sync_watermark.py advance  --workspace W --surface S --through TS [--target T ...]
+    sync_watermark.py defer    --workspace W --surface S [--target T] --reason TEXT
+    sync_watermark.py status   --workspace W --surface S ... [--target S:T ...]
+                               [--targets-from FILE] [--since TS|run] [--max-age 4h]
 
-That last point is the whole design. Detection that nothing consumes changes
-nothing: three consecutive artifacts recorded the same gap in prose and no run
-ever read those lines back.
-
-    sync_watermark.py window   --workspace W --surface S
-    sync_watermark.py advance  --workspace W --surface S --through YYYY-MM-DD
-    sync_watermark.py defer    --workspace W --surface S --reason TEXT
-    sync_watermark.py status   --workspace W [--json]
+TS is an ISO-8601 timestamp (naive means local time), the word `now`, or a
+bare YYYY-MM-DD meaning complete through the END of that day — which is
+refused when that end lies in the future, so a mid-day run cannot stamp
+"today" and must record the moment it actually read.
 """
 
 from __future__ import annotations
@@ -32,14 +42,102 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from datetime import date, datetime, timedelta
 from pathlib import Path
 
 STORE_DIRNAME = "sync-watermarks"
+STORE_SCHEMA = 2
 # A deferral silences a gap for one working day, never indefinitely: an
 # indefinite silence is how a gap becomes furniture.
 DEFERRAL_MAX_AGE = timedelta(days=1)
+_DURATION_PART = re.compile(r"(\d+)\s*([dhm])")
+_DURATION_UNITS = {
+    "d": timedelta(days=1),
+    "h": timedelta(hours=1),
+    "m": timedelta(minutes=1),
+}
+
+
+# --- time -------------------------------------------------------------------
+
+
+def now_local() -> datetime:
+    return datetime.now().astimezone().replace(microsecond=0)
+
+
+def _localize(moment: datetime, reference: datetime) -> datetime:
+    if moment.tzinfo is None:
+        return moment.replace(tzinfo=reference.tzinfo)
+    return moment
+
+
+def parse_moment(text: str, now: datetime) -> datetime:
+    """`now`, an ISO-8601 timestamp (naive = local), or a date = END of that day."""
+    raw = str(text).strip()
+    if raw.lower() == "now":
+        return now
+    if len(raw) == 10:
+        try:
+            day = date.fromisoformat(raw)
+        except ValueError:
+            day = None
+        if day is not None:
+            end = datetime.combine(day + timedelta(days=1), datetime.min.time())
+            return _localize(end, now)
+    try:
+        moment = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"not a timestamp: {text!r} (use ISO-8601, YYYY-MM-DD, or 'now')"
+        ) from exc
+    return _localize(moment, now).replace(microsecond=0)
+
+
+def parse_duration(text: str) -> timedelta:
+    compact = re.sub(r"\s+", "", str(text).strip().lower())
+    parts = _DURATION_PART.findall(compact)
+    if not parts or "".join(f"{n}{u}" for n, u in parts) != compact:
+        raise ValueError(f"not a duration: {text!r} (use forms like 90m, 4h, 1d12h)")
+    return sum((int(n) * _DURATION_UNITS[u] for n, u in parts), timedelta())
+
+
+def stamp(moment: datetime) -> str:
+    return moment.isoformat(timespec="seconds")
+
+
+def human(moment: datetime) -> str:
+    # Stored offsets parse as fixed-offset zones whose %Z reads "UTC-04:00";
+    # render in the machine's local zone so the label is the familiar one.
+    return moment.astimezone().strftime("%a %Y-%m-%d %H:%M %Z")
+
+
+def span(delta: timedelta) -> str:
+    total = int(delta.total_seconds())
+    sign = "-" if total < 0 else ""
+    total = abs(total)
+    days, rest = divmod(total, 86400)
+    hours, rest = divmod(rest, 3600)
+    minutes = rest // 60
+    parts = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes or not parts:
+        parts.append(f"{minutes}m")
+    return sign + " ".join(parts)
+
+
+def _stored(value) -> datetime | None:
+    try:
+        return datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+# --- store --------------------------------------------------------------------
 
 
 def store_path(workspace: str, home: Path | None = None) -> Path:
@@ -50,17 +148,50 @@ def store_path(workspace: str, home: Path | None = None) -> Path:
     return root / STORE_DIRNAME / f"{safe}.json"
 
 
-def load(workspace: str, home: Path | None = None) -> dict:
+def _fresh() -> dict:
+    return {"schema": STORE_SCHEMA, "run": None, "surfaces": {}, "deferrals": {}}
+
+
+def _migrate(data: dict, reference: datetime) -> dict:
+    """Read a schema-1 store as what it meant: a bare date is complete through
+    the END of that day, and a deferral dated to a day started at its midnight."""
+    data.setdefault("surfaces", {})
+    data.setdefault("deferrals", {})
+    data.setdefault("run", None)
+    for entry in data["surfaces"].values():
+        entry.setdefault("targets", {})
+        through = entry.get("through")
+        if isinstance(through, str) and len(through) == 10:
+            # A schema-1 date meant "that day is written" and was recorded
+            # when the write happened. A mirror cannot be complete past the
+            # moment it was written, so the earlier of end-of-day and the
+            # recorded write time is the honest watermark — and never a
+            # moment in the future, which a mid-day "through today" would be.
+            end_of_day = parse_moment(through, reference)
+            written = _stored(entry.get("updated_at"))
+            candidates = [end_of_day, reference]
+            if written is not None:
+                candidates.append(_localize(written, reference))
+            entry["through"] = stamp(min(candidates))
+            entry["migrated_from"] = through
+    for deferral in data["deferrals"].values():
+        if "deferred_at" not in deferral and deferral.get("deferred_on"):
+            day = date.fromisoformat(str(deferral["deferred_on"]))
+            midnight = datetime.combine(day, datetime.min.time())
+            deferral["deferred_at"] = stamp(_localize(midnight, reference))
+    data["schema"] = STORE_SCHEMA
+    return data
+
+
+def load(workspace: str, home: Path | None = None, reference: datetime | None = None) -> dict:
     path = store_path(workspace, home)
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return {"surfaces": {}, "deferrals": {}}
+        return _fresh()
     if not isinstance(data, dict):
-        return {"surfaces": {}, "deferrals": {}}
-    data.setdefault("surfaces", {})
-    data.setdefault("deferrals", {})
-    return data
+        return _fresh()
+    return _migrate(data, reference or now_local())
 
 
 def save(workspace: str, data: dict, home: Path | None = None) -> None:
@@ -71,167 +202,362 @@ def save(workspace: str, data: dict, home: Path | None = None) -> None:
     tmp.replace(path)
 
 
-def _as_date(text: str) -> date | None:
-    try:
-        return date.fromisoformat(str(text)[:10])
-    except (TypeError, ValueError):
-        return None
+def _entry(data: dict, surface: str, target: str | None = None) -> dict:
+    surface_entry = data["surfaces"].get(surface) or {}
+    if target is None:
+        return surface_entry
+    return (surface_entry.get("targets") or {}).get(target) or {}
+
+
+def _through(data: dict, surface: str, target: str | None = None) -> datetime | None:
+    return _stored(_entry(data, surface, target).get("through"))
+
+
+def _key(surface: str, target: str | None = None) -> str:
+    return surface if target is None else f"{surface}:{target}"
+
+
+# --- verbs ----------------------------------------------------------------------
+
+
+def begin(
+    workspace: str, label: str = "", now: datetime | None = None, home: Path | None = None
+) -> dict:
+    """Stamp the run so `status --since run` can ask what THIS run re-read."""
+    moment = now or now_local()
+    data = load(workspace, home, moment)
+    data["run"] = {"started_at": stamp(moment), "label": label.strip()}
+    save(workspace, data, home)
+    return {"workspace": workspace, "started_at": stamp(moment), "label": label.strip(),
+            "human": human(moment)}
 
 
 def window(
-    workspace: str, surface: str, today: date | None = None, home: Path | None = None
+    workspace: str,
+    surface: str,
+    target: str | None = None,
+    now: datetime | None = None,
+    home: Path | None = None,
 ) -> dict:
-    """The range this run must cover for one surface."""
-    moment = today or date.today()
-    data = load(workspace, home)
-    entry = data["surfaces"].get(surface) or {}
-    through = _as_date(entry.get("through", ""))
-    if through is None:
-        return {
-            "surface": surface,
-            "bootstrap": True,
-            "from": None,
-            "to": moment.isoformat(),
-            "gap_days": None,
-            "detail": "no watermark yet — this surface has never recorded a "
-                      "successful write, so the window cannot be narrowed",
-        }
-    start = through + timedelta(days=1)
-    return {
+    """The range this run must cover for one surface or one read target."""
+    moment = now or now_local()
+    data = load(workspace, home, moment)
+    label = surface if target is None else f"{surface} (target {target})"
+    source = "surface" if target is None else "target"
+    through = _through(data, surface, target)
+    if target is not None and through is None and _through(data, surface) is not None:
+        through = _through(data, surface)
+        source = "surface watermark (this target has never been read on its own)"
+    result = {
         "surface": surface,
-        "bootstrap": False,
-        "from": start.isoformat(),
-        "to": moment.isoformat(),
-        "gap_days": max((moment - through).days - 1, 0),
-        "detail": f"mirror complete through {through.isoformat()}",
+        "target": target,
+        "to": stamp(moment),
+        "to_epoch": int(moment.timestamp()),
     }
+    if through is None:
+        result.update(
+            bootstrap=True, source=None, **{"from": None}, from_epoch=None,
+            span=None, age=None,
+            human=(f"{label}: no watermark yet → read to the workspace's backfill "
+                   f"bound and state that bound; latest {human(moment)}"),
+            detail=("no watermark yet — this surface has never recorded a "
+                    "successful write, so the window cannot be narrowed"),
+        )
+        return result
+    elapsed = moment - through
+    result.update(
+        bootstrap=False, source=source, **{"from": stamp(through)},
+        from_epoch=int(through.timestamp()), span=span(elapsed), age=span(elapsed),
+        human=f"{label}: {human(through)} → {human(moment)} ({span(elapsed)})",
+        detail=f"mirror complete through {human(through)} ({span(elapsed)} ago)",
+    )
+    return result
 
 
 def advance(
     workspace: str,
     surface: str,
     through: str,
-    today: date | None = None,
+    targets: tuple[str, ...] | list[str] = (),
+    now: datetime | None = None,
     home: Path | None = None,
 ) -> dict:
-    """Record a successful write. Never moves a watermark backwards."""
-    moment = today or date.today()
-    new = _as_date(through)
-    if new is None:
-        raise ValueError(f"not a date: {through}")
+    """Record a successful write. Never moves a watermark backwards or into
+    the future; with targets, records each target's own read."""
+    moment = now or now_local()
+    new = parse_moment(through, moment)
     if new > moment:
-        raise ValueError(f"refusing a future watermark: {through} > {moment}")
-    data = load(workspace, home)
-    entry = data["surfaces"].get(surface) or {}
-    old = _as_date(entry.get("through", ""))
-    if old is not None and new < old:
-        return {"surface": surface, "through": old.isoformat(), "moved": False,
-                "detail": f"refused: {through} is behind the recorded {old}"}
-    data["surfaces"][surface] = {
-        "through": new.isoformat(),
-        "updated_at": datetime.now().isoformat(timespec="seconds"),
-    }
-    # A surface that just wrote has no outstanding gap, so its deferral is spent.
-    data["deferrals"].pop(surface, None)
+        hint = ""
+        if len(str(through).strip()) == 10:
+            hint = (" — a bare date means complete through the END of that day; "
+                    "pass the moment you actually read (an ISO timestamp or 'now')")
+        raise ValueError(
+            f"refusing a future watermark: {through} resolves to {human(new)}, "
+            f"ahead of {human(moment)}{hint}"
+        )
+    data = load(workspace, home, moment)
+    surface_entry = data["surfaces"].setdefault(surface, {})
+    surface_entry.setdefault("targets", {})
+    entries: list[dict] = []
+    if targets:
+        slots = [(t, surface_entry["targets"].setdefault(t, {})) for t in targets]
+    else:
+        slots = [(None, surface_entry)]
+    for target, entry in slots:
+        key = _key(surface, target)
+        old = _stored(entry.get("through"))
+        if old is not None and new < old:
+            entries.append({"key": key, "through": stamp(old), "moved": False,
+                            "detail": f"refused: {human(new)} is behind the recorded {human(old)}"})
+            continue
+        entry["through"] = stamp(new)
+        entry["updated_at"] = stamp(moment)
+        entry.pop("migrated_from", None)
+        # An entry that just wrote has no outstanding gap, so its deferral is spent.
+        data["deferrals"].pop(key, None)
+        entries.append({"key": key, "through": stamp(new), "moved": True,
+                        "detail": "watermark advanced"})
     save(workspace, data, home)
-    return {"surface": surface, "through": new.isoformat(), "moved": True,
-            "detail": "watermark advanced"}
+    return {"surface": surface, "through": stamp(new), "human": human(new),
+            "entries": entries, "moved": all(e["moved"] for e in entries)}
 
 
 def defer(
     workspace: str,
     surface: str,
     reason: str,
-    today: date | None = None,
+    target: str | None = None,
+    now: datetime | None = None,
     home: Path | None = None,
 ) -> dict:
     if not reason.strip():
         raise ValueError("a deferral requires a reason")
-    moment = today or date.today()
-    data = load(workspace, home)
-    data["deferrals"][surface] = {
-        "reason": reason.strip(),
-        "deferred_on": moment.isoformat(),
-    }
+    moment = now or now_local()
+    data = load(workspace, home, moment)
+    key = _key(surface, target)
+    data["deferrals"][key] = {"reason": reason.strip(), "deferred_at": stamp(moment)}
     save(workspace, data, home)
-    return {"surface": surface, "deferred_on": moment.isoformat()}
+    return {"key": key, "deferred_at": stamp(moment)}
+
+
+def _judge(
+    data: dict,
+    key: str,
+    through: datetime | None,
+    moment: datetime,
+    since: datetime | None,
+    max_age: timedelta | None,
+) -> dict:
+    deferral = data["deferrals"].get(key) or {}
+    deferred_at = _stored(deferral.get("deferred_at"))
+    live = deferred_at is not None and (moment - deferred_at) <= DEFERRAL_MAX_AGE
+    if through is None:
+        state = "missing"
+    elif since is not None and through < since:
+        state = "stale"
+    elif max_age is not None and (moment - through) > max_age:
+        state = "stale"
+    else:
+        state = "current"
+    return {
+        "key": key,
+        "through": stamp(through) if through else None,
+        "age": span(moment - through) if through else None,
+        "state": "deferred" if (state != "current" and live) else state,
+        "blocking": state != "current" and not live,
+        "deferral_reason": deferral.get("reason") if live else None,
+        "stale_deferral": bool(deferred_at and not live),
+    }
 
 
 def status(
     workspace: str,
     surfaces: list[str] | None = None,
-    today: date | None = None,
+    targets: dict[str, list[str]] | None = None,
+    *,
+    since: datetime | None = None,
+    max_age: timedelta | None = None,
+    now: datetime | None = None,
     home: Path | None = None,
 ) -> dict:
-    moment = today or date.today()
-    data = load(workspace, home)
-    names = sorted(set(surfaces or []) | set(data["surfaces"]))
+    """Which declared surfaces and targets are current under one freshness
+    bound: `since` (a run start, typically), `max_age`, or both."""
+    moment = now or now_local()
+    data = load(workspace, home, moment)
+    declared_targets = {s: list(ids) for s, ids in (targets or {}).items()}
+    names = sorted(set(surfaces or []) | set(declared_targets))
+    if not names:
+        raise ValueError(
+            "status requires the declared surface set — pass every declared "
+            "surface with --surface (repeatable) or targets with --target / "
+            "--targets-from; an empty set cannot authorize a ritual"
+        )
+    bound_source = None
+    if since == "run" or (since is None and max_age is None):
+        run = data.get("run") or {}
+        started = _stored(run.get("started_at"))
+        if started is None:
+            raise ValueError(
+                "status needs a freshness bound: --since run (after `begin`), "
+                "--since <timestamp>, or --max-age <duration>"
+            )
+        since, bound_source = started, "run"
     rows, blocking = [], []
     for surface in names:
-        info = window(workspace, surface, moment, home)
-        gap = info["bootstrap"] or (info["gap_days"] or 0) > 0
-        deferral = data["deferrals"].get(surface) or {}
-        deferred_on = _as_date(deferral.get("deferred_on", ""))
-        live_deferral = (
-            deferred_on is not None and (moment - deferred_on) <= DEFERRAL_MAX_AGE
-        )
-        row = {
-            "surface": surface,
-            "through": (data["surfaces"].get(surface) or {}).get("through"),
-            "gap": gap,
-            "gap_days": info["gap_days"],
-            "bootstrap": info["bootstrap"],
-            "deferred": bool(live_deferral),
-            "deferral_reason": deferral.get("reason") if live_deferral else None,
-            "stale_deferral": bool(deferred_on and not live_deferral),
-        }
+        declared = declared_targets.get(surface) or []
+        if declared:
+            target_rows = []
+            for target in declared:
+                row = _judge(data, _key(surface, target), _through(data, surface, target),
+                             moment, since, max_age)
+                row["target"] = target
+                target_rows.append(row)
+            throughs = [_through(data, surface, t) for t in declared]
+            effective = min(throughs) if all(throughs) else None
+            row = _judge(data, surface, effective, moment, since, max_age)
+            surface_deferred = row["state"] == "deferred"
+            blocked = [] if surface_deferred else [t["key"] for t in target_rows if t["blocking"]]
+            row["blocking"] = bool(blocked)
+            if not blocked and not surface_deferred:
+                row["state"] = "current"
+            blocking.extend(blocked)
+        else:
+            target_rows = []
+            row = _judge(data, surface, _through(data, surface), moment, since, max_age)
+            if row["blocking"]:
+                blocking.append(surface)
+        row["surface"] = surface
+        row["targets"] = target_rows
         rows.append(row)
-        if gap and not live_deferral:
-            blocking.append(surface)
-    return {"workspace": workspace, "as_of": moment.isoformat(),
-            "surfaces": rows, "blocking": blocking}
+    return {
+        "workspace": workspace,
+        "as_of": stamp(moment),
+        "since": stamp(since) if since else None,
+        "max_age": span(max_age) if max_age else None,
+        "bound_source": bound_source or ("explicit" if (since or max_age) else None),
+        "surfaces": rows,
+        "blocking": blocking,
+    }
+
+
+# --- CLI ---------------------------------------------------------------------------
+
+
+def _parse_targets(entries: list[str], path: str | None) -> dict[str, list[str]]:
+    declared: dict[str, list[str]] = {}
+
+    def add(surface: str, target: str) -> None:
+        surface, target = surface.strip(), target.strip()
+        if not surface or not target:
+            raise ValueError("a target needs the form surface:id")
+        declared.setdefault(surface, [])
+        if target not in declared[surface]:
+            declared[surface].append(target)
+
+    for entry in entries or []:
+        if ":" not in entry:
+            raise ValueError(f"--target needs the form surface:id, got {entry!r}")
+        add(*entry.split(":", 1))
+    if path:
+        try:
+            payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise ValueError(f"--targets-from {path}: {exc}") from exc
+        if isinstance(payload, dict):
+            for surface, ids in payload.items():
+                if not isinstance(ids, list):
+                    raise ValueError(f"--targets-from: {surface} must map to a list of ids")
+                for target in ids:
+                    add(surface, str(target))
+        elif isinstance(payload, list):
+            for entry in payload:
+                if not isinstance(entry, str) or ":" not in entry:
+                    raise ValueError("--targets-from: list entries need the form surface:id")
+                add(*entry.split(":", 1))
+        else:
+            raise ValueError("--targets-from: expected {surface: [ids]} or [\"surface:id\"]")
+    return declared
+
+
+def _print_status(result: dict) -> None:
+    bound = result["since"] and f"since {human(datetime.fromisoformat(result['since']))}"
+    if result["max_age"]:
+        bound = ((bound + ", ") if bound else "") + f"max age {result['max_age']}"
+    print(f"as of {human(datetime.fromisoformat(result['as_of']))} — bound: {bound}"
+          + (f" ({result['bound_source']})" if result["bound_source"] == "run" else ""))
+    for row in result["surfaces"]:
+        _print_row(row, row["surface"])
+        for target in row["targets"]:
+            if target["state"] != "current":
+                _print_row(target, "  " + target["key"])
+    if result["blocking"]:
+        print(
+            f"\n{len(result['blocking'])} entr{'y' if len(result['blocking']) == 1 else 'ies'} "
+            "with an unclosed gap: " + ", ".join(result["blocking"])
+            + "\nRead them this run, or record an explicit reason with "
+            "`sync_watermark.py defer`. A gap in prose is not a closed gap."
+        )
+
+
+def _print_row(row: dict, label: str) -> None:
+    state = "BLOCKING" if row["blocking"] else row["state"]
+    if row["through"]:
+        through = f"through {human(datetime.fromisoformat(row['through']))} ({row['age']} ago)"
+    else:
+        through = "never written"
+    extra = f" — {row['deferral_reason']}" if row["deferral_reason"] else ""
+    if row["stale_deferral"]:
+        extra += " — deferral expired"
+    print(f"  {state:9s} {label:28s} {through}{extra}")
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     sub = parser.add_subparsers(dest="command", required=True)
-    for name in ("window", "advance", "defer", "status"):
+    for name in ("begin", "window", "advance", "defer", "status"):
         p = sub.add_parser(name)
         p.add_argument("--workspace", required=True)
         p.add_argument("--json", action="store_true")
-        if name != "status":
+        if name == "begin":
+            p.add_argument("--label", default="")
+        if name in ("window", "advance", "defer"):
             p.add_argument("--surface", required=True)
-        else:
-            p.add_argument("--surface", action="append", default=[])
+        if name == "window" or name == "defer":
+            p.add_argument("--target")
         if name == "advance":
             p.add_argument("--through", required=True)
+            p.add_argument("--target", action="append", default=[])
         if name == "defer":
             p.add_argument("--reason", required=True)
+        if name == "status":
+            p.add_argument("--surface", action="append", default=[])
+            p.add_argument("--target", action="append", default=[],
+                           help="declared read target as surface:id (repeatable)")
+            p.add_argument("--targets-from",
+                           help='JSON file: {"surface": ["id", ...]} or ["surface:id", ...]')
+            p.add_argument("--since", help="ISO timestamp, or `run` for the last `begin`")
+            p.add_argument("--max-age", help="duration such as 90m, 4h, 1d")
     args = parser.parse_args(argv)
 
-    if args.command == "status" and not args.surface:
-        # The declared surface set must come from the caller (the ritual's
-        # config), because the store only knows surfaces that have already
-        # been written: a declared surface with no successful write is
-        # exactly the gap this gate exists to block, and a status that
-        # consults only the store exits 0 straight past it.
-        print(
-            "error: status requires the declared surface set — pass every "
-            "declared surface with --surface (repeatable); an empty set "
-            "cannot authorize a ritual",
-            file=sys.stderr,
-        )
-        return 2
-
     try:
-        if args.command == "window":
-            result = window(args.workspace, args.surface)
+        if args.command == "begin":
+            result = begin(args.workspace, args.label)
+        elif args.command == "window":
+            result = window(args.workspace, args.surface, args.target)
         elif args.command == "advance":
-            result = advance(args.workspace, args.surface, args.through)
+            result = advance(args.workspace, args.surface, args.through, tuple(args.target))
         elif args.command == "defer":
-            result = defer(args.workspace, args.surface, args.reason)
+            result = defer(args.workspace, args.surface, args.reason, args.target)
         else:
-            result = status(args.workspace, args.surface)
+            declared = _parse_targets(args.target, args.targets_from)
+            moment = now_local()
+            since = None
+            if args.since:
+                since = ("run" if args.since.strip().lower() == "run"
+                         else parse_moment(args.since, moment))
+            max_age = parse_duration(args.max_age) if args.max_age else None
+            result = status(args.workspace, args.surface, declared, since=since,
+                            max_age=max_age, now=moment)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -239,21 +565,15 @@ def main(argv: list[str] | None = None) -> int:
     if getattr(args, "json", False):
         print(json.dumps(result, indent=2))
     elif args.command == "status":
-        for row in result["surfaces"]:
-            state = (
-                "BLOCKING" if row["gap"] and not row["deferred"]
-                else "deferred" if row["gap"] else "current"
-            )
-            through = row["through"] or "never written"
-            extra = f" — {row['deferral_reason']}" if row["deferred"] else ""
-            print(f"  {state:9s} {row['surface']:22s} through {through}{extra}")
-        if result["blocking"]:
-            print(
-                f"\n{len(result['blocking'])} surface(s) with an unclosed gap: "
-                + ", ".join(result["blocking"])
-                + "\nClose them this run, or record an explicit reason with "
-                "`sync_watermark.py defer`. A gap in prose is not a closed gap."
-            )
+        _print_status(result)
+    elif args.command == "window":
+        print(result["human"])
+        if result["bootstrap"]:
+            print(f"latest={result['to_epoch']}  ({result['detail']})")
+        else:
+            print(f"oldest={result['from_epoch']} latest={result['to_epoch']}")
+    elif args.command == "begin":
+        print(f"run started {result['human']}" + (f" ({result['label']})" if result["label"] else ""))
     else:
         print(json.dumps(result, indent=2))
 

--- a/skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
+++ b/skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
@@ -1,15 +1,17 @@
-"""Regressions for per-surface sync watermarks.
+"""Regressions for per-surface, per-target sync watermarks.
 
-Derived from a real failure, not an imagined one: a local mirror gap spanning
-six days was recorded in three consecutive ritual artifacts and never closed.
-Each run synced "since the last ritual", anchored on when the previous run
-executed, so the hole the skipped run left was never revisited. The gaps the
-artifacts honestly recorded were prose, and no run read those lines back.
+Derived from real failures, not imagined ones. v1 (2026-08-27): a six-day
+mirror gap was recorded in three consecutive ritual artifacts and never
+closed, because each run synced "since the last ritual" and nothing read the
+recorded gap back. v2 (2026-09-01): the day-granular watermark could not see
+the hours — a surface written at 09:15 counted as current all day, a mid-day
+pass re-read only what the morning had skipped, and an "unanswered" claim at
+17:51 rested on a 09:15 read while the answer had gone out at 09:27.
 
-Two properties make the repair structural rather than a matter of diligence:
-the window is computed from the last successful WRITE so a hole is revisited
-automatically, and an unclosed gap makes `status` exit non-zero so a later run
-has to act on it.
+The properties that make both repairs structural: the window follows the
+last successful WRITE to the second; a run stamps itself and `status --since
+run` blocks on every declared surface or target the run did not re-read;
+the window's epoch bound is computed and echoed beside human-readable time.
 """
 
 from __future__ import annotations
@@ -18,8 +20,10 @@ import importlib.util
 import json
 import subprocess
 import sys
-from datetime import date, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+import pytest
 
 
 SCRIPT = Path(__file__).with_name("sync_watermark.py")
@@ -30,196 +34,425 @@ sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
 
 WS = "testspace"
-TODAY = date(2026, 8, 28)
+TZ = timezone(timedelta(hours=-4))
+NOW = datetime(2026, 8, 28, 12, 0, tzinfo=TZ)
+RUN_START = datetime(2026, 8, 28, 11, 39, tzinfo=TZ)
+MORNING = "2026-08-28T09:15:00-04:00"
+IN_RUN = "2026-08-28T11:45:00-04:00"
 
 
-# --- the window follows writes, not runs ----------------------------------
+def at(hour: int, minute: int = 0, day: int = 28) -> datetime:
+    return datetime(2026, 8, day, hour, minute, tzinfo=TZ)
 
 
-def test_window_starts_after_the_last_written_day(tmp_path: Path) -> None:
-    MODULE.advance(WS, "slack", "2026-08-20", today=TODAY, home=tmp_path)
+# --- the window follows writes, to the second ------------------------------
 
-    got = MODULE.window(WS, "slack", today=TODAY, home=tmp_path)
 
-    assert got["from"] == "2026-08-21"
-    assert got["to"] == "2026-08-28"
+def test_window_starts_at_the_last_written_moment(tmp_path: Path) -> None:
+    MODULE.advance(WS, "slack", "2026-08-27T09:15", now=at(9, 20, day=27), home=tmp_path)
+
+    got = MODULE.window(WS, "slack", now=NOW, home=tmp_path)
+
+    assert got["from"] == "2026-08-27T09:15:00-04:00"
+    assert got["from_epoch"] == int(datetime(2026, 8, 27, 9, 15, tzinfo=TZ).timestamp())
+    assert got["to"] == "2026-08-28T12:00:00-04:00"
+    assert got["span"] == "1d 2h 45m"
+    assert "→" in got["human"]
 
 
 def test_a_skipped_run_leaves_a_gap_the_next_run_must_cover(tmp_path: Path) -> None:
-    """The verbatim failure: written through 8/20, nothing since, and the next
-    window must reach back to 8/21 rather than starting near today."""
-    MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
+    """The verbatim v1 failure: written through 8/20, nothing since, and the
+    next window must reach back to 8/20 rather than starting near today."""
+    MODULE.advance(WS, "slack", "2026-08-20T12:00", now=at(12, day=20), home=tmp_path)
 
-    got = MODULE.window(WS, "slack", today=TODAY, home=tmp_path)
+    got = MODULE.window(WS, "slack", now=NOW, home=tmp_path)
 
-    assert got["from"] == "2026-08-21"
-    assert got["gap_days"] == 7
+    assert got["from"] == "2026-08-20T12:00:00-04:00"
+    assert got["span"] == "8d"
 
 
 def test_no_watermark_reports_bootstrap_rather_than_guessing(tmp_path: Path) -> None:
-    got = MODULE.window(WS, "email", today=TODAY, home=tmp_path)
+    got = MODULE.window(WS, "email", now=NOW, home=tmp_path)
 
     assert got["bootstrap"] is True
-    assert got["from"] is None
+    assert got["from"] is None and got["from_epoch"] is None
+    assert "backfill bound" in got["human"]
 
 
-# --- the watermark advances only on a successful write --------------------
+def _schema_one_store(tmp_path: Path, surfaces: dict) -> Path:
+    path = MODULE.store_path(WS, tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({
+        "surfaces": surfaces,
+        "deferrals": {"email": {"reason": "outage", "deferred_on": "2026-08-28"}},
+    }), encoding="utf-8")
+    return path
+
+
+def test_a_schema_one_date_reads_as_complete_through_end_of_that_day(tmp_path: Path) -> None:
+    """Existing stores hold bare dates meaning 'that whole day is written' —
+    capped by the moment the write happened, since a mirror cannot be
+    complete past the time it was written."""
+    path = _schema_one_store(tmp_path, {
+        "yesterday": {"through": "2026-08-27", "updated_at": "2026-08-28T09:12:00"},
+        "slack": {"through": "2026-08-27", "updated_at": "2026-08-27T16:00:00"},
+    })
+
+    assert MODULE.window(WS, "yesterday", now=NOW, home=tmp_path)["from"] == "2026-08-28T00:00:00-04:00"
+    assert MODULE.window(WS, "slack", now=NOW, home=tmp_path)["from"] == "2026-08-27T16:00:00-04:00"
+
+    MODULE.advance(WS, "docs", "now", now=NOW, home=tmp_path)
+    stored = json.loads(path.read_text(encoding="utf-8"))
+    assert stored["schema"] == 2
+    assert stored["surfaces"]["slack"]["migrated_from"] == "2026-08-27"
+    assert stored["deferrals"]["email"]["deferred_at"] == "2026-08-28T00:00:00-04:00"
+
+
+def test_a_schema_one_date_never_migrates_into_the_future(tmp_path: Path) -> None:
+    """The live store on 2026-09-01 said 'through today', written at 16:48 by a
+    mid-day sync; read as end-of-day it would have put the next window's
+    `oldest` five hours in the future and read nothing."""
+    _schema_one_store(tmp_path, {
+        "written": {"through": "2026-08-28", "updated_at": "2026-08-28T09:12:00"},
+        "unstamped": {"through": "2026-08-28"},
+    })
+
+    assert MODULE.window(WS, "written", now=NOW, home=tmp_path)["from"] == "2026-08-28T09:12:00-04:00"
+    assert MODULE.window(WS, "unstamped", now=NOW, home=tmp_path)["from"] == "2026-08-28T12:00:00-04:00"
+
+
+# --- the watermark advances only on a successful write, never into the future
 
 
 def test_watermark_never_moves_backwards(tmp_path: Path) -> None:
-    MODULE.advance(WS, "slack", "2026-08-26", today=TODAY, home=tmp_path)
+    MODULE.advance(WS, "slack", "2026-08-26T10:00", now=NOW, home=tmp_path)
 
-    result = MODULE.advance(WS, "slack", "2026-08-22", today=TODAY, home=tmp_path)
+    result = MODULE.advance(WS, "slack", "2026-08-22T10:00", now=NOW, home=tmp_path)
 
     assert result["moved"] is False
-    assert result["through"] == "2026-08-26"
+    assert result["entries"][0]["through"] == "2026-08-26T10:00:00-04:00"
 
 
 def test_future_watermark_is_refused(tmp_path: Path) -> None:
-    """A run cannot declare tomorrow covered."""
-    try:
-        MODULE.advance(WS, "slack", "2026-09-01", today=TODAY, home=tmp_path)
-    except ValueError as exc:
-        assert "future" in str(exc)
-    else:
-        raise AssertionError("a future watermark must be refused")
+    with pytest.raises(ValueError, match="future"):
+        MODULE.advance(WS, "slack", "2026-08-28T13:00", now=NOW, home=tmp_path)
 
 
-# --- an unclosed gap is blocking, which is what makes it load-bearing -----
+def test_a_bare_date_means_end_of_day_so_today_is_refused_mid_day(tmp_path: Path) -> None:
+    """A mid-day run cannot stamp 'today' — it must record when it read."""
+    with pytest.raises(ValueError, match="END of that day"):
+        MODULE.advance(WS, "slack", "2026-08-28", now=NOW, home=tmp_path)
+
+    result = MODULE.advance(WS, "slack", "2026-08-27", now=NOW, home=tmp_path)
+    assert result["through"] == "2026-08-28T00:00:00-04:00"
 
 
-def test_status_blocks_while_a_gap_is_open(tmp_path: Path) -> None:
-    MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
+def test_now_is_an_accepted_moment(tmp_path: Path) -> None:
+    result = MODULE.advance(WS, "slack", "now", now=NOW, home=tmp_path)
+    assert result["through"] == "2026-08-28T12:00:00-04:00"
 
-    result = MODULE.status(WS, ["slack"], today=TODAY, home=tmp_path)
 
+# --- a run proves its own coverage: status --since run --------------------------
+
+
+def test_status_blocks_on_a_read_older_than_the_run(tmp_path: Path) -> None:
+    """The v2 defect itself: a 09:15 read is not current at an 11:39 run."""
+    MODULE.advance(WS, "slack", MORNING, now=at(9, 16), home=tmp_path)
+    MODULE.begin(WS, "mid-day", now=RUN_START, home=tmp_path)
+
+    result = MODULE.status(WS, ["slack"], now=NOW, home=tmp_path)
+
+    assert result["bound_source"] == "run"
     assert result["blocking"] == ["slack"]
+    assert result["surfaces"][0]["state"] == "stale"
 
 
-def test_status_is_clear_once_the_gap_closes(tmp_path: Path) -> None:
-    MODULE.advance(WS, "slack", "2026-08-28", today=TODAY, home=tmp_path)
+def test_status_is_clear_once_the_surface_is_re_read_in_this_run(tmp_path: Path) -> None:
+    MODULE.advance(WS, "slack", MORNING, now=at(9, 16), home=tmp_path)
+    MODULE.begin(WS, now=RUN_START, home=tmp_path)
+    MODULE.advance(WS, "slack", IN_RUN, now=at(11, 46), home=tmp_path)
 
-    assert MODULE.status(WS, ["slack"], today=TODAY, home=tmp_path)["blocking"] == []
+    assert MODULE.status(WS, ["slack"], now=NOW, home=tmp_path)["blocking"] == []
+
+
+def test_status_max_age_is_an_alternative_bound(tmp_path: Path) -> None:
+    MODULE.advance(WS, "slack", MORNING, now=at(9, 16), home=tmp_path)
+
+    loose = MODULE.status(WS, ["slack"], max_age=timedelta(hours=4), now=NOW, home=tmp_path)
+    tight = MODULE.status(WS, ["slack"], max_age=timedelta(hours=2), now=NOW, home=tmp_path)
+
+    assert loose["blocking"] == []
+    assert tight["blocking"] == ["slack"]
+
+
+def test_status_needs_a_freshness_bound(tmp_path: Path) -> None:
+    MODULE.advance(WS, "slack", MORNING, now=at(9, 16), home=tmp_path)
+    with pytest.raises(ValueError, match="freshness bound"):
+        MODULE.status(WS, ["slack"], now=NOW, home=tmp_path)
+
+
+# --- declared read targets block individually ---------------------------------------
+
+
+def test_declared_targets_block_individually(tmp_path: Path) -> None:
+    """'20 of 60 targets read' becomes a list of keys, not a sentence."""
+    MODULE.begin(WS, now=RUN_START, home=tmp_path)
+    MODULE.advance(WS, "slack", IN_RUN, targets=["C1", "D2"], now=at(11, 46), home=tmp_path)
+
+    result = MODULE.status(WS, targets={"slack": ["C1", "D2", "D3"]}, now=NOW, home=tmp_path)
+
+    assert result["blocking"] == ["slack:D3"]
+    surface = result["surfaces"][0]
+    assert surface["blocking"] is True
+    assert [t["state"] for t in surface["targets"]] == ["current", "current", "missing"]
+
+
+def test_a_target_read_before_the_run_is_stale(tmp_path: Path) -> None:
+    """The DM read at 09:15 and not again: exactly the 17:51 failure."""
+    MODULE.advance(WS, "slack", MORNING, targets=["D3"], now=at(9, 16), home=tmp_path)
+    MODULE.begin(WS, now=RUN_START, home=tmp_path)
+    MODULE.advance(WS, "slack", IN_RUN, targets=["C1"], now=at(11, 46), home=tmp_path)
+
+    result = MODULE.status(WS, targets={"slack": ["C1", "D3"]}, now=NOW, home=tmp_path)
+
+    assert result["blocking"] == ["slack:D3"]
+    assert result["surfaces"][0]["targets"][1]["state"] == "stale"
+
+
+def test_all_targets_current_makes_the_surface_current(tmp_path: Path) -> None:
+    MODULE.begin(WS, now=RUN_START, home=tmp_path)
+    MODULE.advance(WS, "slack", IN_RUN, targets=["C1"], now=at(11, 46), home=tmp_path)
+    MODULE.advance(WS, "slack", "2026-08-28T11:50", targets=["D2"], now=at(11, 51), home=tmp_path)
+
+    result = MODULE.status(WS, targets={"slack": ["C1", "D2"]}, now=NOW, home=tmp_path)
+
+    assert result["blocking"] == []
+    assert result["surfaces"][0]["state"] == "current"
+    assert result["surfaces"][0]["through"] == IN_RUN  # the oldest declared target
+
+
+def test_target_window_falls_back_to_the_surface_watermark(tmp_path: Path) -> None:
+    MODULE.advance(WS, "slack", MORNING, now=at(9, 16), home=tmp_path)
+
+    got = MODULE.window(WS, "slack", target="D2", now=NOW, home=tmp_path)
+
+    assert got["from"] == MORNING
+    assert "surface watermark" in got["source"]
+
+
+# --- deferrals: explicit, dated, and spent by a write ---------------------------------
 
 
 def test_deferral_requires_a_reason(tmp_path: Path) -> None:
-    try:
-        MODULE.defer(WS, "slack", "   ", today=TODAY, home=tmp_path)
-    except ValueError:
-        pass
-    else:
-        raise AssertionError("a reason-less deferral must be refused")
+    with pytest.raises(ValueError):
+        MODULE.defer(WS, "slack", "   ", now=NOW, home=tmp_path)
 
 
 def test_explicit_deferral_unblocks_for_one_day_only(tmp_path: Path) -> None:
     """A deferral silences a gap for a day, never indefinitely — an indefinite
     silence is how a recorded gap becomes furniture."""
-    MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
-    MODULE.defer(WS, "slack", "Slack API outage", today=TODAY, home=tmp_path)
+    MODULE.advance(WS, "slack", MORNING, now=at(9, 16), home=tmp_path)
+    MODULE.begin(WS, now=RUN_START, home=tmp_path)
+    MODULE.defer(WS, "slack", "Slack API outage", now=NOW, home=tmp_path)
 
-    same_day = MODULE.status(WS, ["slack"], today=TODAY, home=tmp_path)
-    later = MODULE.status(WS, ["slack"], today=date(2026, 8, 31), home=tmp_path)
+    same_day = MODULE.status(WS, ["slack"], now=NOW, home=tmp_path)
+    later = MODULE.status(WS, ["slack"], now=NOW + timedelta(days=2), home=tmp_path)
 
     assert same_day["blocking"] == []
+    assert same_day["surfaces"][0]["state"] == "deferred"
     assert later["blocking"] == ["slack"]
     assert later["surfaces"][0]["stale_deferral"] is True
 
 
-def test_a_successful_write_spends_the_deferral(tmp_path: Path) -> None:
-    MODULE.advance(WS, "slack", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
-    MODULE.defer(WS, "slack", "outage", today=TODAY, home=tmp_path)
-    MODULE.advance(WS, "slack", "2026-08-28", today=TODAY, home=tmp_path)
+def test_a_target_deferral_silences_only_that_target(tmp_path: Path) -> None:
+    MODULE.begin(WS, now=RUN_START, home=tmp_path)
+    MODULE.advance(WS, "slack", IN_RUN, targets=["C1"], now=at(11, 46), home=tmp_path)
+    MODULE.defer(WS, "slack", "member left the workspace", target="D2", now=NOW, home=tmp_path)
 
-    row = MODULE.status(WS, ["slack"], today=TODAY, home=tmp_path)["surfaces"][0]
-    assert row["deferred"] is False
+    result = MODULE.status(WS, targets={"slack": ["C1", "D2", "D3"]}, now=NOW, home=tmp_path)
+
+    assert result["blocking"] == ["slack:D3"]
+
+
+def test_a_successful_write_spends_the_deferral(tmp_path: Path) -> None:
+    MODULE.begin(WS, now=RUN_START, home=tmp_path)
+    MODULE.defer(WS, "slack", "outage", now=at(11, 40), home=tmp_path)
+    MODULE.advance(WS, "slack", IN_RUN, now=at(11, 46), home=tmp_path)
+
+    row = MODULE.status(WS, ["slack"], now=NOW, home=tmp_path)["surfaces"][0]
+    assert row["state"] == "current" and row["deferral_reason"] is None
 
 
 def test_surfaces_are_tracked_independently(tmp_path: Path) -> None:
     """One surface closing must not vouch for another — the completeness claim
     that hid the original gap."""
-    MODULE.advance(WS, "slack", "2026-08-28", today=TODAY, home=tmp_path)
-    MODULE.advance(WS, "email", "2026-08-20", today=date(2026, 8, 20), home=tmp_path)
+    MODULE.begin(WS, now=RUN_START, home=tmp_path)
+    MODULE.advance(WS, "slack", IN_RUN, now=at(11, 46), home=tmp_path)
+    MODULE.advance(WS, "email", MORNING, now=at(9, 16), home=tmp_path)
 
-    assert MODULE.status(WS, ["slack", "email"], today=TODAY, home=tmp_path)[
-        "blocking"
-    ] == ["email"]
-
-
-# --- the gate is consumable by a ritual -----------------------------------
+    assert MODULE.status(WS, ["slack", "email"], now=NOW, home=tmp_path)["blocking"] == ["email"]
 
 
-def test_cli_status_exits_nonzero_while_blocking(tmp_path: Path) -> None:
-    """The property that makes this load-bearing: a ritual step can fail on it.
+def test_store_is_scoped_per_workspace(tmp_path: Path) -> None:
+    """Engagement workspaces must not read each other's sync state."""
+    MODULE.advance("alpha", "slack", "now", now=NOW, home=tmp_path)
 
-    The subprocess computes its own date.today(), so this fixture must use
-    live dates: a frozen watermark rotted the sibling green test the first
-    UTC midnight after authorship (caught 2026-08-30 in CI).
-    """
+    assert MODULE.window("beta", "slack", now=NOW, home=tmp_path)["bootstrap"]
+
+
+def test_duration_parsing() -> None:
+    assert MODULE.parse_duration("90m") == timedelta(minutes=90)
+    assert MODULE.parse_duration("1d12h") == timedelta(hours=36)
+    with pytest.raises(ValueError):
+        MODULE.parse_duration("soon")
+
+
+# --- the gate is consumable by a ritual -------------------------------------------------
+
+
+def run_cli(tmp_path: Path, *argv: str) -> subprocess.CompletedProcess[str]:
     env = {"SYNTHESIS_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
-    stale_day = date.today() - timedelta(days=8)
-    MODULE.advance(WS, "slack", stale_day.isoformat(), today=stale_day,
-                   home=tmp_path)
-
-    done = subprocess.run(
-        [sys.executable, str(SCRIPT), "status", "--workspace", WS,
-         "--surface", "slack", "--json"],
-        capture_output=True, text=True, env=env,
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *argv], capture_output=True, text=True, env=env,
     )
+
+
+def test_cli_begin_then_status_since_run_lists_exactly_what_was_skipped(tmp_path: Path) -> None:
+    """The property that makes this load-bearing: a ritual step can fail on it,
+    and the failure names the keys the run did not re-read."""
+    assert run_cli(tmp_path, "begin", "--workspace", WS, "--label", "mid-day").returncode == 0
+    assert run_cli(tmp_path, "advance", "--workspace", WS, "--surface", "slack",
+                   "--target", "C1", "--through", "now").returncode == 0
+
+    done = run_cli(tmp_path, "status", "--workspace", WS, "--surface", "slack",
+                   "--target", "slack:C1", "--target", "slack:D2", "--since", "run", "--json")
+
+    assert done.returncode == 1
+    payload = json.loads(done.stdout)
+    assert payload["blocking"] == ["slack:D2"]
+    assert payload["bound_source"] == "run"
+
+
+def test_cli_targets_from_file(tmp_path: Path) -> None:
+    declared = tmp_path / "targets.json"
+    declared.write_text(json.dumps({"slack": ["C1", "D2"]}), encoding="utf-8")
+    run_cli(tmp_path, "begin", "--workspace", WS)
+    run_cli(tmp_path, "advance", "--workspace", WS, "--surface", "slack",
+            "--target", "C1", "--target", "D2", "--through", "now")
+
+    done = run_cli(tmp_path, "status", "--workspace", WS, "--targets-from", str(declared),
+                   "--since", "run", "--json")
+
+    assert done.returncode == 0, done.stderr
+    assert json.loads(done.stdout)["blocking"] == []
+
+
+def test_cli_window_prints_the_epoch_bounds_a_read_call_takes(tmp_path: Path) -> None:
+    """A window parameter is a claim about time: computed and echoed, never typed."""
+    run_cli(tmp_path, "advance", "--workspace", WS, "--surface", "slack", "--through", "now")
+
+    done = run_cli(tmp_path, "window", "--workspace", WS, "--surface", "slack")
+
+    assert done.returncode == 0
+    assert "→" in done.stdout
+    assert "oldest=" in done.stdout and "latest=" in done.stdout
+
+
+def test_cli_status_refuses_an_empty_surface_set(tmp_path: Path) -> None:
+    """The declared set must come from the caller: the store only knows
+    surfaces already written, so a store-only status walks straight past a
+    declared surface that has never been swept (R-02 external review)."""
+    done = run_cli(tmp_path, "status", "--workspace", WS, "--since", "now", "--json")
+
+    assert done.returncode == 2
+    assert "declared surface set" in done.stderr
+
+
+def test_cli_status_blocks_a_declared_surface_never_written(tmp_path: Path) -> None:
+    """The bootstrap bypass itself: no advance() has ever run, and the
+    declared surface must still block rather than vanish."""
+    done = run_cli(tmp_path, "status", "--workspace", WS, "--surface", "slack",
+                   "--max-age", "1d", "--json")
 
     assert done.returncode == 1
     assert json.loads(done.stdout)["blocking"] == ["slack"]
 
 
-def test_cli_status_exits_zero_when_current(tmp_path: Path) -> None:
-    env = {"SYNTHESIS_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
-    live_today = date.today()
-    MODULE.advance(WS, "slack", live_today.isoformat(), today=live_today,
-                   home=tmp_path)
+def test_cli_since_run_without_begin_is_an_error(tmp_path: Path) -> None:
+    done = run_cli(tmp_path, "status", "--workspace", WS, "--surface", "slack", "--since", "run")
 
-    done = subprocess.run(
-        [sys.executable, str(SCRIPT), "status", "--workspace", WS,
-         "--surface", "slack", "--json"],
-        capture_output=True, text=True, env=env,
-    )
-
-    assert done.returncode == 0
+    assert done.returncode == 2
+    assert "begin" in done.stderr
 
 
-def test_store_is_scoped_per_workspace(tmp_path: Path) -> None:
-    """Engagement workspaces must not read each other's sync state."""
-    MODULE.advance("alpha", "slack", "2026-08-28", today=TODAY, home=tmp_path)
-
-    assert MODULE.window("beta", "slack", today=TODAY, home=tmp_path)["bootstrap"]
-
-
-# --- the documented rules the mechanism depends on ------------------------
+# --- the documented rules the mechanism depends on ------------------------------------
 
 SKILLS_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _skill_text(name: str) -> str:
+    return (SKILLS_ROOT / name / "SKILL.md").read_text(encoding="utf-8")
+
+
 def test_rituals_document_the_watermark_and_blocking_gap() -> None:
     """A mechanism nobody is told to run is not a control."""
-    text = (SKILLS_ROOT / "synthesis-daily-rituals" / "SKILL.md").read_text(
-        encoding="utf-8"
-    )
+    text = _skill_text("synthesis-daily-rituals")
 
     assert "sync_watermark.py" in text
-    assert "last date actually" in text.lower()
-    assert "exits non-zero" in text
+    assert "actually written" in text.lower()
+    assert "exits non-zero" in text or "Non-zero exit" in text
+
+
+def test_rituals_carry_the_watermark_gate_invocation() -> None:
+    """Day-Start Step 3b and Day-End Step 1 carry the exact invocation with
+    explicit surfaces and the run bound."""
+    text = _skill_text("synthesis-daily-rituals")
+    assert text.count("sync_watermark.py status --workspace <W> --surface <s> --since run") >= 2
+
+
+def test_rituals_open_every_sync_with_begin_and_reread_every_target() -> None:
+    """The mid-day defect: a DM read at day-start was treated as current all
+    day. The protocol must stamp the run and re-read every declared target."""
+    text = _skill_text("synthesis-daily-rituals")
+    assert "sync_watermark.py begin" in text
+    assert "already read today" in text
+    assert "re-reads every declared target" in text
+
+
+def test_watermark_reference_carries_the_contract() -> None:
+    reference = (SKILLS_ROOT / "synthesis-daily-rituals" / "references" / "sync-watermarks.md")
+    text = reference.read_text(encoding="utf-8")
+    assert "--since run" in text
+    assert "END of that day" in text
+    assert "--targets-from" in text
+
+
+def test_slack_sync_takes_the_window_from_the_tool() -> None:
+    """A hand-typed `oldest` produced five false empties in one morning."""
+    text = _skill_text("synthesis-slack-sync")
+    assert "sync_watermark.py window" in text
+    assert "sync_watermark.py advance" in text
+    assert "WINDOW_OLDEST" in text
+    assert "LAST_SYNC_TIMESTAMP" not in text
+
+
+def test_slack_sync_counts_the_users_own_outbound() -> None:
+    """The principal's own messages discharge owed items; an 'unanswered'
+    claim must rest on a read inside the current run."""
+    text = _skill_text("synthesis-slack-sync")
+    assert "own outbound" in text.lower()
+    assert "unanswered" in text
+    assert "status --since run" in text
 
 
 def test_transcripts_forbid_a_judgment_gate_before_fetching() -> None:
     """Declared means fetched — and (post R-02 review) the policy must have an
     execution path, not just phrasing: the declared-window sweep enumerates the
     set, fetches every member, and accounts for every member."""
-    text = (SKILLS_ROOT / "synthesis-meeting-transcripts" / "SKILL.md").read_text(
-        encoding="utf-8"
-    )
+    text = _skill_text("synthesis-meeting-transcripts")
 
     assert "does not get a vote" in text
     assert "after* fetching" in text or "after fetching" in text
-    # The execution path itself (v0.9.0): a numbered sweep step, complete
-    # enumeration, and machine-readable unclosed gaps.
     assert "### Step 0: Declared-window sweep" in text
     assert "Enumerate the declared set" in text
     assert "unclosed gap" in text
@@ -230,58 +463,13 @@ def test_slack_sync_bans_deriving_read_ids_in_the_sweep() -> None:
     """Two id-like fields per entry is a trap that hides until someone leaves —
     and (post R-02 review) the sweep steps must consume the preflight rather
     than contradict it: no numbered step may iterate the config for ids."""
-    text = (SKILLS_ROOT / "synthesis-slack-sync" / "SKILL.md").read_text(
-        encoding="utf-8"
-    )
+    text = _skill_text("synthesis-slack-sync")
 
     assert "preflight" in text
     assert "banned" in text
     assert "dm_id" in text
-    # The operational consumption (v3.7.0): a mandatory Step 0 and steps that
-    # iterate its resolved output — the config-iteration phrasing the external
-    # review caught must stay gone.
     assert "### Step 0: Preflight" in text
     assert "resolved-target list" in text
     assert "For each channel in the config" not in text
     assert "For each DM channel in the config" not in text
     assert "RESOLVED_CONVERSATION_ID" in text
-
-
-def test_cli_status_refuses_an_empty_surface_set(tmp_path: Path) -> None:
-    """The declared set must come from the caller: the store only knows
-    surfaces already written, so a store-only status walks straight past a
-    declared surface that has never been swept (R-02 external review)."""
-    env = {"SYNTHESIS_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
-    done = subprocess.run(
-        [sys.executable, str(SCRIPT), "status", "--workspace", WS, "--json"],
-        capture_output=True, text=True, env=env,
-    )
-
-    assert done.returncode == 2
-    assert "declared surface set" in done.stderr
-
-
-def test_cli_status_blocks_a_declared_surface_never_written(tmp_path: Path) -> None:
-    """The bootstrap bypass itself: no advance() has ever run, and the
-    declared surface must still block rather than vanish."""
-    env = {"SYNTHESIS_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"}
-    done = subprocess.run(
-        [sys.executable, str(SCRIPT), "status", "--workspace", WS,
-         "--surface", "slack", "--json"],
-        capture_output=True, text=True, env=env,
-    )
-
-    assert done.returncode == 1
-    assert json.loads(done.stdout)["blocking"] == ["slack"]
-
-
-
-def test_rituals_carry_the_watermark_gate_invocation() -> None:
-    """The release prose said to run status in Day-Start Step 3 and Day-End
-    Step 1; the external review found no operational step actually did. Both
-    checklists must carry the exact invocation with explicit surfaces."""
-    text = (SKILLS_ROOT / "synthesis-daily-rituals" / "SKILL.md").read_text(
-        encoding="utf-8"
-    )
-    assert text.count("sync_watermark.py status --workspace <W> --surface <s>") >= 2
-    assert "refuses an empty surface set" in text or "every declared surface passed explicitly" in text

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,30 +1,28 @@
-# AGENT HEURISTIC: authored for the 4.78.0 coordination-engine hardening.
+# AGENT HEURISTIC: authored for the 4.79.0 sync-watermark v2 transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: coordination-engine-version-skew-and-section-hygiene
+suite: sync-watermarks-carry-time-and-target
 membership: closed
-production_entry_point: skills/synthesis-project-management/scripts/coordination.py
-enforcing_boundary: the coordination engine refuses to parse or rewrite a board newer than itself and names the engine to run, and every Active-sessions rewrite emits a fixed-shape section
+production_entry_point: skills/synthesis-daily-rituals/scripts/sync_watermark.py
+enforcing_boundary: the ritual watermark gate exits non-zero naming every declared surface or read target the current run did not re-read, and read windows are computed from the last written moment rather than typed
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: engines released before 4.78.0 keep their bare column-count message on a newer board and cannot be repaired retroactively; the live collapse of a real board's accumulated padding is proven in the release record rather than by a hermetic case
+unverified_remainder: the live migration of a real workspace store and the first ritual run under the new gate are proven in the release record; the message-guard ledger age limit that already bounds agent sends is unchanged and not re-proven here
 changed_surfaces:
-  - path: skills/synthesis-project-management/scripts/coordination.py
-    cases: [newer-board-refused-with-remedy, wider-row-names-newer-engine, section-padding-collapses]
-  - path: skills/synthesis-project-management/scripts/coordination_schema.py
-    cases: [remedy-names-newest-cached-engine, wider-row-names-newer-engine]
-  - path: skills/synthesis-project-management/scripts/test_coordination.py
-    cases: [newer-board-refused-with-remedy, wider-row-names-newer-engine, section-padding-collapses, remedy-names-newest-cached-engine, skew-doc-contract]
-  - path: skills/synthesis-project-management/references/session-identity.md
-    cases: [skew-doc-contract]
-  - path: skills/synthesis-project-management/references/active-sessions-template.md
-    cases: [skew-doc-contract]
-  - path: skills/synthesis-project-management/SKILL.md
-    cases: [skill-budget]
+  - path: skills/synthesis-daily-rituals/scripts/sync_watermark.py
+    cases: [run-bound-blocks-stale-read, targets-block-individually, window-echoes-epoch-bounds, bare-date-is-end-of-day, schema-one-store-migrates]
+  - path: skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
+    cases: [run-bound-blocks-stale-read, targets-block-individually, window-echoes-epoch-bounds, bare-date-is-end-of-day, schema-one-store-migrates, rituals-doc-contract, slack-doc-contract]
+  - path: skills/synthesis-daily-rituals/references/sync-watermarks.md
+    cases: [rituals-doc-contract]
+  - path: skills/synthesis-daily-rituals/SKILL.md
+    cases: [rituals-doc-contract]
+  - path: skills/synthesis-slack-sync/SKILL.md
+    cases: [slack-doc-contract]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -32,34 +30,38 @@ changed_surfaces:
   - path: .codex-plugin/plugin.json
     cases: [release-manifest-parity]
   - path: CHANGELOG.md
-    cases: [release-changelog-parity, skew-doc-contract]
+    cases: [release-changelog-parity]
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: newer-board-refused-with-remedy
+  - id: run-bound-blocks-stale-read
     control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_rows_refuses_a_board_newer_than_the_engine
-    motivating_defect: a-stale-engine-reported-the-freshly-migrated-shared-board-as-corrupt-with-a-bare-column-count
-  - id: wider-row-names-newer-engine
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_begin_then_status_since_run_lists_exactly_what_was_skipped
+    motivating_defect: a-surface-written-at-0915-counted-as-current-all-day-so-no-run-could-see-its-own-staleness
+  - id: targets-block-individually
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_wider_rows_than_the_engine_knows_name_the_newer_engine
-    motivating_defect: a-row-wider-than-the-engine-knows-has-one-cause-and-the-message-did-not-say-it
-  - id: section-padding-collapses
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_a_target_read_before_the_run_is_stale
+    motivating_defect: mid-day-passes-re-read-only-the-targets-the-morning-skipped-and-a-0927-answer-was-reported-unanswered-at-1751
+  - id: window-echoes-epoch-bounds
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_replace_table_collapses_padding_and_stays_fixed
-    motivating_defect: every-table-rewrite-grew-the-board-by-one-blank-line-until-a-thousand-read-as-a-second-table
-  - id: remedy-names-newest-cached-engine
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_window_prints_the_epoch_bounds_a_read_call_takes
+    motivating_defect: a-hand-typed-oldest-of-0750-today-reported-five-channels-empty-that-were-not
+  - id: bare-date-is-end-of-day
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_engine_remedy_names_the_newest_cached_engine
-    motivating_defect: a-remedy-that-says-update-without-naming-the-path-sends-the-operator-back-to-guessing
-  - id: skew-doc-contract
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_a_bare_date_means_end_of_day_so_today_is_refused_mid_day
+    motivating_defect: a-mid-day-run-that-stamps-today-declares-hours-it-has-not-read
+  - id: schema-one-store-migrates
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_version_skew_documented_on_public_surfaces
-    motivating_defect: a-refusal-nobody-is-told-about-reads-as-a-new-corruption
-  - id: skill-budget
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_a_schema_one_date_reads_as_complete_through_end_of_that_day
+    motivating_defect: existing-stores-hold-bare-dates-and-a-wrong-reading-would-reopen-or-hide-a-day
+  - id: rituals-doc-contract
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget
-    motivating_defect: a-version-bump-must-not-be-an-excuse-for-the-main-document-to-regrow
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_rituals_open_every_sync_with_begin_and_reread_every_target
+    motivating_defect: a-mechanism-nobody-is-told-to-run-is-not-a-control
+  - id: slack-doc-contract
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_slack_sync_counts_the_users_own_outbound
+    motivating_defect: the-principals-own-replies-were-not-sweep-state-so-discharged-items-stayed-owed
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-slack-sync/SKILL.md
+++ b/skills/synthesis-slack-sync/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-project-management"]
 metadata:
   author: "Rajiv Pant"
-  version: "3.7.0"
+  version: "3.8.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -15,6 +15,22 @@ metadata:
 A protocol for syncing Slack channels and threads to local transcript files using Slack MCP. Designed for AI-assisted workflows where an agent reads Slack on behalf of a user, saves transcripts locally, and updates a daily action plan.
 
 This skill provides the **protocol** — the sync methodology, thread re-reading discipline, transcript format, and action plan update rules. A per-project **config file** provides the specifics: which channels, which paths, which DMs. Prefer `.agents/slack-sync.yaml`; existing `.claude/slack-sync.yaml` configs remain supported.
+
+## v3.8.0 — Windows are computed, coverage is recorded, the user's own outbound counts
+
+v3.8.0 (2026-09-01) closes three defects from one day. A hand-typed `oldest`
+(07:50 *today* instead of yesterday) reported five channels empty that were
+not; two mid-day syncs re-read only the targets the morning had skipped,
+so a DM answered at 09:27 was reported unanswered at 17:51 on a 09:15 read;
+and the user's own replies were not treated as sweep state that discharges
+owed items. Steps 1, 3, and 3b now take `oldest` from
+`sync_watermark.py window` (synthesis-daily-rituals) and quote its
+human-readable bounds in the report; Step 4 records every saved read with
+`sync_watermark.py advance --target`; Step 5 cross-references the user's
+own outbound against every owed item and forbids "unanswered" or "unsent"
+on a read older than the current run, which `status --since run` proves.
+Every sync re-reads every declared target — "already read today" is a
+statement about the past.
 
 ## v3.7.0 — The sweep steps consume preflight instead of contradicting it
 
@@ -374,11 +390,19 @@ of the sweep and included in the sync report.)
 For each channel in the preflight's resolved-target list:
 
 ```
-slack_read_channel(resolved_channel_id, oldest=LAST_SYNC_TIMESTAMP, limit=30)
+slack_read_channel(resolved_channel_id, oldest=WINDOW_OLDEST, limit=30)
 ```
 
-- On **first sync of the day** (no channels transcript file exists yet): omit `oldest` or use midnight timestamp.
-- On **subsequent syncs**: use the timestamp of the last sync recorded in the channels transcript file.
+- **`WINDOW_OLDEST` is the `oldest=` epoch printed by**
+  `python3 <synthesis-daily-rituals-root>/scripts/sync_watermark.py window --workspace <W> --surface slack --target <resolved id>`
+  — never hand-computed, never copied from a transcript header, never
+  midnight. Quote the human-readable bounds the command prints in the sync
+  report, so the window is checkable by eye (v3.8.0; a hand-typed `oldest`
+  of 07:50 *today* once reported five channels empty that were not).
+- A **bootstrap window** (no watermark yet for that target or surface) reads
+  to the workspace's backfill bound and states that bound in the report.
+- **Every declared target is read every sync**, including targets read
+  earlier the same day — the window simply starts where the last read stopped.
 - Note the **reply count** on every message that has threads. These will be re-read in Step 2.
 
 ### Step 2: Re-read ALL active threads — today AND recent days
@@ -415,7 +439,7 @@ Rules:
 For each 1:1 DM in the preflight's resolved-target list:
 
 ```
-slack_read_channel(channel_id=RESOLVED_CONVERSATION_ID, oldest=LAST_SYNC_TIMESTAMP, limit=20)
+slack_read_channel(channel_id=RESOLVED_CONVERSATION_ID, oldest=WINDOW_OLDEST, limit=20)
 ```
 
 The resolved conversation id comes from preflight (Step 0), never from a
@@ -428,7 +452,7 @@ unresolved instead of silently skipping it.
 For each group DM in the preflight's resolved-target list:
 
 ```
-slack_read_channel(channel_id=RESOLVED_GROUP_DM_ID, oldest=LAST_SYNC_TIMESTAMP, limit=20)
+slack_read_channel(channel_id=RESOLVED_GROUP_DM_ID, oldest=WINDOW_OLDEST, limit=20)
 ```
 
 Group DMs (multi-party IMs) are separate from 1:1 DMs. They use channel IDs, not user IDs. Only check group DMs the preflight resolved from the config's declared list.
@@ -447,12 +471,20 @@ For each file:
 - Record the sync time (e.g., `## Mid-day sync (~14:30 EDT)`).
 - If the file doesn't exist, create it with the standard header and create directories as needed.
 - If no messages of that type were found, skip that file (do not create empty files).
+- **Record the read once it is saved (v3.8.0):** for each target whose window
+  was read and whose messages (or confirmed absence) are now on disk, run
+  `python3 <synthesis-daily-rituals-root>/scripts/sync_watermark.py advance --workspace <W> --surface slack --target <resolved id> --through <the window's latest>`.
+  The watermark advances only after the write, so a read that failed to save
+  cannot claim coverage — and the gate at the end of the sync
+  (`sync_watermark.py status --workspace <W> --surface slack --since run --targets-from <declared.json>`)
+  lists exactly the targets this sync did not re-read.
 
 Meeting transcripts are NOT part of Slack sync — they are handled by the daily-rituals skill and placed in `{transcripts_repo}/{transcripts_path}/meetings/YYYY-MM-DD-<slug>.md`.
 
 ### Step 5: Update action plan
 
 - **Mark sent messages as SENT** with timestamps. Cross-reference messages the user sent against draft messages in the action plan.
+- **The user's own outbound is first-class sweep state (v3.8.0).** Every message the user sent that Steps 1-3b returned — in channels, threads, DMs, group DMs — is cross-referenced against every owed item, draft, and waiting-on entry, and each item it discharged is marked with the message time. A claim that something is unanswered or unsent must cite the read that established it, and that read must belong to this run: `status --since run` green for that target, or the claim is not made. Origin (2026-09-01): a question answered by the user at 09:27 was reported unanswered at 17:51, citing a 09:15 read.
 - **Update waiting-on-others** table with any new information from thread replies.
 - **Note new action items** or signals worth responding to in the "Things to Know" section.
 - **Draft replies with grounding research.** When a Slack message requires a response (technical question, status request, bug report), research the answer in primary sources (source code, config files, PRs, deploy scripts, running systems) BEFORE drafting. Never draft a reply based solely on transcripts or conversation memory. The user's credibility depends on accuracy.


### PR DESCRIPTION
## Summary

Four sync-system defects reported from one day-start, one mechanism. The v2.27.0 watermarks were day-granular: a surface written at 09:15 counted as current for the rest of the day, mid-day passes re-read only the targets the morning had skipped, an "unanswered" claim at 17:51 rested on the 09:15 read while the answer had gone out at 09:27, and a hand-typed `oldest` of 07:50 *today* reported five channels empty that were not.

- **`sync_watermark.py` v2 (synthesis-daily-rituals 2.30.0).** Watermarks are ISO-8601 moments — the last moment actually written — and a surface carries one per declared read target. `begin` stamps a run; `status --since run` exits non-zero naming every declared surface or target the run did not re-read (`--max-age` as the alternative bound, `--targets-from` for the declared set, per-target deferrals). `window` prints human-readable bounds beside the epoch `oldest` a read call takes. A bare date means the END of that day and is refused while that end lies ahead, so a mid-day run records the moment it read. Schema-1 stores are read as what they meant, capped by their recorded write time and never in the future (caught live: a "through today" written at 16:48 would otherwise have produced a future `oldest`).
- **Protocol (synthesis-slack-sync 3.8.0, rituals Day-Start 3b / Day-End 1 / Mid-Day).** Every sync re-reads every declared target ("already read today" is a statement about the past); Steps 1/3/3b take `oldest` from `window`; Step 4 records each saved read with `advance --target`; Step 5 treats the user's own outbound as first-class sweep state and forbids "unanswered"/"unsent" on a read older than the current run.
- New `references/sync-watermarks.md` carries the contract, store schema, and rationale. Release surfaces at 4.79.0 with a fresh transaction-bound acceptance manifest.

## Verification

- `pytest` rituals + guard + git-hooks group: 112 passed (37 watermark tests, including run-bound staleness, per-target blocking, CLI `begin`/`status --since run`, targets file, epoch echo, end-of-day refusal, schema-1 migration incl. the never-future cap, and the documented-rule contracts on both skills)
- Full AGENTS.md verification list green locally; conformance source 204/204
- Live read of a copy of a real workspace store: schema-1 "through today" written 16:48 → window `16:48 EDT → now`, `oldest` in the past; a surface last written yesterday blocks under a 4h bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)
