### PR TITLE
Address peer sessions by resolver-issued receipts; gate every direct lane; deliver the bus (4.90.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.89.0",
+  "version": "4.90.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.89.0",
+  "version": "4.90.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.90.0] - 2026-09-02
+
+**Peer messages can no longer be addressed by a name, and every direct send
+must match a delivery receipt the resolver issued.** Seven recorded
+misdeliveries between 2026-08-19 and 2026-09-02 — one of them the day after
+the resolver shipped — share one shape: at the moment of sending, an agent
+picked a target by a harness display name (derived from the working
+directory, duplicated by construction) or a chat title, and the only gate in
+place checked that a target was registered, not that it was the one
+resolved. The harness `SendMessage` lane, which its own listing steers
+agents toward, was ungated by design.
+
+synthesis-project-management 2.11.0 closes the whole path:
+
+- **Seats.** `claim` writes a sidecar beside the board
+  (`seats/<session uuid>.json`) with the session's delivery handles —
+  harness session id, desktop session id, pid, machine — refreshed at
+  heartbeat and removed at release; the board row's client ref is unchanged
+  (`ccd:` on the desktop, new `cc:` for terminal sessions, `codex:` for
+  Codex). No schema change; an older engine simply offers the bus.
+- **Lanes.** `resolve` now prints the exact invocation per lane from live
+  truth: the bus, the ccd session id, the harness Unix socket (`uds:…`,
+  taken from the harness peer registry only while that process is alive on
+  this machine — the registry name is shown for display and is never the
+  address), and `codex queue --thread` for Codex threads.
+- **Receipts.** A resolve that returns exactly one target writes a delivery
+  receipt under `receipts/<sender key>/`, valid 20 minutes, naming that
+  target and its addresses. An ambiguous or empty resolve issues nothing.
+- **The gate.** `scripts/peer_send_gate.py --gate` is registered in the
+  plugin's own `hooks/hooks.json` (both clients load it) on `SendMessage`,
+  the desktop session-messaging tool, and the shell tools (for
+  `codex queue`). A direct send passes only when its address equals a live
+  receipt held by this sender, the target row is still active, the harness
+  registry still maps that socket to the receipt's session, the sender holds
+  an active seat, the message carries the sender's board id, and the same
+  text has not gone to a different session within 15 minutes (a broadcast).
+  In-process targets pass; a reply may copy the `from=` of a message this
+  session received; every decision is appended to `peer-sends.jsonl`;
+  anything unverifiable blocks with the remedy.
+- **A delivered bus.** `scripts/board_inbox.py --hook` runs on every
+  UserPromptSubmit and inside the SessionStart context in both clients,
+  injecting unread board messages addressed to this seat or its project
+  with a per-seat watermark. `coordination.py inbox` and `whoami` expose
+  the same view; the doctor counts seats and names orphans.
+- **Codex.** The SessionStart context states a Codex session's coordination
+  identity (its shell carries no thread id) so it exports
+  `SYNTHESIS_CLIENT_SESSION_REF` before claiming; `codex queue --thread`
+  is the direct lane to a Codex thread and is gated like the others.
+
+synthesis-agent-conformance 1.8.0 adds `hook-definition.public-peer-gate`
+and `hook-definition.public-inbox` to source conformance, so a plugin that
+stops routing peer sends through the gate or stops delivering the inbox
+fails CI. The git-hooks installed runtime and the onboarding probe carry the
+new `peer_addressing.py` module alongside the coordination engine; re-run
+the git-hooks installer after updating so the commit gate's engine copy
+matches the source (its doctor reports the drift until then).
+
 ## [4.89.0] - 2026-09-02
 
 **Google Chat gets a declared target set, and a surface that carries

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
-**Google Chat coverage is now claimed per space, never wholesale
-(September 2026).** Release **4.89.0** derives a declared target set for the
-Chat surface from an explicit config core plus a bounded enumeration, and
-refuses a surface-level watermark advance once per-target entries exist.
-See the [4.89.0 release notes](CHANGELOG.md).
+**Peer sessions are addressed by resolver-issued receipts, never by name
+(September 2026).** Release **4.90.0** gates every direct session-to-session
+send in both clients on a delivery receipt from `coordination.py resolve`,
+delivers the board's message bus at each prompt, and reaches Codex threads
+through `codex queue`. See the [4.90.0 release notes](CHANGELOG.md).
 
 **A self-report is a claim, not evidence (September 2026).** Release
 **4.88.0** makes daily parity read each client's installed manifest on disk

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -12,6 +12,41 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/board_inbox.py --hook",
+            "timeout": 10,
+            "statusMessage": "Delivering coordination board messages addressed to this session"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "SendMessage|mcp__ccd_session_mgmt__send_message",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/peer_send_gate.py --gate",
+            "timeout": 15,
+            "statusMessage": "Verifying the peer address against a delivery receipt and the coordination board"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash|exec_command|exec|shell|local_shell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/peer_send_gate.py --gate",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.7.0"
+  version: "1.8.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -872,6 +872,37 @@ def hook_definition_checks(source_root: Path) -> list[Check]:
             and "--format" in commands[0],
             f"{len(commands)} command hook(s): {commands}",
         )
+        gate_matchers = [
+            str(group.get("matcher", ""))
+            for group in mapping.get("PreToolUse", [])
+            if isinstance(group, dict)
+            and any(
+                "peer_send_gate.py" in hook.get("command", "") and "--gate" in hook.get("command", "")
+                for hook in group.get("hooks", [])
+                if isinstance(hook, dict) and hook.get("type") == "command"
+            )
+        ]
+        add(
+            checks,
+            "hook-definition.public-peer-gate",
+            any("SendMessage" in m for m in gate_matchers)
+            and any("ccd_session_mgmt__send_message" in m for m in gate_matchers)
+            and any("Bash" in m and "exec_command" in m for m in gate_matchers),
+            f"PreToolUse matchers routed to the peer send gate: {gate_matchers}",
+        )
+        inbox_commands = [
+            hook.get("command", "")
+            for group in mapping.get("UserPromptSubmit", [])
+            if isinstance(group, dict)
+            for hook in group.get("hooks", [])
+            if isinstance(hook, dict) and hook.get("type") == "command"
+        ]
+        add(
+            checks,
+            "hook-definition.public-inbox",
+            len(inbox_commands) == 1 and "board_inbox.py" in inbox_commands[0] and "--hook" in inbox_commands[0],
+            f"{len(inbox_commands)} UserPromptSubmit command hook(s): {inbox_commands}",
+        )
     except Exception as exc:
         add(checks, "hook-definition.public-config", False, f"{hook_file}: {exc}")
     return checks

--- a/skills/synthesis-agent-conformance/scripts/session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/session_context.py
@@ -449,6 +449,19 @@ def build(
     return "\n".join(lines)
 
 
+def append_inbox(message: str, payload: dict, board: Path, pointer: Path) -> str:
+    """Attach unread board messages for this seat, and for a non-Claude
+    client its coordination identity, so the bus is delivered at session
+    start and a Codex session learns the id its receipts are filed under."""
+    try:
+        from board_inbox import inbox_text
+
+        extra = inbox_text(payload, board=board, pointer=pointer)
+    except Exception as exc:  # the inbox never blocks a session start
+        extra = f"Coordination inbox unavailable: {exc}"
+    return message + ("\n" + extra if extra else "")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--active-project-file", type=Path, default=DEFAULT_POINTER)
@@ -488,6 +501,12 @@ def main() -> int:
         print(f"synthesis project context failed closed: {exc}", file=sys.stderr)
         return 2
     message = append_currency_notice(message, payload)
+    message = append_inbox(
+        message,
+        payload,
+        args.coordination_board.expanduser(),
+        args.active_project_file.expanduser(),
+    )
     try:
         record_live_receipt(payload, args.live_receipt.expanduser())
     except Exception as exc:

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -836,32 +836,69 @@ def test_render_treats_required_unknown_as_non_success(capsys) -> None:
     assert payload["checks"][0]["ok"] is None
 
 
+def _hook_config(*, gate: bool = True, inbox: bool = True) -> dict:
+    hooks: dict = {
+        "SessionStart": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-agent-conformance/scripts/session_context.py --format claude",
+                    }
+                ]
+            }
+        ]
+    }
+    if gate:
+        hooks["PreToolUse"] = [
+            {
+                "matcher": "SendMessage|mcp__ccd_session_mgmt__send_message",
+                "hooks": [{"type": "command", "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/peer_send_gate.py --gate"}],
+            },
+            {
+                "matcher": "Bash|exec_command|exec|shell|local_shell",
+                "hooks": [{"type": "command", "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/peer_send_gate.py --gate"}],
+            },
+        ]
+    if inbox:
+        hooks["UserPromptSubmit"] = [
+            {
+                "hooks": [{"type": "command", "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/board_inbox.py --hook"}]
+            }
+        ]
+    return {"hooks": hooks}
+
+
 def test_hook_definition_checks_require_session_context(tmp_path: Path) -> None:
     hook_file = tmp_path / "hooks" / "hooks.json"
     hook_file.parent.mkdir()
