### PR TITLE
Close the Codex historical-cache post-update window

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.90.1",
+  "version": "4.90.2",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.90.1",
+  "version": "4.90.2",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.90.2] - 2026-09-02
+
+**A Codex update no longer returns while the invoking task's historical hook
+root is still missing.** A native refresh returned successfully, and the task's
+immediately following Stop hook failed because its prior version root had not
+yet been restored. The durable guardian did recover the root, but a 77-version
+archive took 55 seconds and restored oldest first, making the immediately prior
+version last.
+
+synthesis-skills-manager 2.5.1 now restores historical roots newest first.
+synthesis-onboarding 1.4.2 invokes the installed guardian synchronously after a
+Codex refresh, then verifies that the exact version root and every plugin-root
+hook target used by the invoking task are present before reporting success. A
+configured guardian that is missing, unsafe, fails its doctor, or cannot restore
+that exact hook tree makes the ecosystem step non-green. Machines without the
+publisher-installed recovery archive retain the explicit close-other-tasks
+update contract; Claude's update path does not invoke the Codex guardian.
+
 ## [4.90.1] - 2026-09-02
 
 **The delivered inbox starts at the seat's claim.** The first live run of

--- a/README.md
+++ b/README.md
@@ -725,8 +725,11 @@ restart verification fails or the client cannot rehydrate an existing task.
 Installing a cache in place is not a lifecycle reload. Native plugin refresh
 also replaces a versioned cache used by hook commands, so close other live
 sessions before running `onboard.py update`, and make the update the invoking
-session's last action. `install` and `doctor` do not refresh an existing native
-plugin.
+session's last action. On machines where the gated publisher installed the
+durable Codex cache guardian, the update engine restores newest historical
+roots first and verifies the invoking task's exact hook tree synchronously
+before reporting success. `install` and `doctor` do not refresh an existing
+native plugin.
 
 The Codex package also restores the active synthesis project after context
 compaction. Run `synthesis-agent-conformance` to verify both runtime

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,30 +1,30 @@
-# AGENT HEURISTIC: authored for the 4.90.1 inbox since-claim transaction.
+# AGENT HEURISTIC: authored for the 4.90.2 Codex cache recovery transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: inbox-delivers-project-messages-since-the-claim
+suite: codex-update-preserves-the-invoking-hook-root
 membership: closed
-production_entry_point: skills/synthesis-project-management/scripts/board_inbox.py
-enforcing_boundary: a message addressed to a project's sessions is delivered to a seat only when posted at or after that seat's claim moment, while a message naming the session exactly is always delivered; an unparseable claim moment disables the bound, never the delivery
+production_entry_point: skills/synthesis-onboarding/scripts/onboard.py
+enforcing_boundary: a Codex plugin refresh on a machine with the durable recovery guardian cannot report success until the guardian has run synchronously and the exact cache root and every plugin-root hook target used by the invoking task are present; historical recovery restores newest roots first
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: seats claimed by engines before 4.90.0 carry the row's started field in whatever form that engine wrote; a non-ISO value disables the bound for that seat and the SessionStart board read covers its history
+unverified_remainder: machines without a publisher-installed recovery archive retain the explicit close-other-tasks update contract; the continuous guardian, rather than this synchronous boundary alone, handles a later client reconciliation after the update exits
 changed_surfaces:
-  - path: skills/synthesis-project-management/scripts/peer_addressing.py
-    cases: [history-is-not-inbox]
-  - path: skills/synthesis-project-management/scripts/board_inbox.py
-    cases: [new-seat-sees-only-what-followed-its-claim]
-  - path: skills/synthesis-project-management/scripts/coordination.py
-    cases: [history-is-not-inbox]
-  - path: skills/synthesis-project-management/scripts/test_peer_addressing.py
-    cases: [history-is-not-inbox]
-  - path: skills/synthesis-project-management/scripts/test_board_inbox.py
-    cases: [new-seat-sees-only-what-followed-its-claim]
-  - path: skills/synthesis-project-management/SKILL.md
-    cases: [pm-budget]
+  - path: skills/synthesis-skills-manager/scripts/cache_guardian.py
+    cases: [newest-history-first]
+  - path: skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+    cases: [newest-history-first]
+  - path: skills/synthesis-skills-manager/SKILL.md
+    cases: [newest-history-first, synchronous-update-boundary]
+  - path: skills/synthesis-onboarding/scripts/onboard.py
+    cases: [synchronous-update-boundary, exact-invoking-root, guardian-failure-blocks-success, guardian-absence-is-explicit, unsafe-guardian-fails-closed, claude-route-isolated]
+  - path: skills/synthesis-onboarding/scripts/test_onboard.py
+    cases: [synchronous-update-boundary, exact-invoking-root, guardian-failure-blocks-success, guardian-absence-is-explicit, unsafe-guardian-fails-closed, claude-route-isolated]
+  - path: skills/synthesis-onboarding/SKILL.md
+    cases: [synchronous-update-boundary, guardian-failure-blocks-success]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -34,20 +34,36 @@ changed_surfaces:
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
   - path: README.md
