### PR TITLE
Require read freshness on grounding-ledger claims about unanswered or unsent state (4.83.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.82.0",
+  "version": "4.83.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.82.0",
+  "version": "4.83.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.83.0] - 2026-09-01
+
+**Grounding-ledger claims about what is unanswered or unsent must say when
+the source was read.** The guard's ledger mapped every factual claim to a
+source but not to a moment, so a claim that a question was "still
+unanswered" — resting on a read eight hours old while the answer had gone
+out that morning — passed as verified on 2026-09-01. A false receipt in the
+layer built to stop exactly that is worse than no receipt. message-guard
+1.5.0 adds a config-adopted currency lane: claims whose text matches
+`currency_claim_patterns` (unanswered, unsent, no reply, still open, has
+not responded) must carry `read_at`, and the send is blocked when it is
+missing or older than `currency_claim_max_age_minutes`; stable facts need
+none; the ledger template shows the field; the doctor reports the lane.
+Six tests pin refusal without `read_at`, refusal on a stale read, pass on
+a fresh one, pass for a stable fact, and the lane staying off until
+adopted.
+
 ## [4.82.0] - 2026-09-01
 
 **A stable plugin path, and every coordination command says when it is

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**An "unanswered" claim now has to say when you last looked (September
+2026).** Release **4.83.0** adds a config-adopted currency lane to the
+message guard: claims about what is unanswered, unsent, or still open must
+carry a fresh `read_at`, or the send is blocked. See the [4.83.0 release
+notes](CHANGELOG.md).
+
 **Pin a stable path, not a version (September 2026).** Release **4.82.0**
 adds `~/.synthesis/plugins/synthesis-skills/current`, maintained by the
 gated release and repointed only after both clients verify, and makes every

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,32 +1,26 @@
-# AGENT HEURISTIC: authored for the 4.82.0 stable-path and stale-engine-notice transaction.
+# AGENT HEURISTIC: authored for the 4.83.0 message-guard read-freshness transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: stable-plugin-path-and-stale-engine-notice
+suite: currency-claims-carry-read-freshness
 membership: closed
-production_entry_point: skills/synthesis-skills-manager/scripts/release.py
-enforcing_boundary: the gated release repoints the synthesis-owned stable path only at a verified install root, and every coordination command announces an engine older than the newest installed
+production_entry_point: skills/synthesis-message-guard/scripts/message_guard.py
+enforcing_boundary: with the lane adopted, the pre-send gate blocks any ledger claim about an unanswered, unsent, or still-open state whose read_at is missing or older than the configured maximum
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the live repoint of the real stable path happens in this release's own install phase and is proven by its receipt; instruction files outside this repository adopt the path in their own commits
+unverified_remainder: adoption in a private config is an operator act recorded in the session log; the default pattern list is a starting vocabulary, not a complete taxonomy of currency claims
 changed_surfaces:
-  - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [stable-path-atomic-repoint, stable-path-refuses-unverified]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [stable-path-atomic-repoint, stable-path-refuses-unverified]
-  - path: skills/synthesis-skills-manager/SKILL.md
-    cases: [stable-path-doc-contract]
-  - path: skills/synthesis-project-management/scripts/coordination_schema.py
-    cases: [stale-engine-notice]
-  - path: skills/synthesis-project-management/scripts/coordination.py
-    cases: [stale-engine-notice]
-  - path: skills/synthesis-project-management/scripts/test_coordination.py
-    cases: [stale-engine-notice]
-  - path: skills/synthesis-project-management/references/session-identity.md
-    cases: [stable-path-doc-contract]
+  - path: skills/synthesis-message-guard/scripts/message_guard.py
+    cases: [missing-read-at-refused, stale-read-refused, fresh-read-passes, stable-fact-exempt, lane-off-until-adopted]
+  - path: skills/synthesis-message-guard/scripts/test_message_guard.py
+    cases: [missing-read-at-refused, stale-read-refused, fresh-read-passes, stable-fact-exempt, lane-off-until-adopted, template-carries-read-at]
+  - path: skills/synthesis-message-guard/patterns.example.json
+    cases: [lane-off-until-adopted]
+  - path: skills/synthesis-message-guard/SKILL.md
+    cases: [template-carries-read-at]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -38,22 +32,30 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: stable-path-atomic-repoint
+  - id: missing-read-at-refused
     control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_stable_path_points_at_the_verified_install_root
-    motivating_defect: a-versioned-cache-path-pinned-in-instructions-or-a-session-is-stale-by-the-next-release
-  - id: stable-path-refuses-unverified
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_currency_claim_without_read_at_is_refused
+    motivating_defect: a-still-unanswered-claim-resting-on-an-eight-hour-old-read-passed-as-verified
+  - id: stale-read-refused
+    control_class: enforced-gate
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_currency_claim_with_a_stale_read_is_refused
+    motivating_defect: a-read-from-earlier-today-is-a-statement-about-the-past
+  - id: fresh-read-passes
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_stable_path_refuses_an_unverified_or_mismatched_root
-    motivating_defect: a-stable-path-that-can-point-at-an-unverified-tree-is-a-stale-path-with-a-better-name
-  - id: stale-engine-notice
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_currency_claim_with_a_fresh_read_passes
+    motivating_defect: a-gate-that-blocks-fresh-reads-trains-bypass
+  - id: stable-fact-exempt
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_every_command_notes_a_newer_installed_engine
-    motivating_defect: a-session-kept-a-resolved-path-across-six-releases-and-nothing-in-its-output-said-so
-  - id: stable-path-doc-contract
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_a_stable_fact_needs_no_read_at
+    motivating_defect: taxing-every-claim-for-a-defect-in-currency-claims-adds-friction-without-safety
+  - id: lane-off-until-adopted
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_agents_verification_list_matches_ci_workflow
-    motivating_defect: a-path-nobody-is-told-to-pin-keeps-getting-pinned-by-version
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_currency_lane_is_off_until_adopted
+    motivating_defect: a-lane-that-switches-on-by-surprise-blocks-configs-that-never-declared-it
+  - id: template-carries-read-at
+    control_class: acceptance-test
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_ledger_template_carries_read_at
+    motivating_defect: a-field-the-template-does-not-show-is-a-field-nobody-fills
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-message-guard/SKILL.md
+++ b/skills/synthesis-message-guard/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-agent-correspondence"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.3.0"
+  version: "1.5.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -107,6 +107,29 @@ message bus. An unreadable board blocks (fail closed). Unadopted instances
 keep the old posture — inter-session tools stay in `exempt_tool_patterns` —
 and the doctor says which posture is live. Requires the tool's PreToolUse
 wiring to route these calls to the guard; the doctor checks that too.
+
+## Currency claims carry read freshness (config-adopted, v1.5.0)
+
+A claim such as "still unanswered", "unsent", or "no reply yet" is a
+statement about NOW that rests on a read taken at some moment. The ledger
+recorded WHERE such a claim came from but not WHEN the source was read, so
+on 2026-09-01 a "still unanswered by the principal" claim resting on a read
+eight hours old passed as verified while the answer had gone out that
+morning — a false receipt in the layer built to stop exactly that.
+
+Adopt the lane by adding to the config:
+
+```json
+"currency_claim_patterns": ["\\b(unanswered|unsent|not (yet )?(replied|responded|answered|sent)|no (reply|response|answer)( yet)?|still (open|waiting|pending|unanswered)|has(n't| not) (replied|responded|answered|sent))\\b"],
+"currency_claim_max_age_minutes": 30
+```
+
+With it adopted, every `claims[]` entry whose text matches a pattern must
+carry `read_at` (ISO-8601, the moment the source was read THIS run), and
+the send is blocked when `read_at` is missing or older than the maximum —
+the remedy is to re-read the source and refresh it. Stable facts ("PR 96
+merged") need no `read_at`. Without the keys the lane is off and the doctor
+says so. `--ledger-template` shows the field.
 
 ## The ledger contract
 

--- a/skills/synthesis-message-guard/patterns.example.json
+++ b/skills/synthesis-message-guard/patterns.example.json
@@ -27,5 +27,9 @@
   ],
   "doctor_clean_controls": [
     "Thanks for the note. I reviewed the full thread and can meet Tuesday at 10."
-  ]
+  ],
+  "currency_claim_patterns": [
+    "\\b(unanswered|unsent|not (yet )?(replied|responded|answered|sent)|no (reply|response|answer)( yet)?|still (open|waiting|pending|unanswered)|has(n't| not) (replied|responded|answered|sent))\\b"
+  ],
+  "currency_claim_max_age_minutes": 30
 }