-    hook_file.write_text(
-        json.dumps(
-            {
-                "hooks": {
-                    "SessionStart": [
-                        {
-                            "hooks": [
-                                {
-                                    "type": "command",
-                                    "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-agent-conformance/scripts/session_context.py --format claude",
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
+    hook_file.write_text(json.dumps(_hook_config()), encoding="utf-8")
 
     checks = MODULE.hook_definition_checks(tmp_path)
 
-    assert all(check.ok for check in checks)
+    assert all(check.ok for check in checks), [c for c in checks if not c.ok]
+
+
+def test_hook_definition_checks_require_the_peer_gate_and_the_inbox(tmp_path: Path) -> None:
+    """A plugin whose hooks.json stops routing peer sends through the gate, or
+    stops delivering the board inbox, fails source conformance: the 2026-09-02
+    recurrence was a lane nothing gated."""
+    hook_file = tmp_path / "hooks" / "hooks.json"
+    hook_file.parent.mkdir()
+    hook_file.write_text(json.dumps(_hook_config(gate=False, inbox=False)), encoding="utf-8")
+
+    checks = {check.name: check for check in MODULE.hook_definition_checks(tmp_path)}
+
+    assert checks["hook-definition.public-sessionstart"].ok
+    assert not checks["hook-definition.public-peer-gate"].ok
+    assert not checks["hook-definition.public-inbox"].ok
+
+
+def test_shipped_hook_config_routes_peer_sends_through_the_gate() -> None:
+    source_root = Path(__file__).resolve().parents[3]
+    checks = {check.name: check for check in MODULE.hook_definition_checks(source_root)}
+    assert checks["hook-definition.public-peer-gate"].ok, checks["hook-definition.public-peer-gate"].detail
+    assert checks["hook-definition.public-inbox"].ok, checks["hook-definition.public-inbox"].detail
 
 
 def test_hook_live_checks_reject_static_absence_and_accept_receipts(

--- a/skills/synthesis-git-hooks/SKILL.md
+++ b/skills/synthesis-git-hooks/SKILL.md
@@ -218,7 +218,7 @@ synthesis-git-hooks/
 ```
 
 The installer also copies `coordination.py`, `coordination_schema.py`,
-`pointer_lock.py`, and the versioned session-word asset from the declared
+`pointer_lock.py`, `peer_addressing.py`, and the versioned session-word asset from the declared
 `synthesis-project-management` dependency into the shared runtime. Their
 canonical source remains in that owning skill; the git-hooks doctor compares
 the installed copies with those source paths and reports drift. `source-path`

--- a/skills/synthesis-git-hooks/scripts/_load_config.py
+++ b/skills/synthesis-git-hooks/scripts/_load_config.py
@@ -69,6 +69,7 @@ COORDINATION_ENGINE_FILES = (
     "coordination.py",
     "coordination_schema.py",
     "pointer_lock.py",
+    "peer_addressing.py",
 )
 ENGINE_FILES = CORE_ENGINE_FILES + COORDINATION_ENGINE_FILES
 COORDINATION_ASSET = "session-words-v1.txt.zlib.b85"

--- a/skills/synthesis-git-hooks/scripts/install.sh
+++ b/skills/synthesis-git-hooks/scripts/install.sh
@@ -28,6 +28,7 @@ for source in \
     "$COORDINATION_SOURCE/coordination.py" \
     "$COORDINATION_SOURCE/coordination_schema.py" \
     "$COORDINATION_SOURCE/pointer_lock.py" \
+    "$COORDINATION_SOURCE/peer_addressing.py" \
     "$COORDINATION_REFERENCES/session-words-v1.txt.zlib.b85"; do
     [ -f "$source" ] || {
         echo "✖ Required synthesis-project-management dependency missing: $source" >&2
@@ -46,6 +47,7 @@ cp -f "$SCRIPT_DIR/_load_config.py" "$TARGET_DIR/_load_config.py"
 cp -f "$COORDINATION_SOURCE/coordination.py" "$TARGET_DIR/coordination.py"
 cp -f "$COORDINATION_SOURCE/coordination_schema.py" "$TARGET_DIR/coordination_schema.py"
 cp -f "$COORDINATION_SOURCE/pointer_lock.py" "$TARGET_DIR/pointer_lock.py"
+cp -f "$COORDINATION_SOURCE/peer_addressing.py" "$TARGET_DIR/peer_addressing.py"
 printf '%s\n' "$SCRIPT_DIR" > "$TARGET_DIR/source-path"
 cp -f "$COORDINATION_REFERENCES/session-words-v1.txt.zlib.b85" \
     "$TARGET_REFERENCES/session-words-v1.txt.zlib.b85"
@@ -55,7 +57,8 @@ chmod +x \
     "$TARGET_DIR/_load_config.py" \
     "$TARGET_DIR/coordination.py" \
     "$TARGET_DIR/coordination_schema.py" \
-    "$TARGET_DIR/pointer_lock.py"
+    "$TARGET_DIR/pointer_lock.py" \
+    "$TARGET_DIR/peer_addressing.py"
 chmod 644 "$TARGET_DIR/source-path"
 
 if [ -f "$CONFIG_PATH" ]; then

--- a/skills/synthesis-git-hooks/scripts/test_pre_commit.py
+++ b/skills/synthesis-git-hooks/scripts/test_pre_commit.py
@@ -976,6 +976,7 @@ def test_r4_installer_copies_coordination_runtime(tmp_path: Path) -> None:
         "coordination.py",
         "coordination_schema.py",
         "pointer_lock.py",
+        "peer_addressing.py",
         "source-path",
     }
     assert (

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,32 +1,62 @@
-# AGENT HEURISTIC: authored for the 4.89.0 Google Chat preflight transaction.
+# AGENT HEURISTIC: authored for the 4.90.0 peer-addressing transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: gchat-declared-targets-and-no-wholesale-advance
+suite: peer-sends-need-a-resolver-receipt-and-the-bus-is-delivered
 membership: closed
-production_entry_point: skills/synthesis-daily-rituals/scripts/gchat_preflight.py
-enforcing_boundary: the Chat surface's declared set is derived each run from an explicit config core plus a client-side-filtered, explicitly bounded enumeration, and a surface carrying per-target watermarks refuses a wholesale advance
+production_entry_point: skills/synthesis-project-management/scripts/peer_send_gate.py
+enforcing_boundary: a direct session-to-session send in either client passes the plugin's PreToolUse gate only when its address equals a live delivery receipt issued by resolve for this sender, the target row is still active, the harness registry still maps that socket to the resolved session, the sender holds a seat, the message carries the sender's board id, and the same text has not gone to a second session; the board bus is delivered to the addressed seat at its next prompt
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the workspace that reported the defect adds its config targets and runs the first gated Chat sync in its own record; the enumeration wrapper's missing paging cursor is an upstream defect outside this repository
+unverified_remainder: delivery into a live Codex thread through codex queue is proven only to the thread-store lookup (a null thread id is refused by name); Codex sessions register a seat only after their agent exports the ref the SessionStart context states; hook trust for the changed hooks.json is granted by the human in Codex
 changed_surfaces:
-  - path: skills/synthesis-daily-rituals/scripts/gchat_preflight.py
-    cases: [person-never-a-target, wrapper-filter-not-trusted, bounded-enumeration, declared-set-feeds-the-gate, cli-fails-closed]
-  - path: skills/synthesis-daily-rituals/scripts/test_gchat_preflight.py
-    cases: [person-never-a-target, wrapper-filter-not-trusted, bounded-enumeration, declared-set-feeds-the-gate, cli-fails-closed, rituals-doc-contract]
-  - path: skills/synthesis-daily-rituals/scripts/sync_watermark.py
-    cases: [wholesale-advance-refused]
-  - path: skills/synthesis-daily-rituals/scripts/test_sync_watermark.py
-    cases: [wholesale-advance-refused]
-  - path: skills/synthesis-daily-rituals/SKILL.md
-    cases: [rituals-doc-contract, rituals-budget]
-  - path: skills/synthesis-daily-rituals/references/version-history.md
-    cases: [rituals-budget]
-  - path: skills/synthesis-daily-rituals/references/sync-watermarks.md
-    cases: [rituals-doc-contract]
+  - path: skills/synthesis-project-management/scripts/peer_addressing.py
+    cases: [names-are-not-addresses, receipt-binds-intent, live-reverification, seat-at-claim, bus-delivered-once]
+  - path: skills/synthesis-project-management/scripts/peer_send_gate.py
+    cases: [names-are-not-addresses, receipt-binds-intent, live-reverification, sender-must-hold-a-seat, no-broadcast, codex-queue-gated, gate-fails-closed]
+  - path: skills/synthesis-project-management/scripts/board_inbox.py
+    cases: [bus-delivered-once, codex-learns-its-identity, sessionstart-carries-the-inbox]
+  - path: skills/synthesis-project-management/scripts/coordination.py
+    cases: [seat-at-claim, resolve-issues-receipt, ambiguity-issues-nothing, cc-ref-for-terminal-sessions]
+  - path: skills/synthesis-project-management/scripts/test_peer_addressing.py
+    cases: [seat-at-claim, resolve-issues-receipt, ambiguity-issues-nothing, cc-ref-for-terminal-sessions, bus-delivered-once]
+  - path: skills/synthesis-project-management/scripts/test_peer_send_gate.py
+    cases: [names-are-not-addresses, receipt-binds-intent, live-reverification, sender-must-hold-a-seat, no-broadcast, codex-queue-gated, gate-fails-closed]
+  - path: skills/synthesis-project-management/scripts/test_board_inbox.py
+    cases: [bus-delivered-once, codex-learns-its-identity, sessionstart-carries-the-inbox]
+  - path: skills/synthesis-project-management/scripts/test_coordination.py
+    cases: [pm-budget]
+  - path: skills/synthesis-project-management/SKILL.md
+    cases: [pm-budget]
+  - path: skills/synthesis-project-management/references/parallel-agent-protocol.md
+    cases: [pm-budget]
+  - path: skills/synthesis-project-management/references/session-identity.md
+    cases: [pm-budget]
+  - path: skills/synthesis-project-management/references/active-sessions-template.md
+    cases: [pm-budget]
+  - path: skills/synthesis-agent-conformance/scripts/session_context.py
+    cases: [sessionstart-carries-the-inbox]
+  - path: skills/synthesis-agent-conformance/scripts/conformance.py
+    cases: [hook-contract-requires-the-gate, shipped-hooks-route-through-the-gate]
+  - path: skills/synthesis-agent-conformance/scripts/test_conformance.py
+    cases: [hook-contract-requires-the-gate, shipped-hooks-route-through-the-gate]
+  - path: skills/synthesis-agent-conformance/SKILL.md
+    cases: [hook-contract-requires-the-gate]
+  - path: hooks/hooks.json
+    cases: [shipped-hooks-route-through-the-gate]
+  - path: skills/synthesis-git-hooks/scripts/test_pre_commit.py
+    cases: [engine-module-set-complete]
+  - path: skills/synthesis-git-hooks/scripts/install.sh
+    cases: [engine-module-set-complete]
+  - path: skills/synthesis-git-hooks/scripts/_load_config.py
+    cases: [engine-module-set-complete]
+  - path: skills/synthesis-git-hooks/SKILL.md
+    cases: [engine-module-set-complete]
+  - path: skills/synthesis-onboarding/scripts/onboard.py
+    cases: [engine-module-set-complete]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -38,37 +68,77 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: person-never-a-target
+  - id: names-are-not-addresses
     control_class: enforced-gate
-    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_a_person_id_is_never_a_read_target
-    motivating_defect: the-workspace-map-carries-people-ids-and-a-reader-that-takes-them-reads-nothing
-  - id: wrapper-filter-not-trusted
-    control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_the_wrappers_type_filter_is_not_trusted_scope_filters_client_side
-    motivating_defect: the-enumeration-header-asserted-a-filter-that-was-never-applied
-  - id: bounded-enumeration
+    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_display_names_and_refs_are_refused_as_addresses
+    motivating_defect: seven-misdeliveries-chose-a-target-by-a-display-name-or-title-at-the-moment-of-sending
+  - id: receipt-binds-intent
     control_class: enforced-gate
-    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_cli_exits_one_and_names_the_bound_when_the_enumeration_is_capped
-    motivating_defect: a-hundred-of-four-hundred-spaces-read-as-complete-because-nothing-stated-the-bound
-  - id: declared-set-feeds-the-gate
-    control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_cli_writes_the_declared_set_the_gate_consumes
-    motivating_defect: a-surface-with-no-declared-set-is-claimed-on-the-agents-say-so
-  - id: cli-fails-closed
-    control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_cli_refuses_an_empty_set_and_a_malformed_config
-    motivating_defect: an-empty-resolved-set-reported-as-a-quiet-day-is-a-completeness-claim-with-no-evidence
-  - id: wholesale-advance-refused
+    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_socket_address_needs_a_receipt_then_passes
+    motivating_defect: an-existence-check-passed-a-registered-but-wrong-session-the-day-after-the-resolver-shipped
+  - id: live-reverification
     control_class: enforced-gate
-    fixture: ../synthesis-daily-rituals/scripts/test_sync_watermark.py::test_surface_level_advance_is_refused_once_targets_exist
-    motivating_defect: a-surface-level-advance-recorded-coverage-no-per-space-read-backed-and-four-dms-went-unsurfaced
-  - id: rituals-doc-contract
+    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_socket_that_no_longer_maps_to_the_resolved_session_is_refused
+    motivating_defect: a-receipt-older-than-the-target-process-would-otherwise-deliver-to-whoever-inherited-the-socket
+  - id: sender-must-hold-a-seat
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_sender_without_a_seat_is_refused
+    motivating_defect: a-reply-to-an-unregistered-sender-can-only-be-guessed
+  - id: no-broadcast
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_same_text_to_a_second_session_is_a_broadcast
+    motivating_defect: an-unsure-sender-sent-the-same-text-to-every-candidate-three-times-in-the-record
+  - id: codex-queue-gated
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_codex_queue_needs_a_receipt_for_that_thread
+    motivating_defect: the-lane-table-said-codex-had-no-push-channel-while-codex-queue-existed-ungated
+  - id: gate-fails-closed
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_missing_session_id_and_unreadable_board_fail_closed
+    motivating_defect: a-guard-that-cannot-verify-must-block-not-warn-and-pass
+  - id: seat-at-claim
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_gchat_preflight.py::test_rituals_run_the_gchat_preflight_per_target
-    motivating_defect: a-script-the-protocol-does-not-invoke-is-not-a-control
-  - id: rituals-budget
+    fixture: ../synthesis-project-management/scripts/test_peer_addressing.py::test_claim_writes_a_seat_release_removes_it
+    motivating_defect: the-board-carried-one-handle-per-session-while-each-client-addresses-by-a-different-one
+  - id: resolve-issues-receipt
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_rituals_skill_document_stays_within_repo_budget
+    fixture: ../synthesis-project-management/scripts/test_peer_addressing.py::test_resolve_prints_exact_lanes_and_issues_a_receipt
+    motivating_defect: resolve-was-doctrine-an-agent-could-skip-and-the-gate-could-not-tell
+  - id: ambiguity-issues-nothing
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_peer_addressing.py::test_ambiguous_resolve_issues_no_receipt
+    motivating_defect: a-resolver-that-refuses-ambiguity-but-leaves-the-send-ungated-changes-nothing
+  - id: cc-ref-for-terminal-sessions
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_peer_addressing.py::test_terminal_session_claim_registers_cc_ref
+    motivating_defect: a-terminal-session-registered-no-handle-and-was-unreachable-by-any-direct-lane
+  - id: bus-delivered-once
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_board_inbox.py::test_inbox_delivers_once_to_the_named_seat
+    motivating_defect: a-bus-nobody-reads-is-a-dead-letter-so-senders-reached-for-the-guessing-lane
+  - id: codex-learns-its-identity
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_board_inbox.py::test_codex_session_learns_its_identity
+    motivating_defect: no-codex-session-ever-registered-a-ref-because-its-shell-cannot-see-its-thread-id
+  - id: sessionstart-carries-the-inbox
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_board_inbox.py::test_session_context_appends_the_inbox
+    motivating_defect: a-message-posted-while-the-recipient-was-away-must-arrive-when-it-returns
+  - id: hook-contract-requires-the-gate
+    control_class: acceptance-test
+    fixture: ../synthesis-agent-conformance/scripts/test_conformance.py::test_hook_definition_checks_require_the_peer_gate_and_the_inbox
+    motivating_defect: a-gate-that-can-be-unregistered-silently-is-not-a-control
+  - id: shipped-hooks-route-through-the-gate
+    control_class: acceptance-test
+    fixture: ../synthesis-agent-conformance/scripts/test_conformance.py::test_shipped_hook_config_routes_peer_sends_through_the_gate
+    motivating_defect: the-shipped-hook-file-is-the-only-registration-both-clients-load
+  - id: engine-module-set-complete
+    control_class: acceptance-test
+    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_configured_hook_consumes_bound_receipt
+    motivating_defect: a-fixture-that-copies-the-engine-without-its-new-module-proves-nothing
+  - id: pm-budget
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget
     motivating_defect: a-restructured-document-must-not-regrow-with-its-next-feature
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -2068,7 +2068,11 @@ def _runtime_probe(receipts):
 
 def _coordination_probe():
     root = HOME / ".synthesis" / "git-hooks"
-    required = [root / "coordination.py", root / "coordination_schema.py"]
+    required = [
+        root / "coordination.py",
+        root / "coordination_schema.py",
+        root / "peer_addressing.py",
+    ]
     if not all(path.is_file() for path in required):
         return False, "stable coordination runtime is missing"
     board = HOME / ".synthesis" / "coordination" / "active-sessions.md"

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.10.0"
+  version: "2.11.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -14,14 +14,11 @@ metadata:
 
 A lightweight project management system designed for human-agent collaboration. Optimized for context preservation across conversation sessions and context compaction events.
 
-## v2.9.0 — One document, load-bearing; depth in references
+## v2.11.0 — One document, load-bearing; depth in references
 
-Every operating rule stays here, inside the repository's 500-line budget;
-worked examples, full formats, and rationale moved to `references/` with
-pointers in place. Nothing was dropped. v2.8.0's peer-session resolution
-(board v4 client refs, `resolve`, strict bus addressing, staged migration)
-is under Cross-Agent Session Coordination below and in full in
-[references/parallel-agent-protocol.md](references/parallel-agent-protocol.md).
+Every operating rule stays here, inside the 500-line budget; examples and
+rationale live in `references/`. Peer addressing (resolve, receipts, gated
+lanes, delivered bus) is in full in [references/parallel-agent-protocol.md](references/parallel-agent-protocol.md).
 
 ## Configuration
 
@@ -270,9 +267,13 @@ python3 <synthesis-project-management-root>/scripts/coordination.py heartbeat \
 python3 <synthesis-project-management-root>/scripts/coordination.py \
   check-staged --session s-6adk-06yc-yqb2 --repository /path/to/worktree
 
-# Resolve a peer to its exact deliverable target before messaging it
+# Resolve a peer: exact address per lane + the receipt the send gate matches
 python3 <synthesis-project-management-root>/scripts/coordination.py resolve \
   --to example-project --role owner
+
+# This shell's identity, seat, and lanes; unread bus messages for its seat
+python3 <synthesis-project-management-root>/scripts/coordination.py whoami
+python3 <synthesis-project-management-root>/scripts/coordination.py inbox --mark-read
 
 # Leave a handoff (--to must resolve; --free-address records exceptions)
 printf '%s\n' "Source checks pass; live install awaits authorization." |
@@ -312,12 +313,12 @@ Rules:
 6. **Autonomous claim keeps priority.** When an autonomous and interactive
    session overlap, the autonomous session keeps its existing claim; the
    interactive session yields unless the user explicitly reorders them.
-7. **Messages are asynchronous, and addresses are resolved, never guessed.**
-   Address the other session in the message log; the recipient reads it at
-   its next checkpoint. Before any direct client-channel send to a peer
-   session, run `resolve` and address the exact ref it returns; a client's
-   display labels and chat titles are not identities, and an unresolvable
-   peer gets a board message, not a broadcast.
+7. **Direct sends need a receipt; addresses are resolved, never guessed.**
+   `resolve` issues a delivery receipt for one target; the plugin's gate
+   admits a direct send only at that exact address, re-verified live. Names,
+   titles, and `[ref]` labels are never addresses; the message carries your
+   board id; the same text to a second peer is a refused broadcast. The bus
+   reaches the addressed seat at its next prompt: unresolvable means bus.
 8. **Heartbeat and release explicitly.** Refresh the heartbeat at checkpoints.
    A paused or completed session releases or narrows its claims. Stale `active`
    rows remain blocking until explicitly resolved; time alone never transfers

--- a/skills/synthesis-project-management/references/active-sessions-template.md
+++ b/skills/synthesis-project-management/references/active-sessions-template.md
@@ -30,7 +30,10 @@ Append addressed messages here. Use a heading:
 4. Every root session that writes git state uses an isolated worktree and branch.
 5. One session owns canonical project context; contributors use separate artifacts.
 6. An existing autonomous claim keeps priority over an interactive session.
-7. Put asynchronous handoffs under `## Messages`.
+7. Put asynchronous handoffs under `## Messages`, addressed to a session id or
+   `<project> sessions`; the addressed seat receives them at its next prompt.
+   Direct sends go through `resolve` (which issues the delivery receipt the
+   send gate requires); display names and chat titles are never addresses.
 8. Heartbeat at checkpoints; release or narrow claims at pause and session end.
 
 ## Identity

--- a/skills/synthesis-project-management/references/parallel-agent-protocol.md
+++ b/skills/synthesis-project-management/references/parallel-agent-protocol.md
@@ -30,51 +30,88 @@ machine:
    with `retire_worktree.py`, never by hand. Publish the attributed batch
    only for explicit remote handoff or day-end.
 
-## Addressing a peer session — resolve, never guess
+## Addressing a peer session — resolve, receipt, gate
 
 Three naming systems cover one population of sessions: the board's
 identities (UUIDv7 with compact and speakable aliases), each client's chat
-handles (Claude Code's `local_<uuid>` session ids with free-text titles),
-and the harness's display labels (directory-plus-recency strings that
-duplicate freely). Only the board answers "what does this session own," and
-since schema v4 it also carries the join: each row's **client session ref**,
-the client-native delivery handle registered automatically at claim time
-(`ccd:local_<uuid>` from `CLAUDE_CODE_HOST_SESSION_ID`, or any scheme-prefixed
-value exported as `SYNTHESIS_CLIENT_SESSION_REF`, e.g. `codex:<uuid>`).
+handles (Claude Code's `local_<uuid>` desktop session ids, Codex thread
+ids), and the harness's peer registry (derived display names that duplicate
+freely, each backed by a Unix socket). Only the board answers "what does
+this session own"; only the session itself knows all of its handles. The
+join is therefore registered by the session: the board row carries its
+primary **client session ref** (`ccd:local_<uuid>` on the desktop,
+`cc:<uuid>` in a terminal, `codex:<uuid>` for Codex via the exported
+`SYNTHESIS_CLIENT_SESSION_REF`), and a **seat** sidecar beside the board
+(`seats/<session uuid>.json`, written at claim, refreshed at heartbeat,
+removed at release) carries the rest: harness session id, desktop id, pid,
+machine.
 
-The addressing protocol:
+Seven recorded misdeliveries (2026-08-19 through 2026-09-02, one of them
+the day after the resolver shipped) share one shape: an agent chose a
+target by a display name at the moment of sending. The protocol removes
+that moment.
 
 1. **Resolve first.** `coordination.py resolve --to <project|session|ref>`
-   returns the exact target with its delivery lane. Exactly one match exits
-   0; several exit 20 and are printed — narrow with `--role owner` or
-   address one exact id; none exits 21. Titles and display labels are
-   deliberately not selectors.
-2. **Deliver on the returned lane.** A `ccd:` ref is a direct-push target
-   for Claude Code's session-messaging tool on that machine. A Codex session
-   or an unregistered peer is reached through the board message bus
-   (`message --to`), which now also refuses addressees that match no
-   session or registered project (`--free-address` records a deliberate
-   exception). Substance belongs on the durable bus either way; the direct
-   channel is the pointer (the 2026-08-19 rule).
-3. **Never assign work to a guess.** An unresolvable peer means broadcast
-   informationally on the bus and let sessions self-select — a dispatch to
-   the wrong session starts work in a context with the wrong claims, and
-   the receiving session cannot tell it was a guess.
-4. **One seat, one row.** A claim with no `--session` whose detected ref
+   returns exactly one target (exit 0), prints the exact invocation per
+   lane, and writes a **delivery receipt** under
+   `receipts/<sender key>/` naming that target and those addresses, valid
+   for 20 minutes. Several candidates exit 20 and issue nothing — narrow
+   with `--role owner` or an exact id; none exit 21 — use the bus. Titles
+   and display names are deliberately not selectors.
+2. **Lanes are exact addresses, computed from live truth.**
+   - *bus*: `coordination.py message --to <compact id>` — always available,
+     delivered to the addressed seat (or its project's sessions) at that
+     session's next prompt by the plugin's inbox hook.
+   - *ccd*: `mcp__ccd_session_mgmt__send_message` with the row's
+     `local_<uuid>` — same machine only.
+   - *harness*: `SendMessage` to `uds:<socket>` — the registry's socket for
+     the seat's harness session id, only while that process is alive on this
+     machine. The registry name is printed for display; it is never the
+     address. A bare name, `name [ref]`, or `[ref]` is refused.
+   - *codex*: `codex queue --thread <uuid> --message …` — same machine.
+3. **The gate enforces it.** `scripts/peer_send_gate.py --gate`, registered
+   in the plugin's `hooks/hooks.json` for both clients on `SendMessage`,
+   the ccd send tool, and the shell tools (for `codex queue`), admits a
+   direct send only when: the address equals a live receipt held by this
+   sender; the target row is still active; the harness registry still maps
+   that socket to the receipt's session; the sender holds an active seat;
+   the message carries the sender's board id (so the reply resolves without
+   guessing); and the same text has not gone to a different session within
+   15 minutes (that is a broadcast). A reply may copy the `from=` of a
+   message this session received — the harness wrote that address. In-process
+   targets (`main`, spawned agent ids, named teammates) pass. Every decision
+   lands in `peer-sends.jsonl`. Anything the gate cannot verify blocks.
+4. **Never assign work to a guess.** An unresolvable peer means a bus
+   message addressed to the project, which its sessions self-select at their
+   next prompt — a dispatch to the wrong session starts work in a context
+   with the wrong claims, and the receiving session cannot tell it was a
+   guess.
+5. **One seat, one row.** A claim with no `--session` whose detected ref
    matches its own active row updates that row in place; two active rows
    with one ref refuse until the stale one is released. Sub-agents spawned
-   by a session inherit its environment and therefore its seat — they must
-   not claim as independent sessions.
-5. **Enforcement.** Instances that adopt `peer_send_resolution` in
-   synthesis-message-guard get the fail-closed backstop: a direct
-   peer-session send whose target id is not an active board ref is blocked
-   at the PreToolUse boundary with resolve/bus guidance.
+   by a session inherit its environment and therefore its seat.
+6. **Codex sessions register the same way.** Their hooks receive the thread
+   id and the SessionStart context states it; a Codex shell carries no
+   thread id, so the agent exports `SYNTHESIS_CLIENT_SESSION_REF=codex:<id>`
+   before `claim` and `resolve`. Receipts are then filed under the key the
+   gate derives from the hook payload; a mismatch simply finds no receipt.
+   Codex reaches its peers through the same resolver and gate; Claude
+   sessions reach Codex through `codex queue` or the bus.
+7. **`whoami` and `inbox`.** `coordination.py whoami` prints this shell's
+   identity, seat, and the lanes peers would use; `inbox` lists unread bus
+   messages for the seat and marks them read. The doctor counts seats and
+   names those without an active row; `peer_send_gate.py --doctor` verifies
+   the gate's inputs for this session.
+
+The synthesis-message-guard `peer_send_resolution` lane (config-adopted)
+remains a second, independent existence check on the ccd tool; the plugin
+gate above is the intent check and runs regardless of private configuration.
 
 Migration is staged: the engine reads schemas v1–v4 and writes each board's
 declared schema; a shared board flips to v4 only via an explicit `migrate`
 run after every machine's client is current, so older parsers mid-flight
-fail closed on nothing. Until migration, refs print a notice at claim time
-and drop harmlessly; resolve says the board is pre-v4.
+fail closed on nothing. Seats and receipts are sidecars and need no schema
+change; an engine without them simply offers the bus.
 
 ## Release trains — serializing a shared publish surface
 

--- a/skills/synthesis-project-management/references/session-identity.md
+++ b/skills/synthesis-project-management/references/session-identity.md
@@ -17,7 +17,12 @@ Since schema v4 a row also carries a **client session ref** (for example
 `ccd:local_<uuid>`), which is not an identity: it is the client-native
 delivery address registered at claim time, resolvable through
 `coordination.py resolve` but never a substitute for the UUID in pointers,
-leases, or receipts. See the parallel-agent protocol's "Addressing a peer
+leases, or receipts. A session's other handles (harness session id,
+desktop id, pid, machine) live in a **seat** sidecar,
+`seats/<session uuid>.json` beside the board, written at claim and removed
+at release; `resolve` joins the row, the seat, and the harness's live peer
+registry into exact per-lane addresses and issues a delivery receipt the
+send gate matches. See the parallel-agent protocol's "Addressing a peer
 session."
 
 UUIDv7 follows RFC 9562: 48 milliseconds-of-Unix-time bits, required version

--- a/skills/synthesis-project-management/scripts/board_inbox.py
+++ b/skills/synthesis-project-management/scripts/board_inbox.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Deliver the coordination board's addressed messages to the seat they name.
+
+The board's ``## Messages`` section is the one lane every session has — a
+Codex thread, a session on another machine, a session that never claimed a
+direct handle — but a message nobody reads is a dead letter. This hook runs
+at SessionStart and on every UserPromptSubmit in both clients and injects
+the unread messages addressed to this session's seat (any identity form) or
+to its project, then advances a per-seat watermark. Latency is one turn,
+the same class as the harness's own queue.
+
+For a Codex session it also states the session's coordination identity,
+because a Codex shell carries no thread id: the agent exports it as
+``SYNTHESIS_CLIENT_SESSION_REF`` so claims and receipts are filed under the
+same key the gate sees.
+
+Prints nothing when there is nothing to say; never blocks a prompt.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from peer_addressing import (  # noqa: E402
+    CLIENT_CLAUDE,
+    SelfIdentity,
+    identity_from_hook,
+    mark_seen,
+    render_inbox,
+    seat_for_identity,
+    unread_messages,
+)
+
+DEFAULT_BOARD = Path.home() / ".synthesis" / "coordination" / "active-sessions.md"
+DEFAULT_POINTER = Path.home() / ".synthesis" / "active-project.json"
+
+
+def pointer_project(pointer: Path) -> str:
+    try:
+        data = json.loads(pointer.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ""
+    project = data.get("project") if isinstance(data, dict) else None
+    return Path(str(project)).name if project else ""
+
+
+def identity_forms_for(board: Path, identity: SelfIdentity) -> tuple[set[str], str, str]:
+    """(identity forms, project, compact id) for this session's seat, if any."""
+    seat = seat_for_identity(board, identity)
+    if seat is None:
+        return set(), "", ""
+    from coordination import rows  # local import: the engine parses the board
+
+    try:
+        board_rows = rows(board.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set(), "", ""
+    row = next((r for r in board_rows if r.session_uuid == seat.session_uuid), None)
+    if row is None:
+        return set(), "", ""
+    forms = {row.session_uuid, row.compact_id, row.speakable_id}
+    if row.legacy_id:
+        forms.add(row.legacy_id)
+    return forms, row.project, row.compact_id
+
+
+def identity_notice(identity: SelfIdentity) -> str:
+    if identity.client == CLIENT_CLAUDE or not identity.harness_session_id:
+        return ""
+    ref = identity.sender_key
+    return (
+        f"Coordination identity for this session: {ref}. Export "
+        f"SYNTHESIS_CLIENT_SESSION_REF={ref} in every shell that runs "
+        "coordination.py claim or resolve, so your seat and delivery receipts "
+        "are filed under the id the send gate sees."
+    )
+
+
+def inbox_text(
+    payload: dict,
+    *,
+    board: Path = DEFAULT_BOARD,
+    pointer: Path = DEFAULT_POINTER,
+    environ: dict[str, str] | None = None,
+    mark: bool = True,
+) -> str:
+    identity = identity_from_hook(payload, environ)
+    key = identity.sender_key
+    if not key:
+        return ""
+    try:
+        text = board.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    forms, project, _compact = identity_forms_for(board, identity)
+    if not forms:
+        project = pointer_project(pointer)
+    if not forms and not project:
+        notice = identity_notice(identity)
+        return notice
+    messages = unread_messages(
+        text, board=board, sender_key=key, identity_forms=forms, project=project
+    )
+    rendered = render_inbox(messages)
+    if messages and mark:
+        mark_seen(board, key, {message.key for message in messages})
+    notice = identity_notice(identity)
+    return "\n".join(part for part in (notice, rendered) if part)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--board", type=Path, default=DEFAULT_BOARD)
+    parser.add_argument("--active-project-file", type=Path, default=DEFAULT_POINTER)
+    parser.add_argument("--hook", action="store_true", help="read the hook payload on stdin and emit hook JSON")
+    parser.add_argument("--no-mark", action="store_true", help="do not advance the watermark")
+    args = parser.parse_args()
+    board = args.board.expanduser()
+    payload: dict = {}
+    if args.hook:
+        try:
+            payload = json.load(sys.stdin)
+        except Exception:
+            payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
+    try:
+        text = inbox_text(payload, board=board, pointer=args.active_project_file.expanduser(), mark=not args.no_mark)
+    except Exception as exc:  # never block a prompt on inbox trouble; say what failed
+        text = f"Coordination inbox could not be read: {exc}"
+    if not text:
+        return 0
+    if args.hook:
+        event = payload.get("hook_event_name") or "UserPromptSubmit"
+        print(json.dumps({"continue": True, "hookSpecificOutput": {"hookEventName": event, "additionalContext": text}}))
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -25,6 +25,23 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from pointer_lock import locked_pointer
+from peer_addressing import (
+    CLIENT_CODEX,
+    SelfIdentity,
+    all_seats,
+    delivery_lanes,
+    detect_self,
+    lane_invocations,
+    load_receipts,
+    mark_seen,
+    read_seat,
+    remove_seat,
+    render_inbox,
+    seat_for_identity,
+    unread_messages,
+    write_receipt,
+    write_seat,
+)
 from coordination_schema import (
     SCHEMA_VERSION,
     V1_COLUMNS,
@@ -94,7 +111,28 @@ def detect_client_ref() -> str:
     host = os.environ.get("CLAUDE_CODE_HOST_SESSION_ID", "").strip()
     if host:
         return normalize_client_ref(f"ccd:{host}")
+    harness = os.environ.get("CLAUDE_CODE_SESSION_ID", "").strip()
+    if harness:
+        # A terminal session has no desktop chat id; its harness session id
+        # is still a real delivery handle (the peer registry maps it to a
+        # socket), so it registers under the cc: scheme.
+        return normalize_client_ref(f"cc:{harness}")
     return ""
+
+
+def self_identity(requested_ref: str = "") -> SelfIdentity:
+    """What this shell knows about its own session, honoring an explicit ref."""
+    identity = detect_self()
+    if requested_ref.startswith("codex:") and identity.client != CLIENT_CODEX:
+        return SelfIdentity(
+            client=CLIENT_CODEX,
+            harness_session_id=requested_ref[len("codex:"):],
+            explicit_ref=requested_ref,
+            pid=identity.pid,
+        )
+    if requested_ref and not identity.primary_ref:
+        return SelfIdentity(explicit_ref=requested_ref, pid=identity.pid)
+    return identity
 TERMINAL_STATUSES = {"released", "complete", "completed", "closed"}
 CONTEXT_RESERVED_PATTERNS = (
     "context.md",
@@ -188,7 +226,8 @@ def template() -> str:
         "5. Existing autonomous claims keep priority over interactive sessions.\n"
         "6. Heartbeat at checkpoints; release or narrow claims at pause and session end.\n"
         "7. Address peers through resolve — board identity, never client labels; "
-        "an unresolvable peer gets a board message, not a broadcast.\n"
+        "resolve issues the delivery receipt the send gate requires, and an "
+        "unresolvable peer gets a board message, not a broadcast.\n"
     )
 
 
@@ -1611,6 +1650,15 @@ def command_claim(args) -> int:
         f"Claimed {', '.join(requested)} for session {identity.compact_id} "
         f"({identity.speakable_id}; uuid={identity.session_uuid}{legacy})."
     )
+    seat = write_seat(
+        args.board,
+        session_uuid=identity.session_uuid,
+        compact_id=identity.compact_id,
+        machine=args.machine,
+        identity=self_identity(requested_ref),
+    )
+    if seat is not None:
+        print(f"Seat recorded at {seat} (delivery handles for peer resolution).")
     if claimed.get("reused"):
         print(
             "Reused this client session's existing active row "
@@ -1650,6 +1698,21 @@ def command_heartbeat(args) -> int:
         print(f"coordination heartbeat failed: {exc}", file=sys.stderr)
         return 10
     print(f"Heartbeat updated for session {updated['identity'].compact_id}.")
+    existing = read_seat(args.board, updated["identity"].session_uuid)
+    if existing is not None:
+        write_seat(
+            args.board,
+            session_uuid=existing.session_uuid,
+            compact_id=existing.compact_id,
+            machine=existing.machine,
+            identity=self_identity() if self_identity().primary_ref else SelfIdentity(
+                client=existing.client,
+                harness_session_id=existing.harness_session_id,
+                host_session_id=existing.host_session_id,
+                pid=existing.pid,
+            ),
+            cwd=existing.cwd,
+        )
     return 0
 
 
@@ -1686,6 +1749,8 @@ def command_release(args) -> int:
             return 11
         if archived:
             print(f"Archived released session's active-project pointer: {archived}")
+    if remove_seat(args.board, released["identity"].session_uuid):
+        print("Seat removed.")
     print(f"Released session {released['identity'].compact_id}.")
     return 0
 
@@ -1775,8 +1840,18 @@ def delivery_lane(session: Session) -> str:
             f"ccd send_message to session_id {session.client_ref[4:]} "
             f"(valid on machine {session.machine})"
         )
-    if session.client_ref.startswith("codex:") or "codex" in session.agent.lower():
-        return "board message bus (Codex sessions have no direct push channel)"
+    if session.client_ref.startswith("codex:"):
+        return (
+            f"codex queue --thread {session.client_ref[len('codex:'):]} on machine "
+            f"{session.machine}, or the board message bus"
+        )
+    if session.client_ref.startswith("cc:"):
+        return (
+            "harness SendMessage to the uds: socket the resolver prints (valid on "
+            f"machine {session.machine} while the session runs), or the board message bus"
+        )
+    if "codex" in session.agent.lower():
+        return "board message bus (Codex session registered no thread id)"
     return "board message bus (session has no registered client ref)"
 
 
@@ -1872,6 +1947,59 @@ def command_resolve(args) -> int:
         }
         for session in matches
     ]
+    lanes: dict[str, dict] = {}
+    receipt_path = None
+    receipt_note = ""
+    sender_compact = ""
+    if len(entries) == 1:
+        target = matches[0]
+        lanes = delivery_lanes(
+            client_ref=target.client_ref,
+            compact_id=target.compact_id,
+            target_machine=target.machine,
+            seat=read_seat(args.board, target.session_uuid),
+            local_machine=getattr(args, "local_machine", None),
+            registry=getattr(args, "registry", None),
+        )
+        sender = self_identity()
+        own_seat = seat_for_identity(args.board, sender)
+        sender_row = next(
+            (s for s in sessions if own_seat and s.session_uuid == own_seat.session_uuid and active(s)),
+            None,
+        )
+        sender_compact = sender_row.compact_id if sender_row else ""
+        if not getattr(args, "no_receipt", False):
+            receipt_path = write_receipt(
+                args.board,
+                sender=sender,
+                sender_row=(
+                    {"uuid": sender_row.session_uuid, "compact": sender_row.compact_id, "project": sender_row.project}
+                    if sender_row
+                    else None
+                ),
+                selector=args.to,
+                matched_by=kind,
+                target={
+                    "uuid": target.session_uuid,
+                    "compact": target.compact_id,
+                    "project": target.project,
+                    "machine": target.machine,
+                    "agent": target.agent,
+                    "client_ref": target.client_ref,
+                },
+                lanes=lanes,
+            )
+            if receipt_path is None:
+                receipt_note = (
+                    "no delivery receipt issued: this shell carries no session identity "
+                    "(CLAUDE_CODE_SESSION_ID or SYNTHESIS_CLIENT_SESSION_REF), so the send "
+                    "gate will refuse direct lanes; the bus lane remains"
+                )
+            elif sender_row is None:
+                receipt_note = (
+                    "receipt issued, but this session holds no active seat: the send gate "
+                    "requires one (claim before sending) so the peer can resolve a reply"
+                )
     if args.json:
         print(
             json.dumps(
@@ -1880,6 +2008,10 @@ def command_resolve(args) -> int:
                     "matched_by": kind,
                     "board_schema": board_schema(content),
                     "matches": entries,
+                    "lanes": lanes,
+                    "receipt": str(receipt_path) if receipt_path else None,
+                    "receipt_note": receipt_note or None,
+                    "sender": sender_compact or None,
                 },
                 indent=2,
             )
@@ -1895,6 +2027,14 @@ def command_resolve(args) -> int:
             print(f"  uuid: {entry['uuid']}")
             print(f"  client ref: {entry['client_ref'] or '-'}")
             print(f"  delivery: {entry['delivery']}")
+        if lanes:
+            print("Exact invocations (copy verbatim; the message must start with your board id):")
+            for line in lane_invocations(lanes, sender_compact):
+                print(f"  {line}")
+            if receipt_path is not None:
+                print(f"Delivery receipt: {receipt_path} (valid 20 minutes; the send gate matches it)")
+            if receipt_note:
+                print(f"note: {receipt_note}", file=sys.stderr)
     if len(entries) == 1:
         return 0
     if len(entries) > 1:
@@ -1920,6 +2060,111 @@ def command_resolve(args) -> int:
         file=sys.stderr,
     )
     return 21
+
+
+def command_inbox(args) -> int:
+    """Unread board messages addressed to a seat (any identity form) or its project."""
+    lease_refresh(args.board)
+    if not args.board.is_file():
+        print(f"inbox: no coordination board at {args.board}", file=sys.stderr)
+        return 1
+    content = args.board.read_text(encoding="utf-8")
+    sessions = rows(content)
+    selector = getattr(args, "id", None)
+    identity = self_identity()
+    if selector:
+        row = find_session(sessions, selector)
+        if row is None:
+            print(f"inbox: session not found: {selector}", file=sys.stderr)
+            return 1
+        key = f"seat:{row.session_uuid}"
+    else:
+        seat = seat_for_identity(args.board, identity)
+        row = next((s for s in sessions if seat and s.session_uuid == seat.session_uuid), None)
+        if row is None:
+            print(
+                "inbox: this shell holds no seat on the board; pass --session <id> or "
+                "claim first",
+                file=sys.stderr,
+            )
+            return 1
+        key = identity.sender_key or f"seat:{row.session_uuid}"
+    forms = {row.session_uuid, row.compact_id, row.speakable_id} | ({row.legacy_id} if row.legacy_id else set())
+    messages = unread_messages(
+        content, board=args.board, sender_key=key, identity_forms=forms, project=row.project
+    )
+    if getattr(args, "json", False):
+        print(
+            json.dumps(
+                {
+                    "session": row.compact_id,
+                    "unread": [
+                        {"from": m.sender, "to": m.recipient, "at": m.timestamp, "body": m.body}
+                        for m in messages
+                    ],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(render_inbox(messages, limit=len(messages) or 1) or f"No unread messages for {row.compact_id}.")
+    if messages and getattr(args, "mark_read", False):
+        mark_seen(args.board, key, {m.key for m in messages})
+        print(f"Marked {len(messages)} message(s) read for {row.compact_id}.")
+    return 0
+
+
+def command_whoami(args) -> int:
+    """This shell's session identity, seat, board row, and the lanes peers would use."""
+    identity = self_identity()
+    seat = seat_for_identity(args.board, identity) if args.board.is_file() else None
+    sessions = rows(args.board.read_text(encoding="utf-8")) if args.board.is_file() else []
+    row = next((s for s in sessions if seat and s.session_uuid == seat.session_uuid), None)
+    lanes = (
+        delivery_lanes(
+            client_ref=row.client_ref,
+            compact_id=row.compact_id,
+            target_machine=row.machine,
+            seat=seat,
+            local_machine=getattr(args, "local_machine", None),
+            registry=getattr(args, "registry", None),
+        )
+        if row is not None
+        else {}
+    )
+    receipts = load_receipts(args.board, identity.sender_key) if identity.sender_key else []
+    payload = {
+        "client": identity.client or None,
+        "harness_session_id": identity.harness_session_id or None,
+        "host_session_id": identity.host_session_id or None,
+        "primary_ref": identity.primary_ref or None,
+        "sender_key": identity.sender_key or None,
+        "seat": str(seat.compact_id) if seat else None,
+        "row": (
+            {"session": row.compact_id, "uuid": row.session_uuid, "project": row.project, "status": row.status}
+            if row
+            else None
+        ),
+        "lanes_peers_use": lanes,
+        "receipts_held": [r.get("target", {}).get("compact") for r in receipts],
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2))
+        return 0
+    print(f"client: {payload['client'] or '-'}")
+    print(f"harness session id: {payload['harness_session_id'] or '-'}")
+    print(f"host session id: {payload['host_session_id'] or '-'}")
+    print(f"primary ref: {payload['primary_ref'] or '-'}")
+    print(f"sender key: {payload['sender_key'] or '- (direct sends will be refused)'}")
+    if row is None:
+        print("seat: none — claim before messaging peers")
+    else:
+        print(f"seat: {row.compact_id} ({row.project}, {row.status})")
+        print("lanes peers use to reach this session:")
+        for line in lane_invocations(lanes, "<their id>"):
+            print(f"  {line}")
+    print(f"receipts held: {', '.join(r for r in payload['receipts_held'] if r) or 'none'}")
+    return 0 if row is not None and identity.sender_key else 1
 
 
 def command_migrate(args) -> int:
@@ -2170,9 +2415,17 @@ def command_doctor(args) -> int:
         for problem in problems:
             print(f"FAIL coordination: {problem}", file=sys.stderr)
         return 1
+    seats = all_seats(args.board)
+    active_uuids = {session.session_uuid for session in sessions if active(session)}
+    stale_seats = [seat for seat in seats if seat.session_uuid not in active_uuids]
+    seat_line = f", {len(seats)} seat(s)" + (
+        f" ({len(stale_seats)} without an active row; release removes them, resolve ignores them)"
+        if stale_seats
+        else ""
+    )
     print(
         f"PASS coordination: schema v{declared}{schema_note}, "
-        f"{len(sessions)} session(s){lease_line}"
+        f"{len(sessions)} session(s){seat_line}{lease_line}"
     )
     return 0
 
@@ -2280,6 +2533,27 @@ def parser() -> argparse.ArgumentParser:
     resolve.add_argument("--include-released", action="store_true")
     resolve.add_argument("--stale-after-minutes", type=int, default=240)
     resolve.add_argument("--json", action="store_true")
+    resolve.add_argument(
+        "--no-receipt",
+        action="store_true",
+        help="Look up only; do not issue the delivery receipt the send gate matches.",
+    )
+    resolve.add_argument("--registry", type=Path, default=None, help=argparse.SUPPRESS)
+    resolve.add_argument("--local-machine", default=None, help=argparse.SUPPRESS)
+    inbox = commands.add_parser(
+        "inbox",
+        help="Unread board messages addressed to this seat (any identity form) or its project.",
+    )
+    inbox.add_argument("--id", "--session", dest="id")
+    inbox.add_argument("--mark-read", action="store_true")
+    inbox.add_argument("--json", action="store_true")
+    whoami = commands.add_parser(
+        "whoami",
+        help="This shell's session identity, seat, row, and the lanes peers use to reach it.",
+    )
+    whoami.add_argument("--json", action="store_true")
+    whoami.add_argument("--registry", type=Path, default=None, help=argparse.SUPPRESS)
+    whoami.add_argument("--local-machine", default=None, help=argparse.SUPPRESS)
     commands.add_parser("migrate")
     commands.add_parser("doctor")
     stale = commands.add_parser(
@@ -2310,6 +2584,8 @@ COMMANDS = {
     "release": command_release,
     "message": command_message,
     "resolve": command_resolve,
+    "inbox": command_inbox,
+    "whoami": command_whoami,
     "migrate": command_migrate,
     "lease-disable": command_lease_disable,
     "stale": command_stale,

--- a/skills/synthesis-project-management/scripts/peer_addressing.py
+++ b/skills/synthesis-project-management/scripts/peer_addressing.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+"""Peer addressing for coordination-board sessions: seats, lanes, receipts, inbox.
+
+Three naming systems cover one population of agent sessions: the board's
+identities (UUIDv7 with aliases), each client's chat handle (a desktop
+session id, a Codex thread id), and the harness's peer registry (a derived
+display name that collides by construction, plus a Unix socket). Only the
+board says what a session owns; only the session itself knows all of its
+own handles. This module keeps that join and turns it into exact addresses:
+
+- a **seat** is the per-session sidecar of delivery handles written beside
+  the board at claim time (identity stays on the board; handles are a cache
+  the doctor validates);
+- a **lane** is one exact way to deliver to a seat (bus, ccd, harness,
+  codex), computed from live truth at resolve time;
+- a **receipt** binds a sender to one resolved target and its exact
+  per-lane addresses for a bounded time, so the send gate can tell a
+  resolved address from a guessed one;
+- the **inbox** reads the board's addressed message bus for one seat with a
+  per-seat watermark, which is what makes the bus a delivery lane rather
+  than a dead letter.
+
+Everything here is pure file I/O over ``~/.synthesis/coordination`` and the
+harness registry; nothing sends.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import socket
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SEATS_DIRNAME = "seats"
+RECEIPTS_DIRNAME = "receipts"
+INBOX_DIRNAME = "inbox"
+SEND_LOG_NAME = "peer-sends.jsonl"
+RECEIPT_SCHEMA = 1
+SEAT_SCHEMA = 1
+RECEIPT_TTL_MINUTES = 20
+BROADCAST_WINDOW_MINUTES = 15
+DEFAULT_REGISTRY = Path.home() / ".claude" / "sessions"
+
+CLIENT_CLAUDE = "claude-code"
+CLIENT_CODEX = "codex"
+
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+MESSAGE_HEADING = re.compile(
+    r"^### → (?P<recipient>.+?), from (?P<sender>.+?) — (?P<timestamp>\S+)\s*$"
+)
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso(moment: datetime) -> str:
+    return moment.astimezone(timezone.utc).isoformat(timespec="seconds")
+
+
+def parse_iso(value: object) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def coordination_root(board: Path) -> Path:
+    return Path(board).expanduser().parent
+
+
+def seats_dir(board: Path) -> Path:
+    return coordination_root(board) / SEATS_DIRNAME
+
+
+def receipts_dir(board: Path) -> Path:
+    return coordination_root(board) / RECEIPTS_DIRNAME
+
+
+def inbox_dir(board: Path) -> Path:
+    return coordination_root(board) / INBOX_DIRNAME
+
+
+def send_log_path(board: Path) -> Path:
+    return coordination_root(board) / SEND_LOG_NAME
+
+
+def safe_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", value).strip("._") or "unknown"
+
+
+# --------------------------------------------------------------------------
+# Self identity: what the running session knows about its own handles
+# --------------------------------------------------------------------------
+
+@dataclass
+class SelfIdentity:
+    client: str = ""
+    harness_session_id: str = ""
+    host_session_id: str = ""
+    pid: int | None = None
+    explicit_ref: str = ""
+
+    @property
+    def sender_key(self) -> str:
+        """The stable per-session key receipts and inboxes are filed under.
+
+        A Claude Code session is keyed by its harness session id, which the
+        hook payload carries as ``session_id`` and the shell carries as
+        ``CLAUDE_CODE_SESSION_ID``; a Codex session by its thread id, which
+        hooks receive as ``session_id`` and shells learn from the exported
+        ``SYNTHESIS_CLIENT_SESSION_REF``. Both halves must agree or the gate
+        finds no receipt, which is the safe failure."""
+        if self.client == CLIENT_CLAUDE and self.harness_session_id:
+            return f"cc:{self.harness_session_id}"
+        if self.client == CLIENT_CODEX and self.harness_session_id:
+            return f"codex:{self.harness_session_id}"
+        if self.explicit_ref:
+            return self.explicit_ref
+        return ""
+
+    @property
+    def primary_ref(self) -> str:
+        """The single scheme-prefixed delivery ref the board row carries."""
+        if self.explicit_ref:
+            return self.explicit_ref
+        if self.host_session_id:
+            return f"ccd:{self.host_session_id}"
+        if self.client == CLIENT_CLAUDE and self.harness_session_id:
+            return f"cc:{self.harness_session_id}"
+        return ""
+
+
+def detect_self(environ: dict[str, str] | None = None) -> SelfIdentity:
+    env = os.environ if environ is None else environ
+    explicit = env.get("SYNTHESIS_CLIENT_SESSION_REF", "").strip()
+    harness = env.get("CLAUDE_CODE_SESSION_ID", "").strip()
+    host = env.get("CLAUDE_CODE_HOST_SESSION_ID", "").strip()
+    pid_text = env.get("CLAUDE_PID", "").strip()
+    pid = int(pid_text) if pid_text.isdigit() else None
+    if explicit.startswith("codex:"):
+        return SelfIdentity(
+            client=CLIENT_CODEX,
+            harness_session_id=explicit[len("codex:"):],
+            explicit_ref=explicit,
+            pid=pid,
+        )
+    if harness or env.get("CLAUDECODE"):
+        return SelfIdentity(
+            client=CLIENT_CLAUDE,
+            harness_session_id=harness,
+            host_session_id=host,
+            pid=pid,
+            explicit_ref=explicit,
+        )
+    if explicit:
+        return SelfIdentity(explicit_ref=explicit, pid=pid)
+    return SelfIdentity()
+
+
+def identity_from_hook(payload: dict, environ: dict[str, str] | None = None) -> SelfIdentity:
+    """The sender identity as a hook process sees it.
+
+    A hook runs inside the client process tree with the same environment as
+    the shells, plus a payload whose ``session_id`` is authoritative: for
+    Claude Code it is the harness session id, for Codex the thread id."""
+    env = os.environ if environ is None else environ
+    session_id = str(payload.get("session_id") or "").strip()
+    base = detect_self(env)
+    if not session_id:
+        return base
+    if base.client == CLIENT_CLAUDE:
+        return SelfIdentity(
+            client=CLIENT_CLAUDE,
+            harness_session_id=session_id,
+            host_session_id=base.host_session_id,
+            pid=base.pid,
+        )
+    return SelfIdentity(
+        client=CLIENT_CODEX,
+        harness_session_id=session_id,
+        explicit_ref=f"codex:{session_id}",
+    )
+
+
+# --------------------------------------------------------------------------
+# Seats: the per-session sidecar of delivery handles
+# --------------------------------------------------------------------------
+
+@dataclass
+class Seat:
+    session_uuid: str
+    compact_id: str
+    client: str
+    machine: str
+    harness_session_id: str = ""
+    host_session_id: str = ""
+    pid: int | None = None
+    cwd: str = ""
+    updated_at: str = ""
+    schema: int = SEAT_SCHEMA
+
+
+def seat_path(board: Path, session_uuid: str) -> Path:
+    return seats_dir(board) / f"{safe_name(session_uuid)}.json"
+
+
+def write_seat(
+    board: Path,
+    *,
+    session_uuid: str,
+    compact_id: str,
+    machine: str,
+    identity: SelfIdentity,
+    cwd: str = "",
+    now: datetime | None = None,
+) -> Path | None:
+    """Record this session's delivery handles beside its board row.
+
+    Returns None when the session knows no handle at all (nothing to
+    register is not an error: such a session is reachable on the bus)."""
+    if not (identity.harness_session_id or identity.host_session_id or identity.explicit_ref):
+        return None
+    seat = Seat(
+        session_uuid=session_uuid,
+        compact_id=compact_id,
+        client=identity.client or (identity.explicit_ref.split(":", 1)[0] if identity.explicit_ref else ""),
+        machine=machine,
+        harness_session_id=identity.harness_session_id,
+        host_session_id=identity.host_session_id,
+        pid=identity.pid,
+        cwd=cwd or os.getcwd(),
+        updated_at=iso(now or utcnow()),
+    )
+    path = seat_path(board, session_uuid)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    staging = path.with_suffix(".json.tmp")
+    staging.write_text(json.dumps(asdict(seat), indent=2) + "\n", encoding="utf-8")
+    os.replace(staging, path)
+    return path
+
+
+def read_seat(board: Path, session_uuid: str) -> Seat | None:
+    path = seat_path(board, session_uuid)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or data.get("session_uuid") != session_uuid:
+        return None
+    known = {field for field in Seat.__dataclass_fields__}
+    return Seat(**{key: value for key, value in data.items() if key in known})
+
+
+def remove_seat(board: Path, session_uuid: str) -> bool:
+    path = seat_path(board, session_uuid)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def all_seats(board: Path) -> list[Seat]:
+    directory = seats_dir(board)
+    if not directory.is_dir():
+        return []
+    seats = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(data, dict) and data.get("session_uuid"):
+            known = {field for field in Seat.__dataclass_fields__}
+            seats.append(Seat(**{k: v for k, v in data.items() if k in known}))
+    return seats
+
+
+def seat_for_identity(board: Path, identity: SelfIdentity) -> Seat | None:
+    """This session's own seat, found by the handle a hook or shell knows."""
+    for seat in all_seats(board):
+        if identity.harness_session_id and seat.harness_session_id == identity.harness_session_id:
+            if seat.client == identity.client or not identity.client:
+                return seat
+        if identity.host_session_id and seat.host_session_id == identity.host_session_id:
+            return seat
+    return None
+
+
+# --------------------------------------------------------------------------
+# Harness peer registry (Claude Code): sessionId -> socket, name, pid
+# --------------------------------------------------------------------------
+
+def registry_dir(registry: Path | None = None) -> Path:
+    if registry is not None:
+        return Path(registry)
+    override = os.environ.get("SYNTHESIS_PEER_REGISTRY", "").strip()
+    return Path(override).expanduser() if override else DEFAULT_REGISTRY
+
+
+def process_alive(pid: int | None) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(int(pid), 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def registry_entries(registry: Path | None = None) -> list[dict]:
+    directory = registry_dir(registry)
+    if not directory.is_dir():
+        return []
+    entries = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if isinstance(data, dict) and data.get("sessionId") and data.get("messagingSocketPath"):
+            entries.append(data)
+    return entries
+
+
+def registry_entry_for_session(
+    harness_session_id: str,
+    registry: Path | None = None,
+    alive=process_alive,
+) -> dict | None:
+    """The live registry entry whose sessionId is the given harness id."""
+    if not harness_session_id:
+        return None
+    for entry in registry_entries(registry):
+        if entry.get("sessionId") == harness_session_id and alive(entry.get("pid")):
+            return entry
+    return None
+
+
+def registry_entry_for_socket(
+    socket_path: str, registry: Path | None = None, alive=process_alive
+) -> dict | None:
+    for entry in registry_entries(registry):
+        if entry.get("messagingSocketPath") == socket_path and alive(entry.get("pid")):
+            return entry
+    return None
+
+
+def harness_address(entry: dict) -> str:
+    return f"uds:{entry['messagingSocketPath']}"
+
+
+# --------------------------------------------------------------------------
+# Lanes: exact per-client delivery addresses for one resolved target
+# --------------------------------------------------------------------------
+
+def delivery_lanes(
+    *,
+    client_ref: str,
+    compact_id: str,
+    target_machine: str,
+    seat: Seat | None,
+    local_machine: str | None = None,
+    registry: Path | None = None,
+    alive=process_alive,
+) -> dict[str, dict]:
+    """Every exact way to reach one target from this machine.
+
+    The bus is always a lane. Direct lanes exist only on the target's own
+    machine and only while live truth confirms them: the ccd lane needs the
+    row's ``ccd:`` ref, the harness lane needs the registry to still map the
+    seat's harness session id to a running process, the codex lane needs a
+    ``codex:`` ref. A name never appears as an address."""
+    machine = local_machine or socket.gethostname()
+    same_machine = bool(target_machine) and target_machine == machine
+    lanes: dict[str, dict] = {"bus": {"to": compact_id}}
+    if same_machine and client_ref.startswith("ccd:"):
+        lanes["ccd"] = {"session_id": client_ref[len("ccd:"):]}
+    if same_machine and seat is not None and seat.harness_session_id and seat.client == CLIENT_CLAUDE:
+        entry = registry_entry_for_session(seat.harness_session_id, registry, alive)
+        if entry is not None:
+            lanes["harness"] = {
+                "to": harness_address(entry),
+                "name": str(entry.get("name") or ""),
+                "harness_session_id": seat.harness_session_id,
+            }
+    codex_thread = ""
+    if client_ref.startswith("codex:"):
+        codex_thread = client_ref[len("codex:"):]
+    elif seat is not None and seat.client == CLIENT_CODEX and seat.harness_session_id:
+        codex_thread = seat.harness_session_id
+    if same_machine and codex_thread:
+        lanes["codex"] = {
+            "thread": codex_thread,
+            "command": f"codex queue --thread {codex_thread} --message <text>",
+        }
+    return lanes
+
+
+def lane_invocations(lanes: dict[str, dict], sender_compact: str) -> list[str]:
+    """Human-readable exact invocations, one per lane, for the resolver output."""
+    lines = []
+    prefix = f"from {sender_compact}: " if sender_compact else ""
+    if "ccd" in lanes:
+        lines.append(
+            "ccd lane: mcp__ccd_session_mgmt__send_message session_id="
+            f"{lanes['ccd']['session_id']!r} message={prefix + '…'!r}"
+        )
+    if "harness" in lanes:
+        lines.append(
+            f"harness lane: SendMessage to={lanes['harness']['to']!r} "
+            f"(registry name {lanes['harness']['name']!r}; the socket is the address, "
+            f"the name is display only) message={prefix + '…'!r}"
+        )
+    if "codex" in lanes:
+        lines.append(
+            f"codex lane: {lanes['codex']['command'].replace('<text>', repr(prefix + '…'))}"
+        )
+    lines.append(
+        "bus lane: coordination.py message --from "
+        f"{sender_compact or '<your session id>'} --to {lanes['bus']['to']}"
+    )
+    return lines
+
+
+# --------------------------------------------------------------------------
+# Receipts: one sender, one resolved target, exact addresses, bounded time
+# --------------------------------------------------------------------------
+
+def receipt_dir_for(board: Path, sender_key: str) -> Path:
+    return receipts_dir(board) / safe_name(sender_key)
+
+
+def write_receipt(
+    board: Path,
+    *,
+    sender: SelfIdentity,
+    sender_row: dict | None,
+    selector: str,
+    matched_by: str,
+    target: dict,
+    lanes: dict[str, dict],
+    ttl_minutes: int = RECEIPT_TTL_MINUTES,
+    now: datetime | None = None,
+) -> Path | None:
+    """Persist the resolution so the gate can match a send to it.
+
+    Returns None when the sender has no identity: a receipt no gate could
+    attribute would be a receipt anyone could use."""
+    key = sender.sender_key
+    if not key:
+        return None
+    moment = now or utcnow()
+    receipt = {
+        "schema": RECEIPT_SCHEMA,
+        "issued_at": iso(moment),
+        "expires_at": iso(moment + timedelta(minutes=ttl_minutes)),
+        "issued_by": {
+            "sender_key": key,
+            "client": sender.client,
+            "board": sender_row or {},
+        },
+        "selector": selector,
+        "matched_by": matched_by,
+        "target": target,
+        "lanes": lanes,
+    }
+    directory = receipt_dir_for(board, key)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{safe_name(target.get('uuid') or target.get('compact') or 'target')}.json"
+    staging = path.with_suffix(".json.tmp")
+    staging.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    os.replace(staging, path)
+    return path
+
+
+def load_receipts(board: Path, sender_key: str, now: datetime | None = None) -> list[dict]:
+    """Unexpired receipts held by one sender; expired files are pruned."""
+    directory = receipt_dir_for(board, sender_key)
+    if not sender_key or not directory.is_dir():
+        return []
+    moment = now or utcnow()
+    live = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        expires = parse_iso(data.get("expires_at")) if isinstance(data, dict) else None
+        if expires is None or expires < moment:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            continue
+        if data.get("issued_by", {}).get("sender_key") != sender_key:
+            continue
+        live.append(data)
+    return live
+
+
+def receipt_for_address(receipts: list[dict], lane: str, address: str) -> dict | None:
+    """The receipt whose lane address equals the one about to be used."""
+    field = {"ccd": "session_id", "harness": "to", "codex": "thread"}.get(lane)
+    if field is None:
+        return None
+    for receipt in receipts:
+        entry = receipt.get("lanes", {}).get(lane)
+        if isinstance(entry, dict) and str(entry.get(field, "")).strip() == address.strip():
+            return receipt
+    return None
+
+
+# --------------------------------------------------------------------------
+# Send log and the broadcast rule
+# --------------------------------------------------------------------------
+
+def body_digest(text: str) -> str:
+    normalized = re.sub(r"\s+", " ", (text or "")).strip().casefold()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def append_send_log(board: Path, record: dict) -> None:
+    path = send_log_path(board)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def recent_sends(board: Path, *, since: datetime, limit_bytes: int = 2_000_000) -> list[dict]:
+    path = send_log_path(board)
+    if not path.is_file():
+        return []
+    size = path.stat().st_size
+    with path.open("rb") as handle:
+        if size > limit_bytes:
+            handle.seek(size - limit_bytes)
+            handle.readline()
+        raw = handle.read().decode("utf-8", errors="replace")
+    records = []
+    for line in raw.splitlines():
+        try:
+            data = json.loads(line)
+        except ValueError:
+            continue
+        moment = parse_iso(data.get("at")) if isinstance(data, dict) else None
+        if moment is not None and moment >= since:
+            records.append(data)
+    return records
+
+
+def broadcast_conflict(
+    board: Path,
+    *,
+    sender_key: str,
+    digest: str,
+    target_uuid: str,
+    now: datetime | None = None,
+    window_minutes: int = BROADCAST_WINDOW_MINUTES,
+) -> dict | None:
+    """An allowed send of the same text to a different session in the window."""
+    moment = now or utcnow()
+    for record in recent_sends(board, since=moment - timedelta(minutes=window_minutes)):
+        if (
+            record.get("decision") == "allow"
+            and record.get("sender_key") == sender_key
+            and record.get("digest") == digest
+            and record.get("target_uuid")
+            and record.get("target_uuid") != target_uuid
+        ):
+            return record
+    return None
+
+
+# --------------------------------------------------------------------------
+# Inbox: the addressed bus, read for one seat with a watermark
+# --------------------------------------------------------------------------
+
+@dataclass
+class BoardMessage:
+    recipient: str
+    sender: str
+    timestamp: str
+    body: str
+
+    @property
+    def key(self) -> str:
+        return hashlib.sha256(
+            f"{self.recipient}\n{self.sender}\n{self.timestamp}\n{self.body}".encode("utf-8")
+        ).hexdigest()[:16]
+
+
+def parse_messages(board_text: str) -> list[BoardMessage]:
+    """Every addressed message under ``## Messages``, in board order."""
+    lines = board_text.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.strip() == "## Messages")
+    except StopIteration:
+        return []
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        if lines[i].startswith("## "):
+            end = i
+            break
+    messages: list[BoardMessage] = []
+    current: BoardMessage | None = None
+    body: list[str] = []
+
+    def finish(text_lines: list[str]) -> str:
+        # The section ends with the `---` rule that precedes ## Protocol; it
+        # is a boundary, not part of the last message.
+        while text_lines and text_lines[-1].strip() in {"", "---"}:
+            text_lines.pop()
+        return "\n".join(text_lines).strip()
+
+    for line in lines[start + 1:end]:
+        match = MESSAGE_HEADING.match(line)
+        if match:
+            if current is not None:
+                current.body = finish(body)
+                messages.append(current)
+            current = BoardMessage(
+                recipient=match.group("recipient").strip(),
+                sender=match.group("sender").strip(),
+                timestamp=match.group("timestamp").strip(),
+                body="",
+            )
+            body = []
+        elif current is not None:
+            body.append(line)
+    if current is not None:
+        current.body = finish(body)
+        messages.append(current)
+    return messages
+
+
+def addressed_to(message: BoardMessage, identity_forms: set[str], project: str = "") -> bool:
+    """Whether a message names this seat exactly, or its project's sessions.
+
+    Free-text addressees are never delivered: the sender was told the
+    address did not resolve when it posted."""
+    recipient = message.recipient.strip()
+    tokens = {token.strip(",;") for token in recipient.split()}
+    if any(form and form in tokens for form in identity_forms):
+        return True
+    if project and recipient.casefold().startswith(f"{project.casefold()} sessions"):
+        return True
+    return False
+
+
+def watermark_path(board: Path, sender_key: str) -> Path:
+    return inbox_dir(board) / f"{safe_name(sender_key)}.json"
+
+
+def seen_keys(board: Path, sender_key: str) -> set[str]:
+    try:
+        data = json.loads(watermark_path(board, sender_key).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    seen = data.get("seen") if isinstance(data, dict) else None
+    return set(seen) if isinstance(seen, list) else set()
+
+
+def mark_seen(board: Path, sender_key: str, keys: set[str], *, keep: int = 2000) -> None:
+    path = watermark_path(board, sender_key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    merged = list(seen_keys(board, sender_key) | keys)[-keep:]
+    staging = path.with_suffix(".json.tmp")
+    staging.write_text(
+        json.dumps({"seen": merged, "updated_at": iso(utcnow())}) + "\n", encoding="utf-8"
+    )
+    os.replace(staging, path)
+
+
+def unread_messages(
+    board_text: str,
+    *,
+    board: Path,
+    sender_key: str,
+    identity_forms: set[str],
+    project: str = "",
+) -> list[BoardMessage]:
+    seen = seen_keys(board, sender_key) if sender_key else set()
+    return [
+        message
+        for message in parse_messages(board_text)
+        if addressed_to(message, identity_forms, project) and message.key not in seen
+    ]
+
+
+def render_inbox(messages: list[BoardMessage], *, limit: int = 5, body_lines: int = 25) -> str:
+    """A bounded, self-describing rendering: counts plus the newest messages."""
+    if not messages:
+        return ""
+    shown = messages[-limit:]
+    lines = [
+        f"Coordination board inbox: {len(messages)} unread message(s) addressed to this "
+        f"session or its project" + (f"; showing the newest {len(shown)}." if len(messages) > len(shown) else ".")
+    ]
+    for message in shown:
+        lines.append(f"- from {message.sender} at {message.timestamp} → {message.recipient}:")
+        body = message.body.splitlines()
+        for line in body[:body_lines]:
+            lines.append(f"    {line}")
+        if len(body) > body_lines:
+            lines.append(f"    … {len(body) - body_lines} more line(s) on the board")
+    lines.append(
+        "Reply by resolving the sender's session id (coordination.py resolve --to <id>) "
+        "and using the lane it returns; never a chat title or display name."
+    )
+    return "\n".join(lines)

--- a/skills/synthesis-project-management/scripts/peer_send_gate.py
+++ b/skills/synthesis-project-management/scripts/peer_send_gate.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Fail-closed PreToolUse gate for direct peer-session sends, in both clients.
+
+Peer messages reached the wrong chat session seven recorded times between
+2026-08-19 and 2026-09-02, including once after the resolver shipped: the
+harness lane (``SendMessage``) was ungated, its display names collide by
+construction, and the one gate that existed checked that a target was
+registered, not that it was the one the sender resolved. This gate closes
+that on every direct lane the plugin knows:
+
+- ``SendMessage``: in-process targets (``main``, spawned agent ids, named
+  teammates) pass; a peer is addressed only by its ``uds:`` socket, and only
+  when a live resolve receipt names that socket for this sender and the
+  harness registry still maps it to the receipt's session.
+- ``mcp__ccd_session_mgmt__send_message``: the ``session_id`` must equal the
+  ccd address on a live receipt, and the board row must still be active.
+- shell tools: a ``codex queue --thread`` command needs a receipt naming
+  that thread; every other command passes untouched.
+
+Every direct send must carry the sender's own board id so the recipient can
+resolve the reply without guessing, and the same text to a second peer
+within the broadcast window is refused. A reply may copy the ``from=`` of a
+message this session received (the harness wrote that address). Every
+decision is appended to the send log. Anything the gate cannot verify —
+no session id, unreadable board, unknown tool shape — blocks.
+
+Exit 0 admits the call; exit 2 blocks it with the reason and the remedy on
+stderr, which both clients show to the agent.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from peer_addressing import (  # noqa: E402
+    CLIENT_CLAUDE,
+    SelfIdentity,
+    append_send_log,
+    body_digest,
+    broadcast_conflict,
+    identity_from_hook,
+    iso,
+    load_receipts,
+    process_alive,
+    receipt_for_address,
+    receipts_dir,
+    registry_dir,
+    registry_entry_for_socket,
+    seat_for_identity,
+    send_log_path,
+    utcnow,
+)
+
+DEFAULT_BOARD = Path.home() / ".synthesis" / "coordination" / "active-sessions.md"
+HARNESS_TOOL = "SendMessage"
+CCD_TOOL_RE = re.compile(r"ccd_session_mgmt__send_message$")
+SHELL_TOOLS = {"Bash", "exec_command", "exec", "shell", "local_shell"}
+AGENT_ID_RE = re.compile(r"^a[0-9a-f]{16}$")
+CODEX_QUEUE_RE = re.compile(r"(?<![\w./-])codex\s+queue\b")
+THREAD_RE = re.compile(r"--thread(?:=|\s+)(?:\"([^\"]+)\"|'([^']+)'|(\S+))")
+MESSAGE_RE = re.compile(r"--message(?:=|\s+)(?:\"((?:[^\"\\]|\\.)*)\"|'([^']*)'|(\S+))")
+FROM_RE = re.compile(r'cross-session-message from=\\?"([^"\\]+)\\?"')
+TRANSCRIPT_TAIL_BYTES = 4_000_000
+
+RESOLVE_HINT = (
+    "Run `coordination.py resolve --to <project|session id|ref>` (exit 0 means one "
+    "target; it prints the exact address per lane and issues the receipt this gate "
+    "matches), then copy that address verbatim. Exit 20 means several candidates — "
+    "narrow with --role or an exact id, never send to more than one; exit 21 means "
+    "no registered seat — post on the board bus (`coordination.py message --to`) "
+    "instead. Chat titles and display names are not addresses."
+)
+
+
+@dataclass
+class Decision:
+    allow: bool
+    lane: str = ""
+    target: str = ""
+    reason: str = ""
+    target_uuid: str = ""
+    logged: bool = True
+
+
+def board_rows(board: Path):
+    """Active board rows via the engine; a failure to read is a failure to verify."""
+    from coordination import active, rows  # local import: hook-time cost only when needed
+
+    text = Path(board).read_text(encoding="utf-8")
+    return [row for row in rows(text) if active(row)]
+
+
+def teammate_names(home: Path | None = None) -> set[str]:
+    root = (home or Path.home()) / ".claude" / "teams"
+    names: set[str] = set()
+    if not root.is_dir():
+        return names
+    for config in root.glob("*/config.json"):
+        try:
+            data = json.loads(config.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        for member in data.get("members", []) if isinstance(data, dict) else []:
+            if isinstance(member, dict) and member.get("name"):
+                names.add(str(member["name"]))
+    return names
+
+
+def received_addresses(transcript_path: str | None, limit: int = TRANSCRIPT_TAIL_BYTES) -> set[str]:
+    """Every ``from=`` address of a cross-session message in this transcript's tail."""
+    if not transcript_path:
+        return set()
+    path = Path(transcript_path)
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            if size > limit:
+                handle.seek(size - limit)
+            raw = handle.read().decode("utf-8", errors="replace")
+    except OSError:
+        return set()
+    return set(FROM_RE.findall(raw))
+
+
+def shell_command(tool_input: dict) -> str:
+    for field in ("command", "cmd", "script"):
+        value = tool_input.get(field)
+        if isinstance(value, str):
+            return value
+        if isinstance(value, list):
+            return " ".join(str(part) for part in value)
+    return ""
+
+
+def first_group(match: re.Match | None) -> str:
+    if match is None:
+        return ""
+    return next((group for group in match.groups() if group), "")
+
+
+def classify(tool_name: str, tool_input: dict, home: Path | None = None) -> Decision:
+    """Which lane a call belongs to, or an immediate allow for non-peer calls."""
+    if tool_name == HARNESS_TOOL:
+        to = str(tool_input.get("to") or "").strip()
+        if not to:
+            return Decision(False, "harness", "", "SendMessage carries no `to`")
+        if to == "main" or AGENT_ID_RE.match(to) or to in teammate_names(home):
+            return Decision(True, "in-process", to, "in-process agent", logged=False)
+        if to.startswith("uds:"):
+            return Decision(True, "harness", to, "")
+        return Decision(
+            False,
+            "harness",
+            to,
+            f"{to!r} is a display name, not an address: harness names are derived "
+            "from the working directory and collide, and a `[ref]` cannot be verified. "
+            "Peers are addressed by the `uds:` socket the resolver prints.",
+        )
+    if CCD_TOOL_RE.search(tool_name):
+        session_id = str(tool_input.get("session_id") or "").strip()
+        if not session_id:
+            return Decision(False, "ccd", "", "peer send carries no session_id")
+        return Decision(True, "ccd", session_id, "")
+    if tool_name in SHELL_TOOLS:
+        command = shell_command(tool_input)
+        if not CODEX_QUEUE_RE.search(command):
+            return Decision(True, "shell", "", "not a peer send", logged=False)
+        thread = first_group(THREAD_RE.search(command))
+        if not thread:
+            return Decision(False, "codex", "", "codex queue without a --thread value")
+        return Decision(True, "codex", thread, "")
+    return Decision(True, "other", "", "not a peer tool", logged=False)
+
+
+def message_body(lane: str, tool_input: dict) -> str:
+    if lane == "codex":
+        return first_group(MESSAGE_RE.search(shell_command(tool_input)))
+    return str(tool_input.get("message") or "")
+
+
+def evaluate(
+    payload: dict,
+    *,
+    board: Path = DEFAULT_BOARD,
+    registry: Path | None = None,
+    environ: dict[str, str] | None = None,
+    home: Path | None = None,
+    now: datetime | None = None,
+    alive=process_alive,
+) -> Decision:
+    tool_name = str(payload.get("tool_name") or "")
+    tool_input = payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
+    moment = now or utcnow()
+    verdict = classify(tool_name, tool_input, home)
+    if not verdict.allow or not verdict.logged or verdict.lane in {"in-process", "shell", "other"}:
+        return verdict
+    lane, address = verdict.lane, verdict.target
+
+    sender = identity_from_hook(payload, environ)
+    key = sender.sender_key
+    if not key:
+        return Decision(False, lane, address, "the hook payload names no session_id, so the sender cannot be identified")
+
+    try:
+        active_rows = board_rows(board)
+    except Exception as exc:  # unreadable, newer schema, missing: cannot verify
+        return Decision(False, lane, address, f"coordination board unreadable, so the target cannot be verified: {exc}")
+
+    seat = seat_for_identity(board, sender)
+    sender_row = next((row for row in active_rows if seat and row.session_uuid == seat.session_uuid), None)
+    if sender_row is None:
+        return Decision(
+            False,
+            lane,
+            address,
+            "this session holds no active seat on the coordination board, so the "
+            "recipient could not resolve a reply; claim first (`coordination.py claim "
+            "--project … --area …`), then resolve the peer",
+        )
+
+    receipts = load_receipts(board, key, moment)
+    receipt = receipt_for_address(receipts, lane, address)
+    replied = address in received_addresses(payload.get("transcript_path")) if lane in {"harness", "ccd"} else False
+    target_uuid = ""
+    if receipt is not None:
+        target_uuid = str(receipt.get("target", {}).get("uuid") or "")
+        target_row = next((row for row in active_rows if row.session_uuid == target_uuid), None)
+        if target_row is None:
+            return Decision(False, lane, address, f"receipt target {target_uuid} is no longer an active board row; resolve again")
+        if lane == "ccd" and target_row.client_ref != f"ccd:{address}":
+            return Decision(False, lane, address, "the receipt's ccd address no longer matches the target row; resolve again")
+        if lane == "codex" and not (
+            target_row.client_ref == f"codex:{address}"
+            or str(receipt.get("lanes", {}).get("codex", {}).get("thread")) == address
+        ):
+            return Decision(False, lane, address, "the receipt's codex thread no longer matches the target row; resolve again")
+        if lane == "harness":
+            entry = registry_entry_for_socket(address[len("uds:"):], registry, alive)
+            expected = str(receipt.get("lanes", {}).get("harness", {}).get("harness_session_id") or "")
+            if entry is None or entry.get("sessionId") != expected:
+                return Decision(
+                    False,
+                    lane,
+                    address,
+                    "the harness registry no longer maps that socket to the resolved "
+                    "session (it restarted or exited); resolve again",
+                )
+        reason = f"receipt {receipt.get('selector')!r} → {receipt.get('target', {}).get('compact')}"
+    elif replied:
+        reason = "reply to a received cross-session message (address copied from its from=)"
+        matched = next(
+            (row for row in active_rows if row.client_ref in {f"ccd:{address}", address}), None
+        )
+        target_uuid = matched.session_uuid if matched else ""
+    else:
+        return Decision(False, lane, address, f"no delivery receipt names {address!r} for this session. " + RESOLVE_HINT)
+
+    body = message_body(lane, tool_input)
+    subscription_only = lane == "harness" and not body.strip() and bool(tool_input.get("notify_when_idle"))
+    if not subscription_only:
+        if sender_row.compact_id not in body and sender_row.session_uuid not in body:
+            return Decision(
+                False,
+                lane,
+                address,
+                f"the message must carry your board id so the peer can resolve a reply: "
+                f"begin it with `from {sender_row.compact_id} ({sender_row.project}):`",
+            )
+        digest = body_digest(body)
+        conflict = broadcast_conflict(
+            board, sender_key=key, digest=digest, target_uuid=target_uuid or address, now=moment
+        )
+        if conflict is not None:
+            return Decision(
+                False,
+                lane,
+                address,
+                "the same text already went to another session at "
+                f"{conflict.get('at')} ({conflict.get('lane')} {conflict.get('target')}); "
+                "that is a broadcast. Address the project on the board bus instead.",
+            )
+    return Decision(True, lane, address, reason, target_uuid=target_uuid or address)
+
+
+def record(board: Path, payload: dict, decision: Decision, environ: dict[str, str] | None = None, now: datetime | None = None) -> None:
+    sender = identity_from_hook(payload, environ)
+    tool_input = payload.get("tool_input") if isinstance(payload.get("tool_input"), dict) else {}
+    body = message_body(decision.lane, tool_input) if decision.lane in {"harness", "ccd", "codex"} else ""
+    try:
+        append_send_log(
+            board,
+            {
+                "at": iso(now or utcnow()),
+                "decision": "allow" if decision.allow else "deny",
+                "lane": decision.lane,
+                "target": decision.target,
+                "target_uuid": decision.target_uuid,
+                "sender_key": sender.sender_key,
+                "digest": body_digest(body) if body else "",
+                "reason": decision.reason,
+                "tool": payload.get("tool_name"),
+            },
+        )
+    except OSError:
+        pass
+
+
+def gate(board: Path) -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.stderr.write("peer-send-gate BLOCKED: hook payload is not JSON; unknown shape fails closed\n")
+        return 2
+    if not isinstance(payload, dict):
+        sys.stderr.write("peer-send-gate BLOCKED: hook payload is not an object\n")
+        return 2
+    decision = evaluate(payload, board=board)
+    if decision.logged:
+        record(board, payload, decision)
+    if decision.allow:
+        return 0
+    sys.stderr.write(
+        f"peer-send-gate BLOCKED ({decision.lane} lane"
+        + (f", target {decision.target!r}" if decision.target else "")
+        + f"): {decision.reason}\n"
+    )
+    return 2
+
+
+def doctor(board: Path, environ: dict[str, str] | None = None) -> int:
+    ok = True
+
+    def report(passed: bool, name: str, detail: str) -> None:
+        nonlocal ok
+        ok = ok and passed
+        print(f"{'PASS' if passed else 'FAIL'} peer-send-gate.{name}: {detail}")
+
+    try:
+        rows = board_rows(board)
+        report(True, "board", f"{board} readable; {len(rows)} active row(s)")
+    except Exception as exc:
+        report(False, "board", f"{board}: {exc}")
+    identity = identity_from_hook({}, environ)
+    if identity.sender_key:
+        seat = seat_for_identity(board, identity)
+        report(
+            seat is not None,
+            "seat",
+            f"{identity.sender_key} → {seat.compact_id if seat else 'no seat: claim before sending'}",
+        )
+    else:
+        report(False, "identity", "no CLAUDE_CODE_SESSION_ID or SYNTHESIS_CLIENT_SESSION_REF in this environment")
+    directory = receipts_dir(board)
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        probe = directory / ".doctor-probe"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+        report(True, "receipts", f"{directory} writable")
+    except OSError as exc:
+        report(False, "receipts", f"{directory}: {exc}")
+    log = send_log_path(board)
+    report(log.parent.is_dir(), "send-log", str(log))
+    if identity.client == CLIENT_CLAUDE:
+        registry = registry_dir()
+        # A missing registry is a fact about this machine (no harness peers
+        # registered here), not a broken gate: the bus and ccd lanes stand.
+        report(
+            True,
+            "registry",
+            f"{registry} ({'present' if registry.is_dir() else 'absent: harness lane unavailable here; bus and ccd lanes unaffected'})",
+        )
+    return 0 if ok else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--board", type=Path, default=DEFAULT_BOARD)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--gate", action="store_true", help="read a PreToolUse payload on stdin")
+    mode.add_argument("--doctor", action="store_true", help="verify the gate's inputs for this session")
+    args = parser.parse_args()
+    board = args.board.expanduser()
+    if args.doctor:
+        return doctor(board)
+    return gate(board)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/synthesis-project-management/scripts/test_board_inbox.py
+++ b/skills/synthesis-project-management/scripts/test_board_inbox.py
@@ -1,0 +1,103 @@
+"""The board inbox hook: addressed messages reach the seat they name, once, in both clients."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import board_inbox as INBOX  # noqa: E402
+import coordination as ENGINE  # noqa: E402
+
+ME_SID = "11111111-1111-4111-8111-111111111111"
+ME_ENV = {"CLAUDECODE": "1", "CLAUDE_CODE_SESSION_ID": ME_SID, "CLAUDE_CODE_HOST_SESSION_ID": "local_me"}
+
+
+@pytest.fixture(autouse=True)
+def _hermetic(monkeypatch):
+    for name in ("SYNTHESIS_CLIENT_SESSION_REF", "CLAUDE_CODE_HOST_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "CLAUDE_PID", "CLAUDECODE"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def args(board: Path, **values):
+    return type("Args", (), {"board": board, **values})()
+
+
+def claim(board: Path, project: str, env: dict, monkeypatch):
+    for key in ("CLAUDECODE", "CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_HOST_SESSION_ID", "SYNTHESIS_CLIENT_SESSION_REF"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    request = args(board, id=None, agent="agent", machine="m1", project=project, mode="interactive", goal="g", workspace=[f"/tmp/wt-{project} @ feature/{project}"], area=[f"repo-{project}/**"], context_role="owner")
+    assert ENGINE.command_claim(request) == 0
+    return [row for row in ENGINE.rows(board.read_text(encoding="utf-8")) if row.project == project][0]
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    path = tmp_path / "board.md"
+    other = claim(path, "project-o", {}, monkeypatch)
+    me = claim(path, "project-m", ME_ENV, monkeypatch)
+    assert ENGINE.command_message(args(path, sender=other.compact_id, to=me.compact_id, text="Handoff: the review is yours.")) == 0
+    assert ENGINE.command_message(args(path, sender=other.compact_id, to="project-m", text="For every project-m session.")) == 0
+    assert ENGINE.command_message(args(path, sender=other.compact_id, to=other.compact_id, text="Not for me.")) == 0
+    return path
+
+
+def test_inbox_delivers_once_to_the_named_seat(board, tmp_path) -> None:
+    payload = {"session_id": ME_SID, "hook_event_name": "UserPromptSubmit", "cwd": "/tmp"}
+    text = INBOX.inbox_text(payload, board=board, pointer=tmp_path / "pointer.json", environ=ME_ENV)
+    assert "2 unread message(s)" in text
+    assert "Handoff: the review is yours." in text and "For every project-m session." in text
+    assert "Not for me." not in text
+    assert INBOX.inbox_text(payload, board=board, pointer=tmp_path / "pointer.json", environ=ME_ENV) == ""
+
+
+def test_unseated_session_gets_project_messages_from_the_active_pointer(board, tmp_path) -> None:
+    pointer = tmp_path / "pointer.json"
+    pointer.write_text(json.dumps({"project": "/kb/projects/project-m"}), encoding="utf-8")
+    stranger = {"CLAUDECODE": "1", "CLAUDE_CODE_SESSION_ID": "99999999-9999-4999-8999-999999999999"}
+    text = INBOX.inbox_text({"session_id": stranger["CLAUDE_CODE_SESSION_ID"]}, board=board, pointer=pointer, environ=stranger)
+    assert "For every project-m session." in text and "Handoff" not in text
+
+
+def test_codex_session_learns_its_identity(board, tmp_path) -> None:
+    text = INBOX.inbox_text({"session_id": "0a0a0a0a-1b1b-4c1c-8d1d-2e2e2e2e2e2e"}, board=board, pointer=tmp_path / "pointer.json", environ={"CODEX_HOME": "/x"})
+    assert "SYNTHESIS_CLIENT_SESSION_REF=codex:0a0a0a0a-1b1b-4c1c-8d1d-2e2e2e2e2e2e" in text
+
+
+def test_no_session_id_means_silence(board, tmp_path) -> None:
+    assert INBOX.inbox_text({}, board=board, pointer=tmp_path / "pointer.json", environ={}) == ""
+
+
+def test_hook_process_emits_additional_context_json_or_nothing(board, tmp_path) -> None:
+    script = SCRIPTS_DIR / "board_inbox.py"
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE") and k != "SYNTHESIS_CLIENT_SESSION_REF"}
+    env.update(ME_ENV)
+    payload = json.dumps({"session_id": ME_SID, "hook_event_name": "UserPromptSubmit"})
+    first = subprocess.run([sys.executable, str(script), "--board", str(board), "--active-project-file", str(tmp_path / "pointer.json"), "--hook"], input=payload, capture_output=True, text=True, env=env)
+    assert first.returncode == 0, first.stderr
+    data = json.loads(first.stdout)
+    assert data["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    assert "2 unread message(s)" in data["hookSpecificOutput"]["additionalContext"]
+    second = subprocess.run([sys.executable, str(script), "--board", str(board), "--active-project-file", str(tmp_path / "pointer.json"), "--hook"], input=payload, capture_output=True, text=True, env=env)
+    assert second.returncode == 0 and second.stdout == ""
+
+
+def test_session_context_appends_the_inbox(board, tmp_path) -> None:
+    conformance = SCRIPTS_DIR.parents[1] / "synthesis-agent-conformance" / "scripts" / "session_context.py"
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE") and k != "SYNTHESIS_CLIENT_SESSION_REF"}
+    env.update(ME_ENV)
+    env["SYNTHESIS_PUBLIC_SESSIONSTART_RECEIPT"] = str(tmp_path / "receipt.json")
+    payload = json.dumps({"session_id": ME_SID, "hook_event_name": "SessionStart", "cwd": str(tmp_path)})
+    run = subprocess.run([sys.executable, str(conformance), "--active-project-file", str(tmp_path / "pointer.json"), "--coordination-board", str(board), "--format", "claude"], input=payload, capture_output=True, text=True, env=env)
+    assert run.returncode == 0, run.stderr
+    context = json.loads(run.stdout)["hookSpecificOutput"]["additionalContext"]
+    assert "Coordination board inbox: 2 unread" in context

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -31,6 +31,9 @@ def _isolate_client_session_env(monkeypatch):
     simulated session and trip the duplicate-ref refusal."""
     monkeypatch.delenv("SYNTHESIS_CLIENT_SESSION_REF", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_HOST_SESSION_ID", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    monkeypatch.delenv("CLAUDE_PID", raising=False)
+    monkeypatch.delenv("CLAUDECODE", raising=False)
 
 
 def args(board: Path, **values):
@@ -1958,7 +1961,7 @@ def test_every_command_notes_a_newer_installed_engine(tmp_path):
     relative = Path("skills") / "synthesis-project-management" / "scripts"
     older = cache / "4.80.0" / relative
     older.mkdir(parents=True)
-    for name in ("coordination.py", "coordination_schema.py", "pointer_lock.py"):
+    for name in ("coordination.py", "coordination_schema.py", "pointer_lock.py", "peer_addressing.py"):
         (older / name).write_bytes((MODULE_PATH.parent / name).read_bytes())
     newer = cache / "4.81.0" / relative
     newer.mkdir(parents=True)

--- a/skills/synthesis-project-management/scripts/test_peer_addressing.py
+++ b/skills/synthesis-project-management/scripts/test_peer_addressing.py
@@ -1,0 +1,405 @@
+"""Peer addressing: seats, lanes, receipts, inbox, and the engine verbs around them."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import coordination as ENGINE  # noqa: E402
+import peer_addressing as PA  # noqa: E402
+
+CLAUDE_ENV = {
+    "CLAUDECODE": "1",
+    "CLAUDE_CODE_SESSION_ID": "11111111-1111-4111-8111-111111111111",
+    "CLAUDE_CODE_HOST_SESSION_ID": "local_aaaa-1111",
+    "CLAUDE_PID": "4242",
+}
+
+
+@pytest.fixture(autouse=True)
+def _hermetic(monkeypatch):
+    for name in (
+        "SYNTHESIS_CLIENT_SESSION_REF",
+        "CLAUDE_CODE_HOST_SESSION_ID",
+        "CLAUDE_CODE_SESSION_ID",
+        "CLAUDE_PID",
+        "CLAUDECODE",
+        "SYNTHESIS_PEER_REGISTRY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def args(board: Path, **values):
+    return type("Args", (), {"board": board, **values})()
+
+
+def claim(board: Path, project: str, *, machine: str = "m1", area: str | None = None, workspace: str | None = None):
+    request = args(
+        board,
+        id=None,
+        agent=f"agent-{project}",
+        machine=machine,
+        project=project,
+        mode="interactive",
+        goal=f"goal-{project}",
+        workspace=[workspace or f"/tmp/wt-{project} @ feature/{project}"],
+        area=[area or f"repo-{project}/**"],
+        context_role="owner",
+    )
+    assert ENGINE.command_claim(request) == 0
+    return [row for row in ENGINE.rows(board.read_text(encoding="utf-8")) if row.project == project][0]
+
+
+def registry_with(tmp_path: Path, session_id: str, *, name: str = "peer-1a", pid: int | None = None) -> Path:
+    registry = tmp_path / "registry"
+    registry.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "pid": pid or os.getpid(),
+        "sessionId": session_id,
+        "cwd": "/tmp/peer",
+        "messagingSocketPath": f"/tmp/cc-socks/{pid or os.getpid()}.sock",
+        "name": name,
+        "nameSource": "derived",
+    }
+    (registry / f"{entry['pid']}.json").write_text(json.dumps(entry), encoding="utf-8")
+    return registry
+
+
+# --- self identity --------------------------------------------------------------------------
+
+def test_claude_shell_identity_keys_by_harness_session_and_prefers_the_desktop_ref() -> None:
+    identity = PA.detect_self(CLAUDE_ENV)
+    assert identity.client == PA.CLIENT_CLAUDE
+    assert identity.sender_key == "cc:11111111-1111-4111-8111-111111111111"
+    assert identity.primary_ref == "ccd:local_aaaa-1111"
+    assert identity.pid == 4242
+
+
+def test_terminal_session_without_desktop_id_registers_under_cc() -> None:
+    env = {k: v for k, v in CLAUDE_ENV.items() if k != "CLAUDE_CODE_HOST_SESSION_ID"}
+    assert PA.detect_self(env).primary_ref == "cc:11111111-1111-4111-8111-111111111111"
+
+
+def test_codex_identity_comes_from_the_exported_ref() -> None:
+    identity = PA.detect_self({"SYNTHESIS_CLIENT_SESSION_REF": "codex:0a0a-1b1b"})
+    assert identity.client == PA.CLIENT_CODEX
+    assert identity.sender_key == "codex:0a0a-1b1b"
+    assert identity.primary_ref == "codex:0a0a-1b1b"
+
+
+def test_empty_environment_has_no_identity() -> None:
+    identity = PA.detect_self({})
+    assert identity.sender_key == "" and identity.primary_ref == ""
+
+
+def test_hook_payload_session_id_is_authoritative_for_the_sender_key() -> None:
+    claude = PA.identity_from_hook({"session_id": "22222222-2222-4222-8222-222222222222"}, CLAUDE_ENV)
+    assert claude.sender_key == "cc:22222222-2222-4222-8222-222222222222"
+    codex = PA.identity_from_hook({"session_id": "0a0a-1b1b"}, {"CODEX_HOME": "/x"})
+    assert codex.sender_key == "codex:0a0a-1b1b"
+
+
+# --- seats ----------------------------------------------------------------------------------
+
+def test_claim_writes_a_seat_release_removes_it(tmp_path, monkeypatch) -> None:
+    for key, value in CLAUDE_ENV.items():
+        monkeypatch.setenv(key, value)
+    board = tmp_path / "board.md"
+    row = claim(board, "project-a")
+    seat = PA.read_seat(board, row.session_uuid)
+    assert seat is not None
+    assert seat.harness_session_id == CLAUDE_ENV["CLAUDE_CODE_SESSION_ID"]
+    assert seat.host_session_id == CLAUDE_ENV["CLAUDE_CODE_HOST_SESSION_ID"]
+    assert seat.client == PA.CLIENT_CLAUDE and seat.machine == "m1"
+    assert PA.seat_for_identity(board, PA.detect_self(CLAUDE_ENV)).session_uuid == row.session_uuid
+    assert ENGINE.command_release(args(board, id=row.compact_id)) == 0
+    assert PA.read_seat(board, row.session_uuid) is None
+
+
+def test_claim_without_handles_records_no_seat(tmp_path) -> None:
+    board = tmp_path / "board.md"
+    row = claim(board, "project-a")
+    assert PA.read_seat(board, row.session_uuid) is None
+
+
+def test_explicit_codex_ref_seats_a_codex_session(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:0a0a-1b1b")
+    board = tmp_path / "board.md"
+    row = claim(board, "project-c")
+    seat = PA.read_seat(board, row.session_uuid)
+    assert seat is not None and seat.client == PA.CLIENT_CODEX
+    assert seat.harness_session_id == "0a0a-1b1b"
+    assert row.client_ref == "codex:0a0a-1b1b"
+
+
+def test_heartbeat_refreshes_the_seat(tmp_path, monkeypatch) -> None:
+    for key, value in CLAUDE_ENV.items():
+        monkeypatch.setenv(key, value)
+    board = tmp_path / "board.md"
+    row = claim(board, "project-a")
+    before = PA.read_seat(board, row.session_uuid)
+    stale = PA.iso(PA.utcnow() - timedelta(hours=1))
+    path = PA.seat_path(board, row.session_uuid)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["updated_at"] = stale
+    path.write_text(json.dumps(data), encoding="utf-8")
+    assert ENGINE.command_heartbeat(args(board, id=row.compact_id)) == 0
+    after = PA.read_seat(board, row.session_uuid)
+    assert after is not None and after.updated_at > stale
+    assert after.harness_session_id == before.harness_session_id
+
+
+# --- registry and lanes ---------------------------------------------------------------------
+
+def test_registry_entry_requires_a_living_process(tmp_path) -> None:
+    registry = registry_with(tmp_path, "sid-1", pid=999999)
+    assert PA.registry_entry_for_session("sid-1", registry, alive=lambda pid: False) is None
+    entry = PA.registry_entry_for_session("sid-1", registry, alive=lambda pid: True)
+    assert entry is not None and PA.harness_address(entry) == "uds:/tmp/cc-socks/999999.sock"
+
+
+def test_lanes_exist_only_on_the_target_machine_and_only_from_live_truth(tmp_path) -> None:
+    seat = PA.Seat(
+        session_uuid="u", compact_id="s-aaaa-bbbb-cccc", client=PA.CLIENT_CLAUDE,
+        machine="m1", harness_session_id="sid-1", host_session_id="local_x",
+    )
+    registry = registry_with(tmp_path, "sid-1", pid=999999)
+    same = PA.delivery_lanes(
+        client_ref="ccd:local_x", compact_id="s-aaaa-bbbb-cccc", target_machine="m1",
+        seat=seat, local_machine="m1", registry=registry, alive=lambda pid: True,
+    )
+    assert same["bus"] == {"to": "s-aaaa-bbbb-cccc"}
+    assert same["ccd"] == {"session_id": "local_x"}
+    assert same["harness"]["to"] == "uds:/tmp/cc-socks/999999.sock"
+    assert same["harness"]["name"] == "peer-1a"
+    other = PA.delivery_lanes(
+        client_ref="ccd:local_x", compact_id="s-aaaa-bbbb-cccc", target_machine="m2",
+        seat=seat, local_machine="m1", registry=registry, alive=lambda pid: True,
+    )
+    assert set(other) == {"bus"}
+    dead = PA.delivery_lanes(
+        client_ref="ccd:local_x", compact_id="s-aaaa-bbbb-cccc", target_machine="m1",
+        seat=seat, local_machine="m1", registry=registry, alive=lambda pid: False,
+    )
+    assert "harness" not in dead and "ccd" in dead
+
+
+def test_codex_lane_is_the_queue_command(tmp_path) -> None:
+    lanes = PA.delivery_lanes(
+        client_ref="codex:0a0a-1b1b", compact_id="s-1", target_machine="m1",
+        seat=None, local_machine="m1", registry=tmp_path / "none",
+    )
+    assert lanes["codex"]["thread"] == "0a0a-1b1b"
+    assert lanes["codex"]["command"].startswith("codex queue --thread 0a0a-1b1b")
+
+
+def test_invocations_never_use_a_display_name_as_the_address(tmp_path) -> None:
+    registry = registry_with(tmp_path, "sid-1", pid=999999)
+    seat = PA.Seat(session_uuid="u", compact_id="s-1", client=PA.CLIENT_CLAUDE, machine="m1", harness_session_id="sid-1")
+    lanes = PA.delivery_lanes(
+        client_ref="ccd:local_x", compact_id="s-1", target_machine="m1",
+        seat=seat, local_machine="m1", registry=registry, alive=lambda pid: True,
+    )
+    text = "\n".join(PA.lane_invocations(lanes, "s-me"))
+    assert "to='uds:/tmp/cc-socks/999999.sock'" in text
+    assert "display only" in text
+    assert "from s-me" in text
+
+
+# --- receipts -------------------------------------------------------------------------------
+
+def test_receipt_requires_a_sender_identity_and_expires(tmp_path) -> None:
+    board = tmp_path / "board.md"
+    target = {"uuid": "u-t", "compact": "s-t"}
+    assert PA.write_receipt(board, sender=PA.SelfIdentity(), sender_row=None, selector="p", matched_by="project", target=target, lanes={"bus": {"to": "s-t"}}) is None
+    sender = PA.detect_self(CLAUDE_ENV)
+    path = PA.write_receipt(board, sender=sender, sender_row=None, selector="p", matched_by="project", target=target, lanes={"ccd": {"session_id": "local_t"}, "bus": {"to": "s-t"}})
+    assert path is not None and path.is_file()
+    live = PA.load_receipts(board, sender.sender_key)
+    assert len(live) == 1
+    assert PA.receipt_for_address(live, "ccd", "local_t")["target"]["compact"] == "s-t"
+    assert PA.receipt_for_address(live, "ccd", "local_other") is None
+    later = PA.utcnow() + timedelta(minutes=PA.RECEIPT_TTL_MINUTES + 1)
+    assert PA.load_receipts(board, sender.sender_key, later) == []
+    assert not path.exists(), "expired receipts are pruned"
+
+
+def test_broadcast_conflict_sees_the_same_text_sent_elsewhere(tmp_path) -> None:
+    board = tmp_path / "board.md"
+    digest = PA.body_digest("from s-me: please review PR 7")
+    assert PA.body_digest("  FROM s-me:   please review pr 7 ") == digest
+    PA.append_send_log(board, {"at": PA.iso(PA.utcnow()), "decision": "allow", "sender_key": "cc:me", "digest": digest, "target_uuid": "u-1", "lane": "ccd", "target": "local_1"})
+    assert PA.broadcast_conflict(board, sender_key="cc:me", digest=digest, target_uuid="u-2") is not None
+    assert PA.broadcast_conflict(board, sender_key="cc:me", digest=digest, target_uuid="u-1") is None
+    assert PA.broadcast_conflict(board, sender_key="cc:other", digest=digest, target_uuid="u-2") is None
+    old = PA.utcnow() + timedelta(minutes=PA.BROADCAST_WINDOW_MINUTES + 1)
+    assert PA.broadcast_conflict(board, sender_key="cc:me", digest=digest, target_uuid="u-2", now=old) is None
+
+
+# --- inbox ----------------------------------------------------------------------------------
+
+def test_inbox_delivers_seat_and_project_addressed_messages_once(tmp_path, monkeypatch) -> None:
+    board = tmp_path / "board.md"
+    sender = claim(board, "project-a")
+    for key, value in CLAUDE_ENV.items():
+        monkeypatch.setenv(key, value)
+    me = claim(board, "project-b")
+    assert ENGINE.command_message(args(board, sender=sender.compact_id, to=me.compact_id, text="Direct: ready for review.")) == 0
+    assert ENGINE.command_message(args(board, sender=sender.compact_id, to="project-b", text="Project-wide note.")) == 0
+    assert ENGINE.command_message(args(board, sender=sender.compact_id, to=sender.compact_id, text="Note to self.")) == 0
+    messages = PA.parse_messages(board.read_text(encoding="utf-8"))
+    assert [m.body for m in messages] == ["Direct: ready for review.", "Project-wide note.", "Note to self."]
+    forms = {me.session_uuid, me.compact_id, me.speakable_id}
+    unread = PA.unread_messages(board.read_text(encoding="utf-8"), board=board, sender_key="cc:x", identity_forms=forms, project="project-b")
+    assert [m.body for m in unread] == ["Direct: ready for review.", "Project-wide note."]
+    rendered = PA.render_inbox(unread)
+    assert "2 unread message(s)" in rendered and "never a chat title" in rendered
+    PA.mark_seen(board, "cc:x", {m.key for m in unread})
+    assert PA.unread_messages(board.read_text(encoding="utf-8"), board=board, sender_key="cc:x", identity_forms=forms, project="project-b") == []
+
+
+def test_free_text_addressees_are_never_delivered() -> None:
+    message = PA.BoardMessage(recipient="whoever is holding the train", sender="s-1", timestamp="t", body="x")
+    assert not PA.addressed_to(message, {"s-2"}, "project-b")
+    exact = PA.BoardMessage(recipient="s-2", sender="s-1", timestamp="t", body="x")
+    assert PA.addressed_to(exact, {"s-2"}, "")
+
+
+def test_inbox_rendering_is_bounded() -> None:
+    messages = [PA.BoardMessage(recipient="s-2", sender="s-1", timestamp=f"t{i}", body="\n".join(f"line {n}" for n in range(40))) for i in range(8)]
+    rendered = PA.render_inbox(messages, limit=3, body_lines=5)
+    assert "8 unread message(s)" in rendered and "showing the newest 3" in rendered
+    assert rendered.count("… 35 more line(s)") == 3
+
+
+# --- engine verbs ---------------------------------------------------------------------------
+
+def resolve_args(board: Path, to: str, **overrides):
+    values = {"to": to, "role": None, "include_released": False, "stale_after_minutes": 240, "json": False, "no_receipt": False, "registry": None, "local_machine": None}
+    values.update(overrides)
+    return args(board, **values)
+
+
+def two_seats(tmp_path, monkeypatch):
+    """A sender seat (this shell) and a target seat with a live registry entry."""
+    board = tmp_path / "board.md"
+    target_env = {**CLAUDE_ENV, "CLAUDE_CODE_SESSION_ID": "33333333-3333-4333-8333-333333333333", "CLAUDE_CODE_HOST_SESSION_ID": "local_target"}
+    for key, value in target_env.items():
+        monkeypatch.setenv(key, value)
+    target = claim(board, "project-t")
+    for key, value in CLAUDE_ENV.items():
+        monkeypatch.setenv(key, value)
+    sender = claim(board, "project-s")
+    registry = registry_with(tmp_path, target_env["CLAUDE_CODE_SESSION_ID"], pid=os.getpid())
+    return board, sender, target, registry
+
+
+def test_resolve_prints_exact_lanes_and_issues_a_receipt(tmp_path, monkeypatch, capsys) -> None:
+    board, sender, target, registry = two_seats(tmp_path, monkeypatch)
+    assert ENGINE.command_resolve(resolve_args(board, "project-t", registry=registry, local_machine="m1")) == 0
+    out = capsys.readouterr().out
+    assert "ccd send_message to session_id local_target" in out
+    assert f"SendMessage to='uds:/tmp/cc-socks/{os.getpid()}.sock'" in out
+    assert f"from {sender.compact_id}" in out
+    assert "Delivery receipt:" in out
+    receipts = PA.load_receipts(board, PA.detect_self(CLAUDE_ENV).sender_key)
+    assert len(receipts) == 1
+    assert receipts[0]["target"]["uuid"] == target.session_uuid
+    assert receipts[0]["lanes"]["ccd"] == {"session_id": "local_target"}
+    assert receipts[0]["issued_by"]["board"]["compact"] == sender.compact_id
+
+
+def test_resolve_json_carries_lanes_and_receipt(tmp_path, monkeypatch, capsys) -> None:
+    board, sender, target, registry = two_seats(tmp_path, monkeypatch)
+    capsys.readouterr()
+    assert ENGINE.command_resolve(resolve_args(board, target.compact_id, json=True, registry=registry, local_machine="m1")) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload["lanes"]) == {"bus", "ccd", "harness"}
+    assert payload["receipt"] and payload["sender"] == sender.compact_id
+
+
+def test_resolve_without_identity_warns_that_direct_lanes_will_refuse(tmp_path, capsys) -> None:
+    board = tmp_path / "board.md"
+    claim(board, "project-t")
+    assert ENGINE.command_resolve(resolve_args(board, "project-t", local_machine="m1")) == 0
+    captured = capsys.readouterr()
+    assert "no delivery receipt issued" in captured.err
+    assert "bus lane:" in captured.out
+
+
+def test_resolve_no_receipt_looks_up_only(tmp_path, monkeypatch) -> None:
+    board, sender, target, registry = two_seats(tmp_path, monkeypatch)
+    assert ENGINE.command_resolve(resolve_args(board, "project-t", no_receipt=True, registry=registry, local_machine="m1")) == 0
+    assert PA.load_receipts(board, PA.detect_self(CLAUDE_ENV).sender_key) == []
+
+
+def test_ambiguous_resolve_issues_no_receipt(tmp_path, monkeypatch) -> None:
+    board, sender, target, registry = two_seats(tmp_path, monkeypatch)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID")
+    monkeypatch.delenv("CLAUDE_CODE_HOST_SESSION_ID")
+    contributor = args(board, id=None, agent="c", machine="m1", project="project-t", mode="interactive", goal="g", workspace=["/tmp/wt-c @ feature/c"], area=["other-repo/docs/**"], context_role="contributor")
+    assert ENGINE.command_claim(contributor) == 0
+    for key, value in CLAUDE_ENV.items():
+        monkeypatch.setenv(key, value)
+    assert ENGINE.command_resolve(resolve_args(board, "project-t", registry=registry, local_machine="m1")) == 20
+    assert PA.load_receipts(board, PA.detect_self(CLAUDE_ENV).sender_key) == []
+
+
+def test_whoami_reports_seat_and_the_lanes_peers_use(tmp_path, monkeypatch, capsys) -> None:
+    board, sender, target, registry = two_seats(tmp_path, monkeypatch)
+    own_registry = registry_with(tmp_path / "own", CLAUDE_ENV["CLAUDE_CODE_SESSION_ID"], name="me-1b", pid=os.getpid())
+    capsys.readouterr()
+    assert ENGINE.command_whoami(args(board, json=True, registry=own_registry, local_machine="m1")) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["seat"] == sender.compact_id
+    assert payload["sender_key"] == "cc:" + CLAUDE_ENV["CLAUDE_CODE_SESSION_ID"]
+    assert payload["lanes_peers_use"]["harness"]["to"].startswith("uds:")
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID")
+    monkeypatch.delenv("CLAUDECODE")
+    assert ENGINE.command_whoami(args(board, json=False, registry=own_registry, local_machine="m1")) == 1
+
+
+def test_inbox_verb_lists_and_marks(tmp_path, monkeypatch, capsys) -> None:
+    board, sender, target, registry = two_seats(tmp_path, monkeypatch)
+    assert ENGINE.command_message(args(board, sender=target.compact_id, to=sender.compact_id, text="Ping from the target seat.")) == 0
+    capsys.readouterr()
+    assert ENGINE.command_inbox(args(board, id=None, mark_read=False, json=True)) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["session"] == sender.compact_id
+    assert [m["body"] for m in payload["unread"]] == ["Ping from the target seat."]
+    assert ENGINE.command_inbox(args(board, id=None, mark_read=True, json=False)) == 0
+    assert "Marked 1 message(s) read" in capsys.readouterr().out
+    assert ENGINE.command_inbox(args(board, id=None, mark_read=False, json=False)) == 0
+    assert "No unread messages" in capsys.readouterr().out
+
+
+def test_doctor_counts_seats_and_names_orphans(tmp_path, monkeypatch, capsys) -> None:
+    board, sender, target, registry = two_seats(tmp_path, monkeypatch)
+    assert ENGINE.command_doctor(args(board)) == 0
+    assert "2 seat(s)" in capsys.readouterr().out
+    assert ENGINE.command_release(args(board, id=target.compact_id)) == 0
+    PA.write_seat(board, session_uuid=target.session_uuid, compact_id=target.compact_id, machine="m1", identity=PA.SelfIdentity(client="claude-code", harness_session_id="orphan"))
+    assert ENGINE.command_doctor(args(board)) == 0
+    assert "1 without an active row" in capsys.readouterr().out
+
+
+def test_delivery_lane_summary_names_codex_queue_and_cc_sessions() -> None:
+    codex = ENGINE.Session("u", "s-1", "sp", "", "OpenAI Codex", "m1", "p", "t", "t", "autonomous", [], "g", [], "owner", "active", client_ref="codex:0a0a")
+    assert ENGINE.delivery_lane(codex).startswith("codex queue --thread 0a0a")
+    terminal = ENGINE.Session("u", "s-1", "sp", "", "Claude Code", "m1", "p", "t", "t", "interactive", [], "g", [], "owner", "active", client_ref="cc:1111")
+    assert "uds: socket" in ENGINE.delivery_lane(terminal)
+
+
+def test_terminal_session_claim_registers_cc_ref(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "11111111-1111-4111-8111-111111111111")
+    board = tmp_path / "board.md"
+    row = claim(board, "project-a")
+    assert row.client_ref == "cc:11111111-1111-4111-8111-111111111111"

--- a/skills/synthesis-project-management/scripts/test_peer_send_gate.py
+++ b/skills/synthesis-project-management/scripts/test_peer_send_gate.py
@@ -1,0 +1,247 @@
+"""The peer send gate: every direct lane needs a receipt, a live target, and a named sender."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import coordination as ENGINE  # noqa: E402
+import peer_addressing as PA  # noqa: E402
+import peer_send_gate as GATE  # noqa: E402
+
+SENDER_SID = "11111111-1111-4111-8111-111111111111"
+TARGET_SID = "33333333-3333-4333-8333-333333333333"
+SENDER_ENV = {"CLAUDECODE": "1", "CLAUDE_CODE_SESSION_ID": SENDER_SID, "CLAUDE_CODE_HOST_SESSION_ID": "local_sender", "CLAUDE_PID": "1"}
+TARGET_ENV = {"CLAUDECODE": "1", "CLAUDE_CODE_SESSION_ID": TARGET_SID, "CLAUDE_CODE_HOST_SESSION_ID": "local_target", "CLAUDE_PID": "2"}
+
+
+@pytest.fixture(autouse=True)
+def _hermetic(monkeypatch):
+    for name in ("SYNTHESIS_CLIENT_SESSION_REF", "CLAUDE_CODE_HOST_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "CLAUDE_PID", "CLAUDECODE", "SYNTHESIS_PEER_REGISTRY"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def args(board: Path, **values):
+    return type("Args", (), {"board": board, **values})()
+
+
+def claim(board: Path, project: str, env: dict, monkeypatch, *, machine: str = "m1", agent: str = "Claude Code"):
+    for key in ("CLAUDECODE", "CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_HOST_SESSION_ID", "CLAUDE_PID", "SYNTHESIS_CLIENT_SESSION_REF"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    request = args(board, id=None, agent=agent, machine=machine, project=project, mode="interactive", goal=f"goal-{project}", workspace=[f"/tmp/wt-{project} @ feature/{project}"], area=[f"repo-{project}/**"], context_role="owner")
+    assert ENGINE.command_claim(request) == 0
+    return [row for row in ENGINE.rows(board.read_text(encoding="utf-8")) if row.project == project][0]
+
+
+@pytest.fixture
+def world(tmp_path, monkeypatch):
+    """Sender (this shell) and target seats on one board, target alive in the registry."""
+    board = tmp_path / "board.md"
+    target = claim(board, "project-t", TARGET_ENV, monkeypatch)
+    sender = claim(board, "project-s", SENDER_ENV, monkeypatch)
+    registry = tmp_path / "registry"
+    registry.mkdir()
+    entry = {"pid": os.getpid(), "sessionId": TARGET_SID, "cwd": "/tmp/t", "messagingSocketPath": "/tmp/cc-socks/777.sock", "name": "peer-4a"}
+    (registry / f"{os.getpid()}.json").write_text(json.dumps(entry), encoding="utf-8")
+    home = tmp_path / "home"
+    home.mkdir()
+    return type("World", (), {"board": board, "sender": sender, "target": target, "registry": registry, "home": home, "tmp": tmp_path})()
+
+
+def resolve(world, selector: str | None = None):
+    request = args(world.board, to=selector or world.target.compact_id, role=None, include_released=False, stale_after_minutes=240, json=False, no_receipt=False, registry=world.registry, local_machine="m1")
+    assert ENGINE.command_resolve(request) == 0
+
+
+def payload(tool: str, tool_input: dict, *, session_id: str = SENDER_SID, transcript: str | None = None) -> dict:
+    data = {"session_id": session_id, "hook_event_name": "PreToolUse", "tool_name": tool, "tool_input": tool_input, "cwd": "/tmp"}
+    if transcript:
+        data["transcript_path"] = transcript
+    return data
+
+
+def evaluate(world, data: dict, env: dict | None = None) -> GATE.Decision:
+    return GATE.evaluate(data, board=world.board, registry=world.registry, environ=env or SENDER_ENV, home=world.home)
+
+
+def body(world, text: str = "please review the handoff") -> str:
+    return f"from {world.sender.compact_id} (project-s): {text}"
+
+
+# --- classification -------------------------------------------------------------------------
+
+def test_non_peer_tools_and_in_process_targets_pass_without_a_board(tmp_path) -> None:
+    missing = tmp_path / "nope.md"
+    for tool, tool_input in (("Read", {"file_path": "/x"}), ("SendMessage", {"to": "main", "message": "x"}), ("SendMessage", {"to": "acb566644f52b0a44", "message": "x"}), ("Bash", {"command": "git status"})):
+        decision = GATE.evaluate(payload(tool, tool_input), board=missing, registry=tmp_path, environ=SENDER_ENV, home=tmp_path)
+        assert decision.allow and not decision.logged, (tool, decision)
+
+
+def test_named_teammates_pass_when_a_team_registers_them(tmp_path) -> None:
+    team = tmp_path / ".claude" / "teams" / "alpha"
+    team.mkdir(parents=True)
+    (team / "config.json").write_text(json.dumps({"members": [{"name": "researcher"}]}), encoding="utf-8")
+    decision = GATE.evaluate(payload("SendMessage", {"to": "researcher", "message": "go"}), board=tmp_path / "nope.md", registry=tmp_path, environ=SENDER_ENV, home=tmp_path)
+    assert decision.allow and decision.lane == "in-process"
+
+
+def test_display_names_and_refs_are_refused_as_addresses(world) -> None:
+    for to in ("peer-4a", "peer-4a [902d19]", "[902d19]", "example-operations"):
+        decision = evaluate(world, payload("SendMessage", {"to": to, "message": body(world)}))
+        assert not decision.allow, to
+        assert "display name" in decision.reason and "uds:" in decision.reason
+
+
+# --- harness lane ---------------------------------------------------------------------------
+
+def test_socket_address_needs_a_receipt_then_passes(world) -> None:
+    data = payload("SendMessage", {"to": "uds:/tmp/cc-socks/777.sock", "message": body(world)})
+    refused = evaluate(world, data)
+    assert not refused.allow and "no delivery receipt" in refused.reason and "resolve --to" in refused.reason
+    resolve(world)
+    allowed = evaluate(world, data)
+    assert allowed.allow, allowed.reason
+    assert allowed.lane == "harness" and allowed.target_uuid == world.target.session_uuid
+
+
+def test_socket_that_no_longer_maps_to_the_resolved_session_is_refused(world) -> None:
+    resolve(world)
+    for path in world.registry.glob("*.json"):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["sessionId"] = "someone-else"
+        path.write_text(json.dumps(data), encoding="utf-8")
+    decision = evaluate(world, payload("SendMessage", {"to": "uds:/tmp/cc-socks/777.sock", "message": body(world)}))
+    assert not decision.allow and "no longer maps" in decision.reason
+
+
+def test_a_receipt_for_one_socket_does_not_admit_another(world) -> None:
+    resolve(world)
+    decision = evaluate(world, payload("SendMessage", {"to": "uds:/tmp/cc-socks/778.sock", "message": body(world)}))
+    assert not decision.allow and "no delivery receipt" in decision.reason
+
+
+def test_reply_may_copy_the_from_address_of_a_received_message(world) -> None:
+    transcript = world.tmp / "transcript.jsonl"
+    transcript.write_text(json.dumps({"type": "user", "message": {"content": '<cross-session-message from="uds:/tmp/cc-socks/777.sock" from-name="peer-4a">hi</cross-session-message>'}}) + "\n", encoding="utf-8")
+    decision = evaluate(world, payload("SendMessage", {"to": "uds:/tmp/cc-socks/777.sock", "message": body(world, "got it")}, transcript=str(transcript)))
+    assert decision.allow and "reply" in decision.reason
+    other = evaluate(world, payload("SendMessage", {"to": "uds:/tmp/cc-socks/999.sock", "message": body(world, "got it")}, transcript=str(transcript)))
+    assert not other.allow
+
+
+def test_idle_subscription_without_text_needs_only_the_receipt(world) -> None:
+    resolve(world)
+    decision = evaluate(world, payload("SendMessage", {"to": "uds:/tmp/cc-socks/777.sock", "notify_when_idle": True}))
+    assert decision.allow
+
+
+# --- ccd lane -------------------------------------------------------------------------------
+
+def test_ccd_session_id_needs_a_matching_receipt(world) -> None:
+    data = payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_target", "message": body(world)})
+    assert not evaluate(world, data).allow
+    resolve(world, "project-t")
+    decision = evaluate(world, data)
+    assert decision.allow and decision.lane == "ccd"
+    wrong = evaluate(world, payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_other", "message": body(world)}))
+    assert not wrong.allow
+
+
+def test_released_target_is_refused_even_with_a_receipt(world) -> None:
+    resolve(world)
+    assert ENGINE.command_release(args(world.board, id=world.target.compact_id)) == 0
+    decision = evaluate(world, payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_target", "message": body(world)}))
+    assert not decision.allow and "no longer an active board row" in decision.reason
+
+
+# --- sender and body rules ------------------------------------------------------------------
+
+def test_message_must_carry_the_senders_board_id(world) -> None:
+    resolve(world)
+    decision = evaluate(world, payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_target", "message": "please review"}))
+    assert not decision.allow and f"from {world.sender.compact_id}" in decision.reason
+
+
+def test_sender_without_a_seat_is_refused(world) -> None:
+    resolve(world)
+    stranger = {"CLAUDECODE": "1", "CLAUDE_CODE_SESSION_ID": "44444444-4444-4444-8444-444444444444"}
+    decision = GATE.evaluate(payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_target", "message": body(world)}, session_id=stranger["CLAUDE_CODE_SESSION_ID"]), board=world.board, registry=world.registry, environ=stranger, home=world.home)
+    assert not decision.allow and "claim first" in decision.reason
+
+
+def test_missing_session_id_and_unreadable_board_fail_closed(world, tmp_path) -> None:
+    data = payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_target", "message": body(world)})
+    data.pop("session_id")
+    assert not evaluate(world, data).allow
+    decision = GATE.evaluate(payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_target", "message": body(world)}), board=tmp_path / "absent.md", registry=world.registry, environ=SENDER_ENV, home=world.home)
+    assert not decision.allow and "unreadable" in decision.reason
+
+
+def test_same_text_to_a_second_session_is_a_broadcast(world, monkeypatch) -> None:
+    resolve(world)
+    first = payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_target", "message": body(world, "the release shipped")})
+    decision = evaluate(world, first)
+    assert decision.allow
+    GATE.record(world.board, first, decision, SENDER_ENV)
+    third = claim(world.board, "project-u", {"CLAUDECODE": "1", "CLAUDE_CODE_SESSION_ID": "55555555-5555-4555-8555-555555555555", "CLAUDE_CODE_HOST_SESSION_ID": "local_third"}, monkeypatch, machine="m1")
+    for key, value in SENDER_ENV.items():
+        monkeypatch.setenv(key, value)
+    resolve(world, third.compact_id)
+    second = evaluate(world, payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_third", "message": body(world, "the release shipped")}))
+    assert not second.allow and "broadcast" in second.reason
+    different = evaluate(world, payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_third", "message": body(world, "a different note for you")}))
+    assert different.allow
+
+
+# --- codex lane -----------------------------------------------------------------------------
+
+def test_codex_queue_needs_a_receipt_for_that_thread(world, monkeypatch) -> None:
+    codex = claim(world.board, "project-x", {"SYNTHESIS_CLIENT_SESSION_REF": "codex:0a0a0a0a-1b1b-4c1c-8d1d-2e2e2e2e2e2e"}, monkeypatch, agent="OpenAI Codex")
+    monkeypatch.delenv("SYNTHESIS_CLIENT_SESSION_REF")
+    for key, value in SENDER_ENV.items():
+        monkeypatch.setenv(key, value)
+    command = f'codex queue --thread 0a0a0a0a-1b1b-4c1c-8d1d-2e2e2e2e2e2e --message "{body(world, "please pick this up")}"'
+    refused = evaluate(world, payload("Bash", {"command": command}))
+    assert not refused.allow and refused.lane == "codex"
+    resolve(world, codex.compact_id)
+    allowed = evaluate(world, payload("Bash", {"command": command}))
+    assert allowed.allow, allowed.reason
+    assert evaluate(world, payload("exec_command", {"cmd": "codex queue --message x"})).allow is False
+
+
+# --- process contract -----------------------------------------------------------------------
+
+def test_gate_process_blocks_with_exit_2_and_admits_with_exit_0(world) -> None:
+    script = SCRIPTS_DIR / "peer_send_gate.py"
+    env = {**os.environ, **SENDER_ENV, "SYNTHESIS_PEER_REGISTRY": str(world.registry)}
+    for key in ("SYNTHESIS_CLIENT_SESSION_REF",):
+        env.pop(key, None)
+    data = payload("SendMessage", {"to": "peer-4a [902d19]", "message": body(world)})
+    blocked = subprocess.run([sys.executable, str(script), "--board", str(world.board), "--gate"], input=json.dumps(data), capture_output=True, text=True, env=env)
+    assert blocked.returncode == 2 and "peer-send-gate BLOCKED" in blocked.stderr
+    resolve(world)
+    data = payload("SendMessage", {"to": "uds:/tmp/cc-socks/777.sock", "message": body(world)})
+    admitted = subprocess.run([sys.executable, str(script), "--board", str(world.board), "--gate"], input=json.dumps(data), capture_output=True, text=True, env=env)
+    assert admitted.returncode == 0, admitted.stderr
+    log = [json.loads(line) for line in PA.send_log_path(world.board).read_text(encoding="utf-8").splitlines()]
+    assert [entry["decision"] for entry in log] == ["deny", "allow"]
+    garbage = subprocess.run([sys.executable, str(script), "--board", str(world.board), "--gate"], input="not json", capture_output=True, text=True, env=env)
+    assert garbage.returncode == 2
+
+
+def test_doctor_reports_seat_and_stores(world, capsys) -> None:
+    assert GATE.doctor(world.board, SENDER_ENV) == 0
+    out = capsys.readouterr().out
+    assert "PASS peer-send-gate.board" in out and "PASS peer-send-gate.seat" in out
+    assert GATE.doctor(world.board, {}) == 1
+    assert "FAIL peer-send-gate.identity" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Peer messages between agent sessions kept reaching the wrong session, or were broadcast when the sender could not tell which session was meant. The 2026-09-01 resolver added the join and the verb, and the defect recurred the next day, because the lane agents actually use (`SendMessage`, which its own listing steers them toward and whose names collide by construction) was ungated, and the one gate that existed checked that a target was registered, not that it was the one resolved.

This release makes a resolved address the only way through every direct lane, in both clients:

- **Seats** (`seats/<session uuid>.json` beside the board) carry each session's delivery handles; written at claim, refreshed at heartbeat, removed at release. The board row's client ref is unchanged (`cc:` added for terminal sessions).
- **`resolve`** prints the exact invocation per lane from live truth — bus, ccd session id, harness `uds:` socket (from the peer registry, only while that process is alive on this machine; the registry name is display only), `codex queue --thread` — and writes a **delivery receipt** (20 minutes) naming that one target. Ambiguity issues nothing.
- **`peer_send_gate.py --gate`**, registered in the plugin's `hooks/hooks.json` on `SendMessage`, the desktop session-messaging tool, and the shell tools (for `codex queue`): a direct send passes only when its address equals a live receipt held by this sender, the target row is still active, the registry still maps that socket to the receipt's session, the sender holds a seat, the message carries the sender's board id, and the same text has not gone to a second session within 15 minutes. Replies may copy a received `from=`. In-process targets pass. Every decision is logged. Unverifiable blocks.
- **A delivered bus.** `board_inbox.py --hook` on every UserPromptSubmit and inside the SessionStart context injects unread board messages for the seat or its project, once. `coordination.py inbox` / `whoami`; the doctor counts seats.
- **Codex** sessions learn their coordination identity from the SessionStart context and register through `SYNTHESIS_CLIENT_SESSION_REF`; `codex queue` is the gated direct lane to a Codex thread.
- Conformance holds the shipped `hooks/hooks.json` to the contract (`hook-definition.public-peer-gate`, `hook-definition.public-inbox`).

## Verification

- Full AGENTS.md verification list run in CI shape (isolated `HOME`, no session identity in the environment).
- 45 new tests across `test_peer_addressing.py`, `test_peer_send_gate.py`, `test_board_inbox.py`; the gate is exercised as a process (exit 0 / exit 2 with the reason on stderr, send log written).
- Acceptance manifest authored for this transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