-    cases: [release-changelog-parity]
+    cases: [synchronous-update-boundary, guardian-absence-is-explicit]
 cases:
-  - id: history-is-not-inbox
+  - id: newest-history-first
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_restore_prioritizes_newest_historical_roots
+    motivating_defect: a-seventy-seven-version-archive-restored-the-immediately-prior-root-last-and-left-the-invoking-task-without-its-stop-hook-for-fifty-five-seconds
+  - id: synchronous-update-boundary
     control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_peer_addressing.py::test_project_messages_older_than_the_seat_are_history_not_inbox
-    motivating_defect: the-first-live-inbox-run-greeted-a-seat-with-thirty-two-handled-messages-as-unread
-  - id: new-seat-sees-only-what-followed-its-claim
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_update_refreshes_and_accepts_newer_version_from_old_plugin_cache
+    motivating_defect: the-native-update-command-returned-before-the-background-guardian-finished-repairing-the-cache-generation-it-created
+  - id: exact-invoking-root
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_board_inbox.py::test_project_history_before_the_claim_is_not_delivered_to_a_new_seat
-    motivating_defect: every-fresh-seat-on-a-busy-project-would-have-seen-the-same-backlog
-  - id: pm-budget
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_codex_history_sync_runs_durable_doctor_and_checks_started_root
+    motivating_defect: a-green-guardian-receipt-without-the-version-root-the-running-task-loaded-does-not-make-that-task-safe
+  - id: guardian-failure-blocks-success
+    control_class: enforced-gate
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_update_fails_when_invoking_codex_history_is_not_restored
+    motivating_defect: the-updater-reported-success-while-its-own-next-lifecycle-hook-could-not-execute
+  - id: guardian-absence-is-explicit
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget
-    motivating_defect: a-restructured-document-must-not-regrow-with-its-next-feature
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_codex_history_sync_is_optional_without_a_durable_guardian
+    motivating_defect: an-updater-must-not-imply-a-recovery-guarantee-on-a-machine-that-has-no-recovery-archive
+  - id: unsafe-guardian-fails-closed
+    control_class: enforced-gate
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_codex_history_sync_refuses_a_dangling_guardian_symlink
+    motivating_defect: a-dangling-guardian-path-is-a-broken-protection-layer-not-an-absent-optional-layer
+  - id: claude-route-isolated
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_claude_update_does_not_invoke_codex_history_guardian
+    motivating_defect: a-codex-cache-repair-must-not-change-an-unrelated-clients-native-update-contract
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,12 +5,19 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.4.1"
+  version: "1.4.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
 
 # Synthesis Onboarding
+
+**Version 1.4.2** (2026-09-02) closes the invoking-task gap in a Codex
+plugin update on machines with the durable historical-cache guardian. After
+the native refresh returns, the engine runs that guardian synchronously and
+verifies the exact version root and hook targets the current task started
+with before it reports success. A missing or failed configured guardian makes
+the ecosystem step non-green.
 
 Everything a new person needs to go from a bare machine to a working
 synthesis setup — close to one command plus an auth step. Built for two
@@ -157,7 +164,11 @@ match the installed release. Start a new conversation/task only if restart
 verification fails or the client cannot rehydrate it. Native clients resolve
 plugin hooks to versioned cache paths; replacing that cache can invalidate hook
 commands already loaded by another live session. Ordinary `install` and
-`doctor` runs never refresh an existing native plugin.
+`doctor` runs never refresh an existing native plugin. When the gated publisher
+has installed the durable Codex cache guardian on this machine, `update`
+synchronously restores and verifies the invoking task's exact historical hook
+root before it returns; that narrows the unavoidable last-action boundary to
+the client lifecycle reload instead of leaving a post-command restoration race.
 
 ## Scaffolding a personal knowledge workspace
 

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -922,9 +922,11 @@ def synchronize_codex_history(before_version):
         / MARKETPLACE_NAME
     )
     runtime = recovery / (".%s-cache-guardian.py" % PLUGIN_NAME)
