### PR TITLE
Read installed manifests in daily parity; make the guard's clean control a signed message (4.88.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.87.0",
+  "version": "4.88.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.87.0",
+  "version": "4.88.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.88.0] - 2026-09-02
+
+**Two old coordination-board asks closed.** (1) Daily parity now reads each
+client's installed manifest on disk beside the CLI report
+(`parity.<client>-on-disk`, agent-conformance 1.7.0). The ask from
+2026-08-17: parity had stayed green while the Codex tree the client loaded
+sat three releases behind, because the CLI reported the version it intended
+to serve — a self-report is a claim, not evidence. The tree for the reported
+version must exist and its own manifest must carry that version; tests pin
+a report with no tree and a tree whose manifest disagrees. (2) The message
+guard's built-in known-clean doctor control is now a canonical SIGNED agent
+message in Slack wire form, and the example config's `doctor_clean_controls`
+carries it (message-guard 1.6.0). The ask from 2026-08-03: a generic clean
+control passed while a retired-branding pattern compiled under IGNORECASE
+blocked every real signed send. Tests pin that the over-broad pattern now
+trips the control and the scoped fix passes it, and that every example
+clean control passes the example patterns.
+
 ## [4.87.0] - 2026-09-02
 
 **`synthesis-quick-answers` (v1.2.0) now bootstraps and wires itself into the standard workspace convention instead of assuming it or inventing a substitute.** First real colleague adoption surfaced two gaps in the same session: the skill's Setup section assumed a personal knowledge workspace already existed, which isn't true for someone who just installed the plugin — and the "automatic, no reminder needed" property the pattern promises was never actually encoded as a step, so it depended on whoever set it up remembering to wire it in by hand. Fixed by making Setup self-contained: step 1 now calls `synthesis-onboarding`'s `onboard.py init-workspace` to scaffold `~/workspaces/{workspace}/ai-knowledge-{workspace}/` when it's missing (new `depends_on: synthesis-onboarding`), and step 4 makes explicit what was previously left implicit — a single routing line in the workspace's own `AGENTS.md`/`CLAUDE.md` is the entire mechanism that makes every future session apply the skill without being told. A companion set up under the old Setup section still worked, it just required the setter-upper to already know this; now the skill says so.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ carries it (message-guard 1.6.0). The ask from 2026-08-03: a generic clean
 control passed while a retired-branding pattern compiled under IGNORECASE
 blocked every real signed send. Tests pin that the over-broad pattern now
 trips the control and the scoped fix passes it, and that every example
