### PR TITLE
Give Google Chat a declared target set; refuse wholesale watermark advance on a targeted surface (4.89.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.88.0",
+  "version": "4.89.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.88.0",
+  "version": "4.89.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.89.0] - 2026-09-02
+
+**Google Chat gets a declared target set, and a surface that carries
+targets can no longer be advanced wholesale.** The fifth sync defect from
+the field: a surface-level watermark on the Chat surface recorded coverage
+no per-space read backed, and a colleague's four DMs went unsurfaced through
+two syncs and a day-end. daily-rituals 2.34.0 ships
+`scripts/gchat_preflight.py`: the declared set is the config's explicit,
+labeled `targets` (the auditable core — the enumeration shows every DM as
+"Unnamed Space") plus the saved enumeration text, parsed line by line,
+filtered client-side by the config's `scope` because the wrapper ignores
+its own type filter, and marked BOUNDED when the header count exceeds the
+records or the 100-record page cap is hit, since no paging cursor is
+exposed; a bounded set is partial coverage that the report and the deferral
+name rather than a completeness claim. `sync_watermark.py advance` now
+refuses a surface-level write on a surface with per-target entries unless
+`--surface-level` asserts it. Thirteen preflight tests and two watermark
+tests pin the behavior; the missing cursor is recorded as an upstream
+wrapper defect.
+
 ## [4.88.0] - 2026-09-02
 
 **Two old coordination-board asks closed.** (1) Daily parity now reads each

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Google Chat coverage is now claimed per space, never wholesale
+(September 2026).** Release **4.89.0** derives a declared target set for the
+Chat surface from an explicit config core plus a bounded enumeration, and
+refuses a surface-level watermark advance once per-target entries exist.
+See the [4.89.0 release notes](CHANGELOG.md).
+
 **A self-report is a claim, not evidence (September 2026).** Release
 **4.88.0** makes daily parity read each client's installed manifest on disk
 beside the CLI report, and makes the message guard's clean doctor control a

--- a/skills/synthesis-daily-rituals/SKILL.md
+++ b/skills/synthesis-daily-rituals/SKILL.md
@@ -10,7 +10,7 @@ depends_on:
   - synthesis-checkpoint
 metadata:
   author: "Rajiv Pant"
-  version: "2.33.0"
+  version: "2.34.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -109,7 +109,7 @@ The set of remotes for each repo comes from `git remote -v` inside that repo. Th
 
 - [ ] Check for new PRs, CI results, overnight pushes (now that local repos are current).
 - [ ] **Run `/synthesis-slack-sync`** — the `synthesis-slack-sync` skill handles the full Slack sync protocol: verify connector auth, read all channels, re-read all threads with replies, check DMs, save to local transcripts, and update the action plan. See that skill for the detailed protocol and the rationale behind each step. Configuration is in `.agents/slack-sync.yaml` per project, with `.claude/slack-sync.yaml` supported for existing projects.
-- [ ] **Google Chat sync (v2.17.0)** — if the workspace declares `.agents/gchat-sync.yaml`: enumerate spaces fresh via the Chat space-list call (never a hand-maintained ID list — per-meeting spaces churn daily), read DMs/groups/named/meeting spaces per the config's scope windowed by `createTime` since the last sync, treat a full page as possibly-truncated (narrow the window and re-read), keep the raw `users/<id>` on every line beside any resolved name, and save to the workspace convention (e.g., `transcripts/gchat/gchat-YYYY-MM-DD.md`). Same confidentiality handling as Slack DMs. Skip silently when no config exists.
+- [ ] **Google Chat sync (v2.34.0)** — if the workspace declares `.agents/gchat-sync.yaml`: enumerate spaces fresh via the Chat space-list call and save the call's text output to a file (never a hand-maintained ID list — per-meeting spaces churn daily), then run `python3 <skill-root>/scripts/gchat_preflight.py --config .agents/gchat-sync.yaml --spaces <that file> --json --out <declared.json>`. It takes the config's explicit `targets` (space ids with labels — the auditable core, since the enumeration shows every DM as "Unnamed Space") plus the enumeration filtered client-side by the config's `scope` (the wrapper's type filter is not trusted), prints the resolved-target table with a census by type and a BOUND line whenever the enumeration was capped or short (the wrapper pages at 100 and exposes no cursor), and writes the declared set the watermark gate consumes. Read each target with `oldest` from `sync_watermark.py window --surface gchat --target <space id>`, windowed by `createTime`; treat a full page as possibly-truncated (narrow the window and re-read); keep the raw `users/<id>` on every line beside any resolved name; save to the workspace convention (e.g., `transcripts/gchat/gchat-YYYY-MM-DD.md`); record each saved read with `sync_watermark.py advance --surface gchat --target <space id> --through <latest>` — a surface-level advance is refused once targets exist. A bounded enumeration is partial coverage: defer the surface with the bound as the reason, never advance past it. Same confidentiality handling as Slack DMs. Skip silently when no config exists.
 - [ ] **Email sync (v2.19.0)** — when the workspace routinely syncs email (established `transcripts/email/` practice or explicit config): sweep the window's inbound mail AND the user's own sent mail (sent items are correspondence records too — the user's outbound exec mail is often the day's most consequential artifact), using the workspace's designated email tooling and account. Save to the workspace convention (e.g., `transcripts/email/YYYY-MM-DD-<slug>.md`).
 - [ ] **Document-comment sync (v2.19.0)** — when the workspace has an established docs-sweep practice (`transcripts/docs/` or explicit config): Drive documents modified in the window, open comment threads where the newest reply is not the user's (ball in their court), and engagement on documents the user shared out.
 - [ ] **Name any surface not swept.** The declared surface set is the complete decision (v2.12.1 applied to channels); a sync that skips one must say so in its report rather than reporting as complete.