+    if runtime.is_symlink():
+        return False, "durable Codex cache guardian has an unsafe type: %s" % runtime
     if not runtime.exists():
         return True, "durable Codex cache guardian is not installed"
-    if runtime.is_symlink() or not runtime.is_file():
+    if not runtime.is_file():
         return False, "durable Codex cache guardian has an unsafe type: %s" % runtime
     version = str(before_version or "")
     if VERSION_RE.fullmatch(version) is None:

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -69,11 +69,13 @@ from whole_system import (
     validate_personal_policy,
 )
 
-ENGINE_VERSION = "1.4.1"
+ENGINE_VERSION = "1.4.2"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"
 MARKETPLACE_NAME = "synthesis-engineering"
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+HOOK_PLUGIN_PATH_RE = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\s\"']+)")
 
 HOME = Path(os.environ.get("SYNTHESIS_ONBOARD_HOME", str(Path.home())))
 STATE_DIR = Path(os.environ.get("SYNTHESIS_ONBOARD_STATE_DIR", str(HOME / ".synthesis" / "onboarding")))
@@ -904,6 +906,61 @@ def refresh_plugin(client, binary, policy, reconfigure=False):
     return True, "marketplace and installed plugin refreshed"
 
 
+def synchronize_codex_history(before_version):
+    """Synchronously restore the cache root used by the invoking Codex task.
+
+    A release publisher installs the guardian outside Codex's client-owned
+    cache. When that durable runtime is present, an onboarding update consumes
+    it before reporting success; the background watcher remains responsible
+    for any later cache generation. Machines without the publisher-installed
+    recovery archive retain the documented close-other-tasks update contract.
+    """
+    recovery = (
+        HOME
+        / ".synthesis"
+        / "plugin-cache-recovery"
+        / MARKETPLACE_NAME
+    )
+    runtime = recovery / (".%s-cache-guardian.py" % PLUGIN_NAME)
+    if not runtime.exists():
+        return True, "durable Codex cache guardian is not installed"
+    if runtime.is_symlink() or not runtime.is_file():
+        return False, "durable Codex cache guardian has an unsafe type: %s" % runtime
+    version = str(before_version or "")
+    if VERSION_RE.fullmatch(version) is None:
+        return False, "invoking Codex cache version could not be determined"
+    rc, out, err = run(
+        [sys.executable, str(runtime), "--doctor"],
+        env={"HOME": str(HOME)},
+        timeout=600,
+    )
+    if rc != 0:
+        return False, err.strip() or out.strip() or "cache guardian exited %d" % rc
+    historical = (
+        HOME
+        / ".codex"
+        / "plugins"
+        / "cache"
+        / MARKETPLACE_NAME
+        / PLUGIN_NAME
+        / version
+    )
+    if historical.is_symlink() or not historical.is_dir():
+        return False, "invoking Codex cache root %s is absent after guardian verification" % version
+    hooks = historical / "hooks" / "hooks.json"
+    try:
+        hook_text = hooks.read_text(encoding="utf-8")
+        json.loads(hook_text)
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        return False, "invoking Codex hook definition is unavailable for %s: %s" % (version, exc)
+    targets = sorted(set(HOOK_PLUGIN_PATH_RE.findall(hook_text)))
+    missing = [target for target in targets if not (historical / target).is_file()]
+    if not targets or missing:
+        detail = ", ".join(missing[:3]) if missing else "no plugin-root targets"
+        return False, "invoking Codex hook targets are unavailable for %s: %s" % (version, detail)
+    return True, "invoking Codex cache root %s restored and verified" % version
+
+
 def install_plugin(client, binary, policy):
     """Best-effort native plugin install. Returns (success, detail)."""
     add_cmd = marketplace_add_command(client, binary, policy)
@@ -1116,6 +1173,17 @@ def phase_ecosystem(
                     hint=detail,
                 )
                 continue
