### PR TITLE
Restructure the daily-rituals and slack-sync documents under the 500-line budget (4.80.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.79.0",
+  "version": "4.80.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.79.0",
+  "version": "4.80.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.80.0] - 2026-09-01
+
+**The daily-rituals and Slack-sync documents are back under the 500-line
+rule, and a test keeps them there.** `synthesis-daily-rituals/SKILL.md` had
+grown to 1,319 lines and `synthesis-slack-sync/SKILL.md` to 762 against the
+repository's below-500 rule, most of it release-by-release history stacked
+above the checklists, followed by plan formats, worked examples, and
+rationale. Both were restructured rather than trimmed: every operating rule
+and checklist step stays in the main document (454 and 357 lines), while the
+version history and the incidents behind each rule, the daily-plan format
+and cockpit vocabulary, the full draft-grounding protocol, and the
+transcript and permalink formats moved verbatim into `references/`
+(daily-rituals 2.31.0: `version-history.md`, `plan-format.md`,
+`draft-grounding.md`; slack-sync 3.9.0: `version-history.md`,
+`transcript-formats.md`). Where a block was condensed, the main document
+carries a rule digest; wrapped list items and paragraphs were re-flowed to
+the files' single-line style, which is markdown-neutral. A pinned test
+(`synthesis-daily-rituals/scripts/test_skill_documents.py`, in the CI group
+both skills share) fails when either document reaches 500 lines, when a
+load-bearing rule anchor leaves it, when a moved block is missing from its
+reference, or when a reference or template is not linked from the main
+document. Nothing in either protocol changed; every existing documented-rule
+contract test still passes against the main documents.
+
 ## [4.79.0] - 2026-09-01
 
 **Sync watermarks now carry a time and a target, and a run proves its own

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Two operational documents are back under the line budget, with a test
+holding them there (September 2026).** Release **4.80.0** restructures the
+daily-rituals and Slack-sync skills: every rule and checklist step stays in
+`SKILL.md` (454 and 357 lines, down from 1,319 and 762), while history,
+formats, examples, and rationale live in `references/`; regrowth now fails
+CI. See the [4.80.0 release notes](CHANGELOG.md).
+
 **A sync now proves what it re-read, to the minute (September 2026).**
 Release **4.79.0** replaces day-granular sync watermarks with timestamps
 per surface and per declared read target: `begin` stamps a run,

--- a/skills/synthesis-daily-rituals/SKILL.md
+++ b/skills/synthesis-daily-rituals/SKILL.md
@@ -10,7 +10,7 @@ depends_on:
   - synthesis-checkpoint
 metadata:
   author: "Rajiv Pant"
-  version: "2.30.0"
+  version: "2.31.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -19,464 +19,7 @@ metadata:
 
 Standard day-start and day-end rituals for synthesis engineering projects. These are the global (per-person) checklists. Each project may have a project-specific supplement that extends these with channel-specific sync, repo-specific checks, and stakeholder-specific communications.
 
-## v2.30.0 — Watermarks carry a time and a target, and a run proves its own coverage
-
-v2.30.0 (2026-09-01) fixes what a day-granular watermark could not see: a
-surface written at 09:15 counted as current for the rest of the day, so a
-mid-day pass that re-read only what the morning had skipped let the
-morning's own reads go stale — and an "unanswered" claim at 17:51 rested on
-a 09:15 read while the answer had gone out at 09:27. Four defects, one
-mechanism: watermarks are ISO-8601 timestamps (the last moment actually WRITTEN,
-never the last attempted); a surface carries one watermark per
-declared read target; `begin` stamps a run and
-`status --since run` exits non-zero on every declared surface or target not
-re-read during THIS run; and `window` echoes human-readable bounds beside
-the epoch `oldest` a read call takes — a window parameter is a claim about
-time and is computed, not typed. Every sync re-reads every declared target:
-"already read today" is a statement about the past. Contract, store, and
-rationale: [references/sync-watermarks.md](references/sync-watermarks.md).
-
-## v2.27.0 — Sync windows follow the last write, and a recorded gap blocks
-
-v2.27.0 (2026-08-27) replaces run-anchored sync windows with per-surface
-watermarks, and makes a recorded gap something a later run must act on.
-
-**The defect.** A window anchored on when the previous run *executed* cannot see
-its own holes. Skip a run and the hole it leaves is never revisited, because the
-next window starts at now-minus-a-bit rather than at the last day actually
-written to disk. Nothing persisted "the mirror is complete through date X", so
-no run could detect what it had missed. Compounding it, the `gaps` field was
-honest and completely inert: writing a gap and closing a gap are different acts,
-and nothing forced the second. A gap was recorded in three consecutive artifacts
-and no run ever read those lines back.
-
-**The rule.** Each surface carries a watermark — the last date actually
-WRITTEN, never the last date attempted — in `~/.synthesis/sync-watermarks/`,
-managed by `scripts/sync_watermark.py`:
-
-- every sync computes its window from the watermark, so a hole is revisited
-  automatically and nobody has to notice it;
-- the watermark advances only after a successful write, so a run that fetches
-  nothing, errors, or is interrupted cannot declare the day covered;
-- `sync_watermark.py status --workspace W` exits non-zero while any surface has
-  an unclosed gap. Run it in Day-Start Step 3 and Day-End Step 1. An open gap is
-  closed this run or deferred with an explicit reason, and a deferral lasts one
-  working day — an indefinite silence is how a recorded gap becomes furniture.
-
-Surfaces are tracked independently: one surface closing never vouches for
-another, which is the completeness claim that hid the original gap.
-
-**The general lesson, worth more than the fix.** Detection that nothing consumes
-changes nothing. The gap field was accurate every time it was written; what was
-missing was any mechanism that read it back. When adding a check, ask what
-consumes its output and what happens when the answer is bad — a finding with no
-consumer is a note to self.
-
-## v2.26.0 — Lead-time meeting preps: high-stakes meetings get prepared a business day ahead
-
-Same-day prep packs (v2.12.0) are right for routine meetings and structurally wrong for
-high-stakes ones: a strategy-bearing 1:1 prepared minutes before it starts gets a summary of
-what the *agent* has been processing lately, not what the *counterpart* cares about —
-recency bias with a deadline. The origin incident: an exec weekly was rescheduled onto the
-current day, prep was requested sixteen minutes before the start, and the first draft led
-with the week's loudest workstream instead of the principals' stated mandate; there was no
-time to research either half. Preparing one business day ahead is what allows reading the
-prior meeting's transcript, checking the mandate sources, and thinking strategically.
-
-A workspace opts in by declaring **`.agents/meeting-preps.yaml`**:
-
-```yaml
-# .agents/meeting-preps.yaml — lead-time prep declarations (v1)
-lead_time_preps:
-  - name: exec-weekly            # slug used in the prep-pack filename
-    title_contains: "Weekly - Principal and Exec"   # calendar title match (case-insensitive)
-    attendees_any: [exec@example.com]               # OR-matched; either matcher may be omitted
-    business_days_ahead: 1
-    sources:                     # what the prep MUST be built from (the durable record)
-      - prior-meeting-transcript # open loops and commitments from last time
-      - mandate-sources          # the documents/transcripts where this person stated their priorities
-      - project-contexts         # CONTEXTs naming the attendee or the meeting's subjects
-```
-
-Four rules, enforced by the ritual steps below:
-
-1. **Generation is owed at the day-end BEFORE the meeting's business day** (Step 4a) — the
-   Calendar Guardian's tomorrow-review already looks at the right day in every mode
-   including Quick Close, so the prep rides the review that is already mandatory. Day-Start
-   Step 6 verifies presence for today's flagged meetings and regenerates stale packs; the
-   owed-weekly week-ahead scan flags any flagged meeting in the coming week so multi-day
-   research can start early.
-2. **A reschedule triggers an immediate refresh at detection time.** A flagged meeting that
-   MOVES onto today or tomorrow does not wait for the next ritual — whichever sync detects
-   the move regenerates the prep then. Reschedules are precisely when prep is most likely
-   to be stale and most likely to be skipped.
-3. **Prep is built from the durable record, not from session memory.** The declared
-   `sources` are read fresh: the prior meeting's transcript for open commitments, the
-   counterpart's own stated priorities from mandate sources, and project state. The
-   structural point of the lead time is that this reading takes longer than the minutes
-   before a meeting provide — a prep that skips the sources has not used the lead time.
-4. **The pack states its own basis.** Its header lists which declared sources were read and
-   the date of the newest one, so a reader can tell a researched pack from a summary of
-   recent activity. The v2.12.0 file contract (path, filename, H1/When/Who) is unchanged —
-   this section governs *when* and *from what*, not the format.
-
-Workspaces without the config keep v2.12.0 behavior unchanged.
-
-## v2.25.0 — Per-workspace sessions are the default; the principal is the dispatcher
-
-Distributed execution keeps the desk/worker split and the artifact contract, and corrects
-which worker mode is assumed. **The default is now an attended session rooted in each
-workspace, run on that workspace's own schedule** — the mode that matches where the
-principal is actually working, with the right directory, claims, and context. Desk-
-dispatched subagents demote to an opt-in for deliberately closing everything from one place.
-
-Two rules are made explicit because their absence invited a design that cannot work.
-**The principal is the dispatcher:** no session can start work in another, so the desk
-reports which workspaces are owed and the human opens the one that owes. **The desk never
-nudges, triggers, blocks on, or waits for a worker:** it folds what exists and reports the
-rest as not covered, so a desk pass is always complete on its own terms.
-
-Origin: a desk that tried to trigger workers by messaging their sessions went 0 for 2 —
-once to a session stale by two hours, once with no reachable session at all — while the
-artifact path delivered both times. Session messaging is a relay between humans at
-keyboards, not a dispatch primitive; depending on it relocates multi-session overhead
-rather than removing it. Independent close times per workspace are likewise now stated as
-normal operation, which the timestamped artifact schema already supported. Detail:
-`references/ritual-worker-contract.md`.
-
-## v2.24.2 — The shell keeps the consumer's section vocabulary
-
-Separating plan storage changes where content lives, not what the sections are called.
-Renderers classify plan sections by heading vocabulary, so a shell written with invented
-headings renders as undifferentiated prose while every typed region the reader works from
-comes up empty — the plan looks blank exactly when it is full. Shells reuse the
-established headings for any region they populate and confine novelty to the coverage
-block and pointer lines; producer and consumer change together or not at all. Detail and
-origin incident: `references/ritual-worker-contract.md` ("Plan storage separation").
-
-## v2.24.1 — Fragment placement and consumer obligations
-
-Clarifies two points in the plan-separation contract that adopters hit immediately: a
-workspace's fragment belongs in the individual's **private** repository (not the
-organization-shared one) when a workspace carries both, and a consumer that merges
-fragments for display must never cache merged output back into the person-side store and
-must render an unresolved pointer as an explicit marker rather than dropping it.
-
-## v2.24.0 — Plan storage separation: workspace fragments, person-side shell
-
-Organizational data must be erasable by deleting the organization's workspace folders —
-a hard requirement in regulated environments (banks, government, contract exits) and good
-hygiene everywhere. The daily plan therefore stops copying workspace content into the
-person-side repository: **the worker artifact doubles as that workspace's plan fragment**
-(it already holds the plan-facing sections, in the workspace-private repo), and the
-person-side plan becomes a **shell** — coverage line, the principal's own timeline,
-minimal cross-workspace conflict references, the permanent personal section, and pointer
-lines to fragments. Consumers merge at display time; presentation stays converged
-("one brief") while storage separates. The erasure boundary and the strict-shell option
-for title-level erasure are specified in
-[`references/ritual-worker-contract.md`](references/ritual-worker-contract.md) ("Plan
-storage separation"). Pre-existing mixed plan files are left to a deliberate migration.
-
-## v2.23.0 — Distributed ritual execution: desk and workers
-
-The ritual can now fan its sync labor out per workspace while its output stays singular.
-One seat — the **desk**, the ritual's home — frames the day and produces the single brief;
-each workspace runs its labor as a **worker** that writes a structured summary artifact to
-a declared path, and the desk folds artifacts instead of loading workspace detail inline.
-Workers never message the desk: **worker→file, desk→file** — an artifact survives whether
-or not anyone was listening, and a missing artifact is itself the legible "not covered"
-signal. The full schema, path convention, registry format, desk obligations, and failure
-semantics live in [`references/ritual-worker-contract.md`](references/ritual-worker-contract.md);
-the operative rules are in "Distributed ritual execution" below. Every brief now carries a
-mandatory **coverage line**. Design record: the ritual-home seat's 2026-08-11 distributed-
-ritual-architecture artifact (decisions: output never distributes; fan out execution,
-converge presentation).
-
-## v2.22.0 — Local continuity during the day; remote readiness at day-end
-
-Routine turns, day-start, and mid-day sync keep the filesystem-backed project
-record current and rely on session-attributed local receipts. They do not
-create Git commits or network pushes merely to switch Claude Code and Codex on
-one machine. Day-end is the batched cross-machine publication boundary: it
-publishes owned source work under repository policy, flushes exact private
-project-context paths, runs remote-mode doctor and conformance, and verifies
-remote heads. An interrupted task remains locally recoverable from its edit
-manifest even when Stop never ran.
-
-## v2.21.0 — Inbox hygiene joins the morning sync, scoped to the seat
-
-Day-Start gains Step 3d: when `~/.synthesis/inbox-cleanup/scopes.yaml` exists,
-the ritual resolves which accounts this workspace's seat may sweep (personal
-seat: all; client seat: its own only — the inbox-cleanup skill's v1.5.0
-workspace-scope contract) and runs the sweep dry-run-first. Unknown workspace
-or missing config stops the step loudly; sweep results always name the scope
-("7 of 9 in scope, 7 swept") so partial can never impersonate complete.
-
-## v2.20.0 — Calendar Guardian: the rituals hold a perimeter around the calendar
-
-Three additions, all cadence for the chief-of-staff skill's new **Calendar
-guardian** doctrine (which owns the protocols; these steps own the schedule):
-Day-End Step 4a reviews the next working day (plus the weekend on the last
-working day of the week) and places id-tracked, auto-expiring holds over
-tomorrow's open windows — in every mode including Quick Close, because it
-generates the drafts Step 4 then handles. Day-Start Step 6 re-verifies the
-morning against overnight arrivals and refreshes the same-day shield. The
-owed-weekly review (Step 10) gains the week-ahead and month-ahead horizons; the
-month pass is what starts absence-notification clocks while notifying is still
-early and cheap. Requires `calendar_guardian` keys in the chief-of-staff
-private config; without them the steps report "unconfigured" rather than
-guessing thresholds.
-
-## v2.19.0 — Every sync covers every configured surface (email + meeting transcripts + document comments join Slack/Chat)
-
-v2.19.0 (2026-08-09) extends the complete-surface principle from v2.17.0 to its conclusion: a sync request — Day-Start Step 3, the Mid-Day Sync Protocol, or Day-End Step 1 — covers ALL surfaces the workspace routinely syncs, not only the chat surfaces. The declared set: Slack (always), Google Chat (`.agents/gchat-sync.yaml`), **email** (established `transcripts/email/` practice or explicit config), **meeting transcripts** (`.agents/meeting-transcripts.yaml` — any meeting ended in the window), and **document comments** (established `transcripts/docs/` practice or explicit config). The surface set is a declared list exactly like the repo list in the source-code sync — the agent does not re-apply its own judgment about which surfaces feel active (the v2.12.1 rule, applied to channels). A sync that runs fewer surfaces than the declared set must name the omission explicitly in its report; a sync reported without naming its gaps claims a completeness it does not have. Origin incident: 2026-08-09 — a mid-day sync ran Slack and Chat only, reported all-quiet, and missed that the day's most consequential correspondence (a CEO-facing email delivering two Google Docs) had happened entirely on the unswept surfaces.
-
-## v2.18.0 — Dual-client parity in Day-Start; fail-closed context gate in Day-End
-
-v2.18.0 (2026-08-03) adds two checks. Day-Start Step 1 gains the `conformance.py parity` dual-client drift check: the ecosystem's dual-runtime guarantee (Claude Code + Codex) previously had no daily detection layer, and a release that reached one client but not the other — or neither — stayed invisible until something broke. Proven necessary the day it was written: the first live run caught main at 4.12.0 with both installed clients at 4.11.0. Day-End Step 7 gains the fail-closed active-project context gate: `context_doctor.py --project` must be clean for each project worked today before the close-out proceeds. Posture decision recorded in establish-codex-first-class-synthesis: fail-closed for the actor's own active project (fixable in minutes by the session that caused it), report-only for the corpus (gating one session on another's legacy debt manufactures the false alarms that train bypass). Pairs with synthesis-context-lifecycle v1.5.0 and synthesis-agent-conformance parity mode.
-
-## v2.17.0 — Google Chat joins the channel syncs
-
-v2.17.0 (2026-08-03) adds Google Chat as a first-class channel sync beside Slack, in all three sync moments: Day-Start Step 3b, the Mid-Day Sync Protocol, and Day-End Step 1. A workspace opts in by declaring `.agents/gchat-sync.yaml` (sibling to `slack-sync.yaml`); workspaces without the config skip the step silently. Rationale: in many organizations executives and cross-functional teams live in Google Chat while delivery teams live in Slack — syncing only Slack leaves a systematic blind spot exactly where the highest-stakes correspondence happens.
-
-The sub-step is tool-agnostic (any Google Chat-capable MCP; a self-hosted multi-account Workspace server works with plain user OAuth). Four disciplines it encodes, learned from the first production rollout:
-
-1. **Enumerate spaces fresh each run** — per-meeting chat spaces are created for every recorded meeting; a hand-maintained space list is stale within a day. List spaces at sync time, then read what the config's scope selects.
-2. **Window by `createTime`, treat a full page as truncated** — some Chat clients expose no pagination cursor on message listing; when a read returns exactly the page size, narrow the time window and re-read until complete.
-3. **Preserve the raw `users/<id>` on every message line** alongside any resolved display name. Chat sender IDs are stable, workspace-universal profile IDs; keeping them beside inferred names means a later authoritative resolver (the People API) can correct every past attribution mechanically. Inference layers get names wrong; preserved primary keys make those errors repairable instead of permanent.
-4. **Same confidentiality handling as Slack DMs** — Chat DMs carry executive and personnel correspondence; transcripts belong in the workspace-private repo only.
-
-## v2.16.0 — Agent-neutral day-end runtime
-
-v2.16.0 (2026-07-29) installs the launcher and macOS nudge under
-`~/.synthesis/day-end/`, a stable runtime owned by synthesis rather than by one
-agent client's skill cache. The launcher can open Codex or Claude Code; `auto`
-prefers Codex when both CLIs are present, and `--agent codex|claude` persists an
-explicit choice. The installer atomically writes exact files, refuses
-symlinked runtime roots, never removes the runtime tree, and verifies source
-survival in its tests.
-
-## v2.16.0 — Context-integrity doctor joins Day-Start Step 1
-
-v2.16.0 (2026-07-31) adds `context_doctor.py --quiet` beside the git-hooks and message-guard doctors in Step 1. Those two protect the commit and send boundaries; this one protects the durable project record itself — the tiered CONTEXT/REFERENCE/sessions layer that makes work resumable by a different agent on a different machine. It was the last protective layer in the stack with no health check, which meant its correctness rested entirely on an agent remembering to maintain it and reporting honestly that it had. Pairs with synthesis-context-lifecycle v1.4.0.
-
-## v2.15.1 — Message-guard doctor joins Day-Start Step 1
-
-v2.15.1 (2026-07-29) adds the `synthesis-message-guard --doctor` check beside the git-hooks doctor in Step 1. The message guard is the correspondence twin of the commit-boundary scanner: a fail-closed PreToolUse gate that blocks send/draft tool calls without a grounding ledger and a clean register scan. Both guards get their heartbeat in the same ritual step.
-
-## v2.15.0 — Protection-health check in Day-Start Step 1
-
-v2.15.0 (2026-07-28) adds one checkbox to Day-Start Step 1: run the synthesis-git-hooks `--doctor` self-check before any commit-bearing work. Rationale: the commit-boundary scanner is the enforcement layer for credential and confidentiality protection, and a scanner that fails open or drifts from source is invisible precisely because its job is to be invisible when healthy. The ritual is the monitoring loop it was missing. Pairs with synthesis-git-hooks v2.0.0 (fail-closed engine, dependency-free sidecar, drift detection).
-
-## v2.14.0 — Day-End Closure: two-speed day-end, owed-weekly review, decay tags, day-end state
-
-v2.14.0 (2026-07-08) redesigns the day-end around the observed failure mode: on busy or tired evenings the WHOLE ritual gets skipped, and three things decay invisibly — outbound-communication timing (appreciation and replies lose value overnight), lessons that were warm at 5 PM, and the user's own closure on the day. A four-week reconciliation (via `synthesis-catchup-ledger`) showed batch send-passes succeeding whenever a ritual ran, every decay clustering on the zero-ritual days, and the Friday-only Weekly Loose-Ends Review silently disabled for three straight weeks because it lived inside the ritual being skipped. The design principle: make the default evening close small enough to never skip, make starting it one word, make skipping it visible, and decouple the weekly safety net from the evening ritual entirely.
-
-1. **Two-speed day-end, always ask.** The day-end gains a first-class **Quick Close** mode (~10 minutes, exactly three human moments) alongside full mode and observer mode. The session asks the one-letter mode question every time — no time-of-day silent defaults. Spec: "Day-End Modes" block at the top of the Day-End Checklist.
-2. **Weekly Loose-Ends Review is owed weekly, not Friday-evening-bound.** The review runs at the FIRST ritual on or after Friday — day-start included, any day-end mode included — tracked via the state file. See the rewritten Step 10 gating.
-3. **Decay tags.** Time-sensitive drafts carry a `**Decays:** YYYY-MM-DD (reason)` line from creation. Plan generation applies the tag automatically to the classes field evidence shows decay fastest: appreciation/kudos and acknowledgments, public corrections, and event-bound items. Day-End Step 4 becomes an explicit send-or-release pass over the tagged set — nothing decay-tagged carries silently past its date.
-4. **No commitment line without a date or a park.** Every new commitment entering a daily plan gets a do-by, a Decays tag, or an explicit `parked (reason)` marker. Single-mention items that get none of the three are how commitments vanish without a trace.
-5. **Lesson candidates accumulate during the day.** Daily plans gain a `## 🌱 Lesson candidates` H2. Any session — mid-day syncs, checkpoint moments, ad-hoc work — appends one-line candidates as insights occur. Day-end curates (keep/drop) instead of recalling from scratch; "warm" moves from 5 PM to the moment of insight.
-6. **Day-end state file (producer).** Every ritual, both directions, every mode, writes `~/.synthesis/day-end/state.json` (atomic temp+rename) and appends one line to `~/.synthesis/day-end/history.jsonl`:
-
-   ```json
-   {
-     "last_day_end":   { "date": "2026-07-08", "mode": "quick", "outcome": "clean", "sent": 3, "released": 1 },
-     "last_day_start": { "date": "2026-07-08" },
-     "last_weekly_review": "2026-07-03",
-     "streak_day_end": 4
-   }
-   ```
-
-   `streak_day_end` = consecutive workdays with a completed day-end, computed from history at write time. Consumers: the synthesis-console day-end chip, the nudge's suppression check, and the day-start brief line ("day-end: ran Mon ✓ quick · skipped Tue").
-7. **Launcher + nudge ship in `scripts/`.** The ritual is an Agent Skill and always runs INSIDE an agentic coding session — nothing here changes that. `scripts/day-end` is a *launcher, not a runner*: it opens Codex or Claude Code with the ritual invocation as the first prompt, purely to remove cold-start friction at the end of the day. `DAY_END_AGENT_CMD` selects a CLI for one run; the installed `agent-cli` file persists `auto`, `codex`, or `claude`. `scripts/day-end-nudge.sh` shows one generic macOS banner at 16:55 on weekdays unless the state file says today's day-end already ran — notification only, never a mutation, generic fixed text (see the alert-confidentiality rule below). Install steps follow.
-8. **Audio-alert section aligned with alert confidentiality.** Spoken alerts and banners carry zero identifying content and honor the `~/.synthesis/quiet-audio` mute flag — matching the synthesis-repo-guard v2 alert model. The old `say "[user], [task description] is complete"` pattern is retired: task descriptions can name clients, repos, or people, and speakers/screen-shares leak.
-
-**Consumer coupling:** synthesis-console renders `state.json` (day-end chip) and `**Decays:**` lines (draft badges). Producer-grammar changes here require the console's `docs/cockpit-design.md` to change in the same wave — the document-as-contract rule.
-
-### Installing the launcher and nudge (macOS)
-
-```bash
-# Auto-select Codex first when both supported clients are available
-python3 <synthesis-daily-rituals-root>/scripts/install_day_end.py
-
-# Or persist one client explicitly
-python3 <synthesis-daily-rituals-root>/scripts/install_day_end.py --agent codex
-python3 <synthesis-daily-rituals-root>/scripts/install_day_end.py --agent claude
-```
-
-The installer copies the launcher and nudge into
-`~/.synthesis/day-end/bin/`, links `~/.local/bin/day-end` to that stable
-runtime, writes the LaunchAgent with an absolute program path, and reloads it.
-Re-run the installer after the skill changes. Use `--no-launchctl` only for CI
-or an installation audit that should write and verify artifacts without
-loading the LaunchAgent.
-
-## v2.13.0 — Per-workspace `repos.yaml` is the machine-readable repo list
-
-In v2.13.0 (2026-07-08), the source-code sync steps (Day-Start 3a, Day-End 2) enumerate from the workspace repo manifest when one exists: `<workspace>/.agents/repos.yaml` — a symlink into the workspace's private context repo, generated and maintained per synthesis-mac-sync v1.6.0 (which owns the file's schema and lifecycle). Sync every repo with `ritual_sync: yes`. A manifest with `status: dormant` means "skip this workspace's source-code sync entirely — and never delete anything" (retention rule). The workspace `AGENTS.md` "Workspace Repos" table remains the human-readable view and the FALLBACK source when no `repos.yaml` exists. The v2.12.1 rule applies identically to both sources: the declared list is the complete decision — no agent activity-judgment.
-
-## v2.12.1 — Source-code sync scope: the workspace table decides (no agent activity judgment)
-
-In v2.12.1 (2026-07-08), the source-code sync steps (Day-Start 3a, Day-End 2) drop the "associated with active work" qualifier from v2.7.0. The workspace's `AGENTS.md` "Workspace Repos" table is the COMPLETE decision about what to sync: every repo the table marks **Yes** gets synced on every ritual run, whether or not it feels active. The agent must not re-apply its own judgment about which repos are "active" — that judgment layer is exactly what let a collaborator repo drift unnoticed for ~6 weeks (its default branch still tracked a legacy remote after a Git-host migration, silently accumulating "unpushed" commits that the repo guard then flagged repeatedly). Wherever the "associated with active work" phrasing survives in older version notes below, this rule supersedes it. A workspace that wants a repo excluded marks it **No** in the table, with the reason.
-
-## v2.12.0 — Cockpit Mode: meeting-prep packs (`meeting-preps/` + `## 📋 Prep packs`)
-
-In v2.12.0, the Day-Start ritual gains an optional **meeting-prep step** (runs inside Step 6, after the calendar fetch): for each substantive meeting on today's calendar, write a one-pager prep pack to `<knowledge-root>/meeting-preps/YYYY-MM-DD-HHMM-slug.md` and index today's packs in the day plan under a `## 📋 Prep packs` H2 (one list line per pack, linking to the consumer's `/prep/<source>/<slug>` route or the file path).
-
-**What a prep pack joins** (the chief-of-staff briefing-book function): the calendar event (when/who) × relevant transcripts (search by attendee across the workspace's transcripts) × hot items from project CONTEXTs that mention the attendee or the meeting's subject × open commitments in both directions (their waiting-on entries; your unsent drafts to them).
-
-**File contract:**
-- Filename `YYYY-MM-DD-HHMM-slug.md` (24h start time; slug identifies the meeting, e.g. `jessica-payne-1-1`). Packs sort chronologically; "today's packs" is a filename-prefix scan.
-- H1 = meeting title. A `**When:**` line and a `**Who:**` line (comma-separated attendees) near the top.
-- Body H2s are free-form; the recommended skeleton is `Context` / `Open commitments` / `Since last time` / `Suggested agenda`.
-- Packs are ritual-generated and updated by mid-day sweeps when new signals land (a transcript posts, a commitment discharges). Never hand-maintained.
-
-**Which meetings get packs:** 1:1s, externals, and any meeting with an attendee who appears in waiting-on tables or open drafts. Routine standups don't need packs unless something notable is queued.
-
-## v2.11.0 — Cockpit Mode: `## 📅 Calendar` section (typed consumer support)
-
-In v2.11.0, Cockpit Mode plans gain a canonical `## 📅 Calendar` H2 that the plan-generation step (Day-Start Step 6) writes from the user's calendar. This is the file-based bridge that lets consumers (synthesis-console v0.12+) render the day's events, bind Tier-C slots to windows, and visualize preemption — without the consumer needing calendar access of its own. The agent fetches events via the user's calendar tool (e.g. Apple Calendar MCP) at plan-generation time and refreshes the section during mid-day sweeps, so same-day meetings appear within one sweep cadence.
-
-**Canonical item shape** (one list line per event):
-
-```markdown
-## 📅 Calendar
-
-- 09:00–09:30 · Exec staff sync · Tony, Jane, Marcelo
-- 11:30–12:00 · CSA standup · CSA team
-- 15:00–15:30 · 1:1 · Jessica Payne
-```
-
-Rules: 24-hour `HH:MM–HH:MM` range first, then ` · `, then the event title, then optionally ` · ` and a comma-separated attendee list. En-dash or hyphen both parse. Lines that don't match still render as plain markdown (Postel's Law — nothing is dropped). All-day events use the title-only fallback form (no time range).
-
-**Tier-C window binding:** each `## 🎯 Today` slot H3 SHOULD name its window in the heading (e.g. `### Deep 1 — board memo (window 09:30–11:00)`). Consumers match slot windows against calendar events; an overlapping event that is not the slot itself renders as a preemption flag on the slot. The plan-generation step keeps slot windows consistent with the `**Budget:**` line's windows.
-
-## v2.10.0 — Cockpit Mode: Budget-Bound, Stakes-Routed Day Plans
-
-In v2.10.0 (2026-06-12), the day plan gains an alternative canonical mode — **Cockpit Mode** — for users whose discretionary time is scarce and preemption-prone (heavy meeting load, frequent same-day scheduling). The classic mode (full prioritized task board) remains valid; Cockpit Mode is the recommended default when the user's open-item count persistently exceeds what their calendar can absorb. Design rationale and the originating six-week evidence base live with the user's working-system design doc; the durable protocol is here.
-
-**The three rules of Cockpit Mode:**
-
-1. **Budget before backlog.** The plan generation step reads the user's calendar FIRST, computes discretionary windows, and commits at most ~70% of them — the remainder is an explicit preemption buffer. The plan header states the arithmetic (`Budget: windows … = N min. Committed: M min (≤70%). Buffer: N−M min`). A plan that ignores the calendar is a wish list.
-
-2. **Stakes-routed outbound (the tier matrix).** Every outbound communication is classified at creation:
-   - **Tier A — agent sends, clearly agent-labeled** (per the user's bot-labeling rule): routing/triage pings, scheduling requests, receipt acknowledgments, info relays with citations, follow-up nudges on delegated items. Sent within the work block; every send logged to a `## On your behalf` section in the day plan (the TICKER). Tier A never expresses the user's opinions, makes commitments, or touches sensitive relationships. Requires the user's standing approval of the matrix before activation; until then, Tier A routes to Tier B.
-   - **Tier B — one-tap queue:** drafts in the user's voice (kudos, substantive replies) and decisions-with-recommendation, presented in batches of ≤5 with APPROVE / EDIT / SKIP affordances answerable in one line. Two review windows per day.
-   - **Tier C — user-original:** deep work and relationship-critical writing. **Maximum 3 per plan**, each assigned to a named calendar window.
-   Ambiguity routes to Tier B, never to Tier A.
-
-3. **Preemption is normal, not failure.** When a same-day meeting lands on a committed window, the lowest-priority Tier-C item drops to the queue automatically — no re-planning ceremony. Dropped and expired items are caught by the `synthesis-catchup-ledger` ratchet (see that skill); decay rules apply at plan-generation time (stale kudos auto-expire to a consolidated-send; DECAYING items carry do-by dates; event-bound items expire at their event).
-
-**Plan format additions (cockpit-vocabulary compatible):** a `**Budget:**` line in the header; one `## ⚡ Decision needed` H2 when a decision is pending (max ONE per day where possible); `## 🎯 Today — N deep items` (the Tier-C slots); `## ☑️ One-tap batch` (Tier B, with a queued-overflow paragraph); `## On your behalf` (Tier A log); `## 📰 Brief` (readable in ≤90 seconds). Consumers (synthesis-console) treat `On your behalf` as a new lower-row collapsible until typed support ships.
-
-**Relationship to rituals:** day-start still runs the full sync stack (Steps 1–5 unchanged) — Cockpit Mode changes only Step 6 (Day Plan) and Step 7 (Morning Messages: Tier A items send instead of queueing, once the matrix is approved). The user's ritual calendar blocks become review windows; briefs should be prepared BEFORE the block begins whenever the agent runs scheduled/continuous.
-
-## v2.9.0 — Temporal & State Verification as Day-Start Step 1; new synthesis-checkpoint dependency
-
-In v2.9.0 (2026-05-27), the Day-Start ritual gains a new Step 1 — "Temporal & State Verification" — that runs BEFORE all other day-start steps. It anchors today's date from `date`, runs `git log` per active project to verify "last session," and reconciles cached `last_session` fields against git timestamps. Triggered by the 2026-05-27 inbox-cleanup mis-dated-session-log incident; codified to prevent recurrence in any synthesis project.
-
-Step renumbering across the day-start: NEW Step 1 = Temporal & State Verification. Old Step 1 (Context Optimization) → Step 2. Old Step 2 (Sync) → Step 3, with sub-steps 3a/3b/3c. Old Step 3 (Catch-Up Read) → Step 4. Old Step 4 (PR Review Queue) → Step 5. Old Step 5 (Day Plan) → Step 6. Old Step 6 (Morning Messages) → Step 7. The Day-End checklist is unchanged in numbering; Day-End Step 7 (Context Capture) gains explicit push-confirmation language matching the new discipline.
-
-New dependency: `synthesis-checkpoint` — a lightweight skill that codifies the date-verification + state-verification protocol. The day-start ritual delegates to synthesis-checkpoint for the per-project verification work in Step 1.
-
-The discipline this enforces (cross-tool, codified in the active global agent
-instructions and the synthesis-context-temporal-continuity project): treat
-session-log entry dates, "N days ago" claims, and CONTEXT.md fields as caches
-subject to drift. Verify against `date` and `git log` before quoting them into
-any output.
-
-## v2.8.0 — Weekly Loose-Ends Review on Fridays
-
-In v2.8.0 (2026-05-22), the Day-End ritual gains a Friday-only "Weekly Loose-Ends Review" step that scans the prior two weeks of work for incomplete, missed, or forgotten items and consolidates the surviving ones into a carryover list for Monday's day-start.
-
-**Rule:** on Fridays, before the Repo Guard final-verification step, scan the past 14 calendar days of daily plans + project context files + open commitment tables. For every surfaced item, classify it as STILL RELEVANT (carry into Monday), OBSOLETE (annotate-and-close in place), or AMBIGUOUS (surface to user). The output is a `## Weekly Loose-Ends Review` section in Friday's daily plan plus a populated `## Carried Items` section in Monday's plan.
-
-**Why:** the workweek's cracks accumulate invisibly. A missed close-of-business ritual on Wednesday means Thursday's plan doesn't pick up Wednesday's open threads. By Friday, several items can be quietly stranded. Without an explicit weekly catch, the user's mental model of "what's open" drifts from reality — and the longer the drift, the harder the eventual reconciliation. Running this on Friday afternoon catches stale items WHILE context is still warm; Monday begins with a clean carryover instead of an archaeological dig.
-
-**Why Friday and not Monday:** Monday is when the carryover gets ACTIONED. Friday is when the carryover gets ASSEMBLED. Assembling on Monday means starting the week with backwards-looking work; assembling on Friday means closing the week with a clean handoff to next week. The split also lets the user (or the agent) drop OBSOLETE items into context that's still fresh — Monday's view of "is this still relevant?" is fuzzier than Friday's.
-
-**Where in the day-end checklist:** new Step 10, just before Repo Guard (which stays the terminal step). The skill detects day-of-week and skips silently on non-Fridays. See Day-End Checklist below.
-
-**Idempotent re-runs:** if a Friday day-end ritual is missed and the agent runs the Weekly Loose-Ends Review on a later weekday (Saturday catch-up, Monday morning if Friday was skipped), it should still produce the same scan output — the scan is date-bounded, not weekday-bounded. The Friday-default is about WHEN it normally fires, not about whether the scan is meaningful on other days.
-
-## v2.7.0 — Source-Code Sync as a First-Class Ritual Step
-
-In v2.7.0 (2026-05-21), source-code synchronization becomes an explicit, first-class step in both the day-start and day-end rituals — running BEFORE the daily plan is drafted (so any drafts that need to be grounded in code can read current source) and BEFORE end-of-day verification (so tomorrow's day-start begins from a clean, current state).
-
-**Rule:** for every source-code repo associated with active work in the current workspace, fetch from all configured remotes and fast-forward the default branches (typically `main` and `develop`, plus any other long-running branches the team uses) BEFORE drafting the daily plan and BEFORE the end-of-day repo-guard verification. The skill stays generic — the list of repos per workspace is declared in the workspace `AGENTS.md` (with any client adapter importing it), not hardcoded.
-
-**Why:**
-
-- **Drafts must be grounded in current code.** The grounding protocol (see below) requires draft messages to be grounded in primary sources before sending. If local source is days behind origin, a draft that cites a function or PR may be quoting a stale version. Pulling first means the grounding research uses the current code.
-- **Avoid surprise conflicts at end-of-day.** Running fetch + fast-forward at day-end (just before the repo-guard verification) surfaces upstream divergence early — the user doesn't discover at 6 PM that develop moved fifty commits and a feature branch needs rebasing.
-- **One step, not "I'll do it later."** Folding it into the ritual makes it deterministic. The earlier `git fetch --all` checkbox in v2.6.0 and prior was easy to skip and only fetched (no fast-forward) — v2.7.0 makes the step substantive and visible.
-
-**What goes where:**
-
-- This skill defines the GENERIC pattern (fetch from all push remotes, fast-forward default branches, surface diverged or behind-state, report which repos were touched).
-- The WORKSPACE-SPECIFIC list of repos lives in the workspace's canonical
-  `AGENTS.md` (the Claude adapter imports it). Each repo's specific multi-remote
-  configuration is implicit from `git remote -v` inside that repo.
-- The PROJECT-SPECIFIC supplement may add per-project considerations (e.g., "after fetch, check whether feature/X is stale and needs rebase"). See "How to Create a Project Supplement" near the end of this file.
-
-**Sequence within day-start:** Context Optimization (Step 1) → **Source-code sync (Step 2a — NEW)** → Slack sync (Step 2b — was Step 2) → Meeting transcripts (Step 2c — was Step 2b) → Catch-up read (Step 3) → PR review queue (Step 4) → Day plan (Step 5) → Morning messages (Step 6).
-
-**Sequence within day-end (v2.8.0+):** Transcript sync (Step 1) → **Source-code sync (Step 2 — v2.7.0)** → Integration sweep (Step 3) → … → **Weekly Loose-Ends Review (Step 10 — v2.8.0, Fridays only)** → Repo guard final verification (Step 11 — was Step 10 in v2.7.0).
-
-## v2.6.0 — Draft Numbering Convention (numbers, not letters)
-
-In v2.6.0 (2026-04-29 very late evening), the convention for labeling drafts in a daily plan is fixed to **sequential integers** (Draft 1, Draft 2, Draft 3, …) rather than alphabet letters (Draft A, Draft B, …).
-
-**Rule:** the first draft of the day is Draft 1. Each subsequent draft increments by 1. No letter labels. No K-2 / K-3 sub-versioning — if a single piece of work produces multiple draft messages (e.g., the same praise routed to two audience-specific channels), each one gets its own integer (Draft 11, Draft 12, Draft 13). The chronological count of drafts in the plan equals the highest integer in use, which makes it easy to answer "how many drafts today?" by reading a single label.
-
-**Why:** numbers are easier to count at a glance, have no 26-item ceiling, and don't impose a mental "is K the 11th letter?" tax. The K-2 / K-3 sub-versioning that letter-labels invite is uglier than 11 / 12 / 13 and creates label-shape inconsistency in the file. Letter labels also make it harder to grep for "all drafts from #N onward" because alphabet ordering is lexicographic, not arithmetic.
-
-**Retraction handling:** if a draft is retracted (caught fabrication, sent-then-deleted, etc.), reserve the number with a brief marker — e.g., `### Draft 8 — retracted` plus a one-line note pointing to the session log — rather than renumbering subsequent drafts. Renumbering after a retraction creates label-drift across the file and any cross-references in chat. The reserved number is the durable record that the slot existed.
-
-**Cross-file consistency:** when renumbering a daily plan that's already been referenced from CONTEXT.md or session logs (those use the labels in effect at the time), update only the daily plan and add a brief note acknowledging the cross-reference gap. Historical narrative in session logs preserves the labels in use at the time — that's the right behavior, not a bug.
-
-**Pre-draft check:** when adding a new draft to a daily plan, the first thing the agent does is scan the file for the highest existing `Draft N` integer and use N+1. No alphabet thinking.
-
-## v2.5.0 — Draft Fence Convention (nested code blocks)
-
-In v2.5.0 (2026-04-29), the canonical fence convention for draft message bodies is documented to handle the case where a draft contains its own triple-backtick code blocks (install commands, code samples, log excerpts).
-
-**Rule:**
-
-- **Default fence for a draft body is 3 backticks** (` ``` `). Use this when the message body contains no triple-backtick code blocks.
-- **If the draft body contains ANY internal triple-backtick blocks**, the outer fence must be at least one backtick longer than the longest internal fence. In practice this means **4-backtick outer fence** (` ```` `) when the message contains 3-backtick blocks.
-
-**Why:** CommonMark closes a fenced code block at the first fence of equal-or-greater length. A 3-backtick outer wrapper is closed by the first 3-backtick inner fence — splitting the draft into multiple disjoint blocks and breaking the synthesis-console renderer (which attaches its action bar to the first fenced block after `**Send to:**`). A 4-backtick outer wrapper survives 3-backtick inner blocks unchanged; the inner fences become literal content of the outer fence, which is exactly what we want for a draft body containing install snippets or code samples.
-
-**Pasting into Slack:** when the user clicks Copy in synthesis-console, the action reads `.innerText` from the rendered `<pre>` block — outer fence delimiters are stripped, inner ` ``` ` markers are preserved as literal text. Slack then re-interprets the inner ` ``` ` as Slack code blocks. End-to-end behavior is correct.
-
-**Cross-reference:**
-
-- Consumer-side handling lives in synthesis-console `docs/cockpit-design.md` "Drafts" section (the consumer is being updated to handle multi-segment drafts robustly via `augmentDraftBlocks`, but the producer-side convention here is independently correct and should be applied regardless).
-- Lesson backing this rule: `lessons/2026-04-29-document-as-contract-with-llm-producers.md`.
-
-## v2.4.0 — Canonical Plan Format Contract
-
-In v2.4.0 (2026-04-29), the daily plan file format became a versioned contract between this skill (the producer) and synthesis-console v0.8+ (the consumer that renders plans as a cockpit dashboard).
-
-The contract is defined by the **canonical H2 vocabulary** below. The console's parser is tolerant of synonyms and emoji prefixes, but agentic skills (LLMs) must prefer the canonical names where possible because:
-
-- Canonical names are unambiguously typed by the console (NEEDS YOU / TODAY / DRAFTS / lower-row collapsibles)
-- Synonyms are accepted via substring + case-insensitive match, but each new variant adds parser maintenance burden
-- Non-canonical names fall through to "other" and render as plain markdown — visible but not specially typed
-
-When the LLM driving this skill decides to deviate from the template, it MUST stay within the recognized vocabulary table (next section). New section types should be proposed as additions to this contract, not invented ad-hoc.
-
-The **producer-consumer contract** is documented in two places:
-- This file's "Canonical Plan Format" section below (authoritative for skill writers).
-- `synthesis-console/docs/cockpit-design.md` (authoritative for parser implementers).
-
-These two files must stay in sync. When changing one, update the other in the same commit.
-
-## v2.3.0 — Workspace-Rooted Paths
-
-In v2.3.0 (2026-04-22), path configuration changed to reflect the ai-knowledge phase 2 architecture: transcripts live per-workspace in `ai-knowledge-<workspace>-<person>-private/transcripts/`; daily plans and lessons live person-scoped in `ai-knowledge-<person>/` at top-level (no `_` prefix). See synthesis-slack-sync v2.0.0 for the complementary configuration schema.
+Version history, the rationale behind each rule, and the incidents that produced them: [references/version-history.md](references/version-history.md). The distributed desk/worker contract: [references/ritual-worker-contract.md](references/ritual-worker-contract.md). Sync watermarks: [references/sync-watermarks.md](references/sync-watermarks.md). Daily plan format and vocabulary: [references/plan-format.md](references/plan-format.md). Draft grounding and formatting in full: [references/draft-grounding.md](references/draft-grounding.md).
 
 ## Configuration
 
@@ -494,54 +37,26 @@ These values are user-specific. Update them for your environment.
 | `alert_sound` | `/System/Library/Sounds/Glass.aiff` | macOS sound file for autonomous work alerts |
 | `slack_auth_command` | tool-specific Slack auth flow | Command or UI flow to re-authenticate Slack for the current agent |
 
+A project supplement (for example `daily-plans/daily-checklists.md`) lists the repos to sync, the channels and DMs with their ids, PR review targets, stakeholder communications, and any project-specific end-of-day steps; the global checklist invokes it at "Run any project-specific sync steps."
+
 ---
 
 ## Distributed ritual execution — desk and workers (v2.23.0)
 
-Applies whenever a workers registry exists (default `~/.synthesis/ritual/workers.yaml`;
-absent registry = classic single-session ritual, no behavior change). Contract:
-[`references/ritual-worker-contract.md`](references/ritual-worker-contract.md).
+Applies whenever a workers registry exists (default `~/.synthesis/ritual/workers.yaml`; absent registry = classic single-session ritual, no behavior change). Contract: [`references/ritual-worker-contract.md`](references/ritual-worker-contract.md).
 
-- **The desk is the registry's `desk_seat`** — the ritual home. Only the desk produces the
-  daily plan. One brief, one to-do list, one console; if a run produces more than one
-  brief, the design has failed.
-- **Each `active` worker executes its workspace's own checklist steps** (the syncs, the
-  repo pass, the workspace-side triage below). **The default mode is an attended session
-  rooted in that workspace**, run when the principal is working there, on that workspace's
-  own schedule; a desk-dispatched subagent is the opt-in alternative for closing everything
-  from one place. Either way the worker ends by writing the contract artifact to its
-  registered `artifact_dir` — that write IS the worker's completion.
-- **The principal is the dispatcher; the desk never triggers a worker.** No session can
-  start work in another. The desk reports which workspaces are owed and the human opens the
-  session that owes one. Attempts to dispatch by messaging sessions failed twice for the
-  same structural reason — the target must already be open and attended — while the
-  file-based path delivered both times. Contract: "The principal is the dispatcher."
-- **Workspaces close on independent schedules.** Artifacts carry timestamps and `run_type`
-  so the desk folds newest-per-workspace at any pass and refolds as later fragments land.
-  Closing one workspace in the evening and another the next morning is normal operation.
-- **The desk folds, never re-derives.** At every desk pass (day-start, mid-day, day-end)
-  read the newest artifact per (workspace, run_type) for today, reconcile across
-  workspaces — cross-workspace calendar and commitment conflicts are visible only here and
-  are the desk's explicit responsibility — and produce the one brief.
-- **The coverage line is mandatory and comes first** in every brief: each registered
-  workspace as folded (run_type + finish time), **pending**, or **not scheduled**
-  (`on-demand`/`dormant` per the registry). A registered-active workspace with no fresh
-  artifact is reported *not covered* — never reconstructed from stale artifacts or desk
-  guesswork.
-- **Context isolation is the point.** The desk does not load a workspace's channels,
-  repos, or transcripts inline; workers do not see each other or the combined picture.
-  Reconciliation belongs to the desk alone (the parallel-dispatch rule from
-  synthesis-project-management, applied to the day itself).
-- **Storage separates; presentation converges (v2.24.0).** The plan the desk writes is a
-  SHELL: person-scoped content plus pointers to each workspace's fragment (= its artifact).
-  Workspace content is never copied into the person-side repository, so deleting a
-  workspace's folders erases its data. Contract section: "Plan storage separation."
+- **The desk is the registry's `desk_seat`** — the ritual home. Only the desk produces the daily plan. One brief, one to-do list, one console; if a run produces more than one brief, the design has failed.
+- **Each `active` worker executes its workspace's own checklist steps** (the syncs, the repo pass, the workspace-side triage below). **The default mode is an attended session rooted in that workspace**, run when the principal is working there, on that workspace's own schedule; a desk-dispatched subagent is the opt-in alternative for closing everything from one place. Either way the worker ends by writing the contract artifact to its registered `artifact_dir` — that write IS the worker's completion.
+- **The principal is the dispatcher; the desk never triggers a worker.** No session can start work in another. The desk reports which workspaces are owed and the human opens the session that owes one. Attempts to dispatch by messaging sessions failed twice for the same structural reason — the target must already be open and attended — while the file-based path delivered both times. Contract: "The principal is the dispatcher."
+- **Workspaces close on independent schedules.** Artifacts carry timestamps and `run_type` so the desk folds newest-per-workspace at any pass and refolds as later fragments land. Closing one workspace in the evening and another the next morning is normal operation.
+- **The desk folds, never re-derives.** At every desk pass (day-start, mid-day, day-end) read the newest artifact per (workspace, run_type) for today, reconcile across workspaces — cross-workspace calendar and commitment conflicts are visible only here and are the desk's explicit responsibility — and produce the one brief.
+- **The coverage line is mandatory and comes first** in every brief: each registered workspace as folded (run_type + finish time), **pending**, or **not scheduled** (`on-demand`/`dormant` per the registry). A registered-active workspace with no fresh artifact is reported *not covered* — never reconstructed from stale artifacts or desk guesswork.
+- **Context isolation is the point.** The desk does not load a workspace's channels, repos, or transcripts inline; workers do not see each other or the combined picture. Reconciliation belongs to the desk alone (the parallel-dispatch rule from synthesis-project-management, applied to the day itself).
+- **Storage separates; presentation converges (v2.24.0).** The plan the desk writes is a SHELL: person-scoped content plus pointers to each workspace's fragment (= its artifact). Workspace content is never copied into the person-side repository, so deleting a workspace's folders erases its data. Contract section: "Plan storage separation."
 
 ## Day-Start Checklist
 
-Execute in this order (each step depends on the one before it). **Distributed mode:** each
-worker runs its workspace's steps and files its artifact; the desk runs Steps 1 and 8–10
-and folds worker artifacts per the section above.
+Execute in this order (each step depends on the one before it). **Distributed mode:** each worker runs its workspace's steps and files its artifact; the desk runs Steps 1 and 8–10 and folds worker artifacts per the section above.
 
 ### 1. Temporal & State Verification — RUN FIRST, every day
 
@@ -560,9 +75,7 @@ The LLM has no clock and its sense of "today" can drift across conversation gaps
 - [ ] **Day-end state read (v2.14.0):** read `~/.synthesis/day-end/state.json` and report the last day-end (date + mode) in the day plan's header or brief. If the most recent workday's day-end is missing, say so explicitly — visible skips are recoverable skips. Update `last_day_start` in the same file as part of this ritual.
 - [ ] **Weekly-review-owed check (v2.14.0):** if today is on/after the most recent Friday AND `last_weekly_review` predates that Friday, the Weekly Loose-Ends Review is owed — run the Day-End Step 10 scan in THIS session (either ritual direction, any mode) and update `last_weekly_review`. If a `synthesis-catchup-ledger` sweep already ran on/after that Friday, record its date instead of re-scanning — the ledger supersedes the review for its window.
 
-This step is the L2 (skill-rule) anchor of the temporal and continuity
-discipline. Client lifecycle hooks are L1; global `AGENTS.md` rules are L3.
-See `synthesis-context-lifecycle` Session Start Protocol for the rationale.
+This step is the L2 (skill-rule) anchor of the temporal and continuity discipline. Client lifecycle hooks are L1; global `AGENTS.md` rules are L3. See `synthesis-context-lifecycle` Session Start Protocol for the rationale.
 
 ### 2. Context Optimization
 
@@ -600,19 +113,7 @@ The set of remotes for each repo comes from `git remote -v` inside that repo. Th
 - [ ] **Email sync (v2.19.0)** — when the workspace routinely syncs email (established `transcripts/email/` practice or explicit config): sweep the window's inbound mail AND the user's own sent mail (sent items are correspondence records too — the user's outbound exec mail is often the day's most consequential artifact), using the workspace's designated email tooling and account. Save to the workspace convention (e.g., `transcripts/email/YYYY-MM-DD-<slug>.md`).
 - [ ] **Document-comment sync (v2.19.0)** — when the workspace has an established docs-sweep practice (`transcripts/docs/` or explicit config): Drive documents modified in the window, open comment threads where the newest reply is not the user's (ball in their court), and engagement on documents the user shared out.
 - [ ] **Name any surface not swept.** The declared surface set is the complete decision (v2.12.1 applied to channels); a sync that skips one must say so in its report rather than reporting as complete.
-- [ ] **Watermark gate (v2.30.0):** the sweep opened with
-  `python3 <skill-root>/scripts/sync_watermark.py begin --workspace <W> --label day-start`,
-  every read target's `oldest` came from `sync_watermark.py window`, and every
-  saved read was recorded with `sync_watermark.py advance` (per target for
-  Slack and Chat). Now run
-  `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s> --since run`
-  with **every declared surface passed explicitly** and the declared read
-  targets via `--targets-from` — the store only knows what has already been
-  written, so a status that consults only the store walks straight past a
-  declared surface never swept (the command refuses an empty surface set for
-  exactly that reason). Non-zero exit names each surface or target this run
-  did not re-read: read it now or defer it with an explicit reason before the
-  ritual proceeds.
+- [ ] **Watermark gate (v2.30.0):** a watermark is the last moment actually WRITTEN, never the last attempted, and the gate proves this run's coverage. The sweep opened with `python3 <skill-root>/scripts/sync_watermark.py begin --workspace <W> --label day-start`, every read target's `oldest` came from `sync_watermark.py window`, and every saved read was recorded with `sync_watermark.py advance` (per target for Slack and Chat). Now run `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s> --since run` with **every declared surface passed explicitly** and the declared read targets via `--targets-from` (derived from the sync config at sync time, never a stored copy) — the store only knows what has already been written, so a status that consults only the store walks straight past a declared surface never swept (the command refuses an empty surface set for exactly that reason). Non-zero exit names each surface or target this run did not re-read: read it now or defer it with an explicit reason before the ritual proceeds.
 - [ ] Run any project-specific sync steps (see project supplement).
 
 #### 3c. Meeting Transcripts
@@ -633,18 +134,11 @@ After any standup, planning session, or design review with auto-generated notes 
 
 #### 3d. Inbox Hygiene (v2.21.0 — when `~/.synthesis/inbox-cleanup/scopes.yaml` exists)
 
-Inbox cleanup is a chief-of-staff duty, and its reach follows the seat that
-invokes it (the inbox-cleanup skill's workspace-scope contract):
+Inbox cleanup is a chief-of-staff duty, and its reach follows the seat that invokes it (the inbox-cleanup skill's workspace-scope contract):
 
-- [ ] Resolve scope: `resolve_scope.py --workspace <this workspace> --json`.
-  A personal/all-scope seat sweeps every account; any other seat sweeps only
-  its own workspace's accounts. **Exit 2 (unknown workspace, missing config)
-  stops this step with the error surfaced — never improvise an account list.**
-- [ ] Run the inbox-cleanup skill's sweep over exactly the resolved accounts,
-  dry-run-first per that skill's workflow.
-- [ ] Report per account against the resolved scope ("7 of 9 in scope, 7
-  swept"), naming any account skipped and why. Held items and new-sender
-  questions go to the day plan's decisions region, not into silent limbo.
+- [ ] Resolve scope: `resolve_scope.py --workspace <this workspace> --json`. A personal/all-scope seat sweeps every account; any other seat sweeps only its own workspace's accounts. **Exit 2 (unknown workspace, missing config) stops this step with the error surfaced — never improvise an account list.**
+- [ ] Run the inbox-cleanup skill's sweep over exactly the resolved accounts, dry-run-first per that skill's workflow.
+- [ ] Report per account against the resolved scope ("7 of 9 in scope, 7 swept"), naming any account skipped and why. Held items and new-sender questions go to the day plan's decisions region, not into silent limbo.
 
 ### 4. Catch-Up Read
 
@@ -671,16 +165,7 @@ invokes it (the inbox-cleanup skill's workspace-scope contract):
 - [ ] **Seed `## 🌱 Lesson candidates` (v2.14.0)** — an empty H2 that any session appends one-liners to during the day; the day-end curates it (keep/drop).
 - [ ] Update CONTEXT.md action items with new items from catch-up.
 - [ ] Prioritize today's work: integration, reviews, communications, features, meetings.
-- [ ] **Calendar Guardian — morning shield (v2.20.0).** Re-verify today against
-  last night's review (invites land overnight): resolve new arrivals, then
-  place/refresh holds over today's remaining open windows per the chief-of-staff
-  skill's same-day shield — id-tracked, auto-expiring, releasable only from the
-  holds ledger. Same-day requests route through triage (VIP tiers pass per
-  config; everything else becomes a proposed later slot). Check prep exists for
-  every meeting today; surface unanswered RSVPs and prep gaps as decisions.
-  **Lead-time meetings (v2.26.0):** a flagged meeting today whose pack is missing or
-  predates a reschedule is regenerated NOW from its declared sources — and the gap is
-  named in the brief, because it means the owed day-end generation was missed.
+- [ ] **Calendar Guardian — morning shield (v2.20.0).** Re-verify today against last night's review (invites land overnight): resolve new arrivals, then place/refresh holds over today's remaining open windows per the chief-of-staff skill's same-day shield — id-tracked, auto-expiring, releasable only from the holds ledger. Same-day requests route through triage (VIP tiers pass per config; everything else becomes a proposed later slot). Check prep exists for every meeting today; surface unanswered RSVPs and prep gaps as decisions. **Lead-time meetings (v2.26.0):** a flagged meeting today whose pack is missing or predates a reschedule is regenerated NOW from its declared sources — and the gap is named in the brief, because it means the owed day-end generation was missed.
 - [ ] Update the action plan throughout the day as tasks complete or change — it is a living document, not a static morning capture.
 - [ ] **Always include a clickable link to the action plan file** in your response when creating, updating, or referencing it. Use the absolute path in markdown link format: `[2026-03-23.md](/absolute/path/to/daily-plans/2026-03-23.md)`. Never use relative paths — they don't resolve in the IDE.
 
@@ -690,307 +175,29 @@ invokes it (the inbox-cleanup skill's workspace-scope contract):
 - [ ] Send motivational replies acknowledging overnight work (engineers who feel seen ship faster).
 - [ ] Reply to any unanswered threads that need morning response.
 - [ ] **Before drafting ANY reply for the user, re-read the actual Slack thread via MCP — not the local transcript.** The user may have already replied. Another team member may have resolved the question. Drafting from stale transcripts makes the user look absent-minded. Transcripts are caches for historical context; Slack is the source of truth for current thread state.
-- [ ] **Ground ALL draft messages in actual systems — not just transcripts and meeting notes.** Before drafting ANY reply or message for the user, research the topic in primary sources first. This is not optional and applies to every draft, not just explicitly technical ones. See the Grounding Protocol below.
+- [ ] **Ground ALL draft messages in actual systems — not just transcripts and meeting notes.** Before drafting ANY reply or message for the user, research the topic in primary sources first. This is not optional and applies to every draft, not just explicitly technical ones. See the draft rules below and [references/draft-grounding.md](references/draft-grounding.md).
 - [ ] When drafting messages for the user to send manually, ALWAYS include a thread locator: channel name, date/time of parent message, thread timestamp (TS), and the last unanswered reply with date/time and first ~10 words. The user needs this to find the thread instantly.
 
 ---
 
-## Grounding Protocol for Draft Messages
+## Draft Message Rules
 
-Every draft message must be grounded in primary sources before it is written. The depth of research scales with the type of claim being made, but the requirement applies to ALL drafts — not just ones that feel technical.
+Every draft is grounded, temporally correct, Slack-formatted, and numbered. The full protocol — research by question type, the investigate-first rule with its incident, the verification checklist, formatting examples, and appreciation quality — is in [references/draft-grounding.md](references/draft-grounding.md). The rules:
 
-### Research by question type
-
-| Question type | What to check | Examples |
-|--------------|---------------|----------|
-| **Technical** (architecture, how something works, root cause) | Source code, config files, PRs, `git log` | "How does X work?", "Why did Y break?" |
-| **Status** (what's deployed, what's working) | Deploy scripts, version files, environment config, running services | "Is X on production?", "When was Y released?" |
-| **Infrastructure** (secrets, credentials, environments, CI/CD) | Terraform, deploy scripts, `.env.example`, CI/CD workflows, docs | "How do we manage secrets?", "Where does X run?" |
-| **Process** (PR workflow, branching, review, release) | Agent instruction files, contributor guides, recent git history, skill files | "What's the merge process?", "Who reviews?" |
-| **Product** (feature behavior, user-facing text, prompts) | Component code, prompt YAML files, test files | "Does the tool do X?", "What does the user see?" |
-
-### Investigate First, Ask Questions Later
-
-**Before drafting ANY reply to a bug report or user issue, spend 10 minutes investigating.** Read the relevant code, check the config, search for the pattern. If you can fix it in those 10 minutes, fix it and draft a reply with the fix — not a reply asking for more information.
-
-This principle applies to ALL draft messages that respond to reported problems:
-
-- **Do NOT draft** "Can you share the URL?" when you could search the config and find the missing domain yourself.
-- **Do NOT draft** "We're looking into it" when you could have already shipped the fix.
-- **Do NOT draft** "Can you try again?" when you haven't investigated the root cause.
-- **DO investigate** code, config, logs, and infrastructure before composing a reply.
-- **DO fix the problem first** if possible, then draft a reply that leads with the fix.
-- **Only ask the user** for information you genuinely cannot obtain yourself (specific reproduction steps, subjective preferences, environment details unique to them).
-
-**Why:** The user's time is more valuable than the agent's. A fix shipped in 10 minutes builds more trust than a reply asking for more info. Action before questions.
-
-**Example:** A user flagged "Import Failed" on certain stories. The initial draft asked for the specific URL. Instead, investigating the config found that a domain was simply missing from the allowed list. The fix took 10 minutes. No round-trip needed.
-
-### The process
-
-1. **Identify the claim.** Before writing, ask: "What factual assertions will this message make?"
-2. **Research each claim.** Use Grep, Read, Glob, git log, or other tools to find the primary source.
-3. **Note the evidence.** Record file paths, line numbers, config values, or PR numbers that support the claim.
-4. **Draft with citations.** Include specific references where they add credibility (e.g., "We use GCP Secret Manager — see `terraform/modules/secrets/main.tf`").
-5. **Flag uncertainty.** If a claim can't be fully verified, say so in the draft rather than guessing.
-
-### Why this matters
-
-The user's professional reputation depends on accuracy. A wrong technical claim in Slack is visible to the entire team and cannot be unsent. A delayed but accurate response is always better than a fast but wrong one.
-
-**Incident (2026-03-17):** A technical reply was drafted based on conversation memory alone. It was partially wrong. The next day, another reply was drafted after reading the actual code — it was fully correct. The difference was 5 minutes of research.
-
-### Scope
-
-This protocol applies everywhere draft messages are created:
-- Morning messages (Day-Start Step 7)
-- Mid-day sync replies (synthesis-slack-sync Step 5)
-- End-of-day communications (Day-End Step 3)
-- Ad-hoc message requests throughout the day
+- **Ground every draft in primary sources before writing** — code, config, PRs, `git log`, deploy state, instruction files — never in transcripts or conversation memory alone; cite file paths, PR numbers, config values, or SHAs; flag any claim that cannot be verified instead of guessing. Applies to morning messages, mid-day replies, day-end communications, and ad-hoc requests alike.
+- **Investigate first, ask questions later.** Before drafting a reply to a bug report or user issue, spend ten minutes in the code, config, and logs; if the fix fits in those minutes, ship it and lead the reply with the fix. Ask only for what you genuinely cannot obtain yourself.
+- **Temporal integrity at send time, not write time.** Check whether the recipient already has the information, whether forward-looking statements still hold, whether a scheduled message uses the right tense, what happened since drafting, and whether the topic moved to another channel or medium — sweep every synced surface and email for the recipient and topic, re-pull full email threads before replying, and give drafts older than 24 hours full re-verification.
+- **Verification checklist before finalizing:** every technical claim cites a source; every status claim is verified against the live system; every attribution is cross-checked (`gh pr view`, `git log`); no stale information — the target thread re-read via MCP AND the topic swept across other channels, DMs, and email; numbers come from tool output; temporal integrity passes.
+- **Pre-send review gate:** every drafts section carries the verbatim reviewer notice before its first draft — drafts are research-backed starting points the human reads fully, edits into their own voice, and judges for the moment.
+- **Slack formatting:** a blank line after every bullet (otherwise they collapse); Slack markdown (`*bold*`, `_italic_`, `>` quotes, backtick code); a thread locator on every reply draft (channel, human-readable parent time, author, first ~10 words; the TS as secondary reference); concise — over ~15 lines folds behind "Show more".
+- **Draft numbering:** sequential integers (Draft 1, Draft 2, …), never letters or `K-2` sub-versions; before adding a draft, scan for the highest existing `Draft N` and use N+1; a retracted draft keeps its number with a `— retracted` marker and a pointer to the session log rather than renumbering.
+- **Appreciation is specific:** name the work product, what made it good, and the observable impact; generic praise is weak and reads as automated.
 
 ---
 
-## Draft Message Formatting Rules
+## Daily Plan Structure
 
-All draft messages in the daily action plan must follow these formatting and quality rules. The user copy-pastes these directly into Slack — formatting errors waste time and look unprofessional.
-
-### Slack Formatting
-
-1. **Blank line after every bullet.** Slack requires a blank line between bullet points for them to render as separate items. Without blank lines, bullets collapse into a single paragraph. This is the most common formatting error — check every draft before saving.
-
-   **Wrong (collapses in Slack):**
-   ```
-   • Item one
-   • Item two
-   • Item three
-   ```
-
-   **Right (renders as separate bullets):**
-   ```
-   • Item one
-
-   • Item two
-
-   • Item three
-   ```
-
-2. **Use Slack markdown, not GitHub markdown.** Slack uses `*bold*` not `**bold**`. Use `_italic_` not `*italic*`. Use `>` for blockquotes. Use `` `code` `` for inline code.
-
-3. **Thread locators for every reply draft.** Include: channel name, human-readable date/time of parent message, author name, and first ~10 words of the message being replied to. Use the format: `**Channel:** #channel-name — Author Name, Mon Mar 30 at 11:31 AM EDT — "First ten words of the message..."`. The Slack thread TS (Unix timestamp) should be included for technical reference but is NOT the primary locator — the human-readable context is what the user needs to find the thread.
-
-4. **Keep messages concise.** Slack messages over ~15 lines get collapsed behind a "Show more" fold. Front-load the most important information.
-
-### Draft Numbering Convention
-
-Drafts in a daily plan are labeled with sequential integers, not alphabet letters. The first draft of the day is **Draft 1**; each subsequent draft increments by 1.
-
-**Do:**
-
-- `### Draft 1: Multi-provider routing announcement`
-- `### Draft 2: Reply to Oliver — Terraform readiness`
-- `### Draft 11: Patrick public praise — release window`
-- `### Draft 12: User-channel supplement (L&E)` (when same theme is routed to multiple audiences, each variant still gets its own integer)
-
-**Do NOT:**
-
-- `### Draft A: ...`, `### Draft B: ...` (alphabet labels — replaced by integers in v2.6.0)
-- `### Draft K-2: ...`, `### Draft K-3: ...` (letter-with-suffix sub-versioning — replaced by sequential integers)
-
-**Pre-draft step:** before adding a new draft, grep or scan the file for the highest existing `Draft N` integer and use N+1.
-
-**Retraction:** if a draft is retracted (e.g., a fabricated message caught and removed), keep the number reserved in the file (`### Draft N — retracted` with a one-line pointer to the session log) rather than renumbering subsequent drafts. The reserved slot is the durable historical record.
-
-See the v2.6.0 section at the top of this skill for the full rationale (counting tax, lexicographic ordering, sub-version ugliness, cross-file consistency).
-
-### Temporal Integrity
-
-Every draft message must be accurate *at the time it will be sent*, not at the time it was written. This is the most common source of anachronistic messages.
-
-**Before finalizing each draft, check:**
-
-1. **Has the recipient already received this information?** If the same person was tagged in an earlier message or was present at a meeting where this was discussed, don't repeat it. Restructure the message to cover only what's new or what still needs their input.
-
-2. **Do forward-looking statements match reality?** "Will review next" is a commitment. "Staging is ready for QA" is stale if QA already started. "Welcome back" is odd if the person was just in a meeting with you. Audit every verb tense.
-
-3. **Are scheduled-for-later messages written in the right tense?** A message drafted Monday but scheduled for Tuesday must say "yesterday" not "today" when referencing Monday events. The easiest way to catch this: read the message as if you are the recipient reading it at the scheduled send time.
-
-4. **Does the message acknowledge what happened since it was drafted?** If a standup, deployment, or Slack conversation happened between drafting and sending, re-check the message. Information that was "upcoming" may now be "completed."
-
-5. **Has the topic moved to another channel or medium?** Obsolescence is cross-channel and cross-medium: a Slack question may have been answered in email, a meeting, or a different channel entirely. Before sending, sweep recent transcripts across ALL synced surfaces for the recipient + topic, and search email when the subject could plausibly have crossed mediums. For email replies, always re-pull the FULL thread first — the latest message may supersede the one being answered. Drafts older than 24 hours get full fact re-verification, not just a thread re-read. (Agent-assisted send paths should enforce this as a mandatory send-time gate — see the user's send-system skill if one exists.)
-
-**Common temporal integrity failures:**
-- "Welcome back" to someone who was at the meeting you just attended together
-- "Staging is ready for QA" sent to someone who was already tagged in a staging notification
-- "Good that you're meeting with X today" in a message scheduled for tomorrow
-- "I'll review this next" when you've already moved on to other work
-
-### Grounding Verification Checklist
-
-Before finalizing each draft message, verify:
-
-- [ ] **Every technical claim cites a source** — file path, line number, PR number, config value, or git SHA.
-- [ ] **Every status claim is current** — verified against the actual system state (git log, deploy status, environment), not just memory or transcripts.
-- [ ] **Every attribution is correct** — the right person is credited for the right work. Cross-reference PR authors via `gh pr view` or `git log`, not memory.
-- [ ] **No stale information — checked beyond the thread.** Re-read the target thread via MCP to confirm no one has replied or resolved it, AND sweep for the topic across OTHER channels, DMs, and email — resolutions frequently happen outside the thread where the question was asked. A message rendered obsolete by a communication anywhere is obsolete everywhere.
-- [ ] **Numbers are accurate** — test counts, file counts, line counts, character counts are from actual tool output, not estimates.
-- [ ] **Temporal integrity passes** — message is accurate at the time it will be read, not just at the time it was written. See Temporal Integrity section above.
-
-### Pre-Send Review Gate
-
-Every draft message section in a daily plan must include the following notice before the first draft:
-
-> **Review before sending.** These drafts are grounded in real data — code commits, test results, deployment logs, Slack threads, and project context — but they are starting points, not final messages. Read each one, edit it in your own voice, and add the personal touch only you can. Human-to-human communication deserves human effort.
-
-This is not optional. Draft messages are research-backed starting points — not automated communications. The human must:
-1. Read each draft fully before sending
-2. Edit the tone and phrasing to match their voice
-3. Add personal context that only they have (relationship nuance, recent conversations, political awareness)
-4. Verify the message is appropriate for the current moment (not just factually correct)
-
-The grounding section shows the research behind the draft. The human adds the judgment, timing, and personal touch that make the message authentic.
-
-### Appreciation Message Quality
-
-Appreciation messages must be specific and grounded, not generic. Each should reference:
-- The specific work product (PR number, feature name, article title)
-- What made it good (thorough test plan, clean architecture, consistent output, specific design decision)
-- Observable impact (unblocks X, addresses user feedback Y, improves process Z)
-
-**Generic (weak):** "Great work on the PR, Emil!"
-**Grounded (strong):** "Emil — PR #96 was clean with solid UUID validation and 6 permission tests covering all access paths. The immediate user sync on org assignment was the right architectural call — avoids the confusion of next-login delays."
-
----
-
-## Daily Plan Structure: Preserve and Reorganize
-
-The daily action plan is both a **live dashboard** (scannable current state) and a **historical record** (what happened today). These goals conflict if the file is treated as append-only — by evening, sections are scattered and duplicated, making the file unreadable.
-
-### The Rule: Preserve All Information, Reorganize for Clarity
-
-**Never delete information.** Completed tasks, sent messages, timestamps, decisions, and resolved items must always be preserved somewhere in the file.
-
-**Reorganize freely.** Consolidate scattered sections, merge duplicate lists, reorder for readability. The file should have ONE section for each concern, not multiple sections that accumulated through the day. After every sync or major update, the file should read cleanly from top to bottom.
-
-### Required File Structure (v2.4.0+)
-
-The daily plan follows this canonical structure. On each update, consolidate into these sections rather than appending new ones. The synthesis-console v0.8+ cockpit parses these section names to typed regions; staying within the canonical vocabulary maximizes the typed UI surface.
-
-```markdown
-# Daily Action Plan — [Day], [Date]
-
-**[Status line: version, key people, blockers]**
-
----
-
-## Decisions needed from Rajiv     ← cockpit: NEEDS YOU region
-[H3 question per decision. Each H3 may have **Option A:** / **Option B:** lines
- and a **Recommendation:** line. The cockpit renders option buttons that record
- a `**Decided:** Option X — <ISO>` marker back to the file on click.]
-
-## Priority Tasks                  ← cockpit: TODAY region
-### Do today — not negotiable      ← collapsible bucket (P0, expanded by default)
-1. **Task title** — description    ← cockpit renders as checkbox; click writes
-                                       `~~**Title**~~ ✅ **DONE HH:MM TZ**` in place
-
-### Do today — should make it      ← P1 bucket (collapsed by default)
-### Do today — can slip            ← P2 bucket
-### Watch / waiting                ← muted styling
-### Stale targets                  ← muted styling
-
-## Drafts — Ready to Send          ← cockpit: DRAFTS region
-> **Review before sending.** [Standard reviewer notice — keep verbatim.]
-
-### Draft A — [Description]
-**Send to:** `#channel-name` — [thread locator]
-```
-[message body in fenced code block — use 3 backticks if the body has no internal code blocks; use 4 backticks (````) if the body contains any internal ``` blocks. See v2.5.0 — Draft Fence Convention.]
-```
-**Grounding:**
-- [bullet]
-- [bullet]
-
-## Standup Highlights              ← cockpit: lower-row collapsible (context tone)
-## What Happened Yesterday         ← cockpit: lower-row collapsible (briefing)
-## Things to Know                  ← cockpit: lower-row collapsible (briefing)
-## Mid-day Sync                    ← cockpit: lower-row collapsible (briefing)
-## Waiting On Others               ← cockpit: lower-row collapsible (waiting tone)
-## Open PR Queue                   ← cockpit: lower-row collapsible
-## Sent Messages                   ← cockpit: lower-row collapsible (done tone)
-## Completed Today                 ← cockpit: lower-row collapsible (done tone)
-## Sync state                      ← cockpit: lower-row collapsible
-## Bugs (Open)                     ← cockpit: lower-row collapsible (briefing)
-## Carried Items                   ← cockpit: lower-row collapsible (briefing)
-```
-
-### Canonical Section Vocabulary (Authoritative)
-
-The synthesis-console v0.8+ parser classifies each H2 heading into one of these kinds. Use the canonical name where possible. The "synonyms" column lists variants the parser also recognizes via substring + case-insensitive match — these exist for backward compatibility but new plans should prefer the canonical name.
-
-| Cockpit region / kind | Canonical H2 name | Recognized synonyms |
-|----------------------|-------------------|---------------------|
-| **decisions** (NEEDS YOU) | `Decisions needed` | "Decisions to make", "Open ask", "Asks for Rajiv", "Open Items", "Needs your attention", "Open Quality Concerns" |
-| **priority-tasks** (TODAY) | `Priority Tasks` | "Tasks", "Tasks for Rajiv", "Tasks Today", "Today's Tasks", "Today's Priorities", "Still To Do", "This Week", "Remaining Tasks", "Pending This Session", "Pending from Before Vacation" |
-| **drafts** (DRAFTS) | `Drafts — Ready to Send` | "Drafts", "Unsent — Ready to Send", "Unsent Drafts", "DM Reply Drafts", "Draft Messages", "Messages", "Next Steps", "Pending Emails", "Scheduled for Tomorrow / Later" |
-| **standup** | `Standup Highlights` | "Standup Transcript", any heading with "standup", "Newsroom Training" |
-| **sent-messages** | `Sent Messages` | "Messages Sent" |
-| **waiting** | `Waiting On Others` | "Waiting on", "Delegated to Team" |
-| **pr-queue** | `Open PR Queue` | "PR Queue", "Open PRs", "New PRs", "PRs Ready for Review", "PR Reviews Completed" |
-| **sync-state** | `Sync state` | "Staging/Deployment Status", "Deployment Status", "Pre-Migration Status", "Post-Release Status", "Files Created/Modified", "Test Results", "Staging:" |
-| **completed** | `Completed Today` | "Completed This Morning" |
-| **briefing** | `Things to Know` | "What Happened", "What Changed", "Big Things", "Things Rajiv Should Know", "Carried From / Items / Forward", "Carry Forward", "Mid-day Sync", "Morning Sync", "From Slack Sync", "State Catch-Up", "Day Summary", "End of Day Summary", "Bugs (Open)", "QA Findings", "QA Results", "CRITICAL:", "Context", "What to Watch", "Future Work", "Post-Release Issues", "Feature Requests (Carryover)", "Release Process Sync" |
-| **other** (fallback) | (any unrecognized H2) | Renders as plain markdown in the lower-row collapsibles. Nothing is lost; the section just isn't specially typed. |
-
-### Internal Structure Conventions
-
-Within each section, the parser also recognizes structural patterns. Adhering to these makes the UI work correctly:
-
-**Decisions section** (`## Decisions needed`):
-- One H3 per decision (`### 1. Force-push origin/develop?`)
-- Options as bold paragraphs: `**Option A:** description`, `**Option B:** description`
-- Optional: `Recommendation: **A** with rationale`
-- After click: skill / human appends `**Decided:** Option X — <ISO>` directly under the H3
-- **Synthetic asks**: an H2 like `## Open ask for Rajiv` with prose body and NO H3s also surfaces in NEEDS YOU as a single card with the prose verbatim. Use this for one-off requests that don't fit the A/B/C structure.
-
-**Priority Tasks section** (`## Priority Tasks`):
-- One H3 per bucket (`### Do today — not negotiable`)
-- Tasks as numbered list items (`1. **Title** — description`) OR checkbox items (`- [ ] **Title** — description`). Both formats supported.
-- Already-done tasks may be marked any of these ways (parser detects all): `~~Title~~ ✅ DONE HH:MM`, `[x]`, leading `✅`, leading `DONE` or `SENT`.
-- The cockpit's TODAY region surfaces tasks as live checkboxes that write the canonical done marker back to the file on click.
-
-**Drafts section** (`## Drafts — Ready to Send`):
-- One H3 per draft (`### Draft A — Description`)
-- A `**Send to:** target — locator` paragraph identifying the recipient. `**Channel:**` is also accepted.
-- A fenced code block OR blockquote with the message body. **Fence convention (v2.5.0+):** default is 3 backticks; if the body contains any internal triple-backtick code blocks (install commands, log excerpts), use a 4-backtick outer fence (or any length strictly greater than the longest internal fence). The 4-backtick outer fence renders correctly in synthesis-console AND survives the Copy button intact (outer fence stripped, inner ` ``` ` preserved for Slack to re-interpret).
-- Optional: a `**Grounding:**` paragraph or bullet list with research backing.
-- After send: skill / cockpit appends `**Sent:** <ISO> (TS=...) <permalink>` directly under the body.
-- **Drafts may also appear under non-drafts H2s.** When a draft is added to a topical context (e.g., a draft DM written into "Things to Know" alongside the situation that prompted it), the cockpit's DRAFTS region aggregates it from wherever it lives in the document. The canonical placement is still under `## Drafts`, but topical inline drafts work too.
-
-**Pre-Send Review Notice**: every drafts H2 SHOULD include this verbatim blockquote before the first H3 draft (the cockpit doesn't currently re-display it in the DRAFTS region but it remains in the file for archival and Full-Markdown view):
-
-```
-> **Review before sending.** These drafts are grounded in real data — code commits, test results, deployment logs, Slack threads, and project context — but they are starting points, not final messages. Read each one, edit it in your own voice, and add the personal touch only you can. Human-to-human communication deserves human effort.
-```
-
-### What This Means in Practice
-
-- When a draft is sent: move it from "Unsent" to "Sent Messages" with a timestamp. Don't create a new "More Sent Messages" section.
-- When a bug is resolved: update the entry in "Bugs" to show it's resolved. Don't leave the old entry and add a new one elsewhere.
-- When a sync finds new info: update the relevant existing section. Don't append a new section for each sync.
-- When the file gets messy: do a full rewrite that preserves all information in the canonical structure. This is expected and encouraged — it's maintenance, not data loss.
-
-### Why This Replaced "Append-Only"
-
-The original "append-only" rule was designed to prevent accidental deletion of sent message records. The intent was correct — losing records causes duplicate sends and confusion. But in practice, append-only caused the file to balloon with scattered duplicate sections ("More Sent Messages (afternoon)", "More Sent Messages (afternoon, continued)", "Unsent — Ready to Send", "Unsent — Evening"), becoming unreadable by end of day.
-
-The preserve-and-reorganize approach achieves the same safety goal (no information loss) while maintaining readability. The transcript files (`{workspace}/channels/YYYY-MM-DD.md`, `{workspace}/dms/YYYY-MM-DD.md`, `{workspace}/group-dms/YYYY-MM-DD.md`) are the authoritative append-only historical records. The daily plan is the dashboard.
-
-### File Revert Protection
-
-If a file revert is detected (system reminder says "file was externally modified"):
-1. Re-read the ENTIRE file from disk before making any edits.
-2. Compare the on-disk content against your in-memory understanding of the file.
-3. If content is missing (items you know were written earlier are gone), reconstruct the missing content from Slack sync data, session memory, and transcript files.
-4. Never silently accept a reverted file — always verify and restore.
+The daily plan is both a live dashboard and the day's record. **Preserve all information, reorganize for clarity:** never delete completed tasks, sent messages, timestamps, or decisions; consolidate freely so the file has ONE section per concern and reads cleanly top to bottom after every update — a full rewrite that preserves everything is maintenance, not data loss. The canonical structure, the H2 vocabulary the synthesis-console cockpit types (Decisions needed / Priority Tasks / Drafts — Ready to Send / Standup Highlights / Sent Messages / Waiting On Others / Open PR Queue / Sync state / Completed Today / Things to Know / Carried Items), the internal conventions the parser reads (decision options and `**Decided:**` markers, task done markers, draft `**Send to:**` and `**Sent:**` paragraphs, the 3-versus-4-backtick fence rule), and the file-revert protection protocol are in [references/plan-format.md](references/plan-format.md). Stay within that vocabulary; propose new section types as additions to the contract, never ad hoc. If a file revert is detected, re-read the entire file from disk, compare it with what you know was written, reconstruct anything missing from sync data and transcripts, and never silently accept the reverted file.
 
 ---
 
@@ -1010,7 +217,7 @@ The day-start checklist does a full sync. The user will ask for syncs repeatedly
 
 The key discipline encoded in that skill: **every sync must re-read ALL threads with replies from today**, not just fetch new channel-level messages. Thread replies don't appear as channel messages — skipping thread re-reads causes stale action plans and duplicate message sends.
 
-**Every sync re-reads every declared target (v2.30.0).** A DM or channel read at day-start is not current at mid-day: "already read today" is a statement about the past, not about now, and a twelve-minute-old reply is the normal case for a DM. Open each sync with `python3 <skill-root>/scripts/sync_watermark.py begin --workspace <W> --label mid-day`, take each target's `oldest` from `sync_watermark.py window --target <resolved id>`, record each saved read with `sync_watermark.py advance --target <resolved id>`, and close with `sync_watermark.py status --workspace <W> --surface <s> --since run --targets-from <declared.json>` — its BLOCKING list is exactly the set this sync skipped, and the sync is not complete while it is non-empty. The user's own outbound is first-class sweep state: list every owed item their messages discharged since the window opened, and never call anything "unanswered" or "unsent" on a read older than this run. Origin (2026-09-01): two mid-day syncs covered group DMs and channels only; a DM answered at 09:27 was reported unanswered at 17:51 on the strength of a 09:15 read.
+**Every sync re-reads every declared target (v2.30.0).** A DM or channel read at day-start is not current at mid-day: "already read today" is a statement about the past, not about now, and a twelve-minute-old reply is the normal case for a DM. Open each sync with `python3 <skill-root>/scripts/sync_watermark.py begin --workspace <W> --label mid-day`, take each target's `oldest` from `sync_watermark.py window --target <resolved id>`, record each saved read with `sync_watermark.py advance --target <resolved id>`, and close with `sync_watermark.py status --workspace <W> --surface <s> --since run --targets-from <declared.json>` (the declared set derived from the sync config at sync time, never a stored copy) — its BLOCKING list is exactly the set this sync skipped, and the sync is not complete while it is non-empty. The user's own outbound is first-class sweep state: list every owed item their messages discharged since the window opened, and never call anything "unanswered" or "unsent" on a read older than this run. Origin (2026-09-01): two mid-day syncs covered group DMs and channels only; a DM answered at 09:27 was reported unanswered at 17:51 on the strength of a 09:15 read.
 
 **Record after every sync.** Any sync that creates or updates transcripts, daily plans, or context files must leave session-attributed local state. Day-start and mid-day sync do not push merely to make same-machine client switching work; day-end and explicit remote handoff publish the batch.
 
@@ -1052,20 +259,13 @@ From the normal Day-End:
 - Transcript capture
 - Daily plan creation (in observer format)
 - CONTEXT.md + session archive updates
-- **Attributed local persistence** — observer mode records every changed file;
-  its batch reaches the remote at day-end or explicit remote handoff.
-
-### Why This Is Codified
-
-When observer mode is reinvented per conversation, the agent often drops durable state. The rule is now explicit: every observer run leaves attributed local state, while day-end or remote-handoff mode owns publication.
+- **Attributed local persistence** — observer mode records every changed file; its batch reaches the remote at day-end or explicit remote handoff.
 
 ---
 
 ## Day-End Checklist
 
-**Distributed mode (v2.23.0):** each worker runs its workspace's close steps and files a
-`day-end` artifact; the desk folds artifacts, runs the guardian review and the publication
-boundary, and writes the one close-out with its coverage line.
+**Distributed mode (v2.23.0):** each worker runs its workspace's close steps and files a `day-end` artifact; the desk folds artifacts, runs the guardian review and the publication boundary, and writes the one close-out with its coverage line.
 
 ### Day-End Modes (v2.14.0) — ask first, every time
 
@@ -1086,25 +286,14 @@ The Weekly Loose-Ends Review (Step 10) attaches to whichever ritual runs first o
 - [ ] **Run `/synthesis-slack-sync`** for final capture of the day. The `synthesis-slack-sync` skill ensures all channels, threads, and DMs are captured.
 - [ ] **Google Chat final capture (v2.17.0)** — if the workspace declares `.agents/gchat-sync.yaml`, run the same Chat sweep as Day-Start Step 3b for the day's window (fresh space enumeration; raw sender IDs preserved).
 - [ ] **Email + document-comment final capture (v2.19.0)** — when the workspace syncs those surfaces (per Day-Start 3b's declared-set rule): the day's inbound and sent mail, meeting transcripts for any meeting that ended since the last sync, and document comments/engagement for the day's window. Name any surface not swept.
-- [ ] **Watermark gate (v2.30.0):** the final capture opened with
-  `sync_watermark.py begin --workspace <W> --label day-end` and recorded each
-  saved read with `advance`; now run
-  `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s> --since run`
-  with every declared surface and read target passed explicitly (same rule
-  and same reason as Day-Start Step 3b's gate). The day does not close over a
-  surface or target this run did not re-read: read it or defer it with a
-  reason now.
+- [ ] **Watermark gate (v2.30.0):** the final capture opened with `sync_watermark.py begin --workspace <W> --label day-end` and recorded each saved read with `advance`; now run `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s> --since run` with every declared surface and read target passed explicitly (same rule and same reason as Day-Start Step 3b's gate). The day does not close over a surface or target this run did not re-read: read it or defer it with a reason now.
 - [ ] Update CONTEXT.md to mark any items resolved by day's conversations (so tomorrow's day-start does not re-propose them).
 
 ### 2. Source-Code Sync
 
 End-of-day code sync ensures local main/develop reflects everything that landed during the day and that tomorrow's day-start begins from a clean, current state. Run the same source-code sync as Day-Start Step 3a — same workspace repo list, same fetch + fast-forward semantics, same surfacing of divergence.
 
-- [ ] Read the pending repo-guard manifests first. For every recorded source
-  path owned by this ritual session, run its required tests, inspect the staged
-  index, commit only attributed paths, and push under the repository's branch,
-  review, and deployment policy. Do not mutate another active claim. Any path
-  that cannot be published keeps the affected project below `REMOTE_READY`.
+- [ ] Read the pending repo-guard manifests first. For every recorded source path owned by this ritual session, run its required tests, inspect the staged index, commit only attributed paths, and push under the repository's branch, review, and deployment policy. Do not mutate another active claim. Any path that cannot be published keeps the affected project below `REMOTE_READY`.
 
 - [ ] For every repo the workspace manifest marks for sync (`<workspace>/.agents/repos.yaml` `ritual_sync: yes`; fallback: the `AGENTS.md` table's Yes rows — the complete set, no activity judgment; v2.12.1/v2.13.0): `git fetch --all`, then `git pull --ff-only` on each long-running branch (typically `main` and `develop`).
 - [ ] Surface any branches that are diverged or have local-only commits not yet pushed. These are decisions to make NOW, not at next day-start, so the agent can act on them while context is fresh.
@@ -1122,33 +311,17 @@ This step is intentionally not "merge ready PRs" — that's Integration Sweep be
 
 #### 4a. Calendar Guardian — tomorrow's review (v2.20.0)
 
-Runs first inside Step 4, in **every mode including Quick Close** — the next-day
-review is the highest-value evening act the ritual performs, and it generates
-drafts the send-or-release pass below then handles. The review protocol itself
-lives in the chief-of-staff skill's **Calendar guardian** section; this step is
-its evening cadence.
+Runs first inside Step 4, in **every mode including Quick Close** — the next-day review is the highest-value evening act the ritual performs, and it generates drafts the send-or-release pass below then handles. The review protocol itself lives in the chief-of-staff skill's **Calendar guardian** section; this step is its evening cadence.
 
-- [ ] Review the **next working day** across every configured calendar — and on
-  the last working day of the week, the **weekend too**. Run the full per-entry
-  checklist (real? answered? prepared? outcome? shape? physically possible?)
-  and the whole-day overcommitment check against config thresholds.
-- [ ] **Place holds over tomorrow's remaining open windows** per the same-day
-  shield: generically titled, busy, id-tracked in the holds ledger, auto-
-  expiring. Release/move only holds the ledger says the agent created.
-- [ ] Conflicts and overcommitment produce **named candidates to move with
-  drafted reschedule notes** — into the plan's drafts region, where this
-  step's parent pass picks them up. A warning without candidates is not done.
-- [ ] Anything only the principal can decide → one line each in the plan's
-  decisions region. Tomorrow's calendar picture → the plan's calendar section.
-- [ ] **Lead-time prep packs (v2.26.0):** when `.agents/meeting-preps.yaml` exists, generate
-  or refresh the prep pack for every flagged meeting whose lead window includes tomorrow —
-  built from the declared `sources` (prior transcript, mandate sources, project contexts),
-  per the v2.26.0 rules. This runs in every mode including Quick Close, because it rides
-  the tomorrow-review that already does.
+- [ ] Review the **next working day** across every configured calendar — and on the last working day of the week, the **weekend too**. Run the full per-entry checklist (real? answered? prepared? outcome? shape? physically possible?) and the whole-day overcommitment check against config thresholds.
+- [ ] **Place holds over tomorrow's remaining open windows** per the same-day shield: generically titled, busy, id-tracked in the holds ledger, auto-expiring. Release/move only holds the ledger says the agent created.
+- [ ] Conflicts and overcommitment produce **named candidates to move with drafted reschedule notes** — into the plan's drafts region, where this step's parent pass picks them up. A warning without candidates is not done.
+- [ ] Anything only the principal can decide → one line each in the plan's decisions region. Tomorrow's calendar picture → the plan's calendar section.
+- [ ] **Lead-time prep packs (v2.26.0):** when `.agents/meeting-preps.yaml` exists, generate or refresh the prep pack for every flagged meeting whose lead window includes tomorrow — built from the declared `sources` (prior transcript, mandate sources, project contexts), per the v2.26.0 rules and the `.agents/meeting-preps.yaml` schema in [references/version-history.md](references/version-history.md); the pack states its own basis (which declared sources were read, and the newest source's date). This runs in every mode including Quick Close, because it rides the tomorrow-review that already does.
 
 - [ ] Collect today's decay-tagged drafts (every `**Decays:**` line in today's plan) plus unanswered threads from today.
 - [ ] For each item, one of three outcomes — nothing decay-tagged carries silently past its date: **send now** (with the user's one-tap approval; nothing sends without them), **re-date** with a stated reason on the Decays line, or **release** (strike through with a one-line why).
-- [ ] Post end-of-day status updates; send appreciation for the day's contributions (grounded per the Appreciation Message Quality rules).
+- [ ] Post end-of-day status updates; send appreciation for the day's contributions (grounded per the appreciation rule in the Draft Message Rules above).
 - [ ] In Quick Close this pass is human moment #1: it caps at the tagged set plus a one-line "anything else you want to send tonight?" check.
 
 ### 5. Lessons Learned
@@ -1165,20 +338,11 @@ its evening cadence.
 
 ### 7. Context Capture
 
-**Date discipline (matches Day-Start Step 1 and the global agent rules).** All
-session-log entries and CONTEXT.md updates written tonight MUST use today's
-verified date—not a date inferred from session continuity or memory. If the
-conversation has been running for multiple days, the agent's sense of "today"
-may be wrong by hours or days. Re-anchor before writing.
+**Date discipline (matches Day-Start Step 1 and the global agent rules).** All session-log entries and CONTEXT.md updates written tonight MUST use today's verified date—not a date inferred from session continuity or memory. If the conversation has been running for multiple days, the agent's sense of "today" may be wrong by hours or days. Re-anchor before writing.
 
 - [ ] Run `date "+%Y-%m-%d %H:%M:%S %Z (%A)"` once at the start of this step. Use the output as today's authoritative date for every file write that follows. (If `synthesis-checkpoint` is loaded, invoke it instead — it does this anchoring plus a git-log cross-check.)
 - [ ] For each project worked on today: append a session-log entry to `sessions/YYYY-MM.md` with today's verified date in the header. Format the date as ISO `YYYY-MM-DD` (e.g., `## 2026-05-27 (Wed) — Day-end summary`).
-- [ ] Update CONTEXT.md. Refresh the "Last session" field with today's verified date and update "Recent Sessions" with a one-line summary. **Every live entry in an open-items section carries its own age:** stamp it `(as of YYYY-MM-DD, review Nd)` when you write it, and re-stamp it only when you have actually re-checked it — a stamp advanced without a check is a false receipt, which is worse than an obviously old one. Entries that are genuinely done are closed out into `sessions/YYYY-MM.md` — write them there, verify they landed, then remove them from CONTEXT.md.
-
-  Appending is safe under this rule and rewriting is not required, which is the point. The failure being prevented is an entry that keeps the present tense it was written in ("today", "this week") long after that stopped being true; re-deriving the whole list each run would also drop anything today's evidence happens not to surface, turning a visible stale entry into an invisible missing one. A stamped entry ages in public instead: `context_doctor.py` reports it as `item-currency` once it passes its review horizon (14 days when `review Nd` is omitted), so the check runs for any reader at any time rather than only on days this ritual runs.
-  **Match the horizon to what the item is.** The 14-day default is the horizon for something *owed* — blocked on a named person, with a consequence if it slips. A backlog is not that: a list of feature ideas, article ideas, or a bug inventory is a record of intent, and nobody promised it by a date. Stamp those `(as of YYYY-MM-DD, review 180d)`. Measured once on a real corpus, 17 of 38 open-item findings were wishlists ageing at the owed-work horizon, and a check that reports intentions as overdue is how the whole open-items signal gets read as noise.
-
-  **A recorded decision is not an open item at all.** If a bullet under an open-items heading says a thing was settled — "not needed", "kept", "declined" — the fix is structural rather than a longer horizon: move it under a decisions heading, where the checker does not read it as owed. The section HEADING is what decides, so a settled decision parked under "What's Next" will keep being asked to prove it is still current no matter how it is worded.
+- [ ] Update CONTEXT.md. Refresh the "Last session" field with today's verified date and update "Recent Sessions" with a one-line summary. **Every live entry in an open-items section carries its own age:** stamp it `(as of YYYY-MM-DD, review Nd)` when you write it, and re-stamp it only when you have actually re-checked it — a stamp advanced without a check is a false receipt, which is worse than an obviously old one. Entries that are genuinely done are closed out into `sessions/YYYY-MM.md` — write them there, verify they landed, then remove them from CONTEXT.md. `context_doctor.py` reports a stamped entry as `item-currency` once it passes its review horizon (14 days when `review Nd` is omitted); match the horizon to the item — owed work at the default, backlogs and wishlists at `(as of YYYY-MM-DD, review 180d)` — and park a settled decision under a decisions heading, since the section heading is what the checker reads as owed.
 
 - [ ] Update MEMORY.md if current state info is stale (version numbers, environment status, team assignments).
 - [ ] Update `last_session` date in `index.yaml` for each active project worked on today — use today's verified date.
@@ -1198,25 +362,13 @@ may be wrong by hours or days. Re-anchor before writing.
 
 **Owed-weekly gating (replaces the v2.8.0 Friday-only rule).** The review is owed once per week, anchored to Friday, and tracked in `~/.synthesis/day-end/state.json`. Read `last_weekly_review`: if it is on/after the most recent Friday, skip this step silently. If it predates the most recent Friday and today is on/after that Friday, run the scan below — in whichever ritual notices first (Day-Start Step 1 checks the same condition), in any day-end mode including Quick Close — then update `last_weekly_review`. A `synthesis-catchup-ledger` sweep on/after that Friday counts as the week's review (record its date); and if this scan finds 2+ consecutive missed rituals, suggest running that skill — it is the recovery tool for broken cadence. This decoupling exists because a Friday-evening-only review is disabled by exactly the skip it is meant to catch.
 
-This step exists because work falls through the cracks during a week. A missed close-of-business ritual means the next day's plan doesn't pick up the open threads from the day before. By Friday, several items can be stranded invisibly. The Friday review catches these BEFORE the weekend disconnects fresh context, and assembles a clean carryover list for Monday.
-
 **Scope: past 14 calendar days.** Look back from today through 14 days ago. This captures the current week + the previous week — enough to surface items deferred across one weekend boundary, which is the typical failure mode.
 
 **Sources to scan (read each one; do not infer):**
 
-- [ ] **Calendar Guardian — week and month horizons (v2.20.0).** Part of the
-  owed-weekly review, so a skipped Friday still gets caught by the same gating:
-  - **Week ahead:** sweep all configured calendars for collisions, overcommitted
-    days (config thresholds), unanswered RSVPs, and prep-less meetings — while
-    there is still time to move things. Flag every lead-time meeting
-    (`.agents/meeting-preps.yaml`) in the coming week so research that needs
-    more than a day starts early (v2.26.0). Candidates-to-move come with drafted
-    notes, same contract as the nightly review.
-  - **Month ahead:** scan for anything needing lead time — travel, conferences,
-    deadlines, visits. Any commitment that should start an absence-coordination
-    notification clock (its `notify_on_commit` cohort, or a lead-time deadline
-    inside the coming month) gets flagged NOW; this scan is what makes "people
-    hear as soon as it is known" true in practice rather than in intention.
+- [ ] **Calendar Guardian — week and month horizons (v2.20.0).** Part of the owed-weekly review, so a skipped Friday still gets caught by the same gating:
+  - **Week ahead:** sweep all configured calendars for collisions, overcommitted days (config thresholds), unanswered RSVPs, and prep-less meetings — while there is still time to move things. Flag every lead-time meeting (`.agents/meeting-preps.yaml`) in the coming week so research that needs more than a day starts early (v2.26.0). Candidates-to-move come with drafted notes, same contract as the nightly review.
+  - **Month ahead:** scan for anything needing lead time — travel, conferences, deadlines, visits. Any commitment that should start an absence-coordination notification clock (its `notify_on_commit` cohort, or a lead-time deadline inside the coming month) gets flagged NOW; this scan is what makes "people hear as soon as it is known" true in practice rather than in intention.
 - [ ] `daily-plans/YYYY-MM-DD.md` for the past 14 calendar days. In each plan, look for:
   - Drafts (`### Draft N: ...`) without a following `**Sent:**` marker — these are unsent and the deadline already passed
   - Items under `## Priority Tasks → Do today — not negotiable` that lack a completion marker (✅ or "DONE" or strikethrough)
@@ -1240,8 +392,6 @@ This step exists because work falls through the cracks during a week. A missed c
 - [ ] Leave every changed plan and annotation session-attributed; Step 11 publishes the final day-end batch.
 
 **Failure mode to avoid:** writing a `## Weekly Loose-Ends Review` section header without actually scanning the sources. The value is in the scan. If sources have not been read in this invocation, do not write the section — note "Weekly Loose-Ends Review skipped — scan not performed this invocation" in the plan and surface the gap to the user.
-
-**Idempotency:** if a Friday review was missed and the agent runs this step on a later weekday, the scan still works because it's date-bounded (past 14 calendar days from today), not weekday-bounded. The Friday-default is about WHEN it normally fires; the scan output is meaningful on any day.
 
 ### 11. Remote Readiness and Final Verification
 
@@ -1276,20 +426,6 @@ Remote publication is complete only when remote-mode context doctor and continui
 
 ---
 
-## How to Create a Project Supplement
-
-Project supplements live in `daily-plans/` (shared infrastructure). Example: `daily-plans/daily-checklists.md`. Each project MAY also keep project-specific ritual notes in its own directory if they don't apply cross-project. The supplement should contain:
-
-1. **Repos to sync** — which repos to `git fetch --all` on
-2. **Channels to sync** — specific Slack channels and DMs with IDs
-3. **PR review targets** — GitHub/Bitbucket repos to check for pending PRs
-4. **Stakeholder comms** — who to message and in what channels
-5. **Project-specific end-of-day** — any project-specific cleanup (mirror pushes, staging verification, etc.)
-
-The project supplement is referenced from the global checklist at "Run any project-specific sync steps."
-
----
-
 ## Autonomous Work and Audio Alerts
 
 When the user signals stepping away ("going to take a shower", "heading out", "don't wait on me", "continue without me"):
@@ -1308,12 +444,3 @@ When the user signals stepping away ("going to take a shower", "heading out", "d
 
 **Prerequisite:** the current tool must be authorized to run the local alert commands (`afplay` and `say` on macOS). If not, warn at the start of autonomous mode.
 
----
-
-## Principles Behind These Checklists
-
-- **Dependency-ordered:** Each step feeds the next. Sync before reading. Read before planning. Plan before messaging.
-- **Information entropy reduction:** The primary purpose is closing the gap between what happened and what you know.
-- **Human investment:** Motivational messages are not optional — they are a force multiplier on a distributed team.
-- **Career compounding:** Every day produces raw material for thought leadership. The discipline is noticing it.
-- **State capture:** If you do not capture today's state, tomorrow's start takes longer. This compounds.

--- a/skills/synthesis-daily-rituals/references/draft-grounding.md
+++ b/skills/synthesis-daily-rituals/references/draft-grounding.md
@@ -1,0 +1,171 @@
+# Draft messages — grounding protocol and formatting rules
+
+The full protocol behind the draft rules in [SKILL.md](../SKILL.md):
+research by question type, the investigate-first rule and its incident,
+the verification checklist, the pre-send review gate, Slack formatting
+with examples, draft numbering, temporal integrity, and appreciation
+quality. The rules bind as written here; SKILL.md carries the digest.
+
+## Grounding Protocol for Draft Messages
+
+Every draft message must be grounded in primary sources before it is written. The depth of research scales with the type of claim being made, but the requirement applies to ALL drafts — not just ones that feel technical.
+
+### Research by question type
+
+| Question type | What to check | Examples |
+|--------------|---------------|----------|
+| **Technical** (architecture, how something works, root cause) | Source code, config files, PRs, `git log` | "How does X work?", "Why did Y break?" |
+| **Status** (what's deployed, what's working) | Deploy scripts, version files, environment config, running services | "Is X on production?", "When was Y released?" |
+| **Infrastructure** (secrets, credentials, environments, CI/CD) | Terraform, deploy scripts, `.env.example`, CI/CD workflows, docs | "How do we manage secrets?", "Where does X run?" |
+| **Process** (PR workflow, branching, review, release) | Agent instruction files, contributor guides, recent git history, skill files | "What's the merge process?", "Who reviews?" |
+| **Product** (feature behavior, user-facing text, prompts) | Component code, prompt YAML files, test files | "Does the tool do X?", "What does the user see?" |
+
+### Investigate First, Ask Questions Later
+
+**Before drafting ANY reply to a bug report or user issue, spend 10 minutes investigating.** Read the relevant code, check the config, search for the pattern. If you can fix it in those 10 minutes, fix it and draft a reply with the fix — not a reply asking for more information.
+
+This principle applies to ALL draft messages that respond to reported problems:
+
+- **Do NOT draft** "Can you share the URL?" when you could search the config and find the missing domain yourself.
+- **Do NOT draft** "We're looking into it" when you could have already shipped the fix.
+- **Do NOT draft** "Can you try again?" when you haven't investigated the root cause.
+- **DO investigate** code, config, logs, and infrastructure before composing a reply.
+- **DO fix the problem first** if possible, then draft a reply that leads with the fix.
+- **Only ask the user** for information you genuinely cannot obtain yourself (specific reproduction steps, subjective preferences, environment details unique to them).
+
+**Why:** The user's time is more valuable than the agent's. A fix shipped in 10 minutes builds more trust than a reply asking for more info. Action before questions.
+
+**Example:** A user flagged "Import Failed" on certain stories. The initial draft asked for the specific URL. Instead, investigating the config found that a domain was simply missing from the allowed list. The fix took 10 minutes. No round-trip needed.
+
+### The process
+
+1. **Identify the claim.** Before writing, ask: "What factual assertions will this message make?"
+2. **Research each claim.** Use Grep, Read, Glob, git log, or other tools to find the primary source.
+3. **Note the evidence.** Record file paths, line numbers, config values, or PR numbers that support the claim.
+4. **Draft with citations.** Include specific references where they add credibility (e.g., "We use GCP Secret Manager — see `terraform/modules/secrets/main.tf`").
+5. **Flag uncertainty.** If a claim can't be fully verified, say so in the draft rather than guessing.
+
+### Why this matters
+
+The user's professional reputation depends on accuracy. A wrong technical claim in Slack is visible to the entire team and cannot be unsent. A delayed but accurate response is always better than a fast but wrong one.
+
+**Incident (2026-03-17):** A technical reply was drafted based on conversation memory alone. It was partially wrong. The next day, another reply was drafted after reading the actual code — it was fully correct. The difference was 5 minutes of research.
+
+### Scope
+
+This protocol applies everywhere draft messages are created:
+- Morning messages (Day-Start Step 7)
+- Mid-day sync replies (synthesis-slack-sync Step 5)
+- End-of-day communications (Day-End Step 3)
+- Ad-hoc message requests throughout the day
+
+
+## Draft Message Formatting Rules
+
+All draft messages in the daily action plan must follow these formatting and quality rules. The user copy-pastes these directly into Slack — formatting errors waste time and look unprofessional.
+
+### Slack Formatting
+
+1. **Blank line after every bullet.** Slack requires a blank line between bullet points for them to render as separate items. Without blank lines, bullets collapse into a single paragraph. This is the most common formatting error — check every draft before saving.
+
+   **Wrong (collapses in Slack):**
+   ```
+   • Item one
+   • Item two
+   • Item three
+   ```
+
+   **Right (renders as separate bullets):**
+   ```
+   • Item one
+
+   • Item two
+
+   • Item three
+   ```
+
+2. **Use Slack markdown, not GitHub markdown.** Slack uses `*bold*` not `**bold**`. Use `_italic_` not `*italic*`. Use `>` for blockquotes. Use `` `code` `` for inline code.
+
+3. **Thread locators for every reply draft.** Include: channel name, human-readable date/time of parent message, author name, and first ~10 words of the message being replied to. Use the format: `**Channel:** #channel-name — Author Name, Mon Mar 30 at 11:31 AM EDT — "First ten words of the message..."`. The Slack thread TS (Unix timestamp) should be included for technical reference but is NOT the primary locator — the human-readable context is what the user needs to find the thread.
+
+4. **Keep messages concise.** Slack messages over ~15 lines get collapsed behind a "Show more" fold. Front-load the most important information.
+
+### Draft Numbering Convention
+
+Drafts in a daily plan are labeled with sequential integers, not alphabet letters. The first draft of the day is **Draft 1**; each subsequent draft increments by 1.
+
+**Do:**
+
+- `### Draft 1: Multi-provider routing announcement`
+- `### Draft 2: Reply to Oliver — Terraform readiness`
+- `### Draft 11: Patrick public praise — release window`
+- `### Draft 12: User-channel supplement (L&E)` (when same theme is routed to multiple audiences, each variant still gets its own integer)
+
+**Do NOT:**
+
+- `### Draft A: ...`, `### Draft B: ...` (alphabet labels — replaced by integers in v2.6.0)
+- `### Draft K-2: ...`, `### Draft K-3: ...` (letter-with-suffix sub-versioning — replaced by sequential integers)
+
+**Pre-draft step:** before adding a new draft, grep or scan the file for the highest existing `Draft N` integer and use N+1.
+
+**Retraction:** if a draft is retracted (e.g., a fabricated message caught and removed), keep the number reserved in the file (`### Draft N — retracted` with a one-line pointer to the session log) rather than renumbering subsequent drafts. The reserved slot is the durable historical record.
+
+See the v2.6.0 section of version-history.md for the full rationale (counting tax, lexicographic ordering, sub-version ugliness, cross-file consistency).
+
+### Temporal Integrity
+
+Every draft message must be accurate *at the time it will be sent*, not at the time it was written. This is the most common source of anachronistic messages.
+
+**Before finalizing each draft, check:**
+
+1. **Has the recipient already received this information?** If the same person was tagged in an earlier message or was present at a meeting where this was discussed, don't repeat it. Restructure the message to cover only what's new or what still needs their input.
+
+2. **Do forward-looking statements match reality?** "Will review next" is a commitment. "Staging is ready for QA" is stale if QA already started. "Welcome back" is odd if the person was just in a meeting with you. Audit every verb tense.
+
+3. **Are scheduled-for-later messages written in the right tense?** A message drafted Monday but scheduled for Tuesday must say "yesterday" not "today" when referencing Monday events. The easiest way to catch this: read the message as if you are the recipient reading it at the scheduled send time.
+
+4. **Does the message acknowledge what happened since it was drafted?** If a standup, deployment, or Slack conversation happened between drafting and sending, re-check the message. Information that was "upcoming" may now be "completed."
+
+5. **Has the topic moved to another channel or medium?** Obsolescence is cross-channel and cross-medium: a Slack question may have been answered in email, a meeting, or a different channel entirely. Before sending, sweep recent transcripts across ALL synced surfaces for the recipient + topic, and search email when the subject could plausibly have crossed mediums. For email replies, always re-pull the FULL thread first — the latest message may supersede the one being answered. Drafts older than 24 hours get full fact re-verification, not just a thread re-read. (Agent-assisted send paths should enforce this as a mandatory send-time gate — see the user's send-system skill if one exists.)
+
+**Common temporal integrity failures:**
+- "Welcome back" to someone who was at the meeting you just attended together
+- "Staging is ready for QA" sent to someone who was already tagged in a staging notification
+- "Good that you're meeting with X today" in a message scheduled for tomorrow
+- "I'll review this next" when you've already moved on to other work
+
+### Grounding Verification Checklist
+
+Before finalizing each draft message, verify:
+
+- [ ] **Every technical claim cites a source** — file path, line number, PR number, config value, or git SHA.
+- [ ] **Every status claim is current** — verified against the actual system state (git log, deploy status, environment), not just memory or transcripts.
+- [ ] **Every attribution is correct** — the right person is credited for the right work. Cross-reference PR authors via `gh pr view` or `git log`, not memory.
+- [ ] **No stale information — checked beyond the thread.** Re-read the target thread via MCP to confirm no one has replied or resolved it, AND sweep for the topic across OTHER channels, DMs, and email — resolutions frequently happen outside the thread where the question was asked. A message rendered obsolete by a communication anywhere is obsolete everywhere.
+- [ ] **Numbers are accurate** — test counts, file counts, line counts, character counts are from actual tool output, not estimates.
+- [ ] **Temporal integrity passes** — message is accurate at the time it will be read, not just at the time it was written. See Temporal Integrity section above.
+
+### Pre-Send Review Gate
+
+Every draft message section in a daily plan must include the following notice before the first draft:
+
+> **Review before sending.** These drafts are grounded in real data — code commits, test results, deployment logs, Slack threads, and project context — but they are starting points, not final messages. Read each one, edit it in your own voice, and add the personal touch only you can. Human-to-human communication deserves human effort.
+
+This is not optional. Draft messages are research-backed starting points — not automated communications. The human must:
+1. Read each draft fully before sending
+2. Edit the tone and phrasing to match their voice
+3. Add personal context that only they have (relationship nuance, recent conversations, political awareness)
+4. Verify the message is appropriate for the current moment (not just factually correct)
+
+The grounding section shows the research behind the draft. The human adds the judgment, timing, and personal touch that make the message authentic.
+
+### Appreciation Message Quality
+
+Appreciation messages must be specific and grounded, not generic. Each should reference:
+- The specific work product (PR number, feature name, article title)
+- What made it good (thorough test plan, clean architecture, consistent output, specific design decision)
+- Observable impact (unblocks X, addresses user feedback Y, improves process Z)
+
+**Generic (weak):** "Great work on the PR, Emil!"
+**Grounded (strong):** "Emil — PR #96 was clean with solid UUID validation and 6 permission tests covering all access paths. The immediate user sync on org assignment was the right architectural call — avoids the confusion of next-login delays."
+

--- a/skills/synthesis-daily-rituals/references/plan-format.md
+++ b/skills/synthesis-daily-rituals/references/plan-format.md
@@ -1,0 +1,139 @@
+# Daily plan format — structure, vocabulary, and revert protection
+
+The producer side of the daily-plan contract. The consumer side is
+synthesis-console's `docs/cockpit-design.md`; the two change together.
+Cockpit Mode, the `## 📅 Calendar` section, and meeting-prep packs are
+specified in [version-history.md](version-history.md) (v2.10.0–v2.12.0);
+the draft fence and numbering conventions in v2.5.0 and v2.6.0 there.
+
+## Daily Plan Structure: Preserve and Reorganize
+
+The daily action plan is both a **live dashboard** (scannable current state) and a **historical record** (what happened today). These goals conflict if the file is treated as append-only — by evening, sections are scattered and duplicated, making the file unreadable.
+
+### The Rule: Preserve All Information, Reorganize for Clarity
+
+**Never delete information.** Completed tasks, sent messages, timestamps, decisions, and resolved items must always be preserved somewhere in the file.
+
+**Reorganize freely.** Consolidate scattered sections, merge duplicate lists, reorder for readability. The file should have ONE section for each concern, not multiple sections that accumulated through the day. After every sync or major update, the file should read cleanly from top to bottom.
+
+### Required File Structure (v2.4.0+)
+
+The daily plan follows this canonical structure. On each update, consolidate into these sections rather than appending new ones. The synthesis-console v0.8+ cockpit parses these section names to typed regions; staying within the canonical vocabulary maximizes the typed UI surface.
+
+```markdown
+# Daily Action Plan — [Day], [Date]
+
+**[Status line: version, key people, blockers]**
+
+---
+
+## Decisions needed from Rajiv     ← cockpit: NEEDS YOU region
+[H3 question per decision. Each H3 may have **Option A:** / **Option B:** lines
+ and a **Recommendation:** line. The cockpit renders option buttons that record
+ a `**Decided:** Option X — <ISO>` marker back to the file on click.]
+
+## Priority Tasks                  ← cockpit: TODAY region
+### Do today — not negotiable      ← collapsible bucket (P0, expanded by default)
+1. **Task title** — description    ← cockpit renders as checkbox; click writes
+                                       `~~**Title**~~ ✅ **DONE HH:MM TZ**` in place
+
+### Do today — should make it      ← P1 bucket (collapsed by default)
+### Do today — can slip            ← P2 bucket
+### Watch / waiting                ← muted styling
+### Stale targets                  ← muted styling
+
+## Drafts — Ready to Send          ← cockpit: DRAFTS region
+> **Review before sending.** [Standard reviewer notice — keep verbatim.]
+
+### Draft A — [Description]
+**Send to:** `#channel-name` — [thread locator]
+```
+[message body in fenced code block — use 3 backticks if the body has no internal code blocks; use 4 backticks (````) if the body contains any internal ``` blocks. See v2.5.0 — Draft Fence Convention in version-history.md.]
+```
+**Grounding:**
+- [bullet]
+- [bullet]
+
+## Standup Highlights              ← cockpit: lower-row collapsible (context tone)
+## What Happened Yesterday         ← cockpit: lower-row collapsible (briefing)
+## Things to Know                  ← cockpit: lower-row collapsible (briefing)
+## Mid-day Sync                    ← cockpit: lower-row collapsible (briefing)
+## Waiting On Others               ← cockpit: lower-row collapsible (waiting tone)
+## Open PR Queue                   ← cockpit: lower-row collapsible
+## Sent Messages                   ← cockpit: lower-row collapsible (done tone)
+## Completed Today                 ← cockpit: lower-row collapsible (done tone)
+## Sync state                      ← cockpit: lower-row collapsible
+## Bugs (Open)                     ← cockpit: lower-row collapsible (briefing)
+## Carried Items                   ← cockpit: lower-row collapsible (briefing)
+```
+
+### Canonical Section Vocabulary (Authoritative)
+
+The synthesis-console v0.8+ parser classifies each H2 heading into one of these kinds. Use the canonical name where possible. The "synonyms" column lists variants the parser also recognizes via substring + case-insensitive match — these exist for backward compatibility but new plans should prefer the canonical name.
+
+| Cockpit region / kind | Canonical H2 name | Recognized synonyms |
+|----------------------|-------------------|---------------------|
+| **decisions** (NEEDS YOU) | `Decisions needed` | "Decisions to make", "Open ask", "Asks for Rajiv", "Open Items", "Needs your attention", "Open Quality Concerns" |
+| **priority-tasks** (TODAY) | `Priority Tasks` | "Tasks", "Tasks for Rajiv", "Tasks Today", "Today's Tasks", "Today's Priorities", "Still To Do", "This Week", "Remaining Tasks", "Pending This Session", "Pending from Before Vacation" |
+| **drafts** (DRAFTS) | `Drafts — Ready to Send` | "Drafts", "Unsent — Ready to Send", "Unsent Drafts", "DM Reply Drafts", "Draft Messages", "Messages", "Next Steps", "Pending Emails", "Scheduled for Tomorrow / Later" |
+| **standup** | `Standup Highlights` | "Standup Transcript", any heading with "standup", "Newsroom Training" |
+| **sent-messages** | `Sent Messages` | "Messages Sent" |
+| **waiting** | `Waiting On Others` | "Waiting on", "Delegated to Team" |
+| **pr-queue** | `Open PR Queue` | "PR Queue", "Open PRs", "New PRs", "PRs Ready for Review", "PR Reviews Completed" |
+| **sync-state** | `Sync state` | "Staging/Deployment Status", "Deployment Status", "Pre-Migration Status", "Post-Release Status", "Files Created/Modified", "Test Results", "Staging:" |
+| **completed** | `Completed Today` | "Completed This Morning" |
+| **briefing** | `Things to Know` | "What Happened", "What Changed", "Big Things", "Things Rajiv Should Know", "Carried From / Items / Forward", "Carry Forward", "Mid-day Sync", "Morning Sync", "From Slack Sync", "State Catch-Up", "Day Summary", "End of Day Summary", "Bugs (Open)", "QA Findings", "QA Results", "CRITICAL:", "Context", "What to Watch", "Future Work", "Post-Release Issues", "Feature Requests (Carryover)", "Release Process Sync" |
+| **other** (fallback) | (any unrecognized H2) | Renders as plain markdown in the lower-row collapsibles. Nothing is lost; the section just isn't specially typed. |
+
+### Internal Structure Conventions
+
+Within each section, the parser also recognizes structural patterns. Adhering to these makes the UI work correctly:
+
+**Decisions section** (`## Decisions needed`):
+- One H3 per decision (`### 1. Force-push origin/develop?`)
+- Options as bold paragraphs: `**Option A:** description`, `**Option B:** description`
+- Optional: `Recommendation: **A** with rationale`
+- After click: skill / human appends `**Decided:** Option X — <ISO>` directly under the H3
+- **Synthetic asks**: an H2 like `## Open ask for Rajiv` with prose body and NO H3s also surfaces in NEEDS YOU as a single card with the prose verbatim. Use this for one-off requests that don't fit the A/B/C structure.
+
+**Priority Tasks section** (`## Priority Tasks`):
+- One H3 per bucket (`### Do today — not negotiable`)
+- Tasks as numbered list items (`1. **Title** — description`) OR checkbox items (`- [ ] **Title** — description`). Both formats supported.
+- Already-done tasks may be marked any of these ways (parser detects all): `~~Title~~ ✅ DONE HH:MM`, `[x]`, leading `✅`, leading `DONE` or `SENT`.
+- The cockpit's TODAY region surfaces tasks as live checkboxes that write the canonical done marker back to the file on click.
+
+**Drafts section** (`## Drafts — Ready to Send`):
+- One H3 per draft (`### Draft A — Description`)
+- A `**Send to:** target — locator` paragraph identifying the recipient. `**Channel:**` is also accepted.
+- A fenced code block OR blockquote with the message body. **Fence convention (v2.5.0+):** default is 3 backticks; if the body contains any internal triple-backtick code blocks (install commands, log excerpts), use a 4-backtick outer fence (or any length strictly greater than the longest internal fence). The 4-backtick outer fence renders correctly in synthesis-console AND survives the Copy button intact (outer fence stripped, inner ` ``` ` preserved for Slack to re-interpret).
+- Optional: a `**Grounding:**` paragraph or bullet list with research backing.
+- After send: skill / cockpit appends `**Sent:** <ISO> (TS=...) <permalink>` directly under the body.
+- **Drafts may also appear under non-drafts H2s.** When a draft is added to a topical context (e.g., a draft DM written into "Things to Know" alongside the situation that prompted it), the cockpit's DRAFTS region aggregates it from wherever it lives in the document. The canonical placement is still under `## Drafts`, but topical inline drafts work too.
+
+**Pre-Send Review Notice**: every drafts H2 SHOULD include this verbatim blockquote before the first H3 draft (the cockpit doesn't currently re-display it in the DRAFTS region but it remains in the file for archival and Full-Markdown view):
+
+```
+> **Review before sending.** These drafts are grounded in real data — code commits, test results, deployment logs, Slack threads, and project context — but they are starting points, not final messages. Read each one, edit it in your own voice, and add the personal touch only you can. Human-to-human communication deserves human effort.
+```
+
+### What This Means in Practice
+
+- When a draft is sent: move it from "Unsent" to "Sent Messages" with a timestamp. Don't create a new "More Sent Messages" section.
+- When a bug is resolved: update the entry in "Bugs" to show it's resolved. Don't leave the old entry and add a new one elsewhere.
+- When a sync finds new info: update the relevant existing section. Don't append a new section for each sync.
+- When the file gets messy: do a full rewrite that preserves all information in the canonical structure. This is expected and encouraged — it's maintenance, not data loss.
+
+### Why This Replaced "Append-Only"
+
+The original "append-only" rule was designed to prevent accidental deletion of sent message records. The intent was correct — losing records causes duplicate sends and confusion. But in practice, append-only caused the file to balloon with scattered duplicate sections ("More Sent Messages (afternoon)", "More Sent Messages (afternoon, continued)", "Unsent — Ready to Send", "Unsent — Evening"), becoming unreadable by end of day.
+
+The preserve-and-reorganize approach achieves the same safety goal (no information loss) while maintaining readability. The transcript files (`{workspace}/channels/YYYY-MM-DD.md`, `{workspace}/dms/YYYY-MM-DD.md`, `{workspace}/group-dms/YYYY-MM-DD.md`) are the authoritative append-only historical records. The daily plan is the dashboard.
+
+### File Revert Protection
+
+If a file revert is detected (system reminder says "file was externally modified"):
+1. Re-read the ENTIRE file from disk before making any edits.
+2. Compare the on-disk content against your in-memory understanding of the file.
+3. If content is missing (items you know were written earlier are gone), reconstruct the missing content from Slack sync data, session memory, and transcript files.
+4. Never silently accept a reverted file — always verify and restore.
+

--- a/skills/synthesis-daily-rituals/references/version-history.md
+++ b/skills/synthesis-daily-rituals/references/version-history.md
@@ -1,0 +1,504 @@
+# Daily rituals — version history and rationale
+
+The operating checklists live in [SKILL.md](../SKILL.md). This file keeps the
+release-by-release record of why each rule exists — the incidents, the
+design choices, the config schemas each version introduced — so the main
+document can stay within the repository's 500-line budget without losing
+the reasoning. Newest first.
+
+## v2.31.0 — Restructured under the 500-line budget
+
+v2.31.0 (2026-09-01) moves version history, plan formats, draft-grounding
+detail, and rationale out of SKILL.md into `references/` (this file,
+`plan-format.md`, `draft-grounding.md`), leaving every operating rule and
+checklist step in the main document. A pinned test
+(`scripts/test_skill_documents.py`) fails when SKILL.md reaches 500 lines,
+when a load-bearing rule anchor leaves it, when a moved block is missing
+from its reference, or when a reference is not linked from the main
+document. Nothing in the protocol changed.
+
+## v2.30.0 — Watermarks carry a time and a target, and a run proves its own coverage
+
+v2.30.0 (2026-09-01) fixes what a day-granular watermark could not see: a
+surface written at 09:15 counted as current for the rest of the day, so a
+mid-day pass that re-read only what the morning had skipped let the
+morning's own reads go stale — and an "unanswered" claim at 17:51 rested on
+a 09:15 read while the answer had gone out at 09:27. Four defects, one
+mechanism: watermarks are ISO-8601 timestamps (the last moment actually WRITTEN,
+never the last attempted); a surface carries one watermark per
+declared read target; `begin` stamps a run and
+`status --since run` exits non-zero on every declared surface or target not
+re-read during THIS run; and `window` echoes human-readable bounds beside
+the epoch `oldest` a read call takes — a window parameter is a claim about
+time and is computed, not typed. Every sync re-reads every declared target:
+"already read today" is a statement about the past. Contract, store, and
+rationale: [references/sync-watermarks.md](references/sync-watermarks.md).
+
+## v2.27.0 — Sync windows follow the last write, and a recorded gap blocks
+
+v2.27.0 (2026-08-27) replaces run-anchored sync windows with per-surface
+watermarks, and makes a recorded gap something a later run must act on.
+
+**The defect.** A window anchored on when the previous run *executed* cannot see
+its own holes. Skip a run and the hole it leaves is never revisited, because the
+next window starts at now-minus-a-bit rather than at the last day actually
+written to disk. Nothing persisted "the mirror is complete through date X", so
+no run could detect what it had missed. Compounding it, the `gaps` field was
+honest and completely inert: writing a gap and closing a gap are different acts,
+and nothing forced the second. A gap was recorded in three consecutive artifacts
+and no run ever read those lines back.
+
+**The rule.** Each surface carries a watermark — the last date actually
+WRITTEN, never the last date attempted — in `~/.synthesis/sync-watermarks/`,
+managed by `scripts/sync_watermark.py`:
+
+- every sync computes its window from the watermark, so a hole is revisited
+  automatically and nobody has to notice it;
+- the watermark advances only after a successful write, so a run that fetches
+  nothing, errors, or is interrupted cannot declare the day covered;
+- `sync_watermark.py status --workspace W` exits non-zero while any surface has
+  an unclosed gap. Run it in Day-Start Step 3 and Day-End Step 1. An open gap is
+  closed this run or deferred with an explicit reason, and a deferral lasts one
+  working day — an indefinite silence is how a recorded gap becomes furniture.
+
+Surfaces are tracked independently: one surface closing never vouches for
+another, which is the completeness claim that hid the original gap.
+
+**The general lesson, worth more than the fix.** Detection that nothing consumes
+changes nothing. The gap field was accurate every time it was written; what was
+missing was any mechanism that read it back. When adding a check, ask what
+consumes its output and what happens when the answer is bad — a finding with no
+consumer is a note to self.
+
+## v2.26.0 — Lead-time meeting preps: high-stakes meetings get prepared a business day ahead
+
+Same-day prep packs (v2.12.0) are right for routine meetings and structurally wrong for
+high-stakes ones: a strategy-bearing 1:1 prepared minutes before it starts gets a summary of
+what the *agent* has been processing lately, not what the *counterpart* cares about —
+recency bias with a deadline. The origin incident: an exec weekly was rescheduled onto the
+current day, prep was requested sixteen minutes before the start, and the first draft led
+with the week's loudest workstream instead of the principals' stated mandate; there was no
+time to research either half. Preparing one business day ahead is what allows reading the
+prior meeting's transcript, checking the mandate sources, and thinking strategically.
+
+A workspace opts in by declaring **`.agents/meeting-preps.yaml`**:
+
+```yaml
+# .agents/meeting-preps.yaml — lead-time prep declarations (v1)
+lead_time_preps:
+  - name: exec-weekly            # slug used in the prep-pack filename
+    title_contains: "Weekly - Principal and Exec"   # calendar title match (case-insensitive)
+    attendees_any: [exec@example.com]               # OR-matched; either matcher may be omitted
+    business_days_ahead: 1
+    sources:                     # what the prep MUST be built from (the durable record)
+      - prior-meeting-transcript # open loops and commitments from last time
+      - mandate-sources          # the documents/transcripts where this person stated their priorities
+      - project-contexts         # CONTEXTs naming the attendee or the meeting's subjects
+```
+
+Four rules, enforced by the ritual steps below:
+
+1. **Generation is owed at the day-end BEFORE the meeting's business day** (Step 4a) — the
+   Calendar Guardian's tomorrow-review already looks at the right day in every mode
+   including Quick Close, so the prep rides the review that is already mandatory. Day-Start
+   Step 6 verifies presence for today's flagged meetings and regenerates stale packs; the
+   owed-weekly week-ahead scan flags any flagged meeting in the coming week so multi-day
+   research can start early.
+2. **A reschedule triggers an immediate refresh at detection time.** A flagged meeting that
+   MOVES onto today or tomorrow does not wait for the next ritual — whichever sync detects
+   the move regenerates the prep then. Reschedules are precisely when prep is most likely
+   to be stale and most likely to be skipped.
+3. **Prep is built from the durable record, not from session memory.** The declared
+   `sources` are read fresh: the prior meeting's transcript for open commitments, the
+   counterpart's own stated priorities from mandate sources, and project state. The
+   structural point of the lead time is that this reading takes longer than the minutes
+   before a meeting provide — a prep that skips the sources has not used the lead time.
+4. **The pack states its own basis.** Its header lists which declared sources were read and
+   the date of the newest one, so a reader can tell a researched pack from a summary of
+   recent activity. The v2.12.0 file contract (path, filename, H1/When/Who) is unchanged —
+   this section governs *when* and *from what*, not the format.
+
+Workspaces without the config keep v2.12.0 behavior unchanged.
+
+## v2.25.0 — Per-workspace sessions are the default; the principal is the dispatcher
+
+Distributed execution keeps the desk/worker split and the artifact contract, and corrects
+which worker mode is assumed. **The default is now an attended session rooted in each
+workspace, run on that workspace's own schedule** — the mode that matches where the
+principal is actually working, with the right directory, claims, and context. Desk-
+dispatched subagents demote to an opt-in for deliberately closing everything from one place.
+
+Two rules are made explicit because their absence invited a design that cannot work.
+**The principal is the dispatcher:** no session can start work in another, so the desk
+reports which workspaces are owed and the human opens the one that owes. **The desk never
+nudges, triggers, blocks on, or waits for a worker:** it folds what exists and reports the
+rest as not covered, so a desk pass is always complete on its own terms.
+
+Origin: a desk that tried to trigger workers by messaging their sessions went 0 for 2 —
+once to a session stale by two hours, once with no reachable session at all — while the
+artifact path delivered both times. Session messaging is a relay between humans at
+keyboards, not a dispatch primitive; depending on it relocates multi-session overhead
+rather than removing it. Independent close times per workspace are likewise now stated as
+normal operation, which the timestamped artifact schema already supported. Detail:
+`references/ritual-worker-contract.md`.
+
+## v2.24.2 — The shell keeps the consumer's section vocabulary
+
+Separating plan storage changes where content lives, not what the sections are called.
+Renderers classify plan sections by heading vocabulary, so a shell written with invented
+headings renders as undifferentiated prose while every typed region the reader works from
+comes up empty — the plan looks blank exactly when it is full. Shells reuse the
+established headings for any region they populate and confine novelty to the coverage
+block and pointer lines; producer and consumer change together or not at all. Detail and
+origin incident: `references/ritual-worker-contract.md` ("Plan storage separation").
+
+## v2.24.1 — Fragment placement and consumer obligations
+
+Clarifies two points in the plan-separation contract that adopters hit immediately: a
+workspace's fragment belongs in the individual's **private** repository (not the
+organization-shared one) when a workspace carries both, and a consumer that merges
+fragments for display must never cache merged output back into the person-side store and
+must render an unresolved pointer as an explicit marker rather than dropping it.
+
+## v2.24.0 — Plan storage separation: workspace fragments, person-side shell
+
+Organizational data must be erasable by deleting the organization's workspace folders —
+a hard requirement in regulated environments (banks, government, contract exits) and good
+hygiene everywhere. The daily plan therefore stops copying workspace content into the
+person-side repository: **the worker artifact doubles as that workspace's plan fragment**
+(it already holds the plan-facing sections, in the workspace-private repo), and the
+person-side plan becomes a **shell** — coverage line, the principal's own timeline,
+minimal cross-workspace conflict references, the permanent personal section, and pointer
+lines to fragments. Consumers merge at display time; presentation stays converged
+("one brief") while storage separates. The erasure boundary and the strict-shell option
+for title-level erasure are specified in
+[`references/ritual-worker-contract.md`](references/ritual-worker-contract.md) ("Plan
+storage separation"). Pre-existing mixed plan files are left to a deliberate migration.
+
+## v2.23.0 — Distributed ritual execution: desk and workers
+
+The ritual can now fan its sync labor out per workspace while its output stays singular.
+One seat — the **desk**, the ritual's home — frames the day and produces the single brief;
+each workspace runs its labor as a **worker** that writes a structured summary artifact to
+a declared path, and the desk folds artifacts instead of loading workspace detail inline.
+Workers never message the desk: **worker→file, desk→file** — an artifact survives whether
+or not anyone was listening, and a missing artifact is itself the legible "not covered"
+signal. The full schema, path convention, registry format, desk obligations, and failure
+semantics live in [`references/ritual-worker-contract.md`](references/ritual-worker-contract.md);
+the operative rules are in "Distributed ritual execution" below. Every brief now carries a
+mandatory **coverage line**. Design record: the ritual-home seat's 2026-08-11 distributed-
+ritual-architecture artifact (decisions: output never distributes; fan out execution,
+converge presentation).
+
+## v2.22.0 — Local continuity during the day; remote readiness at day-end
+
+Routine turns, day-start, and mid-day sync keep the filesystem-backed project
+record current and rely on session-attributed local receipts. They do not
+create Git commits or network pushes merely to switch Claude Code and Codex on
+one machine. Day-end is the batched cross-machine publication boundary: it
+publishes owned source work under repository policy, flushes exact private
+project-context paths, runs remote-mode doctor and conformance, and verifies
+remote heads. An interrupted task remains locally recoverable from its edit
+manifest even when Stop never ran.
+
+## v2.21.0 — Inbox hygiene joins the morning sync, scoped to the seat
+
+Day-Start gains Step 3d: when `~/.synthesis/inbox-cleanup/scopes.yaml` exists,
+the ritual resolves which accounts this workspace's seat may sweep (personal
+seat: all; client seat: its own only — the inbox-cleanup skill's v1.5.0
+workspace-scope contract) and runs the sweep dry-run-first. Unknown workspace
+or missing config stops the step loudly; sweep results always name the scope
+("7 of 9 in scope, 7 swept") so partial can never impersonate complete.
+
+## v2.20.0 — Calendar Guardian: the rituals hold a perimeter around the calendar
+
+Three additions, all cadence for the chief-of-staff skill's new **Calendar
+guardian** doctrine (which owns the protocols; these steps own the schedule):
+Day-End Step 4a reviews the next working day (plus the weekend on the last
+working day of the week) and places id-tracked, auto-expiring holds over
+tomorrow's open windows — in every mode including Quick Close, because it
+generates the drafts Step 4 then handles. Day-Start Step 6 re-verifies the
+morning against overnight arrivals and refreshes the same-day shield. The
+owed-weekly review (Step 10) gains the week-ahead and month-ahead horizons; the
+month pass is what starts absence-notification clocks while notifying is still
+early and cheap. Requires `calendar_guardian` keys in the chief-of-staff
+private config; without them the steps report "unconfigured" rather than
+guessing thresholds.
+
+## v2.19.0 — Every sync covers every configured surface (email + meeting transcripts + document comments join Slack/Chat)
+
+v2.19.0 (2026-08-09) extends the complete-surface principle from v2.17.0 to its conclusion: a sync request — Day-Start Step 3, the Mid-Day Sync Protocol, or Day-End Step 1 — covers ALL surfaces the workspace routinely syncs, not only the chat surfaces. The declared set: Slack (always), Google Chat (`.agents/gchat-sync.yaml`), **email** (established `transcripts/email/` practice or explicit config), **meeting transcripts** (`.agents/meeting-transcripts.yaml` — any meeting ended in the window), and **document comments** (established `transcripts/docs/` practice or explicit config). The surface set is a declared list exactly like the repo list in the source-code sync — the agent does not re-apply its own judgment about which surfaces feel active (the v2.12.1 rule, applied to channels). A sync that runs fewer surfaces than the declared set must name the omission explicitly in its report; a sync reported without naming its gaps claims a completeness it does not have. Origin incident: 2026-08-09 — a mid-day sync ran Slack and Chat only, reported all-quiet, and missed that the day's most consequential correspondence (a CEO-facing email delivering two Google Docs) had happened entirely on the unswept surfaces.
+
+## v2.18.0 — Dual-client parity in Day-Start; fail-closed context gate in Day-End
+
+v2.18.0 (2026-08-03) adds two checks. Day-Start Step 1 gains the `conformance.py parity` dual-client drift check: the ecosystem's dual-runtime guarantee (Claude Code + Codex) previously had no daily detection layer, and a release that reached one client but not the other — or neither — stayed invisible until something broke. Proven necessary the day it was written: the first live run caught main at 4.12.0 with both installed clients at 4.11.0. Day-End Step 7 gains the fail-closed active-project context gate: `context_doctor.py --project` must be clean for each project worked today before the close-out proceeds. Posture decision recorded in establish-codex-first-class-synthesis: fail-closed for the actor's own active project (fixable in minutes by the session that caused it), report-only for the corpus (gating one session on another's legacy debt manufactures the false alarms that train bypass). Pairs with synthesis-context-lifecycle v1.5.0 and synthesis-agent-conformance parity mode.
+
+## v2.17.0 — Google Chat joins the channel syncs
+
+v2.17.0 (2026-08-03) adds Google Chat as a first-class channel sync beside Slack, in all three sync moments: Day-Start Step 3b, the Mid-Day Sync Protocol, and Day-End Step 1. A workspace opts in by declaring `.agents/gchat-sync.yaml` (sibling to `slack-sync.yaml`); workspaces without the config skip the step silently. Rationale: in many organizations executives and cross-functional teams live in Google Chat while delivery teams live in Slack — syncing only Slack leaves a systematic blind spot exactly where the highest-stakes correspondence happens.
+
+The sub-step is tool-agnostic (any Google Chat-capable MCP; a self-hosted multi-account Workspace server works with plain user OAuth). Four disciplines it encodes, learned from the first production rollout:
+
+1. **Enumerate spaces fresh each run** — per-meeting chat spaces are created for every recorded meeting; a hand-maintained space list is stale within a day. List spaces at sync time, then read what the config's scope selects.
+2. **Window by `createTime`, treat a full page as truncated** — some Chat clients expose no pagination cursor on message listing; when a read returns exactly the page size, narrow the time window and re-read until complete.
+3. **Preserve the raw `users/<id>` on every message line** alongside any resolved display name. Chat sender IDs are stable, workspace-universal profile IDs; keeping them beside inferred names means a later authoritative resolver (the People API) can correct every past attribution mechanically. Inference layers get names wrong; preserved primary keys make those errors repairable instead of permanent.
+4. **Same confidentiality handling as Slack DMs** — Chat DMs carry executive and personnel correspondence; transcripts belong in the workspace-private repo only.
+
+## v2.16.0 — Agent-neutral day-end runtime
+
+v2.16.0 (2026-07-29) installs the launcher and macOS nudge under
+`~/.synthesis/day-end/`, a stable runtime owned by synthesis rather than by one
+agent client's skill cache. The launcher can open Codex or Claude Code; `auto`
+prefers Codex when both CLIs are present, and `--agent codex|claude` persists an
+explicit choice. The installer atomically writes exact files, refuses
+symlinked runtime roots, never removes the runtime tree, and verifies source
+survival in its tests.
+
+## v2.16.0 — Context-integrity doctor joins Day-Start Step 1
+
+v2.16.0 (2026-07-31) adds `context_doctor.py --quiet` beside the git-hooks and message-guard doctors in Step 1. Those two protect the commit and send boundaries; this one protects the durable project record itself — the tiered CONTEXT/REFERENCE/sessions layer that makes work resumable by a different agent on a different machine. It was the last protective layer in the stack with no health check, which meant its correctness rested entirely on an agent remembering to maintain it and reporting honestly that it had. Pairs with synthesis-context-lifecycle v1.4.0.
+
+## v2.15.1 — Message-guard doctor joins Day-Start Step 1
+
+v2.15.1 (2026-07-29) adds the `synthesis-message-guard --doctor` check beside the git-hooks doctor in Step 1. The message guard is the correspondence twin of the commit-boundary scanner: a fail-closed PreToolUse gate that blocks send/draft tool calls without a grounding ledger and a clean register scan. Both guards get their heartbeat in the same ritual step.
+
+## v2.15.0 — Protection-health check in Day-Start Step 1
+
+v2.15.0 (2026-07-28) adds one checkbox to Day-Start Step 1: run the synthesis-git-hooks `--doctor` self-check before any commit-bearing work. Rationale: the commit-boundary scanner is the enforcement layer for credential and confidentiality protection, and a scanner that fails open or drifts from source is invisible precisely because its job is to be invisible when healthy. The ritual is the monitoring loop it was missing. Pairs with synthesis-git-hooks v2.0.0 (fail-closed engine, dependency-free sidecar, drift detection).
+
+## v2.14.0 — Day-End Closure: two-speed day-end, owed-weekly review, decay tags, day-end state
+
+v2.14.0 (2026-07-08) redesigns the day-end around the observed failure mode: on busy or tired evenings the WHOLE ritual gets skipped, and three things decay invisibly — outbound-communication timing (appreciation and replies lose value overnight), lessons that were warm at 5 PM, and the user's own closure on the day. A four-week reconciliation (via `synthesis-catchup-ledger`) showed batch send-passes succeeding whenever a ritual ran, every decay clustering on the zero-ritual days, and the Friday-only Weekly Loose-Ends Review silently disabled for three straight weeks because it lived inside the ritual being skipped. The design principle: make the default evening close small enough to never skip, make starting it one word, make skipping it visible, and decouple the weekly safety net from the evening ritual entirely.
+
+1. **Two-speed day-end, always ask.** The day-end gains a first-class **Quick Close** mode (~10 minutes, exactly three human moments) alongside full mode and observer mode. The session asks the one-letter mode question every time — no time-of-day silent defaults. Spec: "Day-End Modes" block at the top of the Day-End Checklist.
+2. **Weekly Loose-Ends Review is owed weekly, not Friday-evening-bound.** The review runs at the FIRST ritual on or after Friday — day-start included, any day-end mode included — tracked via the state file. See the rewritten Step 10 gating.
+3. **Decay tags.** Time-sensitive drafts carry a `**Decays:** YYYY-MM-DD (reason)` line from creation. Plan generation applies the tag automatically to the classes field evidence shows decay fastest: appreciation/kudos and acknowledgments, public corrections, and event-bound items. Day-End Step 4 becomes an explicit send-or-release pass over the tagged set — nothing decay-tagged carries silently past its date.
+4. **No commitment line without a date or a park.** Every new commitment entering a daily plan gets a do-by, a Decays tag, or an explicit `parked (reason)` marker. Single-mention items that get none of the three are how commitments vanish without a trace.
+5. **Lesson candidates accumulate during the day.** Daily plans gain a `## 🌱 Lesson candidates` H2. Any session — mid-day syncs, checkpoint moments, ad-hoc work — appends one-line candidates as insights occur. Day-end curates (keep/drop) instead of recalling from scratch; "warm" moves from 5 PM to the moment of insight.
+6. **Day-end state file (producer).** Every ritual, both directions, every mode, writes `~/.synthesis/day-end/state.json` (atomic temp+rename) and appends one line to `~/.synthesis/day-end/history.jsonl`:
+
+   ```json
+   {
+     "last_day_end":   { "date": "2026-07-08", "mode": "quick", "outcome": "clean", "sent": 3, "released": 1 },
+     "last_day_start": { "date": "2026-07-08" },
+     "last_weekly_review": "2026-07-03",
+     "streak_day_end": 4
+   }
+   ```
+
+   `streak_day_end` = consecutive workdays with a completed day-end, computed from history at write time. Consumers: the synthesis-console day-end chip, the nudge's suppression check, and the day-start brief line ("day-end: ran Mon ✓ quick · skipped Tue").
+7. **Launcher + nudge ship in `scripts/`.** The ritual is an Agent Skill and always runs INSIDE an agentic coding session — nothing here changes that. `scripts/day-end` is a *launcher, not a runner*: it opens Codex or Claude Code with the ritual invocation as the first prompt, purely to remove cold-start friction at the end of the day. `DAY_END_AGENT_CMD` selects a CLI for one run; the installed `agent-cli` file persists `auto`, `codex`, or `claude`. `scripts/day-end-nudge.sh` shows one generic macOS banner at 16:55 on weekdays unless the state file says today's day-end already ran — notification only, never a mutation, generic fixed text (see the alert-confidentiality rule below). Install steps follow.
+8. **Audio-alert section aligned with alert confidentiality.** Spoken alerts and banners carry zero identifying content and honor the `~/.synthesis/quiet-audio` mute flag — matching the synthesis-repo-guard v2 alert model. The old `say "[user], [task description] is complete"` pattern is retired: task descriptions can name clients, repos, or people, and speakers/screen-shares leak.
+
+**Consumer coupling:** synthesis-console renders `state.json` (day-end chip) and `**Decays:**` lines (draft badges). Producer-grammar changes here require the console's `docs/cockpit-design.md` to change in the same wave — the document-as-contract rule.
+
+### Installing the launcher and nudge (macOS)
+
+```bash
+# Auto-select Codex first when both supported clients are available
+python3 <synthesis-daily-rituals-root>/scripts/install_day_end.py
+
+# Or persist one client explicitly
+python3 <synthesis-daily-rituals-root>/scripts/install_day_end.py --agent codex
+python3 <synthesis-daily-rituals-root>/scripts/install_day_end.py --agent claude
+```
+
+The installer copies the launcher and nudge into
+`~/.synthesis/day-end/bin/`, links `~/.local/bin/day-end` to that stable
+runtime, writes the LaunchAgent with an absolute program path, and reloads it.
+Re-run the installer after the skill changes. Use `--no-launchctl` only for CI
+or an installation audit that should write and verify artifacts without
+loading the LaunchAgent.
+
+## v2.13.0 — Per-workspace `repos.yaml` is the machine-readable repo list
+
+In v2.13.0 (2026-07-08), the source-code sync steps (Day-Start 3a, Day-End 2) enumerate from the workspace repo manifest when one exists: `<workspace>/.agents/repos.yaml` — a symlink into the workspace's private context repo, generated and maintained per synthesis-mac-sync v1.6.0 (which owns the file's schema and lifecycle). Sync every repo with `ritual_sync: yes`. A manifest with `status: dormant` means "skip this workspace's source-code sync entirely — and never delete anything" (retention rule). The workspace `AGENTS.md` "Workspace Repos" table remains the human-readable view and the FALLBACK source when no `repos.yaml` exists. The v2.12.1 rule applies identically to both sources: the declared list is the complete decision — no agent activity-judgment.
+
+## v2.12.1 — Source-code sync scope: the workspace table decides (no agent activity judgment)
+
+In v2.12.1 (2026-07-08), the source-code sync steps (Day-Start 3a, Day-End 2) drop the "associated with active work" qualifier from v2.7.0. The workspace's `AGENTS.md` "Workspace Repos" table is the COMPLETE decision about what to sync: every repo the table marks **Yes** gets synced on every ritual run, whether or not it feels active. The agent must not re-apply its own judgment about which repos are "active" — that judgment layer is exactly what let a collaborator repo drift unnoticed for ~6 weeks (its default branch still tracked a legacy remote after a Git-host migration, silently accumulating "unpushed" commits that the repo guard then flagged repeatedly). Wherever the "associated with active work" phrasing survives in older version notes below, this rule supersedes it. A workspace that wants a repo excluded marks it **No** in the table, with the reason.
+
+## v2.12.0 — Cockpit Mode: meeting-prep packs (`meeting-preps/` + `## 📋 Prep packs`)
+
+In v2.12.0, the Day-Start ritual gains an optional **meeting-prep step** (runs inside Step 6, after the calendar fetch): for each substantive meeting on today's calendar, write a one-pager prep pack to `<knowledge-root>/meeting-preps/YYYY-MM-DD-HHMM-slug.md` and index today's packs in the day plan under a `## 📋 Prep packs` H2 (one list line per pack, linking to the consumer's `/prep/<source>/<slug>` route or the file path).
+
+**What a prep pack joins** (the chief-of-staff briefing-book function): the calendar event (when/who) × relevant transcripts (search by attendee across the workspace's transcripts) × hot items from project CONTEXTs that mention the attendee or the meeting's subject × open commitments in both directions (their waiting-on entries; your unsent drafts to them).
+
+**File contract:**
+- Filename `YYYY-MM-DD-HHMM-slug.md` (24h start time; slug identifies the meeting, e.g. `jessica-payne-1-1`). Packs sort chronologically; "today's packs" is a filename-prefix scan.
+- H1 = meeting title. A `**When:**` line and a `**Who:**` line (comma-separated attendees) near the top.
+- Body H2s are free-form; the recommended skeleton is `Context` / `Open commitments` / `Since last time` / `Suggested agenda`.
+- Packs are ritual-generated and updated by mid-day sweeps when new signals land (a transcript posts, a commitment discharges). Never hand-maintained.
+
+**Which meetings get packs:** 1:1s, externals, and any meeting with an attendee who appears in waiting-on tables or open drafts. Routine standups don't need packs unless something notable is queued.
+
+## v2.11.0 — Cockpit Mode: `## 📅 Calendar` section (typed consumer support)
+
+In v2.11.0, Cockpit Mode plans gain a canonical `## 📅 Calendar` H2 that the plan-generation step (Day-Start Step 6) writes from the user's calendar. This is the file-based bridge that lets consumers (synthesis-console v0.12+) render the day's events, bind Tier-C slots to windows, and visualize preemption — without the consumer needing calendar access of its own. The agent fetches events via the user's calendar tool (e.g. Apple Calendar MCP) at plan-generation time and refreshes the section during mid-day sweeps, so same-day meetings appear within one sweep cadence.
+
+**Canonical item shape** (one list line per event):
+
+```markdown
+## 📅 Calendar
+
+- 09:00–09:30 · Exec staff sync · Tony, Jane, Marcelo
+- 11:30–12:00 · CSA standup · CSA team
+- 15:00–15:30 · 1:1 · Jessica Payne
+```
+
+Rules: 24-hour `HH:MM–HH:MM` range first, then ` · `, then the event title, then optionally ` · ` and a comma-separated attendee list. En-dash or hyphen both parse. Lines that don't match still render as plain markdown (Postel's Law — nothing is dropped). All-day events use the title-only fallback form (no time range).
+
+**Tier-C window binding:** each `## 🎯 Today` slot H3 SHOULD name its window in the heading (e.g. `### Deep 1 — board memo (window 09:30–11:00)`). Consumers match slot windows against calendar events; an overlapping event that is not the slot itself renders as a preemption flag on the slot. The plan-generation step keeps slot windows consistent with the `**Budget:**` line's windows.
+
+## v2.10.0 — Cockpit Mode: Budget-Bound, Stakes-Routed Day Plans
+
+In v2.10.0 (2026-06-12), the day plan gains an alternative canonical mode — **Cockpit Mode** — for users whose discretionary time is scarce and preemption-prone (heavy meeting load, frequent same-day scheduling). The classic mode (full prioritized task board) remains valid; Cockpit Mode is the recommended default when the user's open-item count persistently exceeds what their calendar can absorb. Design rationale and the originating six-week evidence base live with the user's working-system design doc; the durable protocol is here.
+
+**The three rules of Cockpit Mode:**
+
+1. **Budget before backlog.** The plan generation step reads the user's calendar FIRST, computes discretionary windows, and commits at most ~70% of them — the remainder is an explicit preemption buffer. The plan header states the arithmetic (`Budget: windows … = N min. Committed: M min (≤70%). Buffer: N−M min`). A plan that ignores the calendar is a wish list.
+
+2. **Stakes-routed outbound (the tier matrix).** Every outbound communication is classified at creation:
+   - **Tier A — agent sends, clearly agent-labeled** (per the user's bot-labeling rule): routing/triage pings, scheduling requests, receipt acknowledgments, info relays with citations, follow-up nudges on delegated items. Sent within the work block; every send logged to a `## On your behalf` section in the day plan (the TICKER). Tier A never expresses the user's opinions, makes commitments, or touches sensitive relationships. Requires the user's standing approval of the matrix before activation; until then, Tier A routes to Tier B.
+   - **Tier B — one-tap queue:** drafts in the user's voice (kudos, substantive replies) and decisions-with-recommendation, presented in batches of ≤5 with APPROVE / EDIT / SKIP affordances answerable in one line. Two review windows per day.
+   - **Tier C — user-original:** deep work and relationship-critical writing. **Maximum 3 per plan**, each assigned to a named calendar window.
+   Ambiguity routes to Tier B, never to Tier A.
+
+3. **Preemption is normal, not failure.** When a same-day meeting lands on a committed window, the lowest-priority Tier-C item drops to the queue automatically — no re-planning ceremony. Dropped and expired items are caught by the `synthesis-catchup-ledger` ratchet (see that skill); decay rules apply at plan-generation time (stale kudos auto-expire to a consolidated-send; DECAYING items carry do-by dates; event-bound items expire at their event).
+
+**Plan format additions (cockpit-vocabulary compatible):** a `**Budget:**` line in the header; one `## ⚡ Decision needed` H2 when a decision is pending (max ONE per day where possible); `## 🎯 Today — N deep items` (the Tier-C slots); `## ☑️ One-tap batch` (Tier B, with a queued-overflow paragraph); `## On your behalf` (Tier A log); `## 📰 Brief` (readable in ≤90 seconds). Consumers (synthesis-console) treat `On your behalf` as a new lower-row collapsible until typed support ships.
+
+**Relationship to rituals:** day-start still runs the full sync stack (Steps 1–5 unchanged) — Cockpit Mode changes only Step 6 (Day Plan) and Step 7 (Morning Messages: Tier A items send instead of queueing, once the matrix is approved). The user's ritual calendar blocks become review windows; briefs should be prepared BEFORE the block begins whenever the agent runs scheduled/continuous.
+
+## v2.9.0 — Temporal & State Verification as Day-Start Step 1; new synthesis-checkpoint dependency
+
+In v2.9.0 (2026-05-27), the Day-Start ritual gains a new Step 1 — "Temporal & State Verification" — that runs BEFORE all other day-start steps. It anchors today's date from `date`, runs `git log` per active project to verify "last session," and reconciles cached `last_session` fields against git timestamps. Triggered by the 2026-05-27 inbox-cleanup mis-dated-session-log incident; codified to prevent recurrence in any synthesis project.
+
+Step renumbering across the day-start: NEW Step 1 = Temporal & State Verification. Old Step 1 (Context Optimization) → Step 2. Old Step 2 (Sync) → Step 3, with sub-steps 3a/3b/3c. Old Step 3 (Catch-Up Read) → Step 4. Old Step 4 (PR Review Queue) → Step 5. Old Step 5 (Day Plan) → Step 6. Old Step 6 (Morning Messages) → Step 7. The Day-End checklist is unchanged in numbering; Day-End Step 7 (Context Capture) gains explicit push-confirmation language matching the new discipline.
+
+New dependency: `synthesis-checkpoint` — a lightweight skill that codifies the date-verification + state-verification protocol. The day-start ritual delegates to synthesis-checkpoint for the per-project verification work in Step 1.
+
+The discipline this enforces (cross-tool, codified in the active global agent
+instructions and the synthesis-context-temporal-continuity project): treat
+session-log entry dates, "N days ago" claims, and CONTEXT.md fields as caches
+subject to drift. Verify against `date` and `git log` before quoting them into
+any output.
+
+## v2.8.0 — Weekly Loose-Ends Review on Fridays
+
+In v2.8.0 (2026-05-22), the Day-End ritual gains a Friday-only "Weekly Loose-Ends Review" step that scans the prior two weeks of work for incomplete, missed, or forgotten items and consolidates the surviving ones into a carryover list for Monday's day-start.
+
+**Rule:** on Fridays, before the Repo Guard final-verification step, scan the past 14 calendar days of daily plans + project context files + open commitment tables. For every surfaced item, classify it as STILL RELEVANT (carry into Monday), OBSOLETE (annotate-and-close in place), or AMBIGUOUS (surface to user). The output is a `## Weekly Loose-Ends Review` section in Friday's daily plan plus a populated `## Carried Items` section in Monday's plan.
+
+**Why:** the workweek's cracks accumulate invisibly. A missed close-of-business ritual on Wednesday means Thursday's plan doesn't pick up Wednesday's open threads. By Friday, several items can be quietly stranded. Without an explicit weekly catch, the user's mental model of "what's open" drifts from reality — and the longer the drift, the harder the eventual reconciliation. Running this on Friday afternoon catches stale items WHILE context is still warm; Monday begins with a clean carryover instead of an archaeological dig.
+
+**Why Friday and not Monday:** Monday is when the carryover gets ACTIONED. Friday is when the carryover gets ASSEMBLED. Assembling on Monday means starting the week with backwards-looking work; assembling on Friday means closing the week with a clean handoff to next week. The split also lets the user (or the agent) drop OBSOLETE items into context that's still fresh — Monday's view of "is this still relevant?" is fuzzier than Friday's.
+
+**Where in the day-end checklist:** new Step 10, just before Repo Guard (which stays the terminal step). The skill detects day-of-week and skips silently on non-Fridays. See Day-End Checklist below.
+
+**Idempotent re-runs:** if a Friday day-end ritual is missed and the agent runs the Weekly Loose-Ends Review on a later weekday (Saturday catch-up, Monday morning if Friday was skipped), it should still produce the same scan output — the scan is date-bounded, not weekday-bounded. The Friday-default is about WHEN it normally fires, not about whether the scan is meaningful on other days.
+
+## v2.7.0 — Source-Code Sync as a First-Class Ritual Step
+
+In v2.7.0 (2026-05-21), source-code synchronization becomes an explicit, first-class step in both the day-start and day-end rituals — running BEFORE the daily plan is drafted (so any drafts that need to be grounded in code can read current source) and BEFORE end-of-day verification (so tomorrow's day-start begins from a clean, current state).
+
+**Rule:** for every source-code repo associated with active work in the current workspace, fetch from all configured remotes and fast-forward the default branches (typically `main` and `develop`, plus any other long-running branches the team uses) BEFORE drafting the daily plan and BEFORE the end-of-day repo-guard verification. The skill stays generic — the list of repos per workspace is declared in the workspace `AGENTS.md` (with any client adapter importing it), not hardcoded.
+
+**Why:**
+
+- **Drafts must be grounded in current code.** The grounding protocol (see below) requires draft messages to be grounded in primary sources before sending. If local source is days behind origin, a draft that cites a function or PR may be quoting a stale version. Pulling first means the grounding research uses the current code.
+- **Avoid surprise conflicts at end-of-day.** Running fetch + fast-forward at day-end (just before the repo-guard verification) surfaces upstream divergence early — the user doesn't discover at 6 PM that develop moved fifty commits and a feature branch needs rebasing.
+- **One step, not "I'll do it later."** Folding it into the ritual makes it deterministic. The earlier `git fetch --all` checkbox in v2.6.0 and prior was easy to skip and only fetched (no fast-forward) — v2.7.0 makes the step substantive and visible.
+
+**What goes where:**
+
+- This skill defines the GENERIC pattern (fetch from all push remotes, fast-forward default branches, surface diverged or behind-state, report which repos were touched).
+- The WORKSPACE-SPECIFIC list of repos lives in the workspace's canonical
+  `AGENTS.md` (the Claude adapter imports it). Each repo's specific multi-remote
+  configuration is implicit from `git remote -v` inside that repo.
+- The PROJECT-SPECIFIC supplement may add per-project considerations (e.g., "after fetch, check whether feature/X is stale and needs rebase"). See "How to Create a Project Supplement" near the end of this file.
+
+**Sequence within day-start:** Context Optimization (Step 1) → **Source-code sync (Step 2a — NEW)** → Slack sync (Step 2b — was Step 2) → Meeting transcripts (Step 2c — was Step 2b) → Catch-up read (Step 3) → PR review queue (Step 4) → Day plan (Step 5) → Morning messages (Step 6).
+
+**Sequence within day-end (v2.8.0+):** Transcript sync (Step 1) → **Source-code sync (Step 2 — v2.7.0)** → Integration sweep (Step 3) → … → **Weekly Loose-Ends Review (Step 10 — v2.8.0, Fridays only)** → Repo guard final verification (Step 11 — was Step 10 in v2.7.0).
+
+## v2.6.0 — Draft Numbering Convention (numbers, not letters)
+
+In v2.6.0 (2026-04-29 very late evening), the convention for labeling drafts in a daily plan is fixed to **sequential integers** (Draft 1, Draft 2, Draft 3, …) rather than alphabet letters (Draft A, Draft B, …).
+
+**Rule:** the first draft of the day is Draft 1. Each subsequent draft increments by 1. No letter labels. No K-2 / K-3 sub-versioning — if a single piece of work produces multiple draft messages (e.g., the same praise routed to two audience-specific channels), each one gets its own integer (Draft 11, Draft 12, Draft 13). The chronological count of drafts in the plan equals the highest integer in use, which makes it easy to answer "how many drafts today?" by reading a single label.
+
+**Why:** numbers are easier to count at a glance, have no 26-item ceiling, and don't impose a mental "is K the 11th letter?" tax. The K-2 / K-3 sub-versioning that letter-labels invite is uglier than 11 / 12 / 13 and creates label-shape inconsistency in the file. Letter labels also make it harder to grep for "all drafts from #N onward" because alphabet ordering is lexicographic, not arithmetic.
+
+**Retraction handling:** if a draft is retracted (caught fabrication, sent-then-deleted, etc.), reserve the number with a brief marker — e.g., `### Draft 8 — retracted` plus a one-line note pointing to the session log — rather than renumbering subsequent drafts. Renumbering after a retraction creates label-drift across the file and any cross-references in chat. The reserved number is the durable record that the slot existed.
+
+**Cross-file consistency:** when renumbering a daily plan that's already been referenced from CONTEXT.md or session logs (those use the labels in effect at the time), update only the daily plan and add a brief note acknowledging the cross-reference gap. Historical narrative in session logs preserves the labels in use at the time — that's the right behavior, not a bug.
+
+**Pre-draft check:** when adding a new draft to a daily plan, the first thing the agent does is scan the file for the highest existing `Draft N` integer and use N+1. No alphabet thinking.
+
+## v2.5.0 — Draft Fence Convention (nested code blocks)
+
+In v2.5.0 (2026-04-29), the canonical fence convention for draft message bodies is documented to handle the case where a draft contains its own triple-backtick code blocks (install commands, code samples, log excerpts).
+
+**Rule:**
+
+- **Default fence for a draft body is 3 backticks** (` ``` `). Use this when the message body contains no triple-backtick code blocks.
+- **If the draft body contains ANY internal triple-backtick blocks**, the outer fence must be at least one backtick longer than the longest internal fence. In practice this means **4-backtick outer fence** (` ```` `) when the message contains 3-backtick blocks.
+
+**Why:** CommonMark closes a fenced code block at the first fence of equal-or-greater length. A 3-backtick outer wrapper is closed by the first 3-backtick inner fence — splitting the draft into multiple disjoint blocks and breaking the synthesis-console renderer (which attaches its action bar to the first fenced block after `**Send to:**`). A 4-backtick outer wrapper survives 3-backtick inner blocks unchanged; the inner fences become literal content of the outer fence, which is exactly what we want for a draft body containing install snippets or code samples.
+
+**Pasting into Slack:** when the user clicks Copy in synthesis-console, the action reads `.innerText` from the rendered `<pre>` block — outer fence delimiters are stripped, inner ` ``` ` markers are preserved as literal text. Slack then re-interprets the inner ` ``` ` as Slack code blocks. End-to-end behavior is correct.
+
+**Cross-reference:**
+
+- Consumer-side handling lives in synthesis-console `docs/cockpit-design.md` "Drafts" section (the consumer is being updated to handle multi-segment drafts robustly via `augmentDraftBlocks`, but the producer-side convention here is independently correct and should be applied regardless).
+- Lesson backing this rule: `lessons/2026-04-29-document-as-contract-with-llm-producers.md`.
+
+## v2.4.0 — Canonical Plan Format Contract
+
+In v2.4.0 (2026-04-29), the daily plan file format became a versioned contract between this skill (the producer) and synthesis-console v0.8+ (the consumer that renders plans as a cockpit dashboard).
+
+The contract is defined by the **canonical H2 vocabulary** below. The console's parser is tolerant of synonyms and emoji prefixes, but agentic skills (LLMs) must prefer the canonical names where possible because:
+
+- Canonical names are unambiguously typed by the console (NEEDS YOU / TODAY / DRAFTS / lower-row collapsibles)
+- Synonyms are accepted via substring + case-insensitive match, but each new variant adds parser maintenance burden
+- Non-canonical names fall through to "other" and render as plain markdown — visible but not specially typed
+
+When the LLM driving this skill decides to deviate from the template, it MUST stay within the recognized vocabulary table (next section). New section types should be proposed as additions to this contract, not invented ad-hoc.
+
+The **producer-consumer contract** is documented in two places:
+- This file's "Canonical Plan Format" section below (authoritative for skill writers).
+- `synthesis-console/docs/cockpit-design.md` (authoritative for parser implementers).
+
+These two files must stay in sync. When changing one, update the other in the same commit.
+
+## v2.3.0 — Workspace-Rooted Paths
+
+In v2.3.0 (2026-04-22), path configuration changed to reflect the ai-knowledge phase 2 architecture: transcripts live per-workspace in `ai-knowledge-<workspace>-<person>-private/transcripts/`; daily plans and lessons live person-scoped in `ai-knowledge-<person>/` at top-level (no `_` prefix). See synthesis-slack-sync v2.0.0 for the complementary configuration schema.
+
+## Rationale notes moved from the checklists (v2.31.0)
+
+### Day-End Step 7 — why open items carry their own age
+
+Appending is safe under this rule and rewriting is not required, which is the point. The failure being prevented is an entry that keeps the present tense it was written in ("today", "this week") long after that stopped being true; re-deriving the whole list each run would also drop anything today's evidence happens not to surface, turning a visible stale entry into an invisible missing one. A stamped entry ages in public instead: `context_doctor.py` reports it as `item-currency` once it passes its review horizon (14 days when `review Nd` is omitted), so the check runs for any reader at any time rather than only on days this ritual runs.
+**Match the horizon to what the item is.** The 14-day default is the horizon for something *owed* — blocked on a named person, with a consequence if it slips. A backlog is not that: a list of feature ideas, article ideas, or a bug inventory is a record of intent, and nobody promised it by a date. Stamp those `(as of YYYY-MM-DD, review 180d)`. Measured once on a real corpus, 17 of 38 open-item findings were wishlists ageing at the owed-work horizon, and a check that reports intentions as overdue is how the whole open-items signal gets read as noise.
+
+**A recorded decision is not an open item at all.** If a bullet under an open-items heading says a thing was settled — "not needed", "kept", "declined" — the fix is structural rather than a longer horizon: move it under a decisions heading, where the checker does not read it as owed. The section HEADING is what decides, so a settled decision parked under "What's Next" will keep being asked to prove it is still current no matter how it is worded.
+
+### Day-End Step 10 — why the weekly review exists, and its idempotency
+
+This step exists because work falls through the cracks during a week. A missed close-of-business ritual means the next day's plan doesn't pick up the open threads from the day before. By Friday, several items can be stranded invisibly. The Friday review catches these BEFORE the weekend disconnects fresh context, and assembles a clean carryover list for Monday.
+
+**Idempotency:** if a Friday review was missed and the agent runs this step on a later weekday, the scan still works because it's date-bounded (past 14 calendar days from today), not weekday-bounded. The Friday-default is about WHEN it normally fires; the scan output is meaningful on any day.
+
+### Observer mode — why it is codified
+
+When observer mode is reinvented per conversation, the agent often drops durable state. The rule is now explicit: every observer run leaves attributed local state, while day-end or remote-handoff mode owns publication.
+
+## Principles Behind These Checklists
+
+- **Dependency-ordered:** Each step feeds the next. Sync before reading. Read before planning. Plan before messaging.
+- **Information entropy reduction:** The primary purpose is closing the gap between what happened and what you know.
+- **Human investment:** Motivational messages are not optional — they are a force multiplier on a distributed team.
+- **Career compounding:** Every day produces raw material for thought leadership. The discipline is noticing it.
+- **State capture:** If you do not capture today's state, tomorrow's start takes longer. This compounds.

--- a/skills/synthesis-daily-rituals/scripts/test_skill_documents.py
+++ b/skills/synthesis-daily-rituals/scripts/test_skill_documents.py
@@ -1,0 +1,153 @@
+"""Budget and structure contracts for the daily-rituals and slack-sync documents.
+
+AGENTS.md rule 4: keep SKILL.md below 500 lines; detailed material lives in
+references/. On 2026-09-01 both documents were restructured (1,319 and 762
+lines): version history, formats, worked examples, and rationale moved into
+references while every operating rule and checklist step stayed. These tests
+pin the budget, keep load-bearing rule anchors in the main documents, verify
+that each moved block still exists in its reference, and refuse orphaned
+references or templates — so regrowth fails CI instead of accumulating.
+
+slack-sync has no scripts directory in CI; its contract lives here beside the
+daily-rituals tests, in the CI group both skills share.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILLS_ROOT = Path(__file__).resolve().parents[2]
+RITUALS = SKILLS_ROOT / "synthesis-daily-rituals"
+SLACK = SKILLS_ROOT / "synthesis-slack-sync"
+BUDGET = 500
+
+
+def _document(skill_dir: Path) -> str:
+    return (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+
+
+def _assert_budget(skill_dir: Path) -> str:
+    text = _document(skill_dir)
+    count = len(text.splitlines())
+    assert count < BUDGET, f"{skill_dir.name}/SKILL.md is {count} lines; the budget is <{BUDGET}"
+    return text
+
+
+def _assert_anchors(text: str, anchors: tuple[str, ...], name: str) -> None:
+    for anchor in anchors:
+        assert anchor in text, f"load-bearing rule left {name}/SKILL.md: {anchor}"
+
+
+def _assert_moved_blocks(skill_dir: Path, moved: tuple[tuple[str, str], ...]) -> None:
+    for reference_name, marker in moved:
+        reference = (skill_dir / "references" / reference_name).read_text(encoding="utf-8")
+        assert marker in reference, f"moved block missing from {reference_name}: {marker}"
+
+
+def _assert_no_orphans(skill_dir: Path, text: str, subdirs: tuple[str, ...]) -> None:
+    for subdir in subdirs:
+        for path in sorted((skill_dir / subdir).glob("*.md")):
+            assert path.name in text, f"unlinked {subdir} file: {path.name}"
+
+
+# --- synthesis-daily-rituals ---------------------------------------------------------------
+
+
+def test_rituals_skill_document_stays_within_repo_budget() -> None:
+    text = _assert_budget(RITUALS)
+    _assert_anchors(
+        text,
+        (
+            "### 1. Temporal & State Verification",
+            "Archive FIRST, delete second",
+            "#### 3b. Channel Sync",
+            "Watermark gate",
+            "## Mid-Day Sync Protocol",
+            "re-reads every declared target",
+            "### Day-End Modes",
+            "send-or-release pass",
+            "### 11. Remote Readiness and Final Verification",
+            "The desk is the registry's `desk_seat`",
+            "The coverage line is mandatory",
+            "Alert-confidentiality rule",
+            "Investigate first, ask questions later",
+            "Preserve all information, reorganize for clarity",
+            "item-currency",  # synthesis-context-lifecycle/test_item_currency.py depends on it
+        ),
+        "synthesis-daily-rituals",
+    )
+
+
+def test_rituals_moved_blocks_survive_in_their_references() -> None:
+    _assert_moved_blocks(
+        RITUALS,
+        (
+            ("version-history.md", "## v2.30.0 — Watermarks carry a time and a target"),
+            ("version-history.md", "v2.27.0 (2026-08-27) replaces run-anchored sync windows"),
+            ("version-history.md", "lead_time_preps:"),
+            ("version-history.md", "streak_day_end"),
+            ("version-history.md", "Budget before backlog"),
+            ("version-history.md", "## v2.3.0 — Workspace-Rooted Paths"),
+            ("version-history.md", "Match the horizon to what the item is"),
+            ("version-history.md", "**Idempotency:**"),
+            ("version-history.md", "Dependency-ordered"),
+            ("plan-format.md", "### Canonical Section Vocabulary (Authoritative)"),
+            ("plan-format.md", "### Internal Structure Conventions"),
+            ("plan-format.md", "### File Revert Protection"),
+            ("draft-grounding.md", "### Investigate First, Ask Questions Later"),
+            ("draft-grounding.md", "Blank line after every bullet"),
+            ("draft-grounding.md", "### Temporal Integrity"),
+            ("draft-grounding.md", "### Pre-Send Review Gate"),
+            ("draft-grounding.md", "### Appreciation Message Quality"),
+        ),
+    )
+
+
+def test_rituals_references_are_all_linked() -> None:
+    _assert_no_orphans(RITUALS, _document(RITUALS), ("references",))
+
+
+# --- synthesis-slack-sync -----------------------------------------------------------------------
+
+
+def test_slack_sync_skill_document_stays_within_repo_budget() -> None:
+    text = _assert_budget(SLACK)
+    _assert_anchors(
+        text,
+        (
+            "## ⛔ NEVER Use Slack Search API for Lookups",
+            "A zero-result search is NEVER evidence of absence",
+            "### Step 0: Preflight",
+            "### Step 2: Re-read ALL active threads",
+            "WINDOW_OLDEST",
+            "RESOLVED_CONVERSATION_ID",
+            "sync_watermark.py advance",
+            "own outbound",
+            "#### Draft Message Format (MANDATORY)",
+            "## Provenance Discipline",
+            "Always record the TS",
+            "never invent a domain",
+        ),
+        "synthesis-slack-sync",
+    )
+
+
+def test_slack_sync_moved_blocks_survive_in_their_references() -> None:
+    _assert_moved_blocks(
+        SLACK,
+        (
+            ("version-history.md", "## v3.8.0 — Windows are computed"),
+            ("version-history.md", "v3.6.0 (2026-08-27) fixes a class of bug"),
+            ("version-history.md", "### `-private` Discovery Protocol (ADR-014)"),
+            ("version-history.md", "## v3.0.0 — Per-Channel-Per-Day Layout"),
+            ("version-history.md", "## Why Each Step Matters"),
+            ("transcript-formats.md", "### Channel file (`slack/YYYY-MM-DD/<channel>.md`)"),
+            ("transcript-formats.md", "### DMs aggregator file"),
+            ("transcript-formats.md", "## Slack Permalink Construction"),
+            ("transcript-formats.md", "### Retrofitting older daily plans"),
+        ),
+    )
+
+
+def test_slack_sync_references_and_templates_are_all_linked() -> None:
+    _assert_no_orphans(SLACK, _document(SLACK), ("references", "templates"))

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,28 +1,34 @@
-# AGENT HEURISTIC: authored for the 4.79.0 sync-watermark v2 transaction.
+# AGENT HEURISTIC: authored for the 4.80.0 SKILL.md budget restructure.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: sync-watermarks-carry-time-and-target
+suite: rituals-and-slack-sync-documents-under-budget
 membership: closed
-production_entry_point: skills/synthesis-daily-rituals/scripts/sync_watermark.py
-enforcing_boundary: the ritual watermark gate exits non-zero naming every declared surface or read target the current run did not re-read, and read windows are computed from the last written moment rather than typed
+production_entry_point: skills/synthesis-daily-rituals/scripts/test_skill_documents.py
+enforcing_boundary: CI fails when either restructured SKILL.md reaches the repository line budget, loses a load-bearing rule anchor, drops a moved block from its reference, or leaves a reference or template unlinked
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the live migration of a real workspace store and the first ritual run under the new gate are proven in the release record; the message-guard ledger age limit that already bounds agent sends is unchanged and not re-proven here
+unverified_remainder: the re-flow of wrapped lines is asserted markdown-neutral by review, not by a renderer comparison; consumers that read these documents by heading names keep every heading that existed before the restructure, verified by the anchor sets
 changed_surfaces:
-  - path: skills/synthesis-daily-rituals/scripts/sync_watermark.py
-    cases: [run-bound-blocks-stale-read, targets-block-individually, window-echoes-epoch-bounds, bare-date-is-end-of-day, schema-one-store-migrates]
-  - path: skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
-    cases: [run-bound-blocks-stale-read, targets-block-individually, window-echoes-epoch-bounds, bare-date-is-end-of-day, schema-one-store-migrates, rituals-doc-contract, slack-doc-contract]
-  - path: skills/synthesis-daily-rituals/references/sync-watermarks.md
-    cases: [rituals-doc-contract]
   - path: skills/synthesis-daily-rituals/SKILL.md
-    cases: [rituals-doc-contract]
+    cases: [rituals-budget-and-anchors, rituals-moved-blocks, rituals-no-orphans, watermark-doc-contract]
+  - path: skills/synthesis-daily-rituals/references/version-history.md
+    cases: [rituals-moved-blocks, rituals-no-orphans]
+  - path: skills/synthesis-daily-rituals/references/plan-format.md
+    cases: [rituals-moved-blocks, rituals-no-orphans]
+  - path: skills/synthesis-daily-rituals/references/draft-grounding.md
+    cases: [rituals-moved-blocks, rituals-no-orphans]
+  - path: skills/synthesis-daily-rituals/scripts/test_skill_documents.py
+    cases: [rituals-budget-and-anchors, rituals-moved-blocks, rituals-no-orphans, slack-budget-and-anchors, slack-moved-blocks, slack-no-orphans]
   - path: skills/synthesis-slack-sync/SKILL.md
-    cases: [slack-doc-contract]
+    cases: [slack-budget-and-anchors, slack-moved-blocks, slack-no-orphans, slack-doc-contract]
+  - path: skills/synthesis-slack-sync/references/version-history.md
+    cases: [slack-moved-blocks, slack-no-orphans]
+  - path: skills/synthesis-slack-sync/references/transcript-formats.md
+    cases: [slack-moved-blocks, slack-no-orphans]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -34,34 +40,38 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: run-bound-blocks-stale-read
+  - id: rituals-budget-and-anchors
     control_class: enforced-gate
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_begin_then_status_since_run_lists_exactly_what_was_skipped
-    motivating_defect: a-surface-written-at-0915-counted-as-current-all-day-so-no-run-could-see-its-own-staleness
-  - id: targets-block-individually
+    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_rituals_skill_document_stays_within_repo_budget
+    motivating_defect: a-1319-line-main-document-against-a-500-line-rule-with-nothing-that-fails-when-it-grows
+  - id: rituals-moved-blocks
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_a_target_read_before_the_run_is_stale
-    motivating_defect: mid-day-passes-re-read-only-the-targets-the-morning-skipped-and-a-0927-answer-was-reported-unanswered-at-1751
-  - id: window-echoes-epoch-bounds
+    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_rituals_moved_blocks_survive_in_their_references
+    motivating_defect: a-restructure-that-drops-a-block-on-the-way-to-its-reference-loses-a-rule-silently
+  - id: rituals-no-orphans
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_cli_window_prints_the_epoch_bounds_a_read_call_takes
-    motivating_defect: a-hand-typed-oldest-of-0750-today-reported-five-channels-empty-that-were-not
-  - id: bare-date-is-end-of-day
+    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_rituals_references_are_all_linked
+    motivating_defect: a-reference-nobody-links-is-a-document-nobody-reads
+  - id: slack-budget-and-anchors
+    control_class: enforced-gate
+    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_slack_sync_skill_document_stays_within_repo_budget
+    motivating_defect: a-762-line-main-document-against-a-500-line-rule-with-nothing-that-fails-when-it-grows
+  - id: slack-moved-blocks
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_a_bare_date_means_end_of_day_so_today_is_refused_mid_day
-    motivating_defect: a-mid-day-run-that-stamps-today-declares-hours-it-has-not-read
-  - id: schema-one-store-migrates
+    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_slack_sync_moved_blocks_survive_in_their_references
+    motivating_defect: a-restructure-that-drops-a-block-on-the-way-to-its-reference-loses-a-rule-silently
+  - id: slack-no-orphans
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_a_schema_one_date_reads_as_complete_through_end_of_that_day
-    motivating_defect: existing-stores-hold-bare-dates-and-a-wrong-reading-would-reopen-or-hide-a-day
-  - id: rituals-doc-contract
+    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_slack_sync_references_and_templates_are_all_linked
+    motivating_defect: a-reference-nobody-links-is-a-document-nobody-reads
+  - id: watermark-doc-contract
     control_class: acceptance-test
     fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_rituals_open_every_sync_with_begin_and_reread_every_target
-    motivating_defect: a-mechanism-nobody-is-told-to-run-is-not-a-control
+    motivating_defect: a-restructure-must-not-move-a-documented-rule-that-a-mechanism-depends-on-out-of-the-main-document
   - id: slack-doc-contract
     control_class: acceptance-test
     fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_slack_sync_counts_the_users_own_outbound
-    motivating_defect: the-principals-own-replies-were-not-sweep-state-so-discharged-items-stayed-owed
+    motivating_defect: a-restructure-must-not-move-a-documented-rule-that-a-mechanism-depends-on-out-of-the-main-document
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-slack-sync/SKILL.md
+++ b/skills/synthesis-slack-sync/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-project-management"]
 metadata:
   author: "Rajiv Pant"
-  version: "3.8.0"
+  version: "3.9.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -16,207 +16,7 @@ A protocol for syncing Slack channels and threads to local transcript files usin
 
 This skill provides the **protocol** — the sync methodology, thread re-reading discipline, transcript format, and action plan update rules. A per-project **config file** provides the specifics: which channels, which paths, which DMs. Prefer `.agents/slack-sync.yaml`; existing `.claude/slack-sync.yaml` configs remain supported.
 
-## v3.8.0 — Windows are computed, coverage is recorded, the user's own outbound counts
-
-v3.8.0 (2026-09-01) closes three defects from one day. A hand-typed `oldest`
-(07:50 *today* instead of yesterday) reported five channels empty that were
-not; two mid-day syncs re-read only the targets the morning had skipped,
-so a DM answered at 09:27 was reported unanswered at 17:51 on a 09:15 read;
-and the user's own replies were not treated as sweep state that discharges
-owed items. Steps 1, 3, and 3b now take `oldest` from
-`sync_watermark.py window` (synthesis-daily-rituals) and quote its
-human-readable bounds in the report; Step 4 records every saved read with
-`sync_watermark.py advance --target`; Step 5 cross-references the user's
-own outbound against every owed item and forbids "unanswered" or "unsent"
-on a read older than the current run, which `status --since run` proves.
-Every sync re-reads every declared target — "already read today" is a
-statement about the past.
-
-## v3.7.0 — The sweep steps consume preflight instead of contradicting it
-
-v3.7.0 (2026-08-29) closes the gap an external adversarial review found in
-v3.6.0: the rule banned config-derived ids while the numbered steps still
-said "for each channel in the config." Step 0 now defines the mandatory
-resolved-target preflight, Steps 1/3/3b iterate only its output, an empty
-resolved set refuses the sweep, and unresolved surfaces are reported as
-unresolved. The deterministic preflight script is extraction item P2; the
-contract binds now either way. Frontmatter version also catches up — v3.6.0
-shipped with stale skill metadata.
-
-## v3.6.0 — Read targets come from preflight; deriving ids in the sweep is banned
-
-v3.6.0 (2026-08-27) fixes a class of bug that hides for months and then looks
-like something else entirely.
-
-**The defect.** A DM config entry carries two id-like fields: `id`, the user id
-(`U…`), and `dm_id`, the conversation id (`D…`). A reader that reaches for `id`
-hands a user id to a conversation-read API. That resolves implicitly while the
-account is active, so the mistake is invisible — and it starts failing only once
-that person leaves. The symptom then appears as a phantom "dead surface" for
-exactly one person, which reads as a configuration problem. It cost days of
-false unreadable-DM reports and a wrong public claim that the config was
-misaligned, when the config was correct and the reader was not.
-
-**The rule.** Sweeps take their read targets from preflight output, which emits
-the resolved read id per surface and fails closed when one cannot be resolved.
-Deriving ids from config inside the sweep is banned. A sweep that cannot obtain
-a resolved read target reports that surface as unresolved — never as unreadable,
-and never as a config defect, since it has no evidence for either.
-
-**Generalize it.** Any config whose entries carry two id-like fields has this
-trap, and the failure is always asymmetric: the wrong field usually works, so
-the bug is discovered by an unrelated change months later. Where two ids exist,
-resolution belongs in one place that fails closed, and every reader takes the
-resolved value from it rather than choosing a field.
-
-## v3.5.0 — Backfills and archive imports
-
-v3.5.0 (2026-08-19) adds a section for the operation a windowed sync is not: reading a
-conversation to its first message. Retrieval rules (page to the true beginning and report the
-earliest date as proof, expand every thread, name a partial capture by its date range rather
-than "full history") sit alongside the rule that matters more — **everything in a backfill is
-history and reads present-tense, so nothing in it may be reported as currently open without
-reconciling against newer material already held.** Origin: a backfill reported a colleague's
-settled employment arrangement as a six-week-old open loop, to the person who had settled it,
-while a calendar query run two hours earlier already showed the completed account migration.
-
-## v3.4.0 — Question-shape trigger + zero-result absence protocol
-
-v3.4.0 (2026-08-18) hardens the transcripts-first rule at the two seams where it
-historically failed to fire. First, the **question-shape trigger**: verification
-questions ("did X get sent?", "did anyone reply?", "did that happen?") are
-historical lookups wearing a different hat — the rule triggers on the question
-shape, never on whether the task felt like a lookup. Second, **a zero-result
-search is never evidence of absence**: absence claims require a bounded direct
-channel read with the bounds stated in the finding, and any null from a
-modifier-bearing query must be re-run without the modifier before it is trusted.
-Both sections live inside the "NEVER Use Slack Search API" block; the general
-evidence discipline is cross-linked to the new synthesis-grounding-discipline
-skill.
-
-## v3.3.1 — Runtime-resolved checker
-
-v3.3.1 (2026-07-29) invokes the thread checker relative to the skill root
-resolved by the active plugin runtime. The protocol no longer binds Slack sync
-to an `.agents` copy, so Codex and Claude Code execute the same checker from the
-same committed skill version.
-
-## v3.3.0 — Two-Tier Draft Block: Templates Move into Files
-
-In v3.3.0 (2026-04-29), the draft block format gets restructured around a glanceable summary at the top and collapsed verification detail at the bottom. The templates also move out of this prose file and into dedicated files in `templates/`.
-
-The earlier shape (v3.2.0 and prior) put all metadata at uniform visual weight in the rendered output: title + Send-to + body + Grounding bullets all rendered inline as paragraphs and lists. That made the most frequent purpose of the daily plan — glanceable "what's next" reading — hostile, because the verification trail (Grounding) crowded the substance (the message body) at the same visual scale.
-
-v3.3.0 separates two tiers explicitly in the source:
-
-1. **Always-visible glance surface.** Brief H3 title (≤60 char target, ≤80 hard cap), compressed `**Send to:**` line, optional one-line context, the message body itself.
-2. **Click-to-expand detail.** Grounding wrapped in `<details>/<summary>` — markdown-it (and any CommonMark-compliant renderer) renders this as a native HTML collapsible. Closed by default, click to expand. The verification trail is one click away, not occupying glance-bar real estate.
-
-The brief-title rule is the same axis: keep H3 a scannable label, not a summary. Routing metadata, status markers, IDs, timestamps, commit hashes, compound clauses NEVER go in the title; they live in `**Send to:**`, the optional context paragraph, the body, the Grounding `<details>`, or the `**Sent:**` paragraph.
-
-### Templates in their own files
-
-The canonical formats now live as standalone artifacts:
-
-- [`templates/draft-block.md`](templates/draft-block.md) — active draft template (schema v1)
-- [`templates/sent-marker.md`](templates/sent-marker.md) — sent-state marker template (schema v1)
-
-The agent reads the template files literally when writing a draft into a daily plan. SKILL.md describes WHEN and WHY to use the template; the template files ARE the canonical structural form. This separation establishes a pattern the rest of the synthesis-skills ecosystem can adopt — `templates/<name>.md` as a sibling to `SKILL.md` for any skill whose protocol generates a structural artifact.
-
-Why split:
-
-- The template IS the producer-consumer contract artifact. Easier to diff template changes without scrolling through protocol prose.
-- Agents can read template files directly (cheap to load, no parse-the-protocol-prose-to-find-the-format).
-- Independent versioning: protocol stays at v3.x; template can ship its own schema version (`schema v1` in the file header).
-
-### Backward compatibility
-
-Pre-v3.3.0 draft sections (everything inline at uniform visual weight) continue to render correctly through the cockpit's existing parser — the parser doesn't require `<details>` blocks, just recognizes them when present. New drafts written by agents should follow the v3.3.0 templates. Agents rewriting an existing draft for any reason (mid-day update, edit before send, mark sent) should also rewrite the structure to the v3.3.0 form at that opportunity.
-
-This release follows the producer-consumer-contract pattern: when the consumer is the synthesis-console cockpit and the producer is a generative agent, the format and the parser must change together. Cross-reference: synthesis-console `docs/cockpit-design.md` "Drafts" section.
-
-## v3.2.0 — Canonical Sent-State Marker Location
-
-In v3.2.0 (2026-04-29), the prescribed format for marking a draft as SENT changes from H3-jammed metadata to a separate `**Sent:**` paragraph below the draft body.
-
-The pre-v3.2.0 form jammed the entire SENT metadata into the H3 heading text:
-
-```markdown
-### ~~Draft N: title~~ ✅ SENT by Rajiv at Thu Apr 2 6:16 PM EDT in #channel-name
-```
-
-That format renders as four lines of giant strikethrough in synthesis-console (H3 typography is ~1.75rem; long heading text wraps painfully). It also breaks the cockpit's sent-state detection — synthesis-console's parser looks for `**Sent:**` paragraphs to recognize sent drafts and replace the action bar with a "Sent" badge + "Open in Slack" link. With SENT in the H3, the parser doesn't notice, and the user sees Copy/Edit/Send buttons on a draft that already shipped.
-
-The v3.2.0 canonical form keeps the H3 short and puts the metadata in its own paragraph:
-
-```markdown
-### ~~Draft N: title~~
-
-**Send to:** ...
-
-` ` `
-[Message text]
-` ` `
-
-**Sent:** Thu Apr 2 6:16 PM EDT — by Rajiv in #channel-name (TS=1775141956.643419) https://acme.slack.com/archives/C0XXXXXX/p1775141956643419
-
-**Grounding:**
-- ...
-```
-
-**Backward compatibility.** The skill's `thread_checker.py` and synthesis-console v0.8.6+'s parser both accept the legacy H3-jammed form as well as the new canonical form. Existing daily-plan files don't need to be rewritten retroactively — but new SENT markers should use the canonical form, and any time the agent rewrites a sent draft for any reason, it should bring it to the canonical form.
-
-This release follows the same producer-consumer-contract pattern as recent updates to other skills: when the consumer is the synthesis-console cockpit and the producer is a generative agent, the format and the parser must change together. Cross-reference: synthesis-console's `docs/cockpit-design.md` "Drafts" section.
-
-## v3.1.0 — Workspace Domain, Permalinks, and Provenance Discipline
-
-In v3.1.0 (2026-04-29), the skill gains three changes that work together:
-
-1. **A new optional `slack_workspace_domain` config field.** Each project's `slack-sync.yaml` declares the Slack workspace's URL host (e.g., `acme.slack.com`). The skill stays generic — workspace-specific values live in per-project config, never hardcoded.
-
-2. **Clickable permalinks replace bare Unix timestamps in transcript and draft formats.** Previous format wrote `(TS: 1234567890.123456)` as visible text. The new format hides the TS inside a Slack permalink URL — the visible text is the human-readable date/time, the link target is `https://{slack_workspace_domain}/archives/{channel_id}/p{ts_no_dot}`. The TS is still machine-readable (extractable from the URL); it's just not cluttering the rendered view in synthesis-console or any other Markdown viewer. Both formats are accepted by `thread_checker.py` during the transition; new sync output should use the permalink form when `slack_workspace_domain` is configured.
-
-3. **Provenance discipline becomes explicit.** Every `## ... sync (~HH:MM TZ)` section header added to a transcript file MUST be backed by a `slack_read_channel` or `slack_read_thread` call in the same turn. Section bodies may ONLY contain messages those MCP calls returned. If MCP returned no new messages, the section says "No new messages since last sync" and stops — no quotes, no TSes, no claims about specific people having sent specific things. See the dedicated "Provenance Discipline" section below for the full rule and the rationale (2026-04-29 fabrication incident).
-
-### Why these three changes are coupled
-
-Permalinks make TSes machine-traceable in the file (every linked time is a TS visible in the URL), which makes provenance violations grep-able. The Stop-hook backstop at `~/.claude/hooks/quote-provenance-checker.py` looks for TSes that appear in transcript writes but nowhere else in the session — and it parses TSes from BOTH the legacy `(TS: ...)` text and the new `/pNNNNNNNNNNNNNNNN` URL form. The format change and the discipline change reinforce each other.
-
-## v3.0.0 — Per-Channel-Per-Day Layout
-
-In v3.0.0 (2026-04-22 afternoon), the transcript layout changed again within the same day as v2.0.0 was released. The refinement:
-
-**Transcripts now live one-file-per-channel-per-day** inside a dated directory:
-
-```
-{transcripts_repo}/{transcripts_path}/slack/
-├── YYYY-MM-DD/
-│   ├── <channel-name>.md       (one file per channel)
-│   ├── _dms.md                  (all 1:1 DMs for the day, aggregated)
-│   ├── _group-dms.md            (all group DMs for the day, aggregated)
-│   └── _misc.md                 (cross-channel sync notes, if any)
-└── _historical-pre-v3/          (legacy pre-v3 content if any)
-```
-
-### Why v3.0.0
-
-v2.0.0 used one-file-per-day-per-type (`channels/YYYY-MM-DD.md`, `dms/YYYY-MM-DD.md`, `group-dms/YYYY-MM-DD.md`). That worked but had two weaknesses:
-
-1. **Heavy days produced large channel files.** A busy day with 50+ active channels would pack everything into one file.
-2. **Type-based directories made new primitives awkward.** Adding Slack huddles or canvases would mean new top-level folders.
-
-Per-channel-per-day solves both: each file is scoped to one channel's activity on one day (naturally smaller), and new primitives within Slack are new file patterns within the same dated dir, not new folders.
-
-### Aggregation conventions
-
-- **Channels get one file each per day.** `mmc-product-growth-squad.md`, `tech-csa-pull-requests.md`, etc.
-- **DMs are aggregated** into `_dms.md` per day. DMs are typically lower-volume; daily context across all people is more useful than per-person files.
-- **Group DMs are aggregated** into `_group-dms.md` per day. Same rationale.
-- **The `_`-prefix** on `_dms.md` and `_group-dms.md` sorts them to the top of the directory listing, visually signaling they are aggregators rather than channel files.
-
-### `-private` Discovery Protocol (ADR-014)
-
-Any repo matching `ai-knowledge-*-private` is filtered from auto-discovery by default. This skill writes to a `-private` repo intentionally — the config file points at it explicitly. Other tools (ragbot auto-discovery, etc.) must NOT include these repos in their discovery scans unless running in explicit owner context. A sentinel file `.ai-knowledge-private-owner` at the repo root confirms ownership.
+Version history and the incidents behind each rule: [references/version-history.md](references/version-history.md). Transcript and permalink formats: [references/transcript-formats.md](references/transcript-formats.md). Draft templates: [templates/draft-block.md](templates/draft-block.md) and [templates/sent-marker.md](templates/sent-marker.md).
 
 ## Configuration
 
@@ -276,13 +76,15 @@ If the config file is missing, the skill should warn and ask the user to create 
 - DM transcripts (aggregated per day): `{transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/_dms.md`
 - Group DM transcripts (aggregated per day): `{transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/_group-dms.md`
 - Cross-channel sync notes (if any): `{transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/_misc.md`
-- Meeting transcripts (written by synthesis-meeting-transcripts): `{transcripts_repo}/{transcripts_path}/meetings/YYYY-MM-DD-<slug>.mdYYYY-MM-DD-<slug>.md`
+- Meeting transcripts (written by synthesis-meeting-transcripts): `{transcripts_repo}/{transcripts_path}/meetings/YYYY-MM-DD-<slug>.md`
 - Google Chat transcripts (if any): `{transcripts_repo}/{transcripts_path}/gchat/YYYY-MM-DD.md`
 - Email threads (if any): `{transcripts_repo}/{transcripts_path}/email/<thread-id>.md`
 - Attachments: `{transcripts_repo}/{transcripts_path}/attachments/`
 - Daily action plan: `{action_plan_repo}/{action_plan_path}/YYYY-MM-DD.md`
 
 The workspace identifier no longer appears in transcript paths — it's implicit in `transcripts_repo` (the workspace-private repo is named after its workspace). The `<channel-name>` in the per-channel filename is the Slack channel name WITHOUT the leading `#`.
+
+Repos matching `ai-knowledge-*-private` are excluded from auto-discovery by default (ADR-014); this skill writes to one deliberately — the config names it — and a `.ai-knowledge-private-owner` sentinel at the repo root confirms ownership. Other tools must not include these repos in discovery scans unless running in explicit owner context.
 
 ---
 
@@ -318,35 +120,17 @@ Not weak evidence — none. The search index lags, misses thread replies, and fa
 
 Absence claims are a grounding problem: a negative result is only evidence if the instrument could have produced a positive one. The general discipline — positive controls, scoped negative findings, truncated-output rules — lives in [synthesis-grounding-discipline](../synthesis-grounding-discipline/SKILL.md); this section is its Slack instance.
 
-
 ### Backfills and archive imports
 
-A backfill — reading a conversation to its first message rather than to a window — is a
-different operation from a sync, and it fails differently.
+A backfill — reading a conversation to its first message rather than to a window — is a different operation from a sync, and it fails differently.
 
-**Retrieval.** Page until the source says there are no more messages; a page limit or a date
-bound is not the beginning. Report the **earliest message's actual date** per conversation, so
-the reader can tell you reached the start rather than that a cursor quit early. Expand every
-thread: replies do not appear in channel history, and skipping them is the standard way a
-backfill silently loses half a conversation. Preserve raw user IDs beside resolved names.
+**Retrieval.** Page until the source says there are no more messages; a page limit or a date bound is not the beginning. Report the **earliest message's actual date** per conversation, so the reader can tell you reached the start rather than that a cursor quit early. Expand every thread: replies do not appear in channel history, and skipping them is the standard way a backfill silently loses half a conversation. Preserve raw user IDs beside resolved names.
 
-**Naming and framing.** A backfill file states the span it covers and the date it was captured.
-When a conversation is *partly* captured already, name the new file by its date range rather
-than "full history" — that name claims a completeness it does not have.
+**Naming and framing.** A backfill file states the span it covers and the date it was captured. When a conversation is *partly* captured already, name the new file by its date range rather than "full history" — that name claims a completeness it does not have.
 
-**The analysis rule, which matters more than the retrieval.** Everything in a backfill is
-history, and it all reads present-tense. **Do not report anything from it as currently open
-without reconciling against newer material already held locally.** A conversation that stops is
-not a question that stayed unanswered — the thread often continued somewhere else. Scope every
-finding to where you looked ("unanswered in this conversation through <date>"), and title the
-output by what it establishes: a list of where conversations stopped, not a list of open loops.
-The general discipline, with the incident that produced it, is entry 12 of
-[synthesis-grounding-discipline](../synthesis-grounding-discipline/SKILL.md).
+**The analysis rule, which matters more than the retrieval.** Everything in a backfill is history, and it all reads present-tense. **Do not report anything from it as currently open without reconciling against newer material already held locally.** A conversation that stops is not a question that stayed unanswered — the thread often continued somewhere else. Scope every finding to where you looked ("unanswered in this conversation through <date>"), and title the output by what it establishes: a list of where conversations stopped, not a list of open loops. The general discipline, with the incident that produced it, is entry 12 of [synthesis-grounding-discipline](../synthesis-grounding-discipline/SKILL.md).
 
-Candidate open items surfaced this way are exactly what
-[synthesis-catchup-ledger](../synthesis-catchup-ledger/SKILL.md) exists to classify — route them
-through its still-relevant / obsolete / ambiguous triage rather than reporting them raw.
-
+Candidate open items surfaced this way are exactly what [synthesis-catchup-ledger](../synthesis-catchup-ledger/SKILL.md) exists to classify — route them through its still-relevant / obsolete / ambiguous triage rather than reporting them raw.
 
 ---
 
@@ -368,22 +152,9 @@ Skip any file that does not yet exist (e.g., no DMs synced today). Combine the o
 
 ### Step 0: Preflight — resolve every read target (v3.7.0, REQUIRED)
 
-Before any read, build the resolved-target list for this sweep. For every
-surface the config declares — channels, 1:1 DMs, group DMs — record the one
-id a conversation-read call accepts: the channel id for channels and group
-DMs, the **conversation id (`D…`), never the user id (`U…`)**, for DMs. A
-surface whose read id cannot be established is recorded as **unresolved**
-and reported that way — never as unreadable, never as a config defect,
-because the sweep has evidence for neither. An empty resolved-target list
-refuses the sweep rather than reporting a quiet day.
+Before any read, build the resolved-target list for this sweep. For every surface the config declares — channels, 1:1 DMs, group DMs — record the one id a conversation-read call accepts: the channel id for channels and group DMs, the **conversation id (`D…`), never the user id (`U…`)**, for DMs. A surface whose read id cannot be established is recorded as **unresolved** and reported that way — never as unreadable, never as a config defect, because the sweep has evidence for neither. An empty resolved-target list refuses the sweep rather than reporting a quiet day.
 
-Steps 1, 3, and 3b iterate ONLY this resolved-target list. Reaching back
-into the config for an id mid-sweep is the banned move from v3.6.0: where an
-entry carries two id-like fields, the wrong one usually resolves, so the bug
-hides until the person behind it leaves. (A deterministic preflight script
-generalizing the worked private implementation is queued as extraction item
-P2; until it lands, the resolved-target table is produced by hand at the top
-of the sweep and included in the sync report.)
+Steps 1, 3, and 3b iterate ONLY this resolved-target list. Reaching back into the config for an id mid-sweep is the banned move from v3.6.0: where an entry carries two id-like fields, the wrong one usually resolves, so the bug hides until the person behind it leaves. (A deterministic preflight script generalizing the worked private implementation is queued as extraction item P2; until it lands, the resolved-target table is produced by hand at the top of the sweep and included in the sync report.)
 
 ### Step 1: Read channels for new top-level messages
 
@@ -393,16 +164,9 @@ For each channel in the preflight's resolved-target list:
 slack_read_channel(resolved_channel_id, oldest=WINDOW_OLDEST, limit=30)
 ```
 
-- **`WINDOW_OLDEST` is the `oldest=` epoch printed by**
-  `python3 <synthesis-daily-rituals-root>/scripts/sync_watermark.py window --workspace <W> --surface slack --target <resolved id>`
-  — never hand-computed, never copied from a transcript header, never
-  midnight. Quote the human-readable bounds the command prints in the sync
-  report, so the window is checkable by eye (v3.8.0; a hand-typed `oldest`
-  of 07:50 *today* once reported five channels empty that were not).
-- A **bootstrap window** (no watermark yet for that target or surface) reads
-  to the workspace's backfill bound and states that bound in the report.
-- **Every declared target is read every sync**, including targets read
-  earlier the same day — the window simply starts where the last read stopped.
+- **`WINDOW_OLDEST` is the `oldest=` epoch printed by** `python3 <synthesis-daily-rituals-root>/scripts/sync_watermark.py window --workspace <W> --surface slack --target <resolved id>` — never hand-computed, never copied from a transcript header, never midnight. Quote the human-readable bounds the command prints in the sync report, so the window is checkable by eye (v3.8.0; a hand-typed `oldest` of 07:50 *today* once reported five channels empty that were not).
+- A **bootstrap window** (no watermark yet for that target or surface) reads to the workspace's backfill bound and states that bound in the report.
+- **Every declared target is read every sync**, including targets read earlier the same day — the window simply starts where the last read stopped.
 - Note the **reply count** on every message that has threads. These will be re-read in Step 2.
 
 ### Step 2: Re-read ALL active threads — today AND recent days
@@ -442,10 +206,7 @@ For each 1:1 DM in the preflight's resolved-target list:
 slack_read_channel(channel_id=RESOLVED_CONVERSATION_ID, oldest=WINDOW_OLDEST, limit=20)
 ```
 
-The resolved conversation id comes from preflight (Step 0), never from a
-config field chosen mid-sweep. Only check DMs the config marks active —
-preflight carries that scoping — and report any DM preflight marked
-unresolved instead of silently skipping it.
+The resolved conversation id comes from preflight (Step 0), never from a config field chosen mid-sweep. Only check DMs the config marks active — preflight carries that scoping — and report any DM preflight marked unresolved instead of silently skipping it.
 
 ### Step 3b: Check Group DMs
 
@@ -471,13 +232,7 @@ For each file:
 - Record the sync time (e.g., `## Mid-day sync (~14:30 EDT)`).
 - If the file doesn't exist, create it with the standard header and create directories as needed.
 - If no messages of that type were found, skip that file (do not create empty files).
-- **Record the read once it is saved (v3.8.0):** for each target whose window
-  was read and whose messages (or confirmed absence) are now on disk, run
-  `python3 <synthesis-daily-rituals-root>/scripts/sync_watermark.py advance --workspace <W> --surface slack --target <resolved id> --through <the window's latest>`.
-  The watermark advances only after the write, so a read that failed to save
-  cannot claim coverage — and the gate at the end of the sync
-  (`sync_watermark.py status --workspace <W> --surface slack --since run --targets-from <declared.json>`)
-  lists exactly the targets this sync did not re-read.
+- **Record the read once it is saved (v3.8.0):** for each target whose window was read and whose messages (or confirmed absence) are now on disk, run `python3 <synthesis-daily-rituals-root>/scripts/sync_watermark.py advance --workspace <W> --surface slack --target <resolved id> --through <the window's latest>`. The watermark advances only after the write, so a read that failed to save cannot claim coverage — and the gate at the end of the sync (`sync_watermark.py status --workspace <W> --surface slack --since run --targets-from <declared.json>`, the declared set derived from the sync config at sync time and never a stored copy) lists exactly the targets this sync did not re-read.
 
 Meeting transcripts are NOT part of Slack sync — they are handled by the daily-rituals skill and placed in `{transcripts_repo}/{transcripts_path}/meetings/YYYY-MM-DD-<slug>.md`.
 
@@ -500,24 +255,6 @@ The shape (v3.3.0+) is two-tier:
 1. **Glanceable summary** — brief H3 title (≤60 char target), compressed `**Send to:**` line, optional one-line framing context, the message body itself.
 2. **Click-to-expand detail** — Grounding wrapped in `<details>/<summary>` so verification metadata is one click away rather than crowding the glance surface.
 
-```markdown
-### Draft N: <action> <recipient/topic>
-
-**Send to:** #channel · <thread or new>
-
-[Optional one-line context if helpful]
-
-` ` `
-[Message text]
-` ` `
-
-<details><summary>Grounding (N facts verified)</summary>
-
-- ...
-
-</details>
-```
-
 **Protocol rules** (full field-by-field detail in `templates/draft-block.md`):
 
 - **H3 title** is a scannable label. ≤60 char target, ≤80 hard cap. Format: `Draft N: <action> <recipient/topic>`. NEVER include channel IDs, user IDs, thread timestamps, commit hashes, PR numbers, status markers, or compound clauses in the title.
@@ -534,148 +271,13 @@ The shape (v3.3.0+) is two-tier:
 
 ---
 
-## Transcript File Format
+## Transcript Files and Permalinks
 
-Each file under `{transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/` follows one of three shapes: per-channel, `_dms.md` aggregator, or `_group-dms.md` aggregator.
+The per-channel, `_dms.md`, and `_group-dms.md` file shapes, the permalink construction rule, the `Send to:` line form, and the retrofit script are in [references/transcript-formats.md](references/transcript-formats.md). The rules that bind every write:
 
-### Channel file (`slack/YYYY-MM-DD/<channel>.md`)
-
-One file per channel per day. The filename is the channel name without the leading `#` (e.g., `mmc-product-growth-squad.md`).
-
-```markdown
-# Slack #[channel-name] — [Day], [Month] [Date], [Year]
-# Workspace: [workspace]
-
-Last synced: ~HH:MM TZ
-
----
-
-### [Author Name] — [HH:MM TZ]({permalink})
-[Message content]
-**Thread ([N] replies):**
-- [Reply Author] [HH:MM]({reply_permalink}): "[reply text]"
-- [Reply Author] [HH:MM]({reply_permalink}): "[reply text]"
-**Reactions:** [emoji_name] ([count])
-
----
-
-## Mid-day sync (~HH:MM TZ)
-
-### [Author Name] — [HH:MM TZ]({permalink})
-[New message]
-
-#### Thread update — [N] replies — [HH:MM]({thread_permalink})
-- [New reply details]
-
----
-```
-
-Within a single channel file, the channel name appears in the `# Slack #<channel>` top-level header only; messages below don't need `## #channel` subheaders (the entire file is about that channel).
-
-`{permalink}` is constructed per "Slack Permalink Construction" below: the visible text is the human-readable time, the link target carries the TS (`/pNNNNNNNNNNNNNNNN`). Files written before v3.1.0 may carry the legacy `(TS: 1234567890.123456)` format; both are accepted by `thread_checker.py` during the transition.
-
-### DMs aggregator file (`slack/YYYY-MM-DD/_dms.md`)
-
-```markdown
-# Slack DMs — [Day], [Month] [Date], [Year]
-# Workspace: [workspace]
-
-Last synced: ~HH:MM TZ
-
----
-
-## DM with [Person Name] (DM_CHANNEL_ID)
-
-### [Author Name] — [HH:MM TZ]({permalink})
-[Message content]
-
----
-```
-
-### Group DMs aggregator file (`slack/YYYY-MM-DD/_group-dms.md`)
-
-```markdown
-# Slack Group DMs — [Day], [Month] [Date], [Year]
-# Workspace: [workspace]
-
-Last synced: ~HH:MM TZ
-
----
-
-## Group DM: [Group Name or Members] (GROUP_DM_ID)
-
-### [Author Name] — [HH:MM TZ]({permalink})
-[Message content]
-
----
-```
-
-Key rules:
-- **Always record the TS** for every significant message. In v3.1.0+ the TS is embedded in the Slack permalink URL (`/pNNNNNNNNNNNNNNNN`); in pre-v3.1.0 files it appears as `(TS: 1234567890.123456)` text. Both forms are valid; `thread_checker.py` accepts both.
-- **Note reply counts** so the next sync can detect new replies.
-- **Separate sync sessions** with a horizontal rule and a timestamp header.
-- **Each file is scoped to its subject.** A per-channel file contains only that channel's messages. `_dms.md` contains only 1:1 DMs. `_group-dms.md` contains only group DMs. Mid-day syncs append to the same file; they don't fan out to new files.
-- **Directory listing tells the story.** `ls slack/YYYY-MM-DD/` shows which channels were active that day. File sizes show where activity concentrated.
-
----
-
-## Slack Permalink Construction
-
-Every Slack message recorded in a transcript or quoted in a draft message MUST be presented as a clickable permalink (when `slack_workspace_domain` is configured). The permalink format:
-
-```
-https://{slack_workspace_domain}/archives/{channel_id}/p{ts_no_dot}
-```
-
-Where:
-- `{slack_workspace_domain}` is read from `.agents/slack-sync.yaml` (e.g., `acme.slack.com`).
-- `{channel_id}` is the channel ID (e.g., `C0EXAMPLE01`) — comes from the same config or from the MCP read result.
-- `{ts_no_dot}` is the message TS with the `.` removed. Example: TS `1234567890.123456` becomes `1234567890123456`.
-
-For thread replies, the same simple form navigates to the reply within its thread — Slack's permalink resolver handles thread context automatically. (Slack's "Copy link to message" UI emits a richer form with `?thread_ts=...&cid=...` query parameters; the simple `/pNNNNNNNNNNNNNNNN` form is sufficient for navigation and is what we generate.)
-
-### Visible text is human-readable; TS hides in the URL
-
-Instead of:
-
-```markdown
-### Author Name — HH:MM TZ (TS: 1234567890.123456)
-```
-
-Use:
-
-```markdown
-### Author Name — [HH:MM TZ](https://acme.slack.com/archives/C0XXXX/p1234567890123456)
-```
-
-The link target carries the TS for machine extraction (regex: `/p(\d{10})(\d{6})\b`). The visible time renders as a clickable link in synthesis-console, GitHub, VSCode preview, and any other Markdown viewer. No `(TS: ...)` clutter in the rendered view.
-
-### Draft message "Send to:" line
-
-Replies:
-
-```markdown
-**Send to:** #channel-name — reply to **Author's** message at [Wed, Apr 29, 4:09 PM EDT](https://acme.slack.com/archives/C0XXXX/p1777493393596089)
-```
-
-New top-level messages don't need a permalink — there's no parent to link to.
-
-### Fallback when `slack_workspace_domain` is absent
-
-If the per-project config does not set `slack_workspace_domain`, the skill MUST emit a one-time warning ("permalinks disabled — set `slack_workspace_domain` to enable clickable links in transcripts and drafts") and fall back to the legacy `(TS: 1234567890.123456)` text format. The skill does not invent a domain.
-
-### Retrofitting older daily plans
-
-`retrofit_permalinks.py` (shipped alongside `thread_checker.py` in this skill directory) converts a legacy daily plan or transcript file from the bare-TS format to the clickable-permalink format in one pass. It reads the workspace domain and channel-name → channel-ID map from a `slack-sync.yaml` config — generic-skill, no hardcoded workspace.
-
-```bash
-python3 retrofit_permalinks.py <plan.md> --config <slack-sync.yaml>
-python3 retrofit_permalinks.py <plan.md> --config <slack-sync.yaml> --dry-run
-```
-
-Skip rules: lines containing only "parent thread TS" references are left as-is (the visible time on those lines refers to the reply, not the parent — linking it to the parent's TS would be wrong); lines with no resolvable channel hint are left unchanged (the script needs at least one `#channel-name` or `D0…`/`C0…` ID inline to construct a permalink). The script is idempotent — running it on an already-retrofitted file is a no-op.
-
-For multi-workspace daily plans (a single plan referencing messages from more than one Slack workspace), run the script once per workspace's `slack-sync.yaml`. Each pass linkifies only the TSes whose channel resolves via the config it was given; other lines fall through to the next pass.
+- **Always record the TS** for every significant message — embedded in a Slack permalink (`https://{slack_workspace_domain}/archives/{channel_id}/p{ts_no_dot}`) whose visible text is the human-readable time. When `slack_workspace_domain` is absent, warn once per session and fall back to the legacy `(TS: 1234567890.123456)` text; never invent a domain.
+- **Note reply counts** so the next sync can detect new replies; **separate sync sessions** with a horizontal rule and a timestamped `## … sync (~HH:MM TZ)` header; **each file is scoped to its subject** — mid-day syncs append to the same file and never fan out to new ones.
+- `retrofit_permalinks.py <plan.md> --config <slack-sync.yaml>` converts a legacy bare-TS file to permalinks in one idempotent pass (`--dry-run` to preview); for multi-workspace plans run it once per workspace config.
 
 ---
 
@@ -748,15 +350,5 @@ When a channel message references or continues an earlier discussion (broadcast 
 
 This skill is invoked:
 - **By the user** typing `/synthesis-slack-sync` or "sync from Slack" or similar
-- **By `synthesis-daily-rituals`** during Day-Start (Step 2: Sync), Mid-Day Sync, and Day-End (Step 1: Transcript Sync)
+- **By `synthesis-daily-rituals`** during Day-Start (Step 3: Sync), Mid-Day Sync, and Day-End (Step 1: Transcript Sync)
 - **Before drafting any Slack reply** — the daily-rituals skill requires re-reading the actual thread before drafting, to avoid stale-information replies
-
----
-
-## Why Each Step Matters
-
-These steps were developed through real incidents, not theory:
-
-- **Step 2 (thread re-reading):** On 2026-03-24, a mid-day sync skipped thread re-reads. The action plan showed a draft as "unsent" when the user had already sent it hours earlier. The agent proposed sending it again, which would have been a duplicate message.
-- **Step 4 (save to local):** Transcripts are the persistence layer. Without them, every sync starts from scratch, re-reading entire channels. With them, syncs are incremental and fast.
-- **Step 5 (action plan update):** The action plan is the user's dashboard. If it shows stale information (unsent drafts that were sent, unresolved items that were resolved), the user makes wrong decisions.

--- a/skills/synthesis-slack-sync/references/transcript-formats.md
+++ b/skills/synthesis-slack-sync/references/transcript-formats.md
@@ -1,0 +1,146 @@
+# Transcript files and permalinks — formats
+
+The file shapes every sync writes and the permalink form every recorded
+message takes. The binding rules are summarized in [SKILL.md](../SKILL.md)
+("Transcript Files and Permalinks"); this file is the literal format.
+
+## Transcript File Format
+
+Each file under `{transcripts_repo}/{transcripts_path}/slack/YYYY-MM-DD/` follows one of three shapes: per-channel, `_dms.md` aggregator, or `_group-dms.md` aggregator.
+
+### Channel file (`slack/YYYY-MM-DD/<channel>.md`)
+
+One file per channel per day. The filename is the channel name without the leading `#` (e.g., `mmc-product-growth-squad.md`).
+
+```markdown
+# Slack #[channel-name] — [Day], [Month] [Date], [Year]
+# Workspace: [workspace]
+
+Last synced: ~HH:MM TZ
+
+---
+
+### [Author Name] — [HH:MM TZ]({permalink})
+[Message content]
+**Thread ([N] replies):**
+- [Reply Author] [HH:MM]({reply_permalink}): "[reply text]"
+- [Reply Author] [HH:MM]({reply_permalink}): "[reply text]"
+**Reactions:** [emoji_name] ([count])
+
+---
+
+## Mid-day sync (~HH:MM TZ)
+
+### [Author Name] — [HH:MM TZ]({permalink})
+[New message]
+
+#### Thread update — [N] replies — [HH:MM]({thread_permalink})
+- [New reply details]
+
+---
+```
+
+Within a single channel file, the channel name appears in the `# Slack #<channel>` top-level header only; messages below don't need `## #channel` subheaders (the entire file is about that channel).
+
+`{permalink}` is constructed per "Slack Permalink Construction" below: the visible text is the human-readable time, the link target carries the TS (`/pNNNNNNNNNNNNNNNN`). Files written before v3.1.0 may carry the legacy `(TS: 1234567890.123456)` format; both are accepted by `thread_checker.py` during the transition.
+
+### DMs aggregator file (`slack/YYYY-MM-DD/_dms.md`)
+
+```markdown
+# Slack DMs — [Day], [Month] [Date], [Year]
+# Workspace: [workspace]
+
+Last synced: ~HH:MM TZ
+
+---
+
+## DM with [Person Name] (DM_CHANNEL_ID)
+
+### [Author Name] — [HH:MM TZ]({permalink})
+[Message content]
+
+---
+```
+
+### Group DMs aggregator file (`slack/YYYY-MM-DD/_group-dms.md`)
+
+```markdown
+# Slack Group DMs — [Day], [Month] [Date], [Year]
+# Workspace: [workspace]
+
+Last synced: ~HH:MM TZ
+
+---
+
+## Group DM: [Group Name or Members] (GROUP_DM_ID)
+
+### [Author Name] — [HH:MM TZ]({permalink})
+[Message content]
+
+---
+```
+
+Key rules:
+- **Always record the TS** for every significant message. In v3.1.0+ the TS is embedded in the Slack permalink URL (`/pNNNNNNNNNNNNNNNN`); in pre-v3.1.0 files it appears as `(TS: 1234567890.123456)` text. Both forms are valid; `thread_checker.py` accepts both.
+- **Note reply counts** so the next sync can detect new replies.
+- **Separate sync sessions** with a horizontal rule and a timestamp header.
+- **Each file is scoped to its subject.** A per-channel file contains only that channel's messages. `_dms.md` contains only 1:1 DMs. `_group-dms.md` contains only group DMs. Mid-day syncs append to the same file; they don't fan out to new files.
+- **Directory listing tells the story.** `ls slack/YYYY-MM-DD/` shows which channels were active that day. File sizes show where activity concentrated.
+
+## Slack Permalink Construction
+
+Every Slack message recorded in a transcript or quoted in a draft message MUST be presented as a clickable permalink (when `slack_workspace_domain` is configured). The permalink format:
+
+```
+https://{slack_workspace_domain}/archives/{channel_id}/p{ts_no_dot}
+```
+
+Where:
+- `{slack_workspace_domain}` is read from `.agents/slack-sync.yaml` (e.g., `acme.slack.com`).
+- `{channel_id}` is the channel ID (e.g., `C0EXAMPLE01`) — comes from the same config or from the MCP read result.
+- `{ts_no_dot}` is the message TS with the `.` removed. Example: TS `1234567890.123456` becomes `1234567890123456`.
+
+For thread replies, the same simple form navigates to the reply within its thread — Slack's permalink resolver handles thread context automatically. (Slack's "Copy link to message" UI emits a richer form with `?thread_ts=...&cid=...` query parameters; the simple `/pNNNNNNNNNNNNNNNN` form is sufficient for navigation and is what we generate.)
+
+### Visible text is human-readable; TS hides in the URL
+
+Instead of:
+
+```markdown
+### Author Name — HH:MM TZ (TS: 1234567890.123456)
+```
+
+Use:
+
+```markdown
+### Author Name — [HH:MM TZ](https://acme.slack.com/archives/C0XXXX/p1234567890123456)
+```
+
+The link target carries the TS for machine extraction (regex: `/p(\d{10})(\d{6})\b`). The visible time renders as a clickable link in synthesis-console, GitHub, VSCode preview, and any other Markdown viewer. No `(TS: ...)` clutter in the rendered view.
+
+### Draft message "Send to:" line
+
+Replies:
+
+```markdown
+**Send to:** #channel-name — reply to **Author's** message at [Wed, Apr 29, 4:09 PM EDT](https://acme.slack.com/archives/C0XXXX/p1777493393596089)
+```
+
+New top-level messages don't need a permalink — there's no parent to link to.
+
+### Fallback when `slack_workspace_domain` is absent
+
+If the per-project config does not set `slack_workspace_domain`, the skill MUST emit a one-time warning ("permalinks disabled — set `slack_workspace_domain` to enable clickable links in transcripts and drafts") and fall back to the legacy `(TS: 1234567890.123456)` text format. The skill does not invent a domain.
+
+### Retrofitting older daily plans
+
+`retrofit_permalinks.py` (shipped alongside `thread_checker.py` in this skill directory) converts a legacy daily plan or transcript file from the bare-TS format to the clickable-permalink format in one pass. It reads the workspace domain and channel-name → channel-ID map from a `slack-sync.yaml` config — generic-skill, no hardcoded workspace.
+
+```bash
+python3 retrofit_permalinks.py <plan.md> --config <slack-sync.yaml>
+python3 retrofit_permalinks.py <plan.md> --config <slack-sync.yaml> --dry-run
+```
+
+Skip rules: lines containing only "parent thread TS" references are left as-is (the visible time on those lines refers to the reply, not the parent — linking it to the parent's TS would be wrong); lines with no resolvable channel hint are left unchanged (the script needs at least one `#channel-name` or `D0…`/`C0…` ID inline to construct a permalink). The script is idempotent — running it on an already-retrofitted file is a no-op.
+
+For multi-workspace daily plans (a single plan referencing messages from more than one Slack workspace), run the script once per workspace's `slack-sync.yaml`. Each pass linkifies only the TSes whose channel resolves via the config it was given; other lines fall through to the next pass.

--- a/skills/synthesis-slack-sync/references/version-history.md
+++ b/skills/synthesis-slack-sync/references/version-history.md
@@ -1,0 +1,228 @@
+# Slack sync — version history and rationale
+
+The sync protocol lives in [SKILL.md](../SKILL.md). This file keeps the
+release-by-release record of why each rule exists — the incidents and the
+design choices — so the main document stays within the repository's
+500-line budget without losing the reasoning. Newest first.
+
+## v3.9.0 — Restructured under the 500-line budget
+
+v3.9.0 (2026-09-01) moves version history, the transcript and permalink
+formats, and the draft example out of SKILL.md into `references/` (this
+file and `transcript-formats.md`), leaving every step of the protocol and
+every rule in the main document. A pinned test in synthesis-daily-rituals
+(`scripts/test_skill_documents.py`, the CI group both skills share) fails
+when SKILL.md reaches 500 lines, when a load-bearing rule anchor leaves it,
+when a moved block is missing from its reference, or when a reference or
+template is not linked from the main document. Nothing in the protocol
+changed.
+
+## v3.8.0 — Windows are computed, coverage is recorded, the user's own outbound counts
+
+v3.8.0 (2026-09-01) closes three defects from one day. A hand-typed `oldest`
+(07:50 *today* instead of yesterday) reported five channels empty that were
+not; two mid-day syncs re-read only the targets the morning had skipped,
+so a DM answered at 09:27 was reported unanswered at 17:51 on a 09:15 read;
+and the user's own replies were not treated as sweep state that discharges
+owed items. Steps 1, 3, and 3b now take `oldest` from
+`sync_watermark.py window` (synthesis-daily-rituals) and quote its
+human-readable bounds in the report; Step 4 records every saved read with
+`sync_watermark.py advance --target`; Step 5 cross-references the user's
+own outbound against every owed item and forbids "unanswered" or "unsent"
+on a read older than the current run, which `status --since run` proves.
+Every sync re-reads every declared target — "already read today" is a
+statement about the past.
+
+## v3.7.0 — The sweep steps consume preflight instead of contradicting it
+
+v3.7.0 (2026-08-29) closes the gap an external adversarial review found in
+v3.6.0: the rule banned config-derived ids while the numbered steps still
+said "for each channel in the config." Step 0 now defines the mandatory
+resolved-target preflight, Steps 1/3/3b iterate only its output, an empty
+resolved set refuses the sweep, and unresolved surfaces are reported as
+unresolved. The deterministic preflight script is extraction item P2; the
+contract binds now either way. Frontmatter version also catches up — v3.6.0
+shipped with stale skill metadata.
+
+## v3.6.0 — Read targets come from preflight; deriving ids in the sweep is banned
+
+v3.6.0 (2026-08-27) fixes a class of bug that hides for months and then looks
+like something else entirely.
+
+**The defect.** A DM config entry carries two id-like fields: `id`, the user id
+(`U…`), and `dm_id`, the conversation id (`D…`). A reader that reaches for `id`
+hands a user id to a conversation-read API. That resolves implicitly while the
+account is active, so the mistake is invisible — and it starts failing only once
+that person leaves. The symptom then appears as a phantom "dead surface" for
+exactly one person, which reads as a configuration problem. It cost days of
+false unreadable-DM reports and a wrong public claim that the config was
+misaligned, when the config was correct and the reader was not.
+
+**The rule.** Sweeps take their read targets from preflight output, which emits
+the resolved read id per surface and fails closed when one cannot be resolved.
+Deriving ids from config inside the sweep is banned. A sweep that cannot obtain
+a resolved read target reports that surface as unresolved — never as unreadable,
+and never as a config defect, since it has no evidence for either.
+
+**Generalize it.** Any config whose entries carry two id-like fields has this
+trap, and the failure is always asymmetric: the wrong field usually works, so
+the bug is discovered by an unrelated change months later. Where two ids exist,
+resolution belongs in one place that fails closed, and every reader takes the
+resolved value from it rather than choosing a field.
+
+## v3.5.0 — Backfills and archive imports
+
+v3.5.0 (2026-08-19) adds a section for the operation a windowed sync is not: reading a
+conversation to its first message. Retrieval rules (page to the true beginning and report the
+earliest date as proof, expand every thread, name a partial capture by its date range rather
+than "full history") sit alongside the rule that matters more — **everything in a backfill is
+history and reads present-tense, so nothing in it may be reported as currently open without
+reconciling against newer material already held.** Origin: a backfill reported a colleague's
+settled employment arrangement as a six-week-old open loop, to the person who had settled it,
+while a calendar query run two hours earlier already showed the completed account migration.
+
+## v3.4.0 — Question-shape trigger + zero-result absence protocol
+
+v3.4.0 (2026-08-18) hardens the transcripts-first rule at the two seams where it
+historically failed to fire. First, the **question-shape trigger**: verification
+questions ("did X get sent?", "did anyone reply?", "did that happen?") are
+historical lookups wearing a different hat — the rule triggers on the question
+shape, never on whether the task felt like a lookup. Second, **a zero-result
+search is never evidence of absence**: absence claims require a bounded direct
+channel read with the bounds stated in the finding, and any null from a
+modifier-bearing query must be re-run without the modifier before it is trusted.
+Both sections live inside the "NEVER Use Slack Search API" block; the general
+evidence discipline is cross-linked to the new synthesis-grounding-discipline
+skill.
+
+## v3.3.1 — Runtime-resolved checker
+
+v3.3.1 (2026-07-29) invokes the thread checker relative to the skill root
+resolved by the active plugin runtime. The protocol no longer binds Slack sync
+to an `.agents` copy, so Codex and Claude Code execute the same checker from the
+same committed skill version.
+
+## v3.3.0 — Two-Tier Draft Block: Templates Move into Files
+
+In v3.3.0 (2026-04-29), the draft block format gets restructured around a glanceable summary at the top and collapsed verification detail at the bottom. The templates also move out of this prose file and into dedicated files in `templates/`.
+
+The earlier shape (v3.2.0 and prior) put all metadata at uniform visual weight in the rendered output: title + Send-to + body + Grounding bullets all rendered inline as paragraphs and lists. That made the most frequent purpose of the daily plan — glanceable "what's next" reading — hostile, because the verification trail (Grounding) crowded the substance (the message body) at the same visual scale.
+
+v3.3.0 separates two tiers explicitly in the source:
+
+1. **Always-visible glance surface.** Brief H3 title (≤60 char target, ≤80 hard cap), compressed `**Send to:**` line, optional one-line context, the message body itself.
+2. **Click-to-expand detail.** Grounding wrapped in `<details>/<summary>` — markdown-it (and any CommonMark-compliant renderer) renders this as a native HTML collapsible. Closed by default, click to expand. The verification trail is one click away, not occupying glance-bar real estate.
+
+The brief-title rule is the same axis: keep H3 a scannable label, not a summary. Routing metadata, status markers, IDs, timestamps, commit hashes, compound clauses NEVER go in the title; they live in `**Send to:**`, the optional context paragraph, the body, the Grounding `<details>`, or the `**Sent:**` paragraph.
+
+### Templates in their own files
+
+The canonical formats now live as standalone artifacts:
+
+- [`templates/draft-block.md`](templates/draft-block.md) — active draft template (schema v1)
+- [`templates/sent-marker.md`](templates/sent-marker.md) — sent-state marker template (schema v1)
+
+The agent reads the template files literally when writing a draft into a daily plan. SKILL.md describes WHEN and WHY to use the template; the template files ARE the canonical structural form. This separation establishes a pattern the rest of the synthesis-skills ecosystem can adopt — `templates/<name>.md` as a sibling to `SKILL.md` for any skill whose protocol generates a structural artifact.
+
+Why split:
+
+- The template IS the producer-consumer contract artifact. Easier to diff template changes without scrolling through protocol prose.
+- Agents can read template files directly (cheap to load, no parse-the-protocol-prose-to-find-the-format).
+- Independent versioning: protocol stays at v3.x; template can ship its own schema version (`schema v1` in the file header).
+
+### Backward compatibility
+
+Pre-v3.3.0 draft sections (everything inline at uniform visual weight) continue to render correctly through the cockpit's existing parser — the parser doesn't require `<details>` blocks, just recognizes them when present. New drafts written by agents should follow the v3.3.0 templates. Agents rewriting an existing draft for any reason (mid-day update, edit before send, mark sent) should also rewrite the structure to the v3.3.0 form at that opportunity.
+
+This release follows the producer-consumer-contract pattern: when the consumer is the synthesis-console cockpit and the producer is a generative agent, the format and the parser must change together. Cross-reference: synthesis-console `docs/cockpit-design.md` "Drafts" section.
+
+## v3.2.0 — Canonical Sent-State Marker Location
+
+In v3.2.0 (2026-04-29), the prescribed format for marking a draft as SENT changes from H3-jammed metadata to a separate `**Sent:**` paragraph below the draft body.
+
+The pre-v3.2.0 form jammed the entire SENT metadata into the H3 heading text:
+
+```markdown
+### ~~Draft N: title~~ ✅ SENT by Rajiv at Thu Apr 2 6:16 PM EDT in #channel-name
+```
+
+That format renders as four lines of giant strikethrough in synthesis-console (H3 typography is ~1.75rem; long heading text wraps painfully). It also breaks the cockpit's sent-state detection — synthesis-console's parser looks for `**Sent:**` paragraphs to recognize sent drafts and replace the action bar with a "Sent" badge + "Open in Slack" link. With SENT in the H3, the parser doesn't notice, and the user sees Copy/Edit/Send buttons on a draft that already shipped.
+
+The v3.2.0 canonical form keeps the H3 short and puts the metadata in its own paragraph:
+
+```markdown
+### ~~Draft N: title~~
+
+**Send to:** ...
+
+` ` `
+[Message text]
+` ` `
+
+**Sent:** Thu Apr 2 6:16 PM EDT — by Rajiv in #channel-name (TS=1775141956.643419) https://acme.slack.com/archives/C0XXXXXX/p1775141956643419
+
+**Grounding:**
+- ...
+```
+
+**Backward compatibility.** The skill's `thread_checker.py` and synthesis-console v0.8.6+'s parser both accept the legacy H3-jammed form as well as the new canonical form. Existing daily-plan files don't need to be rewritten retroactively — but new SENT markers should use the canonical form, and any time the agent rewrites a sent draft for any reason, it should bring it to the canonical form.
+
+This release follows the same producer-consumer-contract pattern as recent updates to other skills: when the consumer is the synthesis-console cockpit and the producer is a generative agent, the format and the parser must change together. Cross-reference: synthesis-console's `docs/cockpit-design.md` "Drafts" section.
+
+## v3.1.0 — Workspace Domain, Permalinks, and Provenance Discipline
+
+In v3.1.0 (2026-04-29), the skill gains three changes that work together:
+
+1. **A new optional `slack_workspace_domain` config field.** Each project's `slack-sync.yaml` declares the Slack workspace's URL host (e.g., `acme.slack.com`). The skill stays generic — workspace-specific values live in per-project config, never hardcoded.
+
+2. **Clickable permalinks replace bare Unix timestamps in transcript and draft formats.** Previous format wrote `(TS: 1234567890.123456)` as visible text. The new format hides the TS inside a Slack permalink URL — the visible text is the human-readable date/time, the link target is `https://{slack_workspace_domain}/archives/{channel_id}/p{ts_no_dot}`. The TS is still machine-readable (extractable from the URL); it's just not cluttering the rendered view in synthesis-console or any other Markdown viewer. Both formats are accepted by `thread_checker.py` during the transition; new sync output should use the permalink form when `slack_workspace_domain` is configured.
+
+3. **Provenance discipline becomes explicit.** Every `## ... sync (~HH:MM TZ)` section header added to a transcript file MUST be backed by a `slack_read_channel` or `slack_read_thread` call in the same turn. Section bodies may ONLY contain messages those MCP calls returned. If MCP returned no new messages, the section says "No new messages since last sync" and stops — no quotes, no TSes, no claims about specific people having sent specific things. See the dedicated "Provenance Discipline" section below for the full rule and the rationale (2026-04-29 fabrication incident).
+
+### Why these three changes are coupled
+
+Permalinks make TSes machine-traceable in the file (every linked time is a TS visible in the URL), which makes provenance violations grep-able. The Stop-hook backstop at `~/.claude/hooks/quote-provenance-checker.py` looks for TSes that appear in transcript writes but nowhere else in the session — and it parses TSes from BOTH the legacy `(TS: ...)` text and the new `/pNNNNNNNNNNNNNNNN` URL form. The format change and the discipline change reinforce each other.
+
+## v3.0.0 — Per-Channel-Per-Day Layout
+
+In v3.0.0 (2026-04-22 afternoon), the transcript layout changed again within the same day as v2.0.0 was released. The refinement:
+
+**Transcripts now live one-file-per-channel-per-day** inside a dated directory:
+
+```
+{transcripts_repo}/{transcripts_path}/slack/
+├── YYYY-MM-DD/
+│   ├── <channel-name>.md       (one file per channel)
+│   ├── _dms.md                  (all 1:1 DMs for the day, aggregated)
+│   ├── _group-dms.md            (all group DMs for the day, aggregated)
+│   └── _misc.md                 (cross-channel sync notes, if any)
+└── _historical-pre-v3/          (legacy pre-v3 content if any)
+```
+
+### Why v3.0.0
+
+v2.0.0 used one-file-per-day-per-type (`channels/YYYY-MM-DD.md`, `dms/YYYY-MM-DD.md`, `group-dms/YYYY-MM-DD.md`). That worked but had two weaknesses:
+
+1. **Heavy days produced large channel files.** A busy day with 50+ active channels would pack everything into one file.
+2. **Type-based directories made new primitives awkward.** Adding Slack huddles or canvases would mean new top-level folders.
+
+Per-channel-per-day solves both: each file is scoped to one channel's activity on one day (naturally smaller), and new primitives within Slack are new file patterns within the same dated dir, not new folders.
+
+### Aggregation conventions
+
+- **Channels get one file each per day.** `mmc-product-growth-squad.md`, `tech-csa-pull-requests.md`, etc.
+- **DMs are aggregated** into `_dms.md` per day. DMs are typically lower-volume; daily context across all people is more useful than per-person files.
+- **Group DMs are aggregated** into `_group-dms.md` per day. Same rationale.
+- **The `_`-prefix** on `_dms.md` and `_group-dms.md` sorts them to the top of the directory listing, visually signaling they are aggregators rather than channel files.
+
+### `-private` Discovery Protocol (ADR-014)
+
+Any repo matching `ai-knowledge-*-private` is filtered from auto-discovery by default. This skill writes to a `-private` repo intentionally — the config file points at it explicitly. Other tools (ragbot auto-discovery, etc.) must NOT include these repos in their discovery scans unless running in explicit owner context. A sentinel file `.ai-knowledge-private-owner` at the repo root confirms ownership.
+
+## Why Each Step Matters
+
+These steps were developed through real incidents, not theory:
+
+- **Step 2 (thread re-reading):** On 2026-03-24, a mid-day sync skipped thread re-reads. The action plan showed a draft as "unsent" when the user had already sent it hours earlier. The agent proposed sending it again, which would have been a duplicate message.
+- **Step 4 (save to local):** Transcripts are the persistence layer. Without them, every sync starts from scratch, re-reading entire channels. With them, syncs are incremental and fast.
+- **Step 5 (action plan update):** The action plan is the user's dashboard. If it shows stale information (unsent drafts that were sent, unresolved items that were resolved), the user makes wrong decisions.


### PR DESCRIPTION
## Summary

Two skills violated AGENTS.md rule 4 (SKILL.md below 500 lines): `synthesis-daily-rituals/SKILL.md` at 1,319 lines and `synthesis-slack-sync/SKILL.md` at 762. Both are restructured the way the project-management skill was for 4.76.2 — restructured, not trimmed.

- **What stays in the main documents:** every operating rule and every checklist step (Day-Start, Day-End with its modes, Mid-Day, Observer, the distributed desk/worker rules, the Slack sync Steps 0–5, the NEVER-search rules, provenance discipline). Where a block was condensed, a rule digest carries each rule (draft grounding and formatting; daily-plan structure; transcript and permalink rules).
- **What moved, verbatim, into `references/`:** daily-rituals — `version-history.md` (all `## vX.Y.Z` sections plus the rationale paragraphs cut from Steps 7 and 10, the observer rationale, and the principles), `plan-format.md` (canonical structure, cockpit vocabulary, internal conventions, revert protection), `draft-grounding.md` (the full grounding protocol and formatting rules); slack-sync — `version-history.md` (all version sections and "Why each step matters"), `transcript-formats.md` (file shapes, permalink construction, retrofit script).
- **Re-flow:** wrapped list items and paragraphs were joined to the files' dominant single-line style (soft wraps inside one block are one block in markdown); fenced code, tables, headings, blockquotes, and list markers were never joined.
- **Pinned contract:** `synthesis-daily-rituals/scripts/test_skill_documents.py` (the CI group both skills share) fails when either document reaches 500 lines, when a load-bearing rule anchor leaves it, when a moved block is missing from its reference, or when a reference or template is not linked from the main document.
- **Fixed in passing (Slack document):** a doubled `YYYY-MM-DD-<slug>.md` path suffix and a stale "Day-Start Step 2" reference (Step 3 since v2.9.0). The gate text on both skills now says the declared target set is derived from the sync config at sync time, never a stored copy.
- daily-rituals 2.31.0, slack-sync 3.9.0; release surfaces at 4.80.0 with a fresh acceptance manifest.

## Verification

- Results: daily-rituals 446 lines, slack-sync 354 lines
- Every pre-existing documented-rule contract still passes against the main documents (`test_sync_watermark.py`, `test_item_currency.py`); `test_skill_documents.py` adds six contracts
- Full AGENTS.md verification list green locally; conformance source 204/204; scaffold check PASS
- Both rebuilt documents read end to end by the author before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