@@ -206,7 +206,7 @@ The daily plan is both a live dashboard and the day's record. **Preserve all inf
 The day-start checklist does a full sync. The user will ask for syncs repeatedly throughout the day ("sync from Slack", "what's new", "check channels"). **A sync request covers EVERY surface the workspace routinely syncs — not Slack alone, and not only chat surfaces (v2.19.0):**
 
 1. **Slack** — always.
-2. **Google Chat** — when `.agents/gchat-sync.yaml` exists.
+2. **Google Chat** — when `.agents/gchat-sync.yaml` exists; per target, from the declared set `gchat_preflight.py` writes this run (v2.34.0).
 3. **Email** — when the workspace routinely syncs it (evidenced by an established `transcripts/email/` directory or an explicit config). Use the workspace's designated email tooling and account; sweep inbound AND the user's own sent mail for the window.
 4. **Meeting transcripts** — when `.agents/meeting-transcripts.yaml` exists: any meeting that ended during the window gets its transcript fetched (or re-checked, for ones whose notes had not yet generated).
 5. **Document comments** — when the workspace has an established docs-sweep practice (evidenced by `transcripts/docs/` or an explicit config): Drive documents modified in the window, and open comment threads addressed to the user.
@@ -284,7 +284,7 @@ The Weekly Loose-Ends Review (Step 10) attaches to whichever ritual runs first o
 ### 1. Transcript Sync
 
 - [ ] **Run `/synthesis-slack-sync`** for final capture of the day. The `synthesis-slack-sync` skill ensures all channels, threads, and DMs are captured.
-- [ ] **Google Chat final capture (v2.17.0)** — if the workspace declares `.agents/gchat-sync.yaml`, run the same Chat sweep as Day-Start Step 3b for the day's window (fresh space enumeration; raw sender IDs preserved).
+- [ ] **Google Chat final capture (v2.17.0)** — if the workspace declares `.agents/gchat-sync.yaml`, run the same Chat sweep as Day-Start Step 3b for the day's window (fresh space enumeration through `gchat_preflight.py`, per-target reads and advances, raw sender IDs preserved).
 - [ ] **Email + document-comment final capture (v2.19.0)** — when the workspace syncs those surfaces (per Day-Start 3b's declared-set rule): the day's inbound and sent mail, meeting transcripts for any meeting that ended since the last sync, and document comments/engagement for the day's window. Name any surface not swept.
 - [ ] **Watermark gate (v2.30.0):** the final capture opened with `sync_watermark.py begin --workspace <W> --label day-end` and recorded each saved read with `advance`; now run `python3 <skill-root>/scripts/sync_watermark.py status --workspace <W> --surface <s> --since run` with every declared surface and read target passed explicitly (same rule and same reason as Day-Start Step 3b's gate). The day does not close over a surface or target this run did not re-read: read it or defer it with a reason now.
 - [ ] Update CONTEXT.md to mark any items resolved by day's conversations (so tomorrow's day-start does not re-propose them).

--- a/skills/synthesis-daily-rituals/references/sync-watermarks.md
+++ b/skills/synthesis-daily-rituals/references/sync-watermarks.md
@@ -54,7 +54,11 @@ python3 <skill-root>/scripts/sync_watermark.py status  --workspace <W> --surface
   or a bare `YYYY-MM-DD`, which means complete through the **END of that day**
   and is therefore refused for today until the day is over: a mid-day run
   records the moment it read, not the date. With `--target` (repeatable)
-  each target's own watermark advances; without it the surface's does.
+  each target's own watermark advances; without it the surface's does — and
+  once a surface carries per-target entries, a surface-level advance is
+  refused unless `--surface-level` asserts whole-surface coverage
+  explicitly (2026-09-01: a wholesale advance on the Chat surface recorded
+  coverage no per-space read backed).
 - **`defer`** records a gap that genuinely cannot close this run, with a
   reason, for one day. A stale deferral is re-surfaced as blocking.
 - **`status`** takes the declared set — every surface with `--surface`, every
@@ -100,3 +104,36 @@ moment in the future — and rewritten as schema 2 on the next write.
   records each saved read with `advance`; Step 5 cross-references the user's
   own outbound against owed items and forbids "unanswered" on a read older
   than the run.
+
+## Google Chat targets
+
+Google Chat has no config that names every conversation, and its space
+enumeration (as the tooling returns it) is preformatted text that ignores its
+own type filter, pages at 100 with no cursor, orders undocumented, and shows
+every DM as "Unnamed Space". So the declared set for `--targets-from` has two
+parts, derived every run by `scripts/gchat_preflight.py`:
+
+1. **The config core** — explicit, labeled space ids in `.agents/gchat-sync.yaml`:
+
+   ```yaml
+   targets:
+     - space: spaces/AAAAdm000001      # the id a message-read call accepts
+       label: Jane Doe (DM)            # assigned by the workspace; "Unnamed Space" cannot be audited
+       type: DIRECT_MESSAGE            # DIRECT_MESSAGE | GROUP_CHAT | SPACE
+   ```
+
+   A `users/<id>` is a person, never a read target; an entry without a
+   `spaces/<id>` is reported unresolved.
+2. **The saved enumeration** — the text the space-list call returned this
+   run (`--spaces <file>`), parsed line by line, filtered client-side by the
+   config's `scope`, and marked BOUNDED when the header count exceeds the
+   records parsed or the page cap was hit. A bounded set is partial
+   coverage: the report names the bound, the surface is deferred with that
+   bound as the reason, and nothing advances past it.
+
+Each target is then read with `window --surface gchat --target <space id>`
+and recorded with `advance --surface gchat --target <space id>`; the gate
+runs `status --surface gchat --targets-from <declared.json> --since run`.
+Per-target coverage costs one read per space, so the config core is the
+scope that is always swept and the enumeration is the bounded remainder;
+the gate names the scope rather than claiming completeness.

--- a/skills/synthesis-daily-rituals/references/version-history.md
+++ b/skills/synthesis-daily-rituals/references/version-history.md
@@ -6,6 +6,22 @@ design choices, the config schemas each version introduced — so the main
 document can stay within the repository's 500-line budget without losing
 the reasoning. Newest first.
 
+## v2.34.0 — Google Chat gets a declared target set; wholesale advance is refused
+
+v2.34.0 (2026-09-02): the fifth sync defect from the field. A surface-level
+watermark on the Chat surface recorded coverage that no per-space read
+backed, and a colleague's four DMs asking to schedule a meeting went
+unsurfaced through two syncs and a day-end. `scripts/gchat_preflight.py`
+now derives the declared set — the config's explicit, labeled `targets`
+plus the saved enumeration filtered client-side and marked BOUNDED when the
+wrapper's page cap or a short page makes completeness unprovable — and
+`sync_watermark.py advance` refuses a surface-level write on a surface that
+carries per-target entries unless `--surface-level` asserts it. The
+enumeration's defects (text output, an ignored type filter, no paging
+cursor, undocumented order, every DM shown as "Unnamed Space") are stated
+in the script and in references/sync-watermarks.md; the missing cursor is
+an upstream wrapper defect to file, not a thing to design around silently.
+
 ## v2.33.0 — Placeholders resolve under the stable plugin path; parity checks the pointer
 
 v2.33.0 (2026-09-01): SKILL.md says where every `<…-root>` placeholder