+            if name == "codex":
+                history_ok, history_detail = synchronize_codex_history(before_version)
+                if not history_ok:
+                    report.add(
+                        "ecosystem",
+                        ERROR,
+                        "%s historical cache preservation failed for %s" %
+                        (PLUGIN_NAME, name),
+                        hint=history_detail,
+                    )
+                    continue
             after_state, after_version = plugin_record(name, binary)
             if after_state is not True:
                 report.add("ecosystem", ERROR,

--- a/skills/synthesis-onboarding/scripts/test_onboard.py
+++ b/skills/synthesis-onboarding/scripts/test_onboard.py
@@ -531,6 +531,89 @@ class WholeSystemTests(unittest.TestCase):
 class PluginTests(unittest.TestCase):
     policy = {"channel": "stable", "version_pin": None}
 
+    def test_codex_history_sync_runs_durable_doctor_and_checks_started_root(self):
+        with tempfile.TemporaryDirectory(prefix="onboard-history-") as root:
+            home = Path(root)
+            runtime = (
+                home
+                / ".synthesis/plugin-cache-recovery/synthesis-engineering"
+                / ".synthesis-skills-cache-guardian.py"
+            )
+            runtime.parent.mkdir(parents=True)
+            runtime.write_text("guardian\n", encoding="utf-8")
+            historical = (
+                home
+                / ".codex/plugins/cache/synthesis-engineering/synthesis-skills/4.23.0"
+            )
+            target = historical / "skills/synthesis-autopilot/scripts/autopilot_gate.py"
+            target.parent.mkdir(parents=True)
+            target.write_text("pass\n", encoding="utf-8")
+            (historical / "hooks").mkdir()
+            (historical / "hooks/hooks.json").write_text(
+                json.dumps(
+                    {
+                        "hooks": {
+                            "Stop": [
+                                {
+                                    "hooks": [
+                                        {
+                                            "command": (
+                                                "python3 ${CLAUDE_PLUGIN_ROOT}/skills/"
+                                                "synthesis-autopilot/scripts/autopilot_gate.py --gate"
+                                            )
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.object(onboard, "HOME", home), patch.object(
+                onboard, "run", return_value=(0, '{"verified": 1}\n', "")
+            ) as runner:
+                success, detail = onboard.synchronize_codex_history("4.23.0")
+
+        self.assertTrue(success, detail)
+        self.assertIn("4.23.0", detail)
+        runner.assert_called_once_with(
+            [sys.executable, str(runtime), "--doctor"],
+            env={"HOME": str(home)},
+            timeout=600,
+        )
+
+    def test_codex_history_sync_fails_if_started_root_remains_absent(self):
+        with tempfile.TemporaryDirectory(prefix="onboard-history-") as root:
+            home = Path(root)
+            runtime = (
+                home
+                / ".synthesis/plugin-cache-recovery/synthesis-engineering"
+                / ".synthesis-skills-cache-guardian.py"
+            )
+            runtime.parent.mkdir(parents=True)
+            runtime.write_text("guardian\n", encoding="utf-8")
+            with patch.object(onboard, "HOME", home), patch.object(
+                onboard, "run", return_value=(0, '{"verified": 1}\n', "")
+            ):
+                success, detail = onboard.synchronize_codex_history("4.23.0")
+
+        self.assertFalse(success)
+        self.assertIn("4.23.0", detail)
+        self.assertIn("absent", detail)
+
+    def test_codex_history_sync_is_optional_without_a_durable_guardian(self):
+        with tempfile.TemporaryDirectory(prefix="onboard-history-") as root:
+            with patch.object(onboard, "HOME", Path(root)), patch.object(
+                onboard, "run"
+            ) as runner:
+                success, detail = onboard.synchronize_codex_history("4.23.0")
+
+        self.assertTrue(success, detail)
+        self.assertIn("not installed", detail)
+        runner.assert_not_called()
+
     def test_plugin_record_reads_codex_and_claude_versions(self):
         codex = {"installed": [{
             "pluginId": "synthesis-skills@synthesis-engineering",

--- a/skills/synthesis-onboarding/scripts/test_onboard.py
+++ b/skills/synthesis-onboarding/scripts/test_onboard.py
@@ -596,7 +596,11 @@ class PluginTests(unittest.TestCase):
             onboard, "resolve_target_version", return_value=("4.24.0", "fixture")
         ), patch.object(
             onboard, "refresh_plugin", return_value=(True, "refreshed")
-        ) as refresh:
+        ) as refresh, patch.object(
+            onboard,
+            "synchronize_codex_history",
+            return_value=(True, "historical root restored"),
+        ) as synchronize:
             onboard.phase_ecosystem(
                 report,
                 {"codex": "codex"},
@@ -608,8 +612,60 @@ class PluginTests(unittest.TestCase):
         refresh.assert_called_once_with(
             "codex", "codex", self.policy, reconfigure=True
         )
+        synchronize.assert_called_once_with("4.23.0")
         self.assertEqual(report.steps[0]["status"], onboard.CHANGED)
         self.assertIn("4.23.0 -> 4.24.0", report.steps[0]["detail"])
+
+    def test_update_fails_when_invoking_codex_history_is_not_restored(self):
+        report = onboard.Report(as_json=True)
+        with patch.object(
+            onboard, "plugin_record", return_value=(True, "4.23.0")
+        ), patch.object(
+            onboard, "expected_policy_version", return_value=("4.24.0", "fixture")
+        ), patch.object(
+            onboard, "refresh_plugin", return_value=(True, "refreshed")
+        ), patch.object(
+            onboard,
+            "synchronize_codex_history",
+            return_value=(False, "historical root is still absent"),
+        ) as synchronize:
+            onboard.phase_ecosystem(
+                report,
+                {"codex": "codex"},
+                dry_run=False,
+                no_plugin_cli=False,
+                policy=self.policy,
+                refresh_native_plugins=True,
+            )
+
+        synchronize.assert_called_once_with("4.23.0")
+        self.assertEqual(report.steps[0]["status"], onboard.ERROR)
+        self.assertIn("historical cache preservation failed", report.steps[0]["detail"])
+        self.assertEqual(report.steps[0]["hint"], "historical root is still absent")
+        self.assertNotIn("plugin updated", report.steps[0]["detail"])
+
+    def test_claude_update_does_not_invoke_codex_history_guardian(self):
+        report = onboard.Report(as_json=True)
+        with patch.object(
+            onboard,
+            "plugin_record",
+            side_effect=[(True, "4.23.0"), (True, "4.24.0")],
+        ), patch.object(
+            onboard, "expected_policy_version", return_value=("4.24.0", "fixture")
+        ), patch.object(
+            onboard, "refresh_plugin", return_value=(True, "refreshed")
+        ), patch.object(onboard, "synchronize_codex_history") as synchronize:
+            onboard.phase_ecosystem(
+                report,
+                {"claude": "claude"},
+                dry_run=False,
+                no_plugin_cli=False,
+                policy=self.policy,
+                refresh_native_plugins=True,
+            )
+
+        synchronize.assert_not_called()
+        self.assertEqual(report.steps[0]["status"], onboard.CHANGED)
 
     def test_installed_plugin_cache_never_becomes_version_expectation(self):
         with tempfile.TemporaryDirectory(prefix="onboard-plugin-cache-") as root:

--- a/skills/synthesis-onboarding/scripts/test_onboard.py
+++ b/skills/synthesis-onboarding/scripts/test_onboard.py
@@ -614,6 +614,25 @@ class PluginTests(unittest.TestCase):
         self.assertIn("not installed", detail)
         runner.assert_not_called()
 
+    def test_codex_history_sync_refuses_a_dangling_guardian_symlink(self):
+        with tempfile.TemporaryDirectory(prefix="onboard-history-") as root:
+            home = Path(root)
+            runtime = (
+                home
+                / ".synthesis/plugin-cache-recovery/synthesis-engineering"
+                / ".synthesis-skills-cache-guardian.py"
+            )
+            runtime.parent.mkdir(parents=True)
+            runtime.symlink_to(runtime.parent / "missing-guardian.py")
+            with patch.object(onboard, "HOME", home), patch.object(
+                onboard, "run"
+            ) as runner:
+                success, detail = onboard.synchronize_codex_history("4.23.0")
+
+        self.assertFalse(success)
+        self.assertIn("unsafe type", detail)
+        runner.assert_not_called()
+
     def test_plugin_record_reads_codex_and_claude_versions(self):
         codex = {"installed": [{
             "pluginId": "synthesis-skills@synthesis-engineering",

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -5,23 +5,20 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.5.0"
+  version: "2.5.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
 
 # Synthesis Skills Manager
 
-**Version 2.5.0** (2026-09-01) makes Codex cache survival durable beyond the
-release command. The budgeted, tag-backed archive remains authoritative, and a
-standard-library guardian installed outside the client-owned cache restores
-historical roots whenever Codex creates a later cache generation. The newest
-version remains exclusively client-owned; the guardian shares the transition
-lock, refuses unsafe links or differing existing content, runs under the user
-supervisor, and is installed and verified by the gated publisher before it
-returns. Recovery digests still exclude only client-owned metadata. The
-whole-system onboarding suite and its scaffold/component catalog audit remain
-required release checks.
+**Version 2.5.1** (2026-09-02) prioritizes the newest historical Codex roots
+during recovery, so the version most likely to be pinned by a just-updated task
+returns first instead of last. The onboarding update engine now consumes the
+durable guardian synchronously before reporting a successful Codex refresh and
+verifies the invoking task's exact hook tree. The budgeted, tag-backed archive,
+single-writer transition lock, supervisor, refusal of unsafe or differing
+content, and client-owned newest-version boundary remain unchanged.
 
 Manage synthesis skills across a three-repo architecture. Skills are executable
 methodology. Public skills are also packaged as a native plugin for clients that
@@ -308,9 +305,12 @@ The sequence, each stage gating the next:
   the release lock, protects every archived version except the newest
   client-owned version, and rehydrates missing historical roots after any later
   cache replacement. It never deletes a cache path or overwrites differing
-  existing content. An already-running task therefore keeps the complete skill
-  and hook tree its SessionStart loaded even when reconciliation occurs after
-  the publisher has exited.
+  existing content. Restoration runs newest-history-first so the immediately
+  preceding version is available before older roots during a large recovery.
+  The onboarding engine invokes the installed guardian synchronously after a
+  Codex refresh and refuses to report success until the invoking task's exact
+  version root and hook targets are present. The watcher continues protecting
+  those roots against later reconciliation after either command exits.
   The archive has a 512 MiB hard budget and never deletes a historical root
   automatically when that budget is reached; unverifiable cleanup fails the
   release closed. Symlink recovery artifacts and client liveness markers are not

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -20,6 +20,11 @@ verifies the invoking task's exact hook tree. The budgeted, tag-backed archive,
 single-writer transition lock, supervisor, refusal of unsafe or differing
 content, and client-owned newest-version boundary remain unchanged.
 
+**Version 2.5.0** established the durable background guardian and kept recovery
+digests scoped to tracked release content rather than client-owned metadata.
+The whole-system onboarding suite and its scaffold/component catalog audit
+remain required release checks.
+
 Manage synthesis skills across a three-repo architecture. Skills are executable
 methodology. Public skills are also packaged as a native plugin for clients that
 support plugins; private and shared skills remain native user/project skills.

--- a/skills/synthesis-skills-manager/scripts/cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/cache_guardian.py
@@ -252,7 +252,10 @@ def restore_once(home: Path | None = None, *, blocking: bool = False) -> dict[st
         cache.mkdir(parents=True, exist_ok=True)
         if cache.is_symlink():
             raise GuardianError(f"cache parent is a symlink: {cache}")
-        for version in protected:
+        # A task is most likely to be pinned to the version immediately before
+        # the current release. Restore from newest to oldest so that root is
+        # available first even when a large archive takes time to rehydrate.
+        for version in reversed(protected):
             source = archived[version]
             _validate_root(source, version)
             destination = cache / version

--- a/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
@@ -72,6 +72,18 @@ def test_restore_protects_history_but_never_installs_current(tmp_path: Path) -> 
     assert json.loads(guardian.receipt_path(home).read_text(encoding="utf-8"))["verified"] == 1
 
 
+def test_restore_prioritizes_newest_historical_roots(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    archive = guardian.archive_root(home)
+    seed_root(archive / "4.74.0", "4.74.0", "newer history")
+    seed_root(archive / "4.75.0", "4.75.0", "newest history")
+
+    record = guardian.restore_once(home)
+
+    assert record["protected_versions"] == ["4.73.0", "4.74.0", "4.75.0"]
+    assert record["restored"] == ["4.75.0", "4.74.0", "4.73.0"]
+
+
 def test_later_parent_generation_is_repaired_without_touching_current(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Why

A native Codex plugin refresh could return before the durable cache guardian
had restored the version root used by the invoking task. Recovery also processed
older historical roots before the immediately prior release.

## What changed

- Restore historical Codex roots newest first.
- After a Codex refresh, run the installed guardian synchronously and verify the
  invoking task's prior runtime tree before reporting success.
- Fail the ecosystem step when a configured guardian is unsafe, fails, or does
  not restore that hook tree.
- Keep the existing close-other-tasks contract on machines without a recovery
  archive, and leave the Claude update route unchanged.

## Verification

- Gated release check passed for 4.90.2, including the fresh transaction-bound
  R5 acceptance receipt.
- 872 repository pytest cases passed across the CI-equivalent groups.
- Source conformance: 207 checks passed.
- Instruction conformance, scaffold/catalog checks, transcript checks,
  compileall, and adversarial inbox fixtures passed.