-clean control passes the example patterns.
+clean control passes the example patterns. The doctor's leftover
+single-slot-ledger finding now names the file's `created_at`, channel, and
+recipient, so the seat whose helper script wrote it can recognise it
+(2026-09-02: one seat's stale scaffolding kept the machine-wide signal red).
 
 ## [4.87.0] - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**A self-report is a claim, not evidence (September 2026).** Release
+**4.88.0** makes daily parity read each client's installed manifest on disk
+beside the CLI report, and makes the message guard's clean doctor control a
+canonical signed message so a pattern that blocks real signed sends fails
+the doctor. See the [4.88.0 release notes](CHANGELOG.md).
+
 **The stable plugin path is checked every morning (September 2026).**
 Release **4.85.1** creates both new state stores private (0600/0700).
 Release **4.85.0** replaces two shared single-slot state files with

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.6.1"
+  version: "1.7.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -152,6 +152,9 @@ python3 scripts/conformance.py all \
 
 Fix every failed required check. Record genuine client-owned differences as
 boundaries with evidence; do not report parity from matching inventories alone.
+Since 1.7.0 parity also reads each client's installed manifest on disk beside
+the CLI report (`parity.<client>-on-disk`): a self-report is a claim, not
+evidence — it once stayed green while the loaded tree sat three releases behind.
 
 ## Lifecycle hooks
 

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -686,6 +686,46 @@ def stable_path_check(checks: list[Check], home: Path | None, installed: str | N
         f"{link} -> {target.name} (pointer {version}; claude installed {installed})")
 
 
+def installed_cache_root(client: str, version: str, home: Path | None = None) -> Path | None:
+    """The client's cache tree for one version, under whichever marketplace holds it."""
+    base = _client_config_dir(client, home) / "plugins" / "cache"
+    if not base.is_dir():
+        return None
+    for marketplace in sorted(base.iterdir()):
+        found = _plugin_cache_path(base.parent.parent, version, marketplace.name)
+        if found is not None:
+            return found
+    return None
+
+
+def on_disk_check(
+    checks: list[Check], client: str, reported: str | None, home: Path | None
+) -> None:
+    """A self-report is a claim, not evidence (board ask, 2026-08-17): parity
+    once passed green while the Codex tree it loaded sat three releases
+    behind, because the CLI reported the version it intended to serve. The
+    tree the client loads must exist for the reported version and its own
+    manifest must carry that version."""
+    name = f"parity.{client}-on-disk"
+    if reported is None:
+        add(checks, name, False, "no reported version to verify on disk")
+        return
+    root = installed_cache_root(client, reported, home)
+    if root is None:
+        add(checks, name, False,
+            f"{client} reports {reported} but no plugin cache tree carries that version")
+        return
+    manifest_dir = ".claude-plugin" if client == "claude" else ".codex-plugin"
+    manifest = root / manifest_dir / "plugin.json"
+    try:
+        version = str(json.loads(manifest.read_text(encoding="utf-8")).get("version"))
+    except (OSError, ValueError):
+        add(checks, name, False, f"{root} has no readable {manifest_dir}/plugin.json")
+        return
+    add(checks, name, version == reported,
+        f"{root.name}: manifest {version}, reported {reported}")
+
+
 def parity_checks(source_root: Path, home: Path | None = None) -> list[Check]:
     """Dual-client version-drift detection against enabled inventories.
 
@@ -746,6 +786,9 @@ def parity_checks(source_root: Path, home: Path | None = None) -> list[Check]:
             version
             or f"no single enabled {PLUGIN_NAME} installation reported by {client}",
         )
+
+    for client, version in installed.items():
+        on_disk_check(checks, client, version, home)
 
     both = all(installed.values())
     add(

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -87,6 +87,13 @@ def stable_pointer(link: Path, version: str) -> Path:
     return root
 
 
+def cache_tree(root: Path) -> Path:
+    """A fake installed cache tree: both manifest dirs present, then manifests."""
+    root.mkdir(parents=True, exist_ok=True)
+    write_manifests(root)
+    return root
+
+
 def write_manifests(root: Path) -> None:
     payload = json.dumps(
         {
@@ -1893,8 +1900,8 @@ def test_parity_uses_configured_client_homes(tmp_path: Path, monkeypatch) -> Non
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
     for client_home in (codex_home, claude_home):
-        (client_home / "plugins" / "cache" / "market" / "synthesis-skills" / "1.0.0").mkdir(
-            parents=True
+        cache_tree(
+            client_home / "plugins" / "cache" / "market" / "synthesis-skills" / "1.0.0"
         )
 
     class Result:
@@ -1970,6 +1977,9 @@ def test_parity_uses_enabled_inventory_not_newest_cache(
             / "synthesis-skills"
             / "9.9.9"
         ).mkdir(parents=True)
+        cache_tree(
+            tmp_path / f".{client}" / "plugins" / "cache" / "market" / "synthesis-skills" / "1.0.0"
+        )
 
     class Result:
         returncode = 0

--- a/skills/synthesis-agent-conformance/scripts/test_parity.py
+++ b/skills/synthesis-agent-conformance/scripts/test_parity.py
@@ -56,6 +56,16 @@ class ParityTests(unittest.TestCase):
         link.symlink_to(root)
         return root
 
+    def cache_root(self, client: str, version: str, manifest_version: str | None = None) -> Path:
+        """A fake installed cache tree for one client, with its own manifest."""
+        root = self.home / f".{client}" / "plugins" / "cache" / "market" / MODULE.PLUGIN_NAME / version
+        manifest_dir = ".claude-plugin" if client == "claude" else ".codex-plugin"
+        (root / manifest_dir).mkdir(parents=True, exist_ok=True)
+        (root / manifest_dir / "plugin.json").write_text(
+            json.dumps({"version": manifest_version or version})
+        )
+        return root
+
     def checks(self, claude: str | None, codex: str | None):
         versions = {"claude": claude, "codex": codex}
         with patch.object(
@@ -67,6 +77,8 @@ class ParityTests(unittest.TestCase):
 
     def test_everything_current_passes(self):
         self.stable("4.13.0")
+        self.cache_root("claude", "4.13.0")
+        self.cache_root("codex", "4.13.0")
         ok = by_name(self.checks("4.13.0", "4.13.0"))
         self.assertTrue(all(ok.values()), ok)
 
@@ -88,6 +100,24 @@ class ParityTests(unittest.TestCase):
         self.stable("4.12.0")
         ok = by_name(self.checks("4.13.0", "4.13.0"))
         self.assertFalse(ok["parity.stable-path"])
+
+    def test_reported_version_without_a_cache_tree_fails_on_disk(self):
+        """The 2026-08-17 defect: the CLI reports the version it intends to
+        serve while no tree for it exists on disk."""
+        self.stable("4.13.0")
+        self.cache_root("claude", "4.13.0")
+        ok = by_name(self.checks("4.13.0", "4.13.0"))
+        self.assertTrue(ok["parity.codex-installed"])
+        self.assertFalse(ok["parity.codex-on-disk"])
+        self.assertTrue(ok["parity.claude-on-disk"])
+
+    def test_cache_manifest_disagreeing_with_the_report_fails_on_disk(self):
+        self.stable("4.13.0")
+        self.cache_root("claude", "4.13.0")
+        self.cache_root("codex", "4.13.0", manifest_version="4.12.0")
+        ok = by_name(self.checks("4.13.0", "4.13.0"))
+        self.assertFalse(ok["parity.codex-on-disk"])
+        self.assertTrue(ok["parity.claude-on-disk"])
 
     def test_one_client_behind_fails_match_and_current(self):
         ok = by_name(self.checks("4.13.0", "4.12.0"))

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,26 +1,34 @@
-# AGENT HEURISTIC: authored for the 4.87.0 quick-answers-self-bootstrap transaction.
+# AGENT HEURISTIC: authored for the 4.88.0 transaction closing two coordination-board asks.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: quick-answers-self-bootstrap-and-quiet-onboarding
+suite: board-asks-on-disk-parity-and-canonical-clean-control
 membership: closed
-production_entry_point: skills/synthesis-quick-answers/SKILL.md
-enforcing_boundary: synthesis-quick-answers's Setup section now bootstraps a missing personal knowledge workspace itself (via synthesis-onboarding's onboard.py init-workspace) and states the AGENTS.md/CLAUDE.md routing line as the explicit mechanism that makes the pattern automatic, rather than assuming both; onboard.py's plugin-update messages read as plain human status rather than internal agent-protocol jargon; and the CLI's asymmetric single-client behavior (Claude present without Codex, or the reverse) is proven correct by executable tests rather than asserted from a read of the code
+production_entry_point: skills/synthesis-agent-conformance/scripts/conformance.py
+enforcing_boundary: daily parity fails when a client's reported version has no cache tree on disk or a tree whose manifest disagrees, and the guard doctor fails when a pattern blocks the canonical signed message
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the onboarding CLI's other front door — a downstream organization's own install.sh wrapper, whose git pull/clone calls were the actual source of the diffstat wall a live colleague hit — is a separate private repo outside this one's acceptance boundary; that fix is tracked and shipped there, not verified here
+unverified_remainder: the live parity and doctor runs on this machine after install are quoted in the release record; a marketplace snapshot directory that the client consults but that is not its cache tree remains covered by the release's own verification, not by the daily check
 changed_surfaces:
-  - path: skills/synthesis-quick-answers/SKILL.md
-    cases: [quick-answers-self-bootstrap]
-  - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [quick-answers-self-bootstrap, dual-client-graceful-degradation]
-  - path: skills/synthesis-onboarding/scripts/test_onboard.py
-    cases: [dual-client-graceful-degradation]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [quick-answers-self-bootstrap]
+  - path: skills/synthesis-agent-conformance/scripts/conformance.py
+    cases: [on-disk-report-without-tree, on-disk-manifest-disagrees, parity-current]
+  - path: skills/synthesis-agent-conformance/scripts/test_parity.py
+    cases: [on-disk-report-without-tree, on-disk-manifest-disagrees, parity-current]
+  - path: skills/synthesis-agent-conformance/scripts/test_conformance.py
+    cases: [parity-current]
+  - path: skills/synthesis-agent-conformance/SKILL.md
+    cases: [parity-current]
+  - path: skills/synthesis-message-guard/scripts/message_guard.py
+    cases: [clean-control-is-signed, over-broad-pattern-trips-control, example-controls-pass]
+  - path: skills/synthesis-message-guard/scripts/test_message_guard.py
+    cases: [clean-control-is-signed, over-broad-pattern-trips-control, example-controls-pass]
+  - path: skills/synthesis-message-guard/patterns.example.json
+    cases: [example-controls-pass]
+  - path: skills/synthesis-message-guard/SKILL.md
+    cases: [clean-control-is-signed]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -29,15 +37,33 @@ changed_surfaces:
     cases: [release-manifest-parity]
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
+  - path: README.md
+    cases: [release-changelog-parity]
 cases:
-  - id: quick-answers-self-bootstrap
+  - id: on-disk-report-without-tree
+    control_class: enforced-gate
+    fixture: ../synthesis-agent-conformance/scripts/test_parity.py::ParityTests::test_reported_version_without_a_cache_tree_fails_on_disk
+    motivating_defect: parity-stayed-green-while-the-loaded-codex-tree-sat-three-releases-behind-the-reported-version
+  - id: on-disk-manifest-disagrees
+    control_class: enforced-gate
+    fixture: ../synthesis-agent-conformance/scripts/test_parity.py::ParityTests::test_cache_manifest_disagreeing_with_the_report_fails_on_disk
+    motivating_defect: a-tree-that-exists-but-carries-another-version-is-the-same-stale-load-with-a-directory-name
+  - id: parity-current
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_quick_answers_self_bootstrap_release_contract_is_public_and_coherent
-    motivating_defect: a-setup-procedure-that-assumes-infrastructure-the-reader-does-not-have-yet-strands-the-first-real-adopter-and-a-pattern-that-never-states-its-own-automatic-mechanism-degrades-into-manual-invocation-with-extra-steps
-  - id: dual-client-graceful-degradation
+    fixture: ../synthesis-agent-conformance/scripts/test_parity.py::ParityTests::test_everything_current_passes
+    motivating_defect: a-check-that-cannot-pass-on-a-healthy-machine-trains-bypass
+  - id: clean-control-is-signed
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_ecosystem_phase_only_touches_the_present_client
-    motivating_defect: an-installer-that-crashes-or-misreports-when-only-one-of-two-supported-clients-is-present-fails-the-common-case-not-the-edge-case
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_builtin_clean_control_is_a_canonical_signed_message
+    motivating_defect: a-generic-clean-control-passed-while-every-real-signed-send-was-blocked
+  - id: over-broad-pattern-trips-control
+    control_class: enforced-gate
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_over_broad_retired_branding_pattern_trips_the_clean_control
+    motivating_defect: a-retired-branding-pattern-under-global-ignorecase-matched-the-correct-brand-and-the-doctor-stayed-green
+  - id: example-controls-pass
+    control_class: acceptance-test
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_example_clean_controls_include_the_signature_and_pass_example_patterns
+    motivating_defect: an-example-config-whose-own-controls-fail-its-own-patterns-ships-a-broken-doctor
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-message-guard/SKILL.md
+++ b/skills/synthesis-message-guard/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-agent-correspondence"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.5.0"
+  version: "1.6.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -179,7 +179,12 @@ message_guard.py --test            # behavioral suite (31 cases)
    missing-config invocation.
 2. **Positive controls.** `--doctor` requires a known-bad text to trip the
    scanner and a known-clean text to pass — a scanner that stops matching is
-   detected, not trusted.
+   detected, not trusted. Since 1.6.0 the known-clean text is a canonical
+   SIGNED agent message (the Ragbot signature line in Slack wire form): on
+   2026-08-03 a generic clean control passed while a retired-branding pattern
+   compiled under IGNORECASE blocked every real signed send. Add your own
+   canonical messages with `doctor_clean_controls` so a pattern change that
+   blocks real traffic fails the doctor.
 3. **Calibration.** The pattern set must PASS the principal's real sent
    messages and BLOCK the incident drafts. Re-run calibration whenever
    patterns change; a guard that blocks the principal's own voice is

--- a/skills/synthesis-message-guard/patterns.example.json
+++ b/skills/synthesis-message-guard/patterns.example.json
@@ -26,7 +26,8 @@
     "prompt"
   ],
   "doctor_clean_controls": [
-    "Thanks for the note. I reviewed the full thread and can meet Tuesday at 10."
+    "Thanks for the note. I reviewed the full thread and can meet Tuesday at 10.",
+    "🤖 _I'm the principal's <https://ragbot.ai/|Ragbot>, sent under standing direction — every reply is read_"
   ],
   "currency_claim_patterns": [
     "\\b(unanswered|unsent|not (yet )?(replied|responded|answered|sent)|no (reply|response|answer)( yet)?|still (open|waiting|pending|unanswered)|has(n't| not) (replied|responded|answered|sent))\\b"

--- a/skills/synthesis-message-guard/scripts/message_guard.py
+++ b/skills/synthesis-message-guard/scripts/message_guard.py
@@ -56,7 +56,7 @@ import tempfile
 import time
 from datetime import datetime, timezone
 
-ENGINE_VERSION = "1.5.0"
+ENGINE_VERSION = "1.6.0"
 
 
 def config_path():
@@ -638,9 +638,16 @@ def run_gate():
 
 POSITIVE_CONTROL_BAD = ("I'm sorry for the delay — I went quiet on you, and "
                         "I'm the least able to judge this myself.")
+# The clean control is a CANONICAL SIGNED agent message, not generic prose
+# (board ask, 2026-08-03): a generic control passed while a retired-branding
+# pattern compiled under IGNORECASE blocked every real signed send. The
+# doctor's negative control must look like the traffic the guard exists to
+# let through — a Slack-wire-form signature line included.
 POSITIVE_CONTROL_CLEAN = ("Thank you for writing this up properly. The step "
                           "list is the valuable part. Send times that suit "
-                          "you and I will make one of them work.")
+                          "you and I will make one of them work.\n\n"
+                          "🤖 _I'm the principal's <https://ragbot.ai/|Ragbot>, "
+                          "sent under standing direction — every reply is read_")
 
 
 def hook_config_covers(path, sample_tools):

--- a/skills/synthesis-message-guard/scripts/message_guard.py
+++ b/skills/synthesis-message-guard/scripts/message_guard.py
@@ -79,6 +79,25 @@ def ledger_dir():
     return os.path.join(state_dir(), "ledger")
 
 
+def legacy_ledger_detail(path):
+    """Who a leftover single-slot ledger belongs to, so the seat that wrote it
+    can recognise it. 2026-09-02: one seat's helper script, written against
+    the previous layout, kept the machine-wide doctor red for every seat, and
+    nobody could tell whose file it was without recognising the sha."""
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return "unreadable"
+    if not isinstance(data, dict):
+        return "not a ledger object"
+    parts = []
+    for key in ("created_at", "channel", "recipient"):
+        if data.get(key):
+            parts.append("%s %s" % (key, str(data[key])[:80]))
+    return ", ".join(parts) or "no created_at/channel/recipient fields"
+
+
 def ledger_path_for(sha):
     """One ledger per message, named by the sha it is already bound to.
 
@@ -775,10 +794,11 @@ def run_doctor():
     legacy = os.path.join(state_dir(), "ledger.json")
     report(not os.path.exists(legacy),
            "no legacy single-slot ledger.json",
-           "found %s — a leftover from the pre-sha layout. It is inert (the "
-           "gate reads ledger/<sha>.json) but delete it so nothing hand-edits "
-           "the wrong file." % legacy if os.path.exists(legacy) else
-           "sha-keyed store only")
+           ("found %s (%s) — a leftover from the pre-sha layout, usually a "
+            "helper script that outlived the convention. It is inert (the gate "
+            "reads ledger/<sha>.json); whoever it belongs to should delete it."
+            % (legacy, legacy_ledger_detail(legacy)))
+           if os.path.exists(legacy) else "sha-keyed store only")
 
     d = ledger_dir()
     if os.path.isdir(d):

