### PR TITLE
Make the guard behavioral suite hermetic (rides in 4.88.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ single-slot-ledger finding now names the file's `created_at`, channel, and
 recipient, so the seat whose helper script wrote it can recognise it
 (2026-09-02: one seat's stale scaffolding kept the machine-wide signal red).
 
+Also in this release: the guard's behavioral suite is hermetic. It had run
+against the machine's private config, so it passed on every developer
+machine and failed in CI, where no private config exists — main was red
+from 4.85.0 through 4.87.0 without anyone noticing locally. The harness
+falls back to `patterns.example.json` when no config exists and says so,
+and the pytest wrapper always runs it against the example config with an
+isolated home. Two tests pin both.
+
 ## [4.87.0] - 2026-09-02
 
 **`synthesis-quick-answers` (v1.2.0) now bootstraps and wires itself into the standard workspace convention instead of assuming it or inventing a substitute.** First real colleague adoption surfaced two gaps in the same session: the skill's Setup section assumed a personal knowledge workspace already existed, which isn't true for someone who just installed the plugin — and the "automatic, no reminder needed" property the pattern promises was never actually encoded as a step, so it depended on whoever set it up remembering to wire it in by hand. Fixed by making Setup self-contained: step 1 now calls `synthesis-onboarding`'s `onboard.py init-workspace` to scaffold `~/workspaces/{workspace}/ai-knowledge-{workspace}/` when it's missing (new `depends_on: synthesis-onboarding`), and step 4 makes explicit what was previously left implicit — a single routing line in the workspace's own `AGENTS.md`/`CLAUDE.md` is the entire mechanism that makes every future session apply the skill without being told. A companion set up under the old Setup section still worked, it just required the setter-upper to already know this; now the skill says so.

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,77 +1,39 @@
-# AGENT HEURISTIC: authored for the 4.88.0 transaction closing two coordination-board asks.
+# AGENT HEURISTIC: authored for the guard behavioral-suite hermeticity fix (rides in 4.88.0).
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: board-asks-on-disk-parity-and-canonical-clean-control
+suite: guard-behavioral-suite-hermetic
 membership: closed
-production_entry_point: skills/synthesis-agent-conformance/scripts/conformance.py
-enforcing_boundary: daily parity fails when a client's reported version has no cache tree on disk or a tree whose manifest disagrees, and the guard doctor fails when a pattern blocks the canonical signed message
+production_entry_point: skills/synthesis-message-guard/scripts/message_guard.py
+enforcing_boundary: the guard's behavioral suite proves the engine against the skill's example config in an isolated home, so a machine's private config can neither pass it locally nor fail it in CI
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the live parity and doctor runs on this machine after install are quoted in the release record; a marketplace snapshot directory that the client consults but that is not its cache tree remains covered by the release's own verification, not by the daily check
+unverified_remainder: the four releases that shipped while main was red were each verified on this machine by the gated release's own checks; CI's verdict for them is recorded as red and is not rewritten
 changed_surfaces:
-  - path: skills/synthesis-agent-conformance/scripts/conformance.py
-    cases: [on-disk-report-without-tree, on-disk-manifest-disagrees, parity-current]
-  - path: skills/synthesis-agent-conformance/scripts/test_parity.py
-    cases: [on-disk-report-without-tree, on-disk-manifest-disagrees, parity-current]
-  - path: skills/synthesis-agent-conformance/scripts/test_conformance.py
-    cases: [parity-current]
-  - path: skills/synthesis-agent-conformance/SKILL.md
-    cases: [parity-current]
   - path: skills/synthesis-message-guard/scripts/message_guard.py
-    cases: [clean-control-is-signed, over-broad-pattern-trips-control, example-controls-pass]
+    cases: [behavioral-suite-hermetic, behavioral-suite-falls-back]
   - path: skills/synthesis-message-guard/scripts/test_message_guard.py
-    cases: [clean-control-is-signed, over-broad-pattern-trips-control, example-controls-pass]
-  - path: skills/synthesis-message-guard/patterns.example.json
-    cases: [example-controls-pass]
-  - path: skills/synthesis-message-guard/SKILL.md
-    cases: [clean-control-is-signed]
+    cases: [behavioral-suite-hermetic, behavioral-suite-falls-back]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
-  - path: .claude-plugin/plugin.json
-    cases: [release-manifest-parity]
-  - path: .codex-plugin/plugin.json
-    cases: [release-manifest-parity]
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
-  - path: README.md
-    cases: [release-changelog-parity]
 cases:
-  - id: on-disk-report-without-tree
+  - id: behavioral-suite-hermetic
     control_class: enforced-gate
-    fixture: ../synthesis-agent-conformance/scripts/test_parity.py::ParityTests::test_reported_version_without_a_cache_tree_fails_on_disk
-    motivating_defect: parity-stayed-green-while-the-loaded-codex-tree-sat-three-releases-behind-the-reported-version
-  - id: on-disk-manifest-disagrees
-    control_class: enforced-gate
-    fixture: ../synthesis-agent-conformance/scripts/test_parity.py::ParityTests::test_cache_manifest_disagreeing_with_the_report_fails_on_disk
-    motivating_defect: a-tree-that-exists-but-carries-another-version-is-the-same-stale-load-with-a-directory-name
-  - id: parity-current
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_engine_behavioral_suite_passes
+    motivating_defect: main-was-red-for-hours-while-every-developer-machine-was-green-because-the-suite-read-the-private-config
+  - id: behavioral-suite-falls-back
     control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_parity.py::ParityTests::test_everything_current_passes
-    motivating_defect: a-check-that-cannot-pass-on-a-healthy-machine-trains-bypass
-  - id: clean-control-is-signed
-    control_class: acceptance-test
-    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_builtin_clean_control_is_a_canonical_signed_message
-    motivating_defect: a-generic-clean-control-passed-while-every-real-signed-send-was-blocked
-  - id: over-broad-pattern-trips-control
-    control_class: enforced-gate
-    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_over_broad_retired_branding_pattern_trips_the_clean_control
-    motivating_defect: a-retired-branding-pattern-under-global-ignorecase-matched-the-correct-brand-and-the-doctor-stayed-green
-  - id: example-controls-pass
-    control_class: acceptance-test
-    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_example_clean_controls_include_the_signature_and_pass_example_patterns
-    motivating_defect: an-example-config-whose-own-controls-fail-its-own-patterns-ships-a-broken-doctor
+    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_behavioral_suite_falls_back_to_the_example_config
+    motivating_defect: a-harness-that-crashes-on-a-missing-file-proves-nothing-about-the-engine
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
     motivating_defect: an-acceptance-manifest-that-its-own-runner-cannot-consume-issues-authority-it-never-earned
-  - id: release-manifest-parity
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
-    motivating_defect: a-version-that-reaches-only-one-client-manifest-cannot-be-reliably-installed-or-audited
   - id: release-changelog-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed

--- a/skills/synthesis-message-guard/scripts/message_guard.py
+++ b/skills/synthesis-message-guard/scripts/message_guard.py
@@ -924,6 +924,15 @@ def run_tests():
     me = os.path.abspath(__file__)
     tmp = tempfile.mkdtemp(prefix="msg-guard-test-")
     cfg_src = config_path()
+    if not os.path.exists(cfg_src):
+        # The suite proves the ENGINE, not one machine's private patterns.
+        # 2026-09-02: main sat red for hours while every developer machine
+        # was green, because CI has no ~/.synthesis and the harness reached
+        # for it. Fall back to the skill's example config and say so.
+        example = os.path.join(os.path.dirname(me), "..", "patterns.example.json")
+        if os.path.exists(example):
+            print("config: %s is absent; running against patterns.example.json" % cfg_src)
+            cfg_src = os.path.abspath(example)
     env = dict(os.environ)
     env["MESSAGE_GUARD_CONFIG"] = cfg_src
     env["MESSAGE_GUARD_STATE_DIR"] = tmp

--- a/skills/synthesis-message-guard/scripts/test_message_guard.py
+++ b/skills/synthesis-message-guard/scripts/test_message_guard.py
@@ -437,16 +437,44 @@ def test_orphan_sweep_spares_fresh_ledgers(monkeypatch, tmp_path) -> None:
     assert fresh.exists() and not ancient.exists()
 
 
-def test_engine_behavioral_suite_passes() -> None:
-    """Run the engine's own --test so CI covers the gate end to end."""
+def test_engine_behavioral_suite_passes(tmp_path: Path) -> None:
+    """Run the engine's own --test so CI covers the gate end to end —
+    hermetically. The example config and an isolated home, so the machine's
+    private config can neither make the suite pass locally nor fail it in
+    CI (2026-09-02: main was red for hours while every developer machine
+    was green)."""
+    import os as _os
     import subprocess
 
+    env = {
+        **_os.environ,
+        "HOME": str(tmp_path),
+        "MESSAGE_GUARD_CONFIG": str(MODULE_PATH.parent.parent / "patterns.example.json"),
+        "MESSAGE_GUARD_STATE_DIR": str(tmp_path / "state"),
+    }
     proc = subprocess.run(
         [sys.executable, str(MODULE_PATH), "--test"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, env=env,
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "FAIL" not in proc.stdout, proc.stdout
+
+
+def test_behavioral_suite_falls_back_to_the_example_config(tmp_path: Path) -> None:
+    """With no private config at all (a CI runner), the harness runs against
+    the example config instead of crashing on a missing file."""
+    import os as _os
+    import subprocess
+
+    env = {k: v for k, v in _os.environ.items() if k != "MESSAGE_GUARD_CONFIG"}
+    env["HOME"] = str(tmp_path)
+    env["MESSAGE_GUARD_STATE_DIR"] = str(tmp_path / "state")
+    proc = subprocess.run(
+        [sys.executable, str(MODULE_PATH), "--test"],
+        capture_output=True, text=True, env=env,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "running against patterns.example.json" in proc.stdout
 
 
 def test_written_ledger_is_private(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary

CI on main has been red since 4.85.0: the message guard's behavioral suite ran against the machine's private config, so it passed on every developer machine and failed on the CI runner, where no private config exists. This makes it hermetic:

- The harness falls back to the skill's example config when no config exists at the configured path, and prints that it did.
- The pytest wrapper always runs the suite against the example config with an isolated home and state dir, so local and CI runs test the same inputs.
- Two tests pin the hermetic run and the fallback.

Rides in 4.88.0, whose manifests and changelog are already on main; the changelog gains a paragraph. The acceptance manifest is fresh for this transaction (four files), since the release consumes the receipt of the merge it releases from.

## Verification

- Full AGENTS.md verification list green in CI shape (HOME isolated) on this branch; the guard suite passes 31 of 31 cases against the example config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