--- a/skills/synthesis-message-guard/scripts/message_guard.py
+++ b/skills/synthesis-message-guard/scripts/message_guard.py
@@ -51,7 +51,7 @@ import tempfile
 import time
 from datetime import datetime, timezone
 
-ENGINE_VERSION = "1.4.0"
+ENGINE_VERSION = "1.5.0"
 
 
 def config_path():
@@ -82,6 +82,42 @@ def log_path():
 REQUIRED_CONFIG_KEYS = ("gated_tool_patterns", "exempt_tool_patterns",
                         "block_patterns", "warn_patterns",
                         "ledger_max_age_minutes", "text_field_candidates")
+
+
+DEFAULT_CURRENCY_PATTERN = (
+    r"\b(unanswered|unsent|not (yet )?(replied|responded|answered|sent)|"
+    r"no (reply|response|answer)( yet)?|still (open|waiting|pending|unanswered)|"
+    r"has(n't| not) (replied|responded|answered|sent))\b"
+)
+
+
+def currency_config(cfg):
+    """The read-freshness lane, or None when the config has not adopted it.
+
+    A claim like "still unanswered" is a statement about NOW that rests on a
+    read taken at some moment; the ledger recorded the source but not when
+    it was read, so a claim resting on an eight-hour-old read passed as
+    verified on 2026-09-01 while the answer had gone out that morning.
+    Adopt with `currency_claim_patterns` (regexes that mark a claim as a
+    currency claim) and `currency_claim_max_age_minutes`."""
+    patterns = cfg.get("currency_claim_patterns")
+    if not isinstance(patterns, list) or not patterns:
+        return None
+    return {
+        "patterns": [re.compile(p, re.IGNORECASE) for p in patterns],
+        "max_age": float(cfg.get("currency_claim_max_age_minutes", 30)),
+    }
+
+
+def minutes_since(value):
+    """Minutes elapsed since an ISO-8601 moment, or None when unparseable."""
+    try:
+        ts = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - ts).total_seconds() / 60.0
 
 
 def load_config():