--- a/skills/synthesis-daily-rituals/scripts/gchat_preflight.py
+++ b/skills/synthesis-daily-rituals/scripts/gchat_preflight.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Google Chat preflight: the declared read-target set for the watermark gate, fail closed.
+
+Slack got its declared set from a config that names every channel and DM by
+id. Google Chat has no such list: spaces come from a live enumeration whose
+wrapper returns preformatted text (one space per line), ignores its own type
+filter, pages at 100 with no cursor, orders undocumented, and shows every DM
+as "Unnamed Space". On 2026-09-01 a surface-level watermark on this surface
+recorded coverage that no per-space read backed, and a colleague's four DMs
+went unsurfaced through two syncs and a day-end. A watermark records that an
+agent CLAIMED coverage; this script makes the claim mechanical and bounded.
+
+The declared set has two parts:
+
+* the config's explicit ``targets`` — space ids with labels the workspace
+  assigns — the auditable core (a human can read it; "Unnamed Space" cannot
+  be audited);
+* the saved enumeration (``--spaces``: the text the space-list call
+  returned), parsed line by line and filtered CLIENT-SIDE by the config's
+  ``scope`` (the wrapper's type filter is not trusted), marked BOUNDED when
+  the header count exceeds the records parsed or a page cap was hit.
+
+Output: the resolved-target table for the sync report, a census by type, a
+BOUND line when the enumeration was capped or short, and (``--json`` /
+``--out``) the ``{"gchat": [space ids]}`` the watermark gate consumes. Exit 0
+when the set is complete, 1 when it is bounded or a config target is
+unresolved (the report must name it), 2 on an empty set or a malformed
+config. Nothing is guessed: a config target that is not ``spaces/<id>`` is
+unresolved, and a ``users/<id>`` is a person, never a read target.
+
+    gchat_preflight.py --config .agents/gchat-sync.yaml --spaces spaces.txt --json --out declared.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SURFACE = "gchat"
+PAGE_CAP = 100
+SPACE_ID = re.compile(r"^spaces/[A-Za-z0-9_-]+$")
+RECORD = re.compile(r"^\s*[-*]\s*(?P<name>.*?)\s*\(ID:\s*(?P<id>spaces/[A-Za-z0-9_-]+),\s*Type:\s*(?P<type>[A-Z_]+)\)\s*$")
+HEADER = re.compile(r"Found\s+(?P<count>\d+)\s+Chat spaces", re.IGNORECASE)
+SCOPE_KEYS = {
+    "DIRECT_MESSAGE": "direct_messages",
+    "GROUP_CHAT": "group_chats",
+    "SPACE": "named_spaces",
+}
+
+
+class ConfigError(ValueError):
+    """The config or the enumeration cannot be read as a declared set."""
+
+
+@dataclass(frozen=True)
+class Target:
+    space: str | None
+    label: str
+    kind: str
+    source: str
+    reason: str | None = None
+
+    @property
+    def resolved(self) -> bool:
+        return self.space is not None
+
+
+def _load_yaml(path: Path) -> dict:
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover - environment-specific
+        raise ConfigError("PyYAML is required to read the sync config") from exc
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ConfigError(f"cannot read {path}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"{path} is not valid YAML: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ConfigError(f"{path} must be a mapping at the top level")
+    return payload
+
+
+def config_targets(config: dict) -> list[Target]:
+    """The explicit, labeled core of the declared set."""
+    entries = config.get("targets") or []
+    if not isinstance(entries, list):
+        raise ConfigError("targets must be a list of {space, label} entries")
+    targets: list[Target] = []
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ConfigError(f"targets[{index}] must be a mapping, got {type(entry).__name__}")
+        label = str(entry.get("label") or entry.get("space") or f"targets[{index}]")
+        kind = str(entry.get("type") or "DIRECT_MESSAGE").upper()
+        raw = str(entry.get("space") or "").strip()
+        if not raw:
+            targets.append(Target(None, label, kind, "config", "no space id in the config entry"))
+        elif raw.startswith("users/"):
+            targets.append(Target(None, label, kind, "config", f"{raw} is a person, not a space"))
+        elif not SPACE_ID.match(raw):
+            targets.append(Target(None, label, kind, "config", f"{raw} is not a spaces/<id>"))
+        else:
+            targets.append(Target(raw, label, kind, "config"))
+    return targets
+
+
+def parse_enumeration(text: str) -> tuple[list[Target], int | None]:
+    """Records from the space-list call's text, and the count its header claimed."""
+    claimed = None
+    records: list[Target] = []
+    for line in text.splitlines():
+        header = HEADER.search(line)
+        if header and claimed is None:
+            claimed = int(header.group("count"))
+            continue
+        match = RECORD.match(line)
+        if match:
+            records.append(Target(match.group("id"), match.group("name").strip() or "Unnamed Space",
+                                  match.group("type").upper(), "enumeration"))
+    return records, claimed
+
+
+def in_scope(kind: str, scope: dict) -> bool:
+    key = SCOPE_KEYS.get(kind)
+    if key is None:
+        return False
+    return str(scope.get(key, "all")).lower() == "all"
+
+
+def bound(records: list[Target], claimed: int | None) -> str | None:
+    """Why the enumeration cannot be called complete, or None when it can."""
+    if len(records) >= PAGE_CAP:
+        claim = f" (header claimed {claimed})" if claimed is not None and claimed > len(records) else ""
+        return (f"page returned {len(records)} records, the wrapper's cap, and no cursor exists "
+                f"to page further{claim}")
+    if claimed is not None and claimed > len(records):
+        return f"header claimed {claimed} spaces but {len(records)} records were returned"
+    return None
+
+
+def census(targets: list[Target]) -> str:
+    counts: dict[str, int] = {}
+    for target in targets:
+        if target.resolved:
+            counts[target.kind] = counts.get(target.kind, 0) + 1
+    unresolved = sum(1 for t in targets if not t.resolved)
+    parts = [f"{counts[k]} {k}" for k in sorted(counts)]
+    parts.append(f"{unresolved} unresolved")
+    return "census: " + " / ".join(parts)
+
+
+def declared_set(targets: list[Target]) -> dict[str, list[str]]:
+    seen: list[str] = []
+    for target in targets:
+        if target.resolved and target.space not in seen:
+            seen.append(target.space)
+    return {SURFACE: seen}
+
+
+def merge(core: list[Target], enumerated: list[Target]) -> list[Target]:
+    known = {t.space for t in core if t.resolved}
+    return core + [t for t in enumerated if t.space not in known]
+
+
+def render_table(workspace: str, targets: list[Target], enumeration_bound: str | None,
+                 enumerated: bool) -> str:
+    lines = [f"# Google Chat preflight — workspace {workspace}", "",
+             "| type | space | label | source | status |", "|---|---|---|---|---|"]
+    for target in targets:
+        status = "resolved" if target.resolved else f"UNRESOLVED — {target.reason}"
+        lines.append(f"| {target.kind} | {target.space or '—'} | {target.label} | {target.source} | {status} |")
+    lines.extend(["", census(targets)])
+    if not enumerated:
+        lines.append("enumeration: none supplied — the declared set is the config core only; "
+                     "coverage is partial and the gate must say so")
+    elif enumeration_bound:
+        lines.append(f"BOUNDED: {enumeration_bound} — coverage is partial; defer the surface with this bound, "
+                     "never advance past it")
+    else:
+        lines.append("enumeration: complete (header count matches the records parsed, below the page cap)")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--config", required=True, help="path to .agents/gchat-sync.yaml")
+    parser.add_argument("--spaces", help="file holding the text the space-list call returned this run")
+    parser.add_argument("--json", action="store_true", help="print the declared set as JSON instead of the table")
+    parser.add_argument("--out", help="also write the declared set JSON here (the gate's --targets-from)")
+    args = parser.parse_args(argv)
+
+    try:
+        config = _load_yaml(Path(args.config).expanduser())
+        core = config_targets(config)
+        enumerated: list[Target] = []
+        claimed = None
+        if args.spaces:
+            try:
+                text = Path(args.spaces).expanduser().read_text(encoding="utf-8")
+            except OSError as exc:
+                raise ConfigError(f"cannot read {args.spaces}: {exc}") from exc
+            records, claimed = parse_enumeration(text)
+            scope = config.get("scope") or {}
+            if not isinstance(scope, dict):
+                raise ConfigError("scope must be a mapping")
+            enumerated = [t for t in records if in_scope(t.kind, scope)]
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    targets = merge(core, enumerated)
+    resolved = [t for t in targets if t.resolved]
+    if not resolved:
+        print("error: no read target could be resolved; the sweep is refused rather than reported "
+              "as a quiet day", file=sys.stderr)
+        return 2
+
+    enumeration_bound = bound(enumerated, claimed) if args.spaces else None
+    declared = declared_set(targets)
+    if args.out:
+        out = Path(args.out).expanduser()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(declared, indent=2) + "\n", encoding="utf-8")
+    if args.json:
+        print(json.dumps(declared, indent=2))
+    else:
+        print(render_table(str(config.get("workspace") or "?"), targets, enumeration_bound, bool(args.spaces)))
+
+    partial = []
+    unresolved = [t for t in targets if not t.resolved]
+    if unresolved:
+        partial.append(f"{len(unresolved)} config target(s) unresolved — name each in the sync report")
+    if not args.spaces:
+        partial.append("no enumeration supplied — coverage is the config core only")
+    elif enumeration_bound:
+        partial.append(f"enumeration bounded: {enumeration_bound}")
+    if partial:
+        print("; ".join(partial), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/synthesis-daily-rituals/scripts/sync_watermark.py
+++ b/skills/synthesis-daily-rituals/scripts/sync_watermark.py
@@ -281,6 +281,7 @@ def advance(
     targets: tuple[str, ...] | list[str] = (),
     now: datetime | None = None,
     home: Path | None = None,
+    surface_level: bool = False,
 ) -> dict:
     """Record a successful write. Never moves a watermark backwards or into
     the future; with targets, records each target's own read."""
@@ -302,6 +303,17 @@ def advance(
     if targets:
         slots = [(t, surface_entry["targets"].setdefault(t, {})) for t in targets]
     else:
+        if surface_entry.get("targets") and not surface_level:
+            # 2026-09-01: a surface-level advance on the Chat surface recorded
+            # coverage that no per-space read backed, and four DMs went
+            # unsurfaced. Once a surface carries per-target watermarks, a
+            # wholesale advance is a claim without evidence — refuse it.
+            raise ValueError(
+                f"{surface} carries per-target watermarks "
+                f"({len(surface_entry['targets'])} target(s)); a surface-level advance would "
+                "claim coverage no target read backs — advance the targets you read, or pass "
+                "--surface-level to assert whole-surface coverage explicitly"
+            )
         slots = [(None, surface_entry)]
     for target, entry in slots:
         key = _key(surface, target)
@@ -527,6 +539,8 @@ def main(argv: list[str] | None = None) -> int:
         if name == "advance":
             p.add_argument("--through", required=True)
             p.add_argument("--target", action="append", default=[])
+            p.add_argument("--surface-level", action="store_true",
+                           help="assert whole-surface coverage on a surface that carries targets")
         if name == "defer":
             p.add_argument("--reason", required=True)
         if name == "status":
@@ -545,7 +559,8 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "window":
             result = window(args.workspace, args.surface, args.target)
         elif args.command == "advance":
-            result = advance(args.workspace, args.surface, args.through, tuple(args.target))
+            result = advance(args.workspace, args.surface, args.through, tuple(args.target),
+                             surface_level=args.surface_level)
         elif args.command == "defer":
             result = defer(args.workspace, args.surface, args.reason, args.target)
         else:

--- a/skills/synthesis-daily-rituals/scripts/test_gchat_preflight.py
+++ b/skills/synthesis-daily-rituals/scripts/test_gchat_preflight.py
@@ -1,0 +1,198 @@
+"""Regressions for the Google Chat preflight.
+
+Derived from a real miss: on 2026-09-01 a surface-level watermark on the
+gchat surface recorded coverage no per-space read backed, and a colleague's
+four DMs went unsurfaced through two syncs and a day-end. The enumeration
+behind this surface returns text, ignores its own type filter, pages at 100
+with no cursor, orders undocumented, and labels every DM "Unnamed Space" —
+so the declared set is an explicit, labeled config core plus a client-side
+filtered, explicitly bounded enumeration, and the gate names the bound.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("gchat_preflight.py")
+SPEC = importlib.util.spec_from_file_location("gchat_preflight", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+SKILLS_ROOT = Path(__file__).resolve().parents[2]
+WATERMARK = Path(__file__).with_name("sync_watermark.py")
+
+CONFIG = """
+workspace: example-workspace
+scope:
+  direct_messages: all
+  group_chats: all
+  named_spaces: all
+  meeting_chat_spaces: all
+targets:
+  - space: spaces/AAAAdm000001
+    label: Jane Doe (DM)
+    type: DIRECT_MESSAGE
+  - space: spaces/AAAAgrp00001
+    label: Project Alpha (group)
+    type: GROUP_CHAT
+"""
+
+ENUMERATION = """Found 4 Chat spaces (type: DIRECT_MESSAGE):
+- Unnamed Space (ID: spaces/AAAAdm000001, Type: DIRECT_MESSAGE)
+- Unnamed Space (ID: spaces/AAAAdm000002, Type: DIRECT_MESSAGE)
+- Engineering (ID: spaces/AAAAsp000001, Type: SPACE)
+- Project Alpha (ID: spaces/AAAAgrp00001, Type: GROUP_CHAT)
+"""
+
+
+def write(tmp_path: Path, name: str, text: str) -> Path:
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def run_cli(*argv: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run([sys.executable, str(SCRIPT), *argv], capture_output=True, text=True)
+
+
+# --- the config core is explicit and labeled ----------------------------------------------------
+
+
+def test_config_targets_are_the_labeled_core(tmp_path: Path) -> None:
+    core = MODULE.config_targets(MODULE._load_yaml(write(tmp_path, "c.yaml", CONFIG)))
+
+    assert [(t.space, t.label, t.kind) for t in core] == [
+        ("spaces/AAAAdm000001", "Jane Doe (DM)", "DIRECT_MESSAGE"),
+        ("spaces/AAAAgrp00001", "Project Alpha (group)", "GROUP_CHAT"),
+    ]
+
+
+def test_a_person_id_is_never_a_read_target(tmp_path: Path) -> None:
+    config = CONFIG.replace("space: spaces/AAAAgrp00001", "space: users/107000000000000000000")
+    core = MODULE.config_targets(MODULE._load_yaml(write(tmp_path, "c.yaml", config)))
+
+    bad = core[1]
+    assert bad.resolved is False
+    assert "is a person" in bad.reason
+    assert "users/" not in json.dumps(MODULE.declared_set(core))
+
+
+# --- the enumeration is parsed as text, filtered client-side, and bounded honestly ---------------
+
+
+def test_enumeration_is_parsed_from_the_wrappers_text() -> None:
+    records, claimed = MODULE.parse_enumeration(ENUMERATION)
+
+    assert claimed == 4
+    assert [(t.space, t.label, t.kind) for t in records][:2] == [
+        ("spaces/AAAAdm000001", "Unnamed Space", "DIRECT_MESSAGE"),
+        ("spaces/AAAAdm000002", "Unnamed Space", "DIRECT_MESSAGE"),
+    ]
+
+
+def test_the_wrappers_type_filter_is_not_trusted_scope_filters_client_side(tmp_path: Path) -> None:
+    """The header says DIRECT_MESSAGE while the body mixes SPACE and GROUP_CHAT
+    records; the config's scope decides, not the header."""
+    config = CONFIG.replace("named_spaces: all", "named_spaces: none")
+    cfg = MODULE._load_yaml(write(tmp_path, "c.yaml", config))
+    records, _ = MODULE.parse_enumeration(ENUMERATION)
+
+    kept = [t for t in records if MODULE.in_scope(t.kind, cfg["scope"])]
+
+    assert [t.space for t in kept] == ["spaces/AAAAdm000001", "spaces/AAAAdm000002", "spaces/AAAAgrp00001"]
+
+
+def test_short_page_and_page_cap_mark_the_set_bounded() -> None:
+    records, claimed = MODULE.parse_enumeration(ENUMERATION.replace("Found 4", "Found 443"))
+    assert "443" in MODULE.bound(records, claimed)
+
+    capped = "Found 443 Chat spaces (type: SPACE):\n" + "".join(
+        f"- Space {i} (ID: spaces/AAAAcap{i:05d}, Type: SPACE)\n" for i in range(MODULE.PAGE_CAP)
+    )
+    records, claimed = MODULE.parse_enumeration(capped)
+    assert "cap" in MODULE.bound(records, claimed)
+
+    records, claimed = MODULE.parse_enumeration(ENUMERATION)
+    assert MODULE.bound(records, claimed) is None
+
+
+def test_merge_keeps_config_labels_and_adds_enumerated_spaces(tmp_path: Path) -> None:
+    core = MODULE.config_targets(MODULE._load_yaml(write(tmp_path, "c.yaml", CONFIG)))
+    records, _ = MODULE.parse_enumeration(ENUMERATION)
+
+    merged = MODULE.merge(core, records)
+
+    assert [t.space for t in merged] == [
+        "spaces/AAAAdm000001", "spaces/AAAAgrp00001", "spaces/AAAAdm000002", "spaces/AAAAsp000001",
+    ]
+    assert merged[0].label == "Jane Doe (DM)"  # the config label wins over "Unnamed Space"
+    assert MODULE.census(merged) == "census: 2 DIRECT_MESSAGE / 1 GROUP_CHAT / 1 SPACE / 0 unresolved"
+
+
+# --- the CLI feeds the gate and fails closed ----------------------------------------------------
+
+
+def test_cli_writes_the_declared_set_the_gate_consumes(tmp_path: Path) -> None:
+    out = tmp_path / "declared.json"
+    done = run_cli("--config", str(write(tmp_path, "c.yaml", CONFIG)),
+                   "--spaces", str(write(tmp_path, "spaces.txt", ENUMERATION)), "--out", str(out))
+
+    assert done.returncode == 0, done.stderr
+    assert "census: 2 DIRECT_MESSAGE / 1 GROUP_CHAT / 1 SPACE / 0 unresolved" in done.stdout
+    assert "enumeration: complete" in done.stdout
+    declared = json.loads(out.read_text(encoding="utf-8"))
+    assert declared == {"gchat": ["spaces/AAAAdm000001", "spaces/AAAAgrp00001",
+                                  "spaces/AAAAdm000002", "spaces/AAAAsp000001"]}
+    spec = importlib.util.spec_from_file_location("sync_watermark", WATERMARK)
+    watermark = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(watermark)
+    assert watermark._parse_targets([], str(out)) == declared
+
+
+def test_cli_exits_one_and_names_the_bound_when_the_enumeration_is_capped(tmp_path: Path) -> None:
+    done = run_cli("--config", str(write(tmp_path, "c.yaml", CONFIG)),
+                   "--spaces", str(write(tmp_path, "spaces.txt", ENUMERATION.replace("Found 4", "Found 443"))))
+
+    assert done.returncode == 1
+    assert "BOUNDED" in done.stdout
+    assert "443" in done.stderr
+
+
+def test_cli_without_an_enumeration_is_the_config_core_only_and_partial(tmp_path: Path) -> None:
+    done = run_cli("--config", str(write(tmp_path, "c.yaml", CONFIG)), "--json")
+
+    assert done.returncode == 1
+    assert json.loads(done.stdout) == {"gchat": ["spaces/AAAAdm000001", "spaces/AAAAgrp00001"]}
+    assert "config core only" in done.stderr
+
+
+def test_cli_refuses_an_empty_set_and_a_malformed_config(tmp_path: Path) -> None:
+    empty = run_cli("--config", str(write(tmp_path, "e.yaml", "workspace: w\nscope: {}\n")))
+    assert empty.returncode == 2
+    assert "refused" in empty.stderr
+
+    malformed = run_cli("--config", str(write(tmp_path, "m.yaml", "targets:\n  - just-a-string\n")))
+    assert malformed.returncode == 2
+    assert "must be a mapping" in malformed.stderr
+
+
+# --- the documented rules the mechanism depends on ----------------------------------------------
+
+
+def test_rituals_run_the_gchat_preflight_per_target() -> None:
+    text = (SKILLS_ROOT / "synthesis-daily-rituals" / "SKILL.md").read_text(encoding="utf-8")
+    assert "gchat_preflight.py --config" in text
+    assert "advance --surface gchat --target" in text
+    assert "surface-level advance is refused" in text
+
+
+def test_reference_documents_gchat_targets_and_the_refusal() -> None:
+    text = (SKILLS_ROOT / "synthesis-daily-rituals" / "references" / "sync-watermarks.md").read_text(encoding="utf-8")
+    assert "## Google Chat targets" in text
+    assert "--surface-level" in text

--- a/skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
+++ b/skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
@@ -240,6 +240,34 @@ def test_target_window_falls_back_to_the_surface_watermark(tmp_path: Path) -> No
     assert "surface watermark" in got["source"]
 
 
+# --- a surface that carries targets cannot be advanced wholesale (v2.34.0) --------------------
+
+
+def test_surface_level_advance_is_refused_once_targets_exist(tmp_path: Path) -> None:
+    """The 2026-09-01 Chat miss: a wholesale advance claimed coverage no
+    per-space read backed."""
+    MODULE.advance(WS, "gchat", IN_RUN, targets=["spaces/A"], now=at(11, 46), home=tmp_path)
+
+    with pytest.raises(ValueError, match="per-target watermarks"):
+        MODULE.advance(WS, "gchat", "now", now=NOW, home=tmp_path)
+
+    explicit = MODULE.advance(WS, "gchat", "now", now=NOW, home=tmp_path, surface_level=True)
+    assert explicit["moved"] is True
+
+
+def test_cli_surface_level_flag_is_required_once_targets_exist(tmp_path: Path) -> None:
+    run_cli(tmp_path, "advance", "--workspace", WS, "--surface", "gchat",
+            "--target", "spaces/A", "--through", "now")
+
+    refused = run_cli(tmp_path, "advance", "--workspace", WS, "--surface", "gchat", "--through", "now")
+    assert refused.returncode == 2
+    assert "--surface-level" in refused.stderr
+
+    allowed = run_cli(tmp_path, "advance", "--workspace", WS, "--surface", "gchat", "--through", "now",
+                      "--surface-level")
+    assert allowed.returncode == 0
+
+
 # --- deferrals: explicit, dated, and spent by a write ---------------------------------
 
 

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,39 +1,83 @@
-# AGENT HEURISTIC: authored for the guard behavioral-suite hermeticity fix (rides in 4.88.0).
+# AGENT HEURISTIC: authored for the 4.89.0 Google Chat preflight transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: guard-behavioral-suite-hermetic
+suite: gchat-declared-targets-and-no-wholesale-advance
 membership: closed
-production_entry_point: skills/synthesis-message-guard/scripts/message_guard.py
-enforcing_boundary: the guard's behavioral suite proves the engine against the skill's example config in an isolated home, so a machine's private config can neither pass it locally nor fail it in CI
+production_entry_point: skills/synthesis-daily-rituals/scripts/gchat_preflight.py
+enforcing_boundary: the Chat surface's declared set is derived each run from an explicit config core plus a client-side-filtered, explicitly bounded enumeration, and a surface carrying per-target watermarks refuses a wholesale advance
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the four releases that shipped while main was red were each verified on this machine by the gated release's own checks; CI's verdict for them is recorded as red and is not rewritten
+unverified_remainder: the workspace that reported the defect adds its config targets and runs the first gated Chat sync in its own record; the enumeration wrapper's missing paging cursor is an upstream defect outside this repository
 changed_surfaces:
-  - path: skills/synthesis-message-guard/scripts/message_guard.py
-    cases: [behavioral-suite-hermetic, behavioral-suite-falls-back]
-  - path: skills/synthesis-message-guard/scripts/test_message_guard.py
-    cases: [behavioral-suite-hermetic, behavioral-suite-falls-back]
+  - path: skills/synthesis-daily-rituals/scripts/gchat_preflight.py
+    cases: [person-never-a-target, wrapper-filter-not-trusted, bounded-enumeration, declared-set-feeds-the-gate, cli-fails-closed]
+  - path: skills/synthesis-daily-rituals/scripts/test_gchat_preflight.py
+    cases: [person-never-a-target, wrapper-filter-not-trusted, bounded-enumeration, declared-set-feeds-the-gate, cli-fails-closed, rituals-doc-contract]
+  - path: skills/synthesis-daily-rituals/scripts/sync_watermark.py
+    cases: [wholesale-advance-refused]
+  - path: skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
+    cases: [wholesale-advance-refused]
+  - path: skills/synthesis-daily-rituals/SKILL.md
+    cases: [rituals-doc-contract, rituals-budget]
+  - path: skills/synthesis-daily-rituals/references/version-history.md
+    cases: [rituals-budget]
+  - path: skills/synthesis-daily-rituals/references/sync-watermarks.md
+    cases: [rituals-doc-contract]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
+  - path: .claude-plugin/plugin.json
+    cases: [release-manifest-parity]
+  - path: .codex-plugin/plugin.json
+    cases: [release-manifest-parity]
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
+  - path: README.md
+    cases: [release-changelog-parity]
 cases:
-  - id: behavioral-suite-hermetic
+  - id: person-never-a-target
     control_class: enforced-gate
-    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_engine_behavioral_suite_passes
-    motivating_defect: main-was-red-for-hours-while-every-developer-machine-was-green-because-the-suite-read-the-private-config
-  - id: behavioral-suite-falls-back
+    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_a_person_id_is_never_a_read_target
+    motivating_defect: the-workspace-map-carries-people-ids-and-a-reader-that-takes-them-reads-nothing
+  - id: wrapper-filter-not-trusted
     control_class: acceptance-test
-    fixture: ../synthesis-message-guard/scripts/test_message_guard.py::test_behavioral_suite_falls_back_to_the_example_config
-    motivating_defect: a-harness-that-crashes-on-a-missing-file-proves-nothing-about-the-engine
+    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_the_wrappers_type_filter_is_not_trusted_scope_filters_client_side
+    motivating_defect: the-enumeration-header-asserted-a-filter-that-was-never-applied
+  - id: bounded-enumeration
+    control_class: enforced-gate
+    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_cli_exits_one_and_names_the_bound_when_the_enumeration_is_capped
+    motivating_defect: a-hundred-of-four-hundred-spaces-read-as-complete-because-nothing-stated-the-bound
+  - id: declared-set-feeds-the-gate
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_cli_writes_the_declared_set_the_gate_consumes
+    motivating_defect: a-surface-with-no-declared-set-is-claimed-on-the-agents-say-so
+  - id: cli-fails-closed
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_cli_refuses_an_empty_set_and_a_malformed_config
+    motivating_defect: an-empty-resolved-set-reported-as-a-quiet-day-is-a-completeness-claim-with-no-evidence
+  - id: wholesale-advance-refused
+    control_class: enforced-gate
+    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_surface_level_advance_is_refused_once_targets_exist
+    motivating_defect: a-surface-level-advance-recorded-coverage-no-per-space-read-backed-and-four-dms-went-unsurfaced
+  - id: rituals-doc-contract
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_rituals_run_the_gchat_preflight_per_target
+    motivating_defect: a-script-the-protocol-does-not-invoke-is-not-a-control
+  - id: rituals-budget
+    control_class: acceptance-test
+    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_rituals_skill_document_stays_within_repo_budget
+    motivating_defect: a-restructured-document-must-not-regrow-with-its-next-feature
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
     motivating_defect: an-acceptance-manifest-that-its-own-runner-cannot-consume-issues-authority-it-never-earned
+  - id: release-manifest-parity
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
+    motivating_defect: a-version-that-reaches-only-one-client-manifest-cannot-be-reliably-installed-or-audited
   - id: release-changelog-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed


### PR DESCRIPTION
## Summary

The fifth sync defect reported from the field: a surface-level watermark on the Google Chat surface recorded coverage that no per-space read backed, and a colleague's DMs went unsurfaced through two syncs and a day-end. Slack's declared set had made that claim mechanical; Chat had no declared set at all.

- **`synthesis-daily-rituals/scripts/gchat_preflight.py`** (daily-rituals 2.34.0). The declared set is the config's explicit, labeled `targets` (the auditable core: the enumeration shows every DM as "Unnamed Space") plus the saved text of the space-list call, parsed line by line, filtered client-side by the config's `scope` (the wrapper ignores its own type filter), and marked BOUNDED when the header count exceeds the records parsed or the 100-record page cap is hit (no paging cursor is exposed). A `users/<id>` is a person, never a target. Output: the resolved-target table with a census by type and a BOUND line, and `--json --out` for the gate's `--targets-from`. Exit 1 on a bound or an unresolved config target so the report must name it; 2 on an empty set or a malformed config.
- **`sync_watermark.py advance`** refuses a surface-level write on a surface that carries per-target entries unless `--surface-level` asserts whole-surface coverage explicitly, closing the fail-open the defect exploited.
- Day-Start 3b, Mid-Day, and Day-End take the Chat declared set from the script and record reads per target; the reference documents the config `targets` schema and the enumeration's four defects, and records the missing paging cursor as an upstream wrapper defect rather than designing around it silently.
- Release surfaces at 4.89.0 with a fresh acceptance manifest.

## Verification

- `test_gchat_preflight.py` (13): labeled core; person ids refused; text parsing; client-side scope over an untrusted header; short-page and page-cap bounds; merge keeps config labels; CLI writes the set `sync_watermark._parse_targets` consumes; exit 1 with the bound named; config-core-only is partial; empty and malformed refused; both document contracts
- `test_sync_watermark.py` (+2): wholesale advance refused once targets exist, allowed with the explicit flag, via API and CLI
- Full AGENTS.md verification list green in CI shape (HOME isolated); rituals SKILL.md stays at 446 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