--- a/skills/synthesis-message-guard/scripts/test_message_guard.py
+++ b/skills/synthesis-message-guard/scripts/test_message_guard.py
@@ -481,3 +481,41 @@ def test_loose_ledger_permissions_are_repaired(monkeypatch, tmp_path) -> None:
     MODULE.tighten_ledger_store()
     assert stray.stat().st_mode & 0o777 == 0o600
     assert d.stat().st_mode & 0o777 == 0o700
+
+
+# --- the clean control is a canonical signed message (v1.6.0, board ask 2026-08-03) ------
+
+
+def test_builtin_clean_control_is_a_canonical_signed_message() -> None:
+    assert "ragbot.ai" in MODULE.POSITIVE_CONTROL_CLEAN
+    assert "🤖" in MODULE.POSITIVE_CONTROL_CLEAN
+
+
+def test_over_broad_retired_branding_pattern_trips_the_clean_control() -> None:
+    """The exact 2026-08-03 defect: 'RagBot|RAGbot' under the engine's global
+    IGNORECASE matched the correct 'Ragbot' and blocked every real send while
+    the generic clean control kept passing. The canonical control catches it;
+    the scoped fix passes it."""
+    import re
+
+    over_broad = [("retired-branding", re.compile("RagBot|RAGbot", re.IGNORECASE))]
+    hits, _ = MODULE.scan_text(MODULE.POSITIVE_CONTROL_CLEAN, over_broad, [])
+    assert hits, "the canonical control must expose the over-broad pattern"
+
+    scoped = [("retired-branding", re.compile(r"(?-i:RagBot|RAGbot|ragbot(?!\.ai))", re.IGNORECASE))]
+    hits2, _ = MODULE.scan_text(MODULE.POSITIVE_CONTROL_CLEAN, scoped, [])
+    assert hits2 == [], hits2
+
+
+def test_example_clean_controls_include_the_signature_and_pass_example_patterns() -> None:
+    import re
+
+    example = json.loads((MODULE_PATH.parent.parent / "patterns.example.json").read_text(encoding="utf-8"))
+    cblock = [(p["name"], re.compile(p["regex"], re.IGNORECASE)) for p in example["block_patterns"]]
+    cwarn = [(p["name"], re.compile(p["regex"], re.IGNORECASE)) for p in example["warn_patterns"]]
+    controls = example["doctor_clean_controls"]
+    assert any("ragbot.ai" in c for c in controls)
+    for control in controls:
+        hits, _ = MODULE.scan_text(control, cblock, cwarn)
+        assert hits == [], (control, hits)
+