@@ -278,12 +314,27 @@ def validate_ledger(ledger, text, cfg, tool_name):
                 "local transcripts) and record each query and where it ran.")
 
     claims = ledger.get("claims")
+    currency = currency_config(cfg)
     if ledger.get("no_factual_claims") is True:
         pass
     elif isinstance(claims, list) and claims:
         for i, c in enumerate(claims):
             if not (isinstance(c, dict) and c.get("claim") and c.get("source")):
                 fails.append("claims[%d] must have non-empty claim and source" % i)
+                continue
+            if currency and any(rx.search(str(c["claim"])) for rx in currency["patterns"]):
+                age = minutes_since(c.get("read_at"))
+                snippet = str(c["claim"])[:60]
+                if age is None:
+                    fails.append(
+                        "claims[%d] asserts a currency state (%r) but has no read_at — "
+                        "re-read the source THIS RUN and record when (ISO-8601). A read "
+                        "from earlier today is a statement about the past." % (i, snippet))
+                elif age > currency["max_age"]:
+                    fails.append(
+                        "claims[%d] rests on a read %.0f min old (max %.0f for currency "
+                        "claims: %r) — re-read the source and refresh read_at."
+                        % (i, age, currency["max_age"], snippet))
     else:
         fails.append(
             "ledger needs a claims[] array mapping every factual claim to its "
@@ -633,6 +684,18 @@ def run_doctor():
                "not adopted; adopt it to gate peer sends on board "
                "registration)")
 
