### PR TITLE
Deliver project-addressed board messages only from the seat's claim onward (4.90.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.90.0",
+  "version": "4.90.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.90.0",
+  "version": "4.90.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.90.1] - 2026-09-02
+
+**The delivered inbox starts at the seat's claim.** The first live run of
+4.90.0's inbox greeted a seat with every message ever addressed to its
+project as unread — thirty-two of them, all handled weeks earlier — and
+every fresh seat on a busy project would have seen the same. A message
+addressed to a project's sessions was for the sessions of its time: the
+inbox now delivers it only when it was posted at or after the seat's claim
+moment (the board row's `started`), while a message that names the session
+exactly is always delivered. The SessionStart board read still covers
+history. An unparseable claim moment disables the bound, never the
+delivery. synthesis-project-management 2.11.1.
+
 ## [4.90.0] - 2026-09-02
 
 **Peer messages can no longer be addressed by a name, and every direct send

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **Peer sessions are addressed by resolver-issued receipts, never by name
-(September 2026).** Release **4.90.0** gates every direct session-to-session
+(September 2026).** Release **4.90.1** gates every direct session-to-session
 send in both clients on a delivery receipt from `coordination.py resolve`,
 delivers the board's message bus at each prompt, and reaches Codex threads
-through `codex queue`. See the [4.90.0 release notes](CHANGELOG.md).
+through `codex queue`. See the [4.90.1 release notes](CHANGELOG.md).
 
 **A self-report is a claim, not evidence (September 2026).** Release
 **4.88.0** makes daily parity read each client's installed manifest on disk

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,62 +1,30 @@
-# AGENT HEURISTIC: authored for the 4.90.0 peer-addressing transaction.
+# AGENT HEURISTIC: authored for the 4.90.1 inbox since-claim transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: peer-sends-need-a-resolver-receipt-and-the-bus-is-delivered
+suite: inbox-delivers-project-messages-since-the-claim
 membership: closed
-production_entry_point: skills/synthesis-project-management/scripts/peer_send_gate.py
-enforcing_boundary: a direct session-to-session send in either client passes the plugin's PreToolUse gate only when its address equals a live delivery receipt issued by resolve for this sender, the target row is still active, the harness registry still maps that socket to the resolved session, the sender holds a seat, the message carries the sender's board id, and the same text has not gone to a second session; the board bus is delivered to the addressed seat at its next prompt
+production_entry_point: skills/synthesis-project-management/scripts/board_inbox.py
+enforcing_boundary: a message addressed to a project's sessions is delivered to a seat only when posted at or after that seat's claim moment, while a message naming the session exactly is always delivered; an unparseable claim moment disables the bound, never the delivery
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: delivery into a live Codex thread through codex queue is proven only to the thread-store lookup (a null thread id is refused by name); Codex sessions register a seat only after their agent exports the ref the SessionStart context states; hook trust for the changed hooks.json is granted by the human in Codex
+unverified_remainder: seats claimed by engines before 4.90.0 carry the row's started field in whatever form that engine wrote; a non-ISO value disables the bound for that seat and the SessionStart board read covers its history
 changed_surfaces:
   - path: skills/synthesis-project-management/scripts/peer_addressing.py
-    cases: [names-are-not-addresses, receipt-binds-intent, live-reverification, seat-at-claim, bus-delivered-once]
-  - path: skills/synthesis-project-management/scripts/peer_send_gate.py
-    cases: [names-are-not-addresses, receipt-binds-intent, live-reverification, sender-must-hold-a-seat, no-broadcast, codex-queue-gated, gate-fails-closed]
+    cases: [history-is-not-inbox]
   - path: skills/synthesis-project-management/scripts/board_inbox.py
-    cases: [bus-delivered-once, codex-learns-its-identity, sessionstart-carries-the-inbox]
+    cases: [new-seat-sees-only-what-followed-its-claim]
   - path: skills/synthesis-project-management/scripts/coordination.py
-    cases: [seat-at-claim, resolve-issues-receipt, ambiguity-issues-nothing, cc-ref-for-terminal-sessions]
+    cases: [history-is-not-inbox]
   - path: skills/synthesis-project-management/scripts/test_peer_addressing.py
-    cases: [seat-at-claim, resolve-issues-receipt, ambiguity-issues-nothing, cc-ref-for-terminal-sessions, bus-delivered-once]
-  - path: skills/synthesis-project-management/scripts/test_peer_send_gate.py
-    cases: [names-are-not-addresses, receipt-binds-intent, live-reverification, sender-must-hold-a-seat, no-broadcast, codex-queue-gated, gate-fails-closed]
+    cases: [history-is-not-inbox]
   - path: skills/synthesis-project-management/scripts/test_board_inbox.py
-    cases: [bus-delivered-once, codex-learns-its-identity, sessionstart-carries-the-inbox]
-  - path: skills/synthesis-project-management/scripts/test_coordination.py
-    cases: [pm-budget]
+    cases: [new-seat-sees-only-what-followed-its-claim]
   - path: skills/synthesis-project-management/SKILL.md
     cases: [pm-budget]
-  - path: skills/synthesis-project-management/references/parallel-agent-protocol.md
-    cases: [pm-budget]
-  - path: skills/synthesis-project-management/references/session-identity.md
-    cases: [pm-budget]
-  - path: skills/synthesis-project-management/references/active-sessions-template.md
-    cases: [pm-budget]
-  - path: skills/synthesis-agent-conformance/scripts/session_context.py
-    cases: [sessionstart-carries-the-inbox]
-  - path: skills/synthesis-agent-conformance/scripts/conformance.py
-    cases: [hook-contract-requires-the-gate, shipped-hooks-route-through-the-gate]
-  - path: skills/synthesis-agent-conformance/scripts/test_conformance.py
-    cases: [hook-contract-requires-the-gate, shipped-hooks-route-through-the-gate]
-  - path: skills/synthesis-agent-conformance/SKILL.md
-    cases: [hook-contract-requires-the-gate]
-  - path: hooks/hooks.json
-    cases: [shipped-hooks-route-through-the-gate]
-  - path: skills/synthesis-git-hooks/scripts/test_pre_commit.py
-    cases: [engine-module-set-complete]
-  - path: skills/synthesis-git-hooks/scripts/install.sh
-    cases: [engine-module-set-complete]
-  - path: skills/synthesis-git-hooks/scripts/_load_config.py
-    cases: [engine-module-set-complete]
-  - path: skills/synthesis-git-hooks/SKILL.md
-    cases: [engine-module-set-complete]
-  - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [engine-module-set-complete]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -68,74 +36,14 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: names-are-not-addresses
+  - id: history-is-not-inbox
     control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_display_names_and_refs_are_refused_as_addresses
-    motivating_defect: seven-misdeliveries-chose-a-target-by-a-display-name-or-title-at-the-moment-of-sending
-  - id: receipt-binds-intent
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_socket_address_needs_a_receipt_then_passes
-    motivating_defect: an-existence-check-passed-a-registered-but-wrong-session-the-day-after-the-resolver-shipped
-  - id: live-reverification
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_socket_that_no_longer_maps_to_the_resolved_session_is_refused
-    motivating_defect: a-receipt-older-than-the-target-process-would-otherwise-deliver-to-whoever-inherited-the-socket
-  - id: sender-must-hold-a-seat
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_sender_without_a_seat_is_refused
-    motivating_defect: a-reply-to-an-unregistered-sender-can-only-be-guessed
-  - id: no-broadcast
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_same_text_to_a_second_session_is_a_broadcast
-    motivating_defect: an-unsure-sender-sent-the-same-text-to-every-candidate-three-times-in-the-record
-  - id: codex-queue-gated
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_codex_queue_needs_a_receipt_for_that_thread
-    motivating_defect: the-lane-table-said-codex-had-no-push-channel-while-codex-queue-existed-ungated
-  - id: gate-fails-closed
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_missing_session_id_and_unreadable_board_fail_closed
-    motivating_defect: a-guard-that-cannot-verify-must-block-not-warn-and-pass
-  - id: seat-at-claim
+    fixture: ../synthesis-project-management/scripts/test_peer_addressing.py::test_project_messages_older_than_the_seat_are_history_not_inbox
+    motivating_defect: the-first-live-inbox-run-greeted-a-seat-with-thirty-two-handled-messages-as-unread
+  - id: new-seat-sees-only-what-followed-its-claim
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_peer_addressing.py::test_claim_writes_a_seat_release_removes_it
-    motivating_defect: the-board-carried-one-handle-per-session-while-each-client-addresses-by-a-different-one
-  - id: resolve-issues-receipt
-    control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_peer_addressing.py::test_resolve_prints_exact_lanes_and_issues_a_receipt
-    motivating_defect: resolve-was-doctrine-an-agent-could-skip-and-the-gate-could-not-tell
-  - id: ambiguity-issues-nothing
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_peer_addressing.py::test_ambiguous_resolve_issues_no_receipt
-    motivating_defect: a-resolver-that-refuses-ambiguity-but-leaves-the-send-ungated-changes-nothing
-  - id: cc-ref-for-terminal-sessions
-    control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_peer_addressing.py::test_terminal_session_claim_registers_cc_ref
-    motivating_defect: a-terminal-session-registered-no-handle-and-was-unreachable-by-any-direct-lane
-  - id: bus-delivered-once
-    control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_board_inbox.py::test_inbox_delivers_once_to_the_named_seat
-    motivating_defect: a-bus-nobody-reads-is-a-dead-letter-so-senders-reached-for-the-guessing-lane
-  - id: codex-learns-its-identity
-    control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_board_inbox.py::test_codex_session_learns_its_identity
-    motivating_defect: no-codex-session-ever-registered-a-ref-because-its-shell-cannot-see-its-thread-id
-  - id: sessionstart-carries-the-inbox
-    control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_board_inbox.py::test_session_context_appends_the_inbox
-    motivating_defect: a-message-posted-while-the-recipient-was-away-must-arrive-when-it-returns
-  - id: hook-contract-requires-the-gate
-    control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_conformance.py::test_hook_definition_checks_require_the_peer_gate_and_the_inbox
-    motivating_defect: a-gate-that-can-be-unregistered-silently-is-not-a-control
-  - id: shipped-hooks-route-through-the-gate
-    control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_conformance.py::test_shipped_hook_config_routes_peer_sends_through_the_gate
-    motivating_defect: the-shipped-hook-file-is-the-only-registration-both-clients-load
-  - id: engine-module-set-complete
-    control_class: acceptance-test
-    fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_configured_hook_consumes_bound_receipt
-    motivating_defect: a-fixture-that-copies-the-engine-without-its-new-module-proves-nothing
+    fixture: ../synthesis-project-management/scripts/test_board_inbox.py::test_project_history_before_the_claim_is_not_delivered_to_a_new_seat
+    motivating_defect: every-fresh-seat-on-a-busy-project-would-have-seen-the-same-backlog
   - id: pm-budget
     control_class: acceptance-test
     fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.11.0"
+  version: "2.11.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-project-management/scripts/board_inbox.py
+++ b/skills/synthesis-project-management/scripts/board_inbox.py
@@ -50,24 +50,24 @@ def pointer_project(pointer: Path) -> str:
     return Path(str(project)).name if project else ""
 
 
-def identity_forms_for(board: Path, identity: SelfIdentity) -> tuple[set[str], str, str]:
-    """(identity forms, project, compact id) for this session's seat, if any."""
+def identity_forms_for(board: Path, identity: SelfIdentity) -> tuple[set[str], str, str, str]:
+    """(identity forms, project, compact id, started) for this session's seat, if any."""
     seat = seat_for_identity(board, identity)
     if seat is None:
-        return set(), "", ""
+        return set(), "", "", ""
     from coordination import rows  # local import: the engine parses the board
 
     try:
         board_rows = rows(board.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return set(), "", ""
+        return set(), "", "", ""
     row = next((r for r in board_rows if r.session_uuid == seat.session_uuid), None)
     if row is None:
-        return set(), "", ""
+        return set(), "", "", ""
     forms = {row.session_uuid, row.compact_id, row.speakable_id}
     if row.legacy_id:
         forms.add(row.legacy_id)
-    return forms, row.project, row.compact_id
+    return forms, row.project, row.compact_id, row.started
 
 
 def identity_notice(identity: SelfIdentity) -> str:
@@ -98,14 +98,15 @@ def inbox_text(
         text = board.read_text(encoding="utf-8")
     except OSError:
         return ""
-    forms, project, _compact = identity_forms_for(board, identity)
+    forms, project, _compact, started = identity_forms_for(board, identity)
     if not forms:
         project = pointer_project(pointer)
+        started = ""
     if not forms and not project:
         notice = identity_notice(identity)
         return notice
     messages = unread_messages(
-        text, board=board, sender_key=key, identity_forms=forms, project=project
+        text, board=board, sender_key=key, identity_forms=forms, project=project, since=started
     )
     rendered = render_inbox(messages)
     if messages and mark:

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -2091,7 +2091,12 @@ def command_inbox(args) -> int:
         key = identity.sender_key or f"seat:{row.session_uuid}"
     forms = {row.session_uuid, row.compact_id, row.speakable_id} | ({row.legacy_id} if row.legacy_id else set())
     messages = unread_messages(
-        content, board=args.board, sender_key=key, identity_forms=forms, project=row.project
+        content,
+        board=args.board,
+        sender_key=key,
+        identity_forms=forms,
+        project=row.project,
+        since=row.started,
     )
     if getattr(args, "json", False):
         print(

--- a/skills/synthesis-project-management/scripts/peer_addressing.py
+++ b/skills/synthesis-project-management/scripts/peer_addressing.py
@@ -647,16 +647,31 @@ def parse_messages(board_text: str) -> list[BoardMessage]:
     return messages
 
 
-def addressed_to(message: BoardMessage, identity_forms: set[str], project: str = "") -> bool:
+def addressed_to(
+    message: BoardMessage,
+    identity_forms: set[str],
+    project: str = "",
+    since: object = None,
+) -> bool:
     """Whether a message names this seat exactly, or its project's sessions.
 
-    Free-text addressees are never delivered: the sender was told the
-    address did not resolve when it posted."""
+    A message that names the session exactly is always its own. A message
+    addressed to the project's sessions was for the sessions of its time:
+    it is delivered only when posted at or after ``since`` (the seat's claim
+    moment), so a new seat is not greeted with the project's whole history
+    as unread — the SessionStart board read still covers history. A
+    ``since`` that does not parse disables the bound rather than the
+    delivery. Free-text addressees are never delivered: the sender was told
+    the address did not resolve when it posted."""
     recipient = message.recipient.strip()
     tokens = {token.strip(",;") for token in recipient.split()}
     if any(form and form in tokens for form in identity_forms):
         return True
     if project and recipient.casefold().startswith(f"{project.casefold()} sessions"):
+        floor = parse_iso(since) if since else None
+        posted = parse_iso(message.timestamp)
+        if floor is not None and posted is not None and posted < floor:
+            return False
         return True
     return False
 
@@ -692,12 +707,13 @@ def unread_messages(
     sender_key: str,
     identity_forms: set[str],
     project: str = "",
+    since: object = None,
 ) -> list[BoardMessage]:
     seen = seen_keys(board, sender_key) if sender_key else set()
     return [
         message
         for message in parse_messages(board_text)
-        if addressed_to(message, identity_forms, project) and message.key not in seen
+        if addressed_to(message, identity_forms, project, since) and message.key not in seen
     ]
 
 

--- a/skills/synthesis-project-management/scripts/test_board_inbox.py
+++ b/skills/synthesis-project-management/scripts/test_board_inbox.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -58,6 +59,27 @@ def test_inbox_delivers_once_to_the_named_seat(board, tmp_path) -> None:
     assert "Handoff: the review is yours." in text and "For every project-m session." in text
     assert "Not for me." not in text
     assert INBOX.inbox_text(payload, board=board, pointer=tmp_path / "pointer.json", environ=ME_ENV) == ""
+
+
+def test_project_history_before_the_claim_is_not_delivered_to_a_new_seat(tmp_path, monkeypatch) -> None:
+    """An earlier seat of the project received a message weeks ago; a seat
+    claimed today must not see it as unread, while a message posted after
+    its claim is delivered."""
+    path = tmp_path / "board.md"
+    other = claim(path, "project-o", {}, monkeypatch)
+    earlier = claim(path, "project-m", {}, monkeypatch)
+    assert ENGINE.command_message(args(path, sender=other.compact_id, to="project-m", text="Posted before the seat existed.")) == 0
+    assert ENGINE.command_release(args(path, id=earlier.compact_id)) == 0
+    text = path.read_text(encoding="utf-8")
+    text = re.sub(r"(### → project-m sessions, from \S+ — )\S+", r"\g<1>2026-01-01T00:00:00-05:00", text, count=1)
+    path.write_text(text, encoding="utf-8")
+    me = claim(path, "project-m", ME_ENV, monkeypatch)
+    assert ENGINE.command_message(args(path, sender=other.compact_id, to="project-m", text="Posted after the claim.")) == 0
+    delivered = INBOX.inbox_text({"session_id": ME_SID}, board=path, pointer=tmp_path / "pointer.json", environ=ME_ENV)
+    assert "Posted after the claim." in delivered
+    assert "Posted before the seat existed." not in delivered
+    assert "1 unread message(s)" in delivered
+    assert me.project == "project-m"
 
 
 def test_unseated_session_gets_project_messages_from_the_active_pointer(board, tmp_path) -> None:

--- a/skills/synthesis-project-management/scripts/test_peer_addressing.py
+++ b/skills/synthesis-project-management/scripts/test_peer_addressing.py
@@ -266,6 +266,21 @@ def test_inbox_delivers_seat_and_project_addressed_messages_once(tmp_path, monke
     assert PA.unread_messages(board.read_text(encoding="utf-8"), board=board, sender_key="cc:x", identity_forms=forms, project="project-b") == []
 
 
+def test_project_messages_older_than_the_seat_are_history_not_inbox() -> None:
+    """A fresh seat on a busy project must not be greeted with every message
+    ever addressed to that project as unread; the SessionStart board read
+    covers history. A message naming the session exactly is always its own."""
+    old = PA.BoardMessage(recipient="project-b sessions", sender="s-1", timestamp="2026-08-17T21:44:31-04:00", body="x")
+    new = PA.BoardMessage(recipient="project-b sessions", sender="s-1", timestamp="2026-09-02T18:00:00-04:00", body="y")
+    direct = PA.BoardMessage(recipient="s-2", sender="s-1", timestamp="2026-08-17T21:44:31-04:00", body="z")
+    since = "2026-09-02T17:00:00-04:00"
+    assert not PA.addressed_to(old, {"s-2"}, "project-b", since)
+    assert PA.addressed_to(new, {"s-2"}, "project-b", since)
+    assert PA.addressed_to(direct, {"s-2"}, "project-b", since)
+    assert PA.addressed_to(old, {"s-2"}, "project-b", "2026-07-29 ~14:00"), "an unparseable floor disables the bound, not the delivery"
+    assert PA.addressed_to(old, {"s-2"}, "project-b", None)
+
+
 def test_free_text_addressees_are_never_delivered() -> None:
     message = PA.BoardMessage(recipient="whoever is holding the train", sender="s-1", timestamp="t", body="x")
     assert not PA.addressed_to(message, {"s-2"}, "project-b")


### PR DESCRIPTION
## Summary

Patch to 4.90.0's delivered inbox. Its first live run counted every message ever addressed to the seat's project as unread (thirty-two, all handled weeks earlier), and every fresh seat on a busy project would have seen the same backlog notice.

A message addressed to a project's sessions was for the sessions of its time: the inbox now delivers it only when it was posted at or after the seat's claim moment (the board row's `started`). A message that names the session exactly is always delivered. An unparseable claim moment disables the bound, never the delivery. The SessionStart board read still covers history.

## Verification

- Full AGENTS.md verification list run in CI shape (isolated `HOME`, no session identity in the environment).
- Two new tests (the bound itself; a new seat on a board with older project traffic).
- Acceptance manifest authored for this transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