--- a/skills/synthesis-message-guard/scripts/test_message_guard.py
+++ b/skills/synthesis-message-guard/scripts/test_message_guard.py
@@ -519,3 +519,27 @@ def test_example_clean_controls_include_the_signature_and_pass_example_patterns(
         hits, _ = MODULE.scan_text(control, cblock, cwarn)
         assert hits == [], (control, hits)
 
+
+# --- a leftover single-slot ledger names its owner (2026-09-02) ----------------------------
+
+
+def test_legacy_ledger_detail_names_the_owner(tmp_path: Path) -> None:
+    """One seat's stale helper script kept the machine-wide doctor red; the
+    finding must let its owner recognise the file without decoding a sha."""
+    leftover = tmp_path / "ledger.json"
+    leftover.write_text(json.dumps({
+        "created_at": "2026-09-02T18:11:27+00:00",
+        "channel": "gmail",
+        "recipient": "colleague@example.com",
+        "message_sha256": "abc",
+    }), encoding="utf-8")
+
+    detail = MODULE.legacy_ledger_detail(str(leftover))
+
+    assert "created_at 2026-09-02T18:11:27+00:00" in detail
+    assert "channel gmail" in detail
+    assert "recipient colleague@example.com" in detail
+
+    leftover.write_text("not json", encoding="utf-8")
+    assert MODULE.legacy_ledger_detail(str(leftover)) == "unreadable"
+


### PR DESCRIPTION
## Summary

Two old coordination-board asks addressed to this ecosystem, closed in one release.

- **Daily parity reads the installed manifest on disk (2026-08-17 ask).** Parity had stayed green while the Codex tree the client loaded sat three releases behind, because the CLI reported the version it intended to serve. `parity.<client>-on-disk` now requires the cache tree for the reported version to exist under the client's config dir and its own manifest to carry that version; a missing tree, an unreadable manifest, or a disagreeing version fails. agent-conformance 1.7.0.
- **The guard doctor's clean control is a canonical signed message (2026-08-03 ask).** A generic clean control had passed while a retired-branding pattern compiled under the engine's global IGNORECASE blocked every real signed send. The built-in negative control is now a signed agent message in Slack wire form, and `patterns.example.json` carries it in `doctor_clean_controls`. message-guard 1.6.0.
- Release surfaces at 4.88.0 with a fresh acceptance manifest.

## Verification

- `test_parity.py`: everything-current now includes both cache trees; a report with no tree fails `codex-on-disk` while `codex-installed` still passes; a tree whose manifest disagrees fails. Two conformance fixtures gained manifests in their fake cache trees.
- `test_message_guard.py`: the built-in control carries the signature; the over-broad `RagBot|RAGbot` pattern under IGNORECASE trips it and the scoped fix passes it; every example clean control passes the example patterns.
- Full AGENTS.md verification list green locally; conformance source 204/204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
