### PR TITLE
Maintain a stable plugin path; announce a stale engine on every coordination command (4.82.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.81.0",
+  "version": "4.82.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.81.0",
+  "version": "4.82.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.82.0] - 2026-09-01
+
+**A stable plugin path, and every coordination command says when it is
+running from an old engine.** Versioned cache paths go stale on the next
+release: a session that resolved `coordination.py` at lunch and kept the
+path for four hours crossed six releases and read the migrated board with a
+parser that could not know it, and the personal workspace's own day-start
+commands pinned a release twenty versions behind. Two fixes. The gated
+release now maintains `~/.synthesis/plugins/synthesis-skills/current`, a
+synthesis-owned symlink outside the client-owned caches, repointed
+atomically only after both clients verified the version and refused when
+the target is not a verified install root (`install.stable-path`);
+instruction files and scripts reference it instead of a version. And every
+`coordination.py` invocation from an engine older than the newest installed
+prints a one-line stderr notice naming the newer path, so staleness shows
+in output the agent is already reading — behavior otherwise unchanged.
+Tests pin the atomic repoint, the refusal of unverified or mismatched
+roots, the notice from an older cache, and its absence from the newest.
+
 ## [4.81.0] - 2026-09-01
 
 **The Slack sync preflight is a script, and the watermark gate's declared

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Pin a stable path, not a version (September 2026).** Release **4.82.0**
+adds `~/.synthesis/plugins/synthesis-skills/current`, maintained by the
+gated release and repointed only after both clients verify, and makes every
+coordination command announce when it is running from an engine older than
+the newest installed. See the [4.82.0 release notes](CHANGELOG.md).
+
 **Slack read targets are resolved by a script that fails closed
 (September 2026).** Release **4.81.0** ships the sync preflight: one read
 id per target from the config, id prefixes validated per class, a census

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,38 +1,32 @@
-# AGENT HEURISTIC: authored for the 4.81.0 Slack preflight transaction.
+# AGENT HEURISTIC: authored for the 4.82.0 stable-path and stale-engine-notice transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: slack-preflight-owns-target-resolution
+suite: stable-plugin-path-and-stale-engine-notice
 membership: closed
-production_entry_point: skills/synthesis-slack-sync/scripts/preflight.py
-enforcing_boundary: the preflight resolves one read id per declared target from the sync config, refuses user ids and wrong-class prefixes, prints a census, and writes the declared set the watermark gate consumes, failing closed on an empty set or a malformed config
+production_entry_point: skills/synthesis-skills-manager/scripts/release.py
+enforcing_boundary: the gated release repoints the synthesis-owned stable path only at a verified install root, and every coordination command announces an engine older than the newest installed
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the run against a real workspace config is recorded in the private session record only; whether the Slack API accepts G-prefixed group-DM ids in every workspace is not exercised here
+unverified_remainder: the live repoint of the real stable path happens in this release's own install phase and is proven by its receipt; instruction files outside this repository adopt the path in their own commits
 changed_surfaces:
-  - path: skills/synthesis-slack-sync/scripts/preflight.py
-    cases: [dm-read-id-is-the-conversation-id, user-id-refused, declared-set-feeds-the-gate, census-shows-shape, cli-fails-closed]
-  - path: skills/synthesis-slack-sync/scripts/test_preflight.py
-    cases: [dm-read-id-is-the-conversation-id, user-id-refused, declared-set-feeds-the-gate, census-shows-shape, cli-fails-closed, slack-doc-contract, rituals-doc-contract, ci-membership]
-  - path: skills/synthesis-slack-sync/SKILL.md
-    cases: [slack-doc-contract, slack-budget]
-  - path: skills/synthesis-slack-sync/references/version-history.md
-    cases: [slack-budget]
-  - path: skills/synthesis-daily-rituals/SKILL.md
-    cases: [rituals-doc-contract, rituals-budget]
-  - path: skills/synthesis-daily-rituals/references/version-history.md
-    cases: [rituals-budget]
-  - path: .github/workflows/validate.yml
-    cases: [ci-membership, ci-doc-parity]
-  - path: AGENTS.md
-    cases: [ci-membership, ci-doc-parity]
   - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [release-gate-membership]
+    cases: [stable-path-atomic-repoint, stable-path-refuses-unverified]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [release-gate-membership, ci-doc-parity]
+    cases: [stable-path-atomic-repoint, stable-path-refuses-unverified]
+  - path: skills/synthesis-skills-manager/SKILL.md
+    cases: [stable-path-doc-contract]
+  - path: skills/synthesis-project-management/scripts/coordination_schema.py
+    cases: [stale-engine-notice]
+  - path: skills/synthesis-project-management/scripts/coordination.py
+    cases: [stale-engine-notice]
+  - path: skills/synthesis-project-management/scripts/test_coordination.py
+    cases: [stale-engine-notice]
+  - path: skills/synthesis-project-management/references/session-identity.md
+    cases: [stable-path-doc-contract]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -44,54 +38,22 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: dm-read-id-is-the-conversation-id
+  - id: stable-path-atomic-repoint
     control_class: enforced-gate
-    fixture: ../synthesis-slack-sync/scripts/test_preflight.py::test_dms_resolve_to_the_conversation_id_never_the_user_id
-    motivating_defect: a-uniform-read-of-id-hands-user-ids-to-a-conversation-read-call-and-reports-quiet-empties
-  - id: user-id-refused
-    control_class: enforced-gate
-    fixture: ../synthesis-slack-sync/scripts/test_preflight.py::test_a_user_id_offered_as_a_conversation_id_is_refused
-    motivating_defect: a-user-id-in-a-read-set-is-always-a-bug-and-was-never-refused
-  - id: declared-set-feeds-the-gate
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_stable_path_points_at_the_verified_install_root
+    motivating_defect: a-versioned-cache-path-pinned-in-instructions-or-a-session-is-stale-by-the-next-release
+  - id: stable-path-refuses-unverified
     control_class: acceptance-test
-    fixture: ../synthesis-slack-sync/scripts/test_preflight.py::test_declared_set_is_the_shape_the_watermark_gate_takes
-    motivating_defect: a-hand-maintained-declared-set-is-a-second-source-of-truth-that-drifts-or-is-wrong-when-written
-  - id: census-shows-shape
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_stable_path_refuses_an_unverified_or_mismatched_root
+    motivating_defect: a-stable-path-that-can-point-at-an-unverified-tree-is-a-stale-path-with-a-better-name
+  - id: stale-engine-notice
     control_class: acceptance-test
-    fixture: ../synthesis-slack-sync/scripts/test_preflight.py::test_census_shows_the_shape
-    motivating_defect: a-wrong-derivation-showed-as-quiet-empties-instead-of-a-visibly-wrong-shape
-  - id: cli-fails-closed
-    control_class: acceptance-test
-    fixture: ../synthesis-slack-sync/scripts/test_preflight.py::test_cli_refuses_an_empty_resolved_set
-    motivating_defect: an-empty-resolved-set-reported-as-a-quiet-day-is-a-completeness-claim-with-no-evidence
-  - id: slack-doc-contract
-    control_class: acceptance-test
-    fixture: ../synthesis-slack-sync/scripts/test_preflight.py::test_slack_sync_names_the_preflight_command_and_census
-    motivating_defect: a-script-the-protocol-does-not-invoke-is-not-a-control
-  - id: rituals-doc-contract
-    control_class: acceptance-test
-    fixture: ../synthesis-slack-sync/scripts/test_preflight.py::test_rituals_take_the_declared_set_from_preflight
-    motivating_defect: a-gate-fed-by-a-stored-copy-goes-green-over-an-incomplete-sweep
-  - id: ci-membership
-    control_class: acceptance-test
-    fixture: ../synthesis-slack-sync/scripts/test_preflight.py::test_preflight_is_in_the_shared_ci_group
-    motivating_defect: tests-outside-the-ci-list-run-at-no-boundary
-  - id: ci-doc-parity
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_every_command_notes_a_newer_installed_engine
+    motivating_defect: a-session-kept-a-resolved-path-across-six-releases-and-nothing-in-its-output-said-so
+  - id: stable-path-doc-contract
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_agents_verification_list_matches_ci_workflow
-    motivating_defect: a-documented-check-list-that-ci-outgrew-fails-locally-green-branches
-  - id: release-gate-membership
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_required_checks_cover_ci_pytest_groups
-    motivating_defect: the-release-gate-skipped-two-test-groups-ci-runs-until-a-coverage-test-asked
-  - id: slack-budget
-    control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_slack_sync_skill_document_stays_within_repo_budget
-    motivating_defect: a-restructured-document-must-not-regrow-with-its-next-feature
-  - id: rituals-budget
-    control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_rituals_skill_document_stays_within_repo_budget
-    motivating_defect: a-restructured-document-must-not-regrow-with-its-next-feature
+    motivating_defect: a-path-nobody-is-told-to-pin-keeps-getting-pinned-by-version
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-project-management/references/session-identity.md
+++ b/skills/synthesis-project-management/references/session-identity.md
@@ -95,6 +95,13 @@ same, run the current engine's `coordination.py`. `doctor` reports the same
 line. Origin (2026-09-01): a session on an older cache read the freshly
 migrated v4 board and reported the board itself as corrupt.
 
+Since 4.82.0 every command also prints a one-line stderr notice whenever a
+newer engine is installed beside the one running (`note: this coordination
+engine is X but Y is installed; run <path>`), so a path resolved once and
+kept for hours shows its age in output the agent is already reading. The
+version-independent path to pin is `~/.synthesis/plugins/synthesis-skills/current`,
+maintained by the gated release (see synthesis-skills-manager).
+
 ## Collision boundary
 
 The UUID remains authoritative even if a human alias collision were ever

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -35,6 +35,7 @@ from coordination_schema import (
     column_count_error,
     display_id,
     engine_remedy,
+    newer_installed_engine,
     identity_lookup_keys,
     new_identity,
     selector_keys,
@@ -2315,9 +2316,30 @@ COMMANDS = {
 }
 
 
+def stale_engine_notice(script_path: Path | str = __file__) -> str | None:
+    """One line for stderr when this engine is older than the newest installed.
+
+    A session resolves a plugin path once and keeps it for hours while the
+    ecosystem ships several releases a day; the path goes stale by design of
+    the cadence, and nothing said so until a newer board broke the old
+    parser. The notice makes staleness visible in output an agent is already
+    reading, on every invocation, without changing the command's behavior."""
+    found = newer_installed_engine(script_path)
+    if found is None:
+        return None
+    running, newest, path = found
+    return (
+        f"note: this coordination engine is {running} but {newest} is installed; "
+        f"run {path} (or the stable path ~/.synthesis/plugins/synthesis-skills/current)"
+    )
+
+
 def main() -> int:
     args = parser().parse_args()
     args.board = args.board.expanduser()
+    notice = stale_engine_notice()
+    if notice:
+        print(notice, file=sys.stderr)
     command = COMMANDS.get(args.command, command_doctor)
     try:
         return command(args)

--- a/skills/synthesis-project-management/scripts/coordination_schema.py
+++ b/skills/synthesis-project-management/scripts/coordination_schema.py
@@ -310,6 +310,33 @@ def _version_key(name: str) -> tuple[int, ...]:
     return tuple(int(part) for part in name.split("."))
 
 
+def newer_installed_engine(script_path: Path | str) -> tuple[str, str, Path] | None:
+    """(running version, newest installed version, newest script path) when the
+    running script lives in a versioned plugin cache and a newer sibling
+    version carries the same script; None otherwise."""
+    script = Path(script_path).resolve()
+    version_dir = next(
+        (
+            parent
+            for parent in script.parents
+            if _VERSION_DIR.match(parent.name) and (parent / "skills").is_dir()
+        ),
+        None,
+    )
+    if version_dir is None:
+        return None
+    relative = script.relative_to(version_dir)
+    siblings = [
+        candidate
+        for candidate in version_dir.parent.iterdir()
+        if _VERSION_DIR.match(candidate.name) and (candidate / relative).is_file()
+    ]
+    newest = max(siblings, key=lambda candidate: _version_key(candidate.name))
+    if _version_key(newest.name) > _version_key(version_dir.name):
+        return version_dir.name, newest.name, newest / relative
+    return None
+
+
 def engine_remedy(script_path: Path | str) -> str:
     """Name the engine a stale script should hand off to.
 

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -1949,3 +1949,31 @@ def test_cli_presents_a_refusal_as_one_error_line(tmp_path):
     assert done.stderr.startswith("error: board declares schema v")
     assert "Traceback" not in done.stderr
 
+
+def test_every_command_notes_a_newer_installed_engine(tmp_path):
+    """The resolved-path foot-gun: a session keeps a versioned path for hours
+    while releases ship. Every invocation from an older cached engine now says
+    so on stderr, naming the newer path, without changing its behavior."""
+    cache = tmp_path / "plugins" / "synthesis-skills"
+    relative = Path("skills") / "synthesis-project-management" / "scripts"
+    older = cache / "4.80.0" / relative
+    older.mkdir(parents=True)
+    for name in ("coordination.py", "coordination_schema.py", "pointer_lock.py"):
+        (older / name).write_bytes((MODULE_PATH.parent / name).read_bytes())
+    newer = cache / "4.81.0" / relative
+    newer.mkdir(parents=True)
+    (newer / "coordination.py").write_text("#\n", encoding="utf-8")
+
+    done = subprocess.run(
+        [sys.executable, str(older / "coordination.py"), "--board", str(tmp_path / "board.md"), "doctor"],
+        capture_output=True, text=True, check=False,
+    )
+    assert "note: this coordination engine is 4.80.0 but 4.81.0 is installed" in done.stderr
+    assert str(newer / "coordination.py") in done.stderr
+
+    current = subprocess.run(
+        [sys.executable, str(MODULE_PATH), "--board", str(tmp_path / "board.md"), "doctor"],
+        capture_output=True, text=True, check=False,
+    )
+    assert "note: this coordination engine" not in current.stderr
+

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -332,6 +332,26 @@ The general rule this encodes, worth applying beyond releases: **when a
 verification asks a system to describe itself, verify the description against
 the artifact.** A self-report is a claim, not evidence.
 
+## The stable path — never pin a version
+
+Instruction files and long-lived sessions that pin a versioned cache path
+(`…/synthesis-skills/4.59.0/…`) go stale on the next release — on 2026-09-01
+a session on a months-old engine read the shared coordination board as
+corrupt, and a workspace's own day-start commands pinned a release twenty
+versions behind. The gated release therefore maintains a synthesis-owned,
+version-independent path:
+
+```
+~/.synthesis/plugins/synthesis-skills/current  ->  <the verified install root>
+```
+
+It lives outside the client-owned caches (which the clients replace on their
+own schedule), is repointed atomically by `release.py` only after both
+clients verified the version, and is refused when the target root is not a
+verified install (`install.stable-path`). Reference it from instruction
+files and scripts instead of a version; `--install-only` repoints it on a
+new machine. `SYNTHESIS_STABLE_PLUGIN_ROOT` overrides the parent for tests.
+
 ## The release train — one publisher at a time
 
 On 2026-09-01, two agent sessions releasing this repository in parallel

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -515,6 +515,56 @@ def plugin_cache_parent(client: str) -> Path:
     return installed_root(client, "0.0.0").parent
 
 
+STABLE_ROOT = Path(
+    os.environ.get("SYNTHESIS_STABLE_PLUGIN_ROOT", str(Path.home() / ".synthesis" / "plugins"))
+)
+
+
+def stable_path() -> Path:
+    """The version-independent path instruction files and sessions may pin.
+
+    Versioned cache paths go stale on the next release — a session on a
+    months-old engine read the shared board as corrupt on 2026-09-01, and the
+    personal workspace's own day-start commands pinned a release twenty
+    versions behind. The stable path is synthesis-owned, outside the
+    client-owned caches (which the clients replace on their own schedule),
+    and is repointed atomically only after both clients verified a version.
+    """
+    return STABLE_ROOT / PLUGIN_NAME / "current"
+
+
+def refresh_stable_path(
+    version: str, result: Result, dry_run: bool, *, target: Path | None = None
+) -> bool:
+    link = stable_path()
+    root = target or installed_root("claude", version)
+    if dry_run:
+        return result.add("install.stable-path", True, f"would point {link} -> {root}")
+    manifest = root / ".claude-plugin" / "plugin.json"
+    try:
+        installed = json.loads(manifest.read_text(encoding="utf-8"))["version"]
+    except (OSError, ValueError, KeyError) as exc:
+        return result.add(
+            "install.stable-path", False, f"{root} is not a verified install root: {exc}"
+        )
+    if installed != version:
+        return result.add(
+            "install.stable-path", False, f"{root} carries {installed}, expected {version}"
+        )
+    link.parent.mkdir(parents=True, exist_ok=True)
+    staging = link.with_name(link.name + ".tmp")
+    if staging.is_symlink() or staging.exists():
+        staging.unlink()
+    os.symlink(root, staging)
+    os.replace(staging, link)
+    resolved = Path(os.path.realpath(link))
+    return result.add(
+        "install.stable-path",
+        resolved == Path(os.path.realpath(root)),
+        f"{link} -> {root}",
+    )
+
+
 def _tree_digest(root: Path) -> str:
     """Hash recovery-owned paths and bytes, excluding client-managed metadata."""
     digest = hashlib.sha256()
@@ -1410,6 +1460,12 @@ def main(argv: list[str] | None = None) -> int:
             f"\nRELEASE INCOMPLETE for {version}: "
             f"{len(result.failed)} step(s) failed. The clients are NOT confirmed current — "
             "re-run with --install-only after fixing."
+        )
+        return 1
+    if not refresh_stable_path(version, result, args.dry_run):
+        print(
+            f"\nRELEASE INCOMPLETE for {version}: the stable path could not be "
+            "repointed at the verified install — re-run with --install-only."
         )
         return 1
     print(f"\nRELEASED {version}: published, installed, and verified on both clients.")

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -13,6 +13,7 @@ converts an unknown into a false assurance.
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -117,6 +118,44 @@ def test_first_json_handles_nested_arrays() -> None:
 
 def test_first_json_returns_empty_when_absent() -> None:
     assert release._first_json("no json here") == ""
+
+
+def _install_root(tmp_path: Path, version: str) -> Path:
+    root = tmp_path / "cache" / version
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"version": version}), encoding="utf-8"
+    )
+    return root
+
+
+def test_stable_path_points_at_the_verified_install_root(tmp_path, monkeypatch) -> None:
+    """Instruction files pin the stable path; it must follow every verified
+    release atomically and never point at an unverified tree."""
+    monkeypatch.setattr(release, "STABLE_ROOT", tmp_path / "plugins")
+    first = _install_root(tmp_path, "4.82.0")
+    assert release.refresh_stable_path("4.82.0", release.Result(), False, target=first)
+    link = release.stable_path()
+    assert link.is_symlink()
+    assert Path(os.path.realpath(link)) == first.resolve()
+
+    second = _install_root(tmp_path, "4.83.0")
+    assert release.refresh_stable_path("4.83.0", release.Result(), False, target=second)
+    assert Path(os.path.realpath(link)) == second.resolve()
+    assert not link.with_name(link.name + ".tmp").exists()
+
+
+def test_stable_path_refuses_an_unverified_or_mismatched_root(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(release, "STABLE_ROOT", tmp_path / "plugins")
+    bare = tmp_path / "cache" / "4.82.0"
+    bare.mkdir(parents=True)
+    result = release.Result()
+    assert not release.refresh_stable_path("4.82.0", result, False, target=bare)
+    assert not release.stable_path().exists()
+
+    other = _install_root(tmp_path, "4.81.0")
+    assert not release.refresh_stable_path("4.82.0", release.Result(), False, target=other)
+    assert not release.stable_path().exists()
 
 
 def test_required_checks_do_not_depend_on_shell_glob_expansion() -> None:


### PR DESCRIPTION
## Summary

Versioned cache paths go stale on the next release. Today a session that resolved `coordination.py` once and kept the path for four hours crossed six releases and read the migrated board with a parser that could not know it; the personal workspace's own day-start commands pinned a release twenty versions behind.

- **Stable path.** `release.py` maintains `~/.synthesis/plugins/synthesis-skills/current` — synthesis-owned, outside the client-owned caches the clients replace on their own schedule — repointed atomically (staging symlink + `os.replace`) only after both clients verified the version, and refused (`install.stable-path`) when the target root is not a verified install or carries a different version. `--install-only` repoints it on a new machine; `SYNTHESIS_STABLE_PLUGIN_ROOT` overrides the parent for tests. Documented in the skills-manager SKILL.md ("The stable path — never pin a version").
- **Stale-engine notice.** Every `coordination.py` invocation from an engine older than the newest installed sibling prints one stderr line naming the newer path (`newer_installed_engine` in `coordination_schema.py`, shared with `engine_remedy`), so staleness shows in output the agent is already reading; behavior otherwise unchanged. Documented in the project-management session-identity reference beside the 4.78.0 skew refusal.
- Release surfaces at 4.82.0 with a fresh acceptance manifest.

## Verification

- `test_release.py`: atomic repoint across two versions with no staging leftover; refusal of a bare root and of a version-mismatched root (67 → 69 tests)
- `test_coordination.py`: a copied older engine in a fake cache prints the notice naming the newer path; the source engine prints none (113 tests)
- Full AGENTS.md verification list green locally; conformance source 204/204; skills-manager SKILL.md 434 lines, project-management SKILL.md 498

🤖 Generated with [Claude Code](https://claude.com/claude-code)