+    currency_cfg = currency_config(cfg)
+    if currency_cfg:
+        stale_probe = any(rx.search("still unanswered by the recipient")
+                          for rx in currency_cfg["patterns"])
+        report(stale_probe, "currency-claim freshness lane adopted (unanswered/unsent "
+               "claims must carry a fresh read_at)",
+               "max age %.0f min" % currency_cfg["max_age"])
+    else:
+        report(True, "currency-claim freshness lane not adopted (adopt "
+               "currency_claim_patterns + currency_claim_max_age_minutes to gate "
+               "unanswered/unsent claims on read freshness)", "informational")
+
     client_configs = [
         (
             "Claude Code",
@@ -842,7 +905,7 @@ def main():
             "is_reply": True,
             "thread_fully_read": {"how": "<tool used>", "source_ids": []},
             "history_searched": [{"query": "", "where": "", "results": ""}],
-            "claims": [{"claim": "", "source": ""}],
+            "claims": [{"claim": "", "source": "", "read_at": "<ISO-8601 moment the source was read this run; required for unanswered/unsent/still-open claims>"}],
             "no_factual_claims": False,
             "voice_rules_pass": False,
             "invented_precision_scan": False,

--- a/skills/synthesis-message-guard/scripts/test_message_guard.py
+++ b/skills/synthesis-message-guard/scripts/test_message_guard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -294,3 +295,81 @@ def test_peer_other_tools_stay_in_correspondence_lane(tmp_path: Path) -> None:
         peer_cfg(board),
     )
     assert (handled, fails) == (False, [])
+
+
+# --- currency claims carry read freshness (v1.5.0) ----------------------------------------------
+
+CURRENCY_CFG = {
+    "ledger_max_age_minutes": 30,
+    "currency_claim_patterns": [MODULE.DEFAULT_CURRENCY_PATTERN],
+    "currency_claim_max_age_minutes": 30,
+}
+PLAIN_CFG = {"ledger_max_age_minutes": 30}
+TEXT = "Following up on the deploy question from this morning."
+
+
+def _ledger(claims: list[dict]) -> dict:
+    return {
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "message_sha256": MODULE.sha256_text(TEXT),
+        "is_reply": False,
+        "claims": claims,
+        "voice_rules_pass": True,
+        "invented_precision_scan": True,
+        "recipient_address_check": True,
+    }
+
+
+def _moment(minutes_ago: float) -> str:
+    return (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).isoformat()
+
+
+def test_currency_claim_without_read_at_is_refused() -> None:
+    """The 2026-09-01 failure: 'still unanswered' rested on a read eight hours
+    old, and the ledger could not tell because it recorded where, not when."""
+    ledger = _ledger([{"claim": "Jordan's question is still unanswered", "source": "DM D0EXAMPLE"}])
+
+    fails = MODULE.validate_ledger(ledger, TEXT, CURRENCY_CFG, "mcp__x__send_gmail_message")
+
+    assert any("read_at" in f and "currency state" in f for f in fails), fails
+
+
+def test_currency_claim_with_a_stale_read_is_refused() -> None:
+    ledger = _ledger([{"claim": "no reply from Jordan yet", "source": "DM D0EXAMPLE",
+                       "read_at": _moment(8 * 60)}])
+
+    fails = MODULE.validate_ledger(ledger, TEXT, CURRENCY_CFG, "mcp__x__send_gmail_message")
+
+    assert any("min old" in f for f in fails), fails
+
+
+def test_currency_claim_with_a_fresh_read_passes() -> None:
+    ledger = _ledger([{"claim": "no reply from Jordan yet", "source": "DM D0EXAMPLE",
+                       "read_at": _moment(5)}])
+
+    fails = MODULE.validate_ledger(ledger, TEXT, CURRENCY_CFG, "mcp__x__send_gmail_message")
+
+    assert not [f for f in fails if "claims[" in f], fails
+
+
+def test_a_stable_fact_needs_no_read_at() -> None:
+    ledger = _ledger([{"claim": "PR 96 merged this afternoon", "source": "gh pr view 96"}])
+
+    fails = MODULE.validate_ledger(ledger, TEXT, CURRENCY_CFG, "mcp__x__send_gmail_message")
+
+    assert not [f for f in fails if "claims[" in f], fails
+
+
+def test_currency_lane_is_off_until_adopted() -> None:
+    ledger = _ledger([{"claim": "Jordan's question is still unanswered", "source": "DM D0EXAMPLE"}])
+
+    fails = MODULE.validate_ledger(ledger, TEXT, PLAIN_CFG, "mcp__x__send_gmail_message")
+
+    assert not [f for f in fails if "read_at" in f], fails
+
+
+def test_ledger_template_carries_read_at() -> None:
+    template = MODULE.ledger_template() if hasattr(MODULE, "ledger_template") else None
+    text = json.dumps(template) if template is not None else MODULE_PATH.read_text(encoding="utf-8")
+    assert "read_at" in text
+


### PR DESCRIPTION
## Summary

The guard's grounding ledger maps every factual claim to a source but not to a moment. On 2026-09-01 a claim that a question was "still unanswered" — resting on a read eight hours old while the answer had gone out that morning — passed as verified. A false receipt in the layer built to stop exactly that is worse than no receipt.

- **message-guard 1.5.0, config-adopted currency lane.** With `currency_claim_patterns` and `currency_claim_max_age_minutes` in the config, every `claims[]` entry whose text matches a pattern (unanswered, unsent, no reply, still open, has not responded) must carry `read_at` (ISO-8601, the moment the source was read this run); the send is blocked when it is missing or older than the maximum, with a remedy naming the claim. Stable facts need no `read_at`. Without the keys the lane is off and the doctor says so; `--ledger-template` shows the field; `patterns.example.json` carries the default vocabulary.
- SKILL.md gains the lane's section; frontmatter version catches up from a stale 1.3.0. Release surfaces at 4.83.0 with a fresh acceptance manifest.

## Verification

- `test_message_guard.py`: refusal without `read_at`, refusal on an eight-hour-old read, pass on a five-minute-old read, pass for a stable fact, lane off until adopted, template carries the field (19 → 25 tests)
- context-lifecycle, implementation-integrity, and release suites green; conformance source 204/204; guard SKILL.md 217 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
