### PR TITLE
Judge the newest live receipt for an address; state the shell-lane gate's boundary (4.90.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.90.2",
+  "version": "4.90.3",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.90.2",
+  "version": "4.90.3",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.90.3] - 2026-09-02
+
+**The shell-lane gate's boundary is stated where agents read it.** The
+codex lane was verified end to end against a live thread (registration,
+resolve, receipt, `codex queue` without the app-server daemon), and the
+verification showed the one place the gate cannot see: it reads the tool
+call's command text, so a `codex queue` run from inside a script file
+passes as an ordinary command — the boundary every shell-level guard
+shares. The protocol reference and the gate's docstring now say so and
+require the direct invocation; a test pins both statements.
+
+**A stale receipt no longer shadows a fresh one.** The same verification
+found a gate defect: a session that releases and claims again keeps its
+client handle under a new board identity, so two receipts can name one
+address, and the gate judged whichever sorted first — refusing a send the
+fresh receipt authorized. It now judges the newest receipt whose target
+row is still active. synthesis-project-management 2.11.2.
+
 ## [4.90.2] - 2026-09-02
 
 **A Codex update no longer returns while the invoking task's historical hook

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **Peer sessions are addressed by resolver-issued receipts, never by name
-(September 2026).** Release **4.90.1** gates every direct session-to-session
+(September 2026).** Releases **4.90.0** through **4.90.3** gate every direct session-to-session
 send in both clients on a delivery receipt from `coordination.py resolve`,
 delivers the board's message bus at each prompt, and reaches Codex threads
-through `codex queue`. See the [4.90.1 release notes](CHANGELOG.md).
+through `codex queue`. See the [4.90.3 release notes](CHANGELOG.md).
 
 **A self-report is a claim, not evidence (September 2026).** Release
 **4.88.0** makes daily parity read each client's installed manifest on disk

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,30 +1,28 @@
-# AGENT HEURISTIC: authored for the 4.90.2 Codex cache recovery transaction.
+# AGENT HEURISTIC: authored for the 4.90.3 shell-lane boundary and receipt-shadowing transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: codex-update-preserves-the-invoking-hook-root
+suite: shell-lane-boundary-stated-and-fresh-receipts-win
 membership: closed
-production_entry_point: skills/synthesis-onboarding/scripts/onboard.py
-enforcing_boundary: a Codex plugin refresh on a machine with the durable recovery guardian cannot report success until the guardian has run synchronously and the exact cache root and every plugin-root hook target used by the invoking task are present; historical recovery restores newest roots first
+production_entry_point: skills/synthesis-project-management/scripts/peer_send_gate.py
+enforcing_boundary: the send gate judges the newest live receipt whose target row is still active, so a session that released and claimed again under a new identity with the same handle is reachable through its fresh receipt; and the shell lane's command-text boundary is stated in the protocol and the gate rather than implied away
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: machines without a publisher-installed recovery archive retain the explicit close-other-tasks update contract; the continuous guardian, rather than this synchronous boundary alone, handles a later client reconciliation after the update exits
+unverified_remainder: a codex queue wrapped in a script file is invisible to the command-text gate by construction; the protocol requires the direct invocation and the send log shows no decision for a wrapped call
 changed_surfaces:
-  - path: skills/synthesis-skills-manager/scripts/cache_guardian.py
-    cases: [newest-history-first]
-  - path: skills/synthesis-skills-manager/scripts/test_cache_guardian.py
-    cases: [newest-history-first]
-  - path: skills/synthesis-skills-manager/SKILL.md
-    cases: [newest-history-first, synchronous-update-boundary]
-  - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [synchronous-update-boundary, exact-invoking-root, guardian-failure-blocks-success, guardian-absence-is-explicit, unsafe-guardian-fails-closed, claude-route-isolated]
-  - path: skills/synthesis-onboarding/scripts/test_onboard.py
-    cases: [synchronous-update-boundary, exact-invoking-root, guardian-failure-blocks-success, guardian-absence-is-explicit, unsafe-guardian-fails-closed, claude-route-isolated]
-  - path: skills/synthesis-onboarding/SKILL.md
-    cases: [synchronous-update-boundary, guardian-failure-blocks-success]
+  - path: skills/synthesis-project-management/scripts/peer_addressing.py
+    cases: [fresh-receipt-wins]
+  - path: skills/synthesis-project-management/scripts/peer_send_gate.py
+    cases: [fresh-receipt-wins, boundary-stated]
+  - path: skills/synthesis-project-management/scripts/test_peer_send_gate.py
+    cases: [fresh-receipt-wins, boundary-stated]
+  - path: skills/synthesis-project-management/references/parallel-agent-protocol.md
+    cases: [boundary-stated]
+  - path: skills/synthesis-project-management/SKILL.md
+    cases: [pm-budget]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -34,36 +32,20 @@ changed_surfaces:
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
   - path: README.md
-    cases: [synchronous-update-boundary, guardian-absence-is-explicit]
+    cases: [release-changelog-parity]
 cases:
-  - id: newest-history-first
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_restore_prioritizes_newest_historical_roots
-    motivating_defect: a-seventy-seven-version-archive-restored-the-immediately-prior-root-last-and-left-the-invoking-task-without-its-stop-hook-for-fifty-five-seconds
-  - id: synchronous-update-boundary
+  - id: fresh-receipt-wins
     control_class: enforced-gate
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_update_refreshes_and_accepts_newer_version_from_old_plugin_cache
-    motivating_defect: the-native-update-command-returned-before-the-background-guardian-finished-repairing-the-cache-generation-it-created
-  - id: exact-invoking-root
+    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_a_reclaimed_seat_is_not_shadowed_by_its_old_receipt
+    motivating_defect: the-gate-judged-whichever-receipt-sorted-first-and-refused-a-send-the-fresh-receipt-authorized
+  - id: boundary-stated
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_codex_history_sync_runs_durable_doctor_and_checks_started_root
-    motivating_defect: a-green-guardian-receipt-without-the-version-root-the-running-task-loaded-does-not-make-that-task-safe
-  - id: guardian-failure-blocks-success
-    control_class: enforced-gate
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_update_fails_when_invoking_codex_history_is_not_restored
-    motivating_defect: the-updater-reported-success-while-its-own-next-lifecycle-hook-could-not-execute
-  - id: guardian-absence-is-explicit
+    fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_shell_lane_boundary_is_stated_in_the_protocol_and_the_gate
+    motivating_defect: a-guard-that-implies-coverage-it-does-not-have-is-worse-than-one-that-states-its-boundary
+  - id: pm-budget
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_codex_history_sync_is_optional_without_a_durable_guardian
-    motivating_defect: an-updater-must-not-imply-a-recovery-guarantee-on-a-machine-that-has-no-recovery-archive
-  - id: unsafe-guardian-fails-closed
-    control_class: enforced-gate
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_codex_history_sync_refuses_a_dangling_guardian_symlink
-    motivating_defect: a-dangling-guardian-path-is-a-broken-protection-layer-not-an-absent-optional-layer
-  - id: claude-route-isolated
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_claude_update_does_not_invoke_codex_history_guardian
-    motivating_defect: a-codex-cache-repair-must-not-change-an-unrelated-clients-native-update-contract
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget
+    motivating_defect: a-restructured-document-must-not-regrow-with-its-next-feature
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.11.1"
+  version: "2.11.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-project-management/references/parallel-agent-protocol.md
+++ b/skills/synthesis-project-management/references/parallel-agent-protocol.md
@@ -81,6 +81,12 @@ that moment.
    message this session received — the harness wrote that address. In-process
    targets (`main`, spawned agent ids, named teammates) pass. Every decision
    lands in `peer-sends.jsonl`. Anything the gate cannot verify blocks.
+   One boundary is stated rather than hidden: on the shell lane the gate
+   reads the command text of the tool call, so a `codex queue` invoked
+   from inside a script file is invisible to it — the boundary every
+   shell-level guard shares. Invoke `codex queue` directly in the tool
+   call; wrapping it in a script is evasion, not delivery, and the send
+   log will show no decision for it.
 4. **Never assign work to a guess.** An unresolvable peer means a bus
    message addressed to the project, which its sessions self-select at their
    next prompt — a dispatch to the wrong session starts work in a context

--- a/skills/synthesis-project-management/scripts/peer_addressing.py
+++ b/skills/synthesis-project-management/scripts/peer_addressing.py
@@ -512,16 +512,28 @@ def load_receipts(board: Path, sender_key: str, now: datetime | None = None) -> 
     return live
 
 
-def receipt_for_address(receipts: list[dict], lane: str, address: str) -> dict | None:
-    """The receipt whose lane address equals the one about to be used."""
+def receipts_for_address(receipts: list[dict], lane: str, address: str) -> list[dict]:
+    """Every live receipt whose lane address equals the one about to be used,
+    newest first. A session that released and claimed again keeps its client
+    handle but gets a new board identity, so two receipts can name one
+    address; the gate must judge the newest one whose target is still
+    active, not whichever file sorts first."""
     field = {"ccd": "session_id", "harness": "to", "codex": "thread"}.get(lane)
     if field is None:
-        return None
-    for receipt in receipts:
-        entry = receipt.get("lanes", {}).get(lane)
-        if isinstance(entry, dict) and str(entry.get(field, "")).strip() == address.strip():
-            return receipt
-    return None
+        return []
+    matches = [
+        receipt
+        for receipt in receipts
+        if isinstance(receipt.get("lanes", {}).get(lane), dict)
+        and str(receipt["lanes"][lane].get(field, "")).strip() == address.strip()
+    ]
+    return sorted(matches, key=lambda r: str(r.get("issued_at", "")), reverse=True)
+
+
+def receipt_for_address(receipts: list[dict], lane: str, address: str) -> dict | None:
+    """The newest receipt whose lane address equals the one about to be used."""
+    matches = receipts_for_address(receipts, lane, address)
+    return matches[0] if matches else None
 
 
 # --------------------------------------------------------------------------

--- a/skills/synthesis-project-management/scripts/peer_send_gate.py
+++ b/skills/synthesis-project-management/scripts/peer_send_gate.py
@@ -15,7 +15,10 @@ that on every direct lane the plugin knows:
 - ``mcp__ccd_session_mgmt__send_message``: the ``session_id`` must equal the
   ccd address on a live receipt, and the board row must still be active.
 - shell tools: a ``codex queue --thread`` command needs a receipt naming
-  that thread; every other command passes untouched.
+  that thread; every other command passes untouched. The gate reads the
+  tool call's command text: a ``codex queue`` run from inside a script
+  file is invisible to it, the boundary every shell-level guard shares,
+  so the protocol requires the direct invocation.
 
 Every direct send must carry the sender's own board id so the recipient can
 resolve the reply without guessing, and the same text to a second peer
@@ -54,6 +57,7 @@ from peer_addressing import (  # noqa: E402
     process_alive,
     receipt_for_address,
     receipts_dir,
+    receipts_for_address,
     registry_dir,
     registry_entry_for_socket,
     seat_for_identity,
@@ -229,7 +233,14 @@ def evaluate(
         )
 
     receipts = load_receipts(board, key, moment)
-    receipt = receipt_for_address(receipts, lane, address)
+    candidates = receipts_for_address(receipts, lane, address)
+    # A handle can appear on two receipts when its session released and
+    # claimed again (new identity, same handle); the newest receipt whose
+    # target row is still active is the one that counts.
+    receipt = next(
+        (r for r in candidates if any(row.session_uuid == str(r.get("target", {}).get("uuid") or "") for row in active_rows)),
+        candidates[0] if candidates else None,
+    )
     replied = address in received_addresses(payload.get("transcript_path")) if lane in {"harness", "ccd"} else False
     target_uuid = ""
     if receipt is not None:

--- a/skills/synthesis-project-management/scripts/test_peer_send_gate.py
+++ b/skills/synthesis-project-management/scripts/test_peer_send_gate.py
@@ -157,6 +157,21 @@ def test_ccd_session_id_needs_a_matching_receipt(world) -> None:
     assert not wrong.allow
 
 
+def test_a_reclaimed_seat_is_not_shadowed_by_its_old_receipt(world, monkeypatch) -> None:
+    """Live on 2026-09-02: a thread was released and claimed again under a new
+    board identity with the same handle; the gate matched the stale receipt
+    first and refused a send the fresh receipt authorized."""
+    resolve(world)
+    assert ENGINE.command_release(args(world.board, id=world.target.compact_id)) == 0
+    reclaimed = claim(world.board, "project-t2", TARGET_ENV, monkeypatch)
+    for key, value in SENDER_ENV.items():
+        monkeypatch.setenv(key, value)
+    resolve(world, reclaimed.compact_id)
+    decision = evaluate(world, payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_target", "message": body(world)}))
+    assert decision.allow, decision.reason
+    assert decision.target_uuid == reclaimed.session_uuid
+
+
 def test_released_target_is_refused_even_with_a_receipt(world) -> None:
     resolve(world)
     assert ENGINE.command_release(args(world.board, id=world.target.compact_id)) == 0
@@ -217,6 +232,18 @@ def test_codex_queue_needs_a_receipt_for_that_thread(world, monkeypatch) -> None
     allowed = evaluate(world, payload("Bash", {"command": command}))
     assert allowed.allow, allowed.reason
     assert evaluate(world, payload("exec_command", {"cmd": "codex queue --message x"})).allow is False
+
+
+def test_shell_lane_boundary_is_stated_in_the_protocol_and_the_gate() -> None:
+    """The command-text gate cannot see a codex queue wrapped in a script; the
+    protocol and the gate's own docstring must say so rather than imply
+    coverage the gate does not have."""
+    protocol = (SCRIPTS_DIR.parent / "references" / "parallel-agent-protocol.md").read_text(encoding="utf-8")
+    assert "inside a script file is invisible to it" in protocol
+    assert "Invoke `codex queue` directly in the tool" in protocol
+    assert "inside a script" in (GATE.__doc__ or "")
+    wrapped = GATE.classify("Bash", {"command": "bash /tmp/run-queue.sh"})
+    assert wrapped.allow and not wrapped.logged, "a wrapper is not classified as a peer send; the doc states why"
 
 
 # --- process contract -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two findings from verifying the 4.90.0 codex lane end to end against a live Codex thread (registration, resolve, receipt, `codex queue` without the app-server daemon).

- **A stale receipt no longer shadows a fresh one.** A session that releases and claims again keeps its client handle under a new board identity, so two receipts can name one address. The gate judged whichever sorted first and refused a send the fresh receipt authorized. It now judges the newest receipt whose target row is still active.
- **The shell-lane boundary is stated.** The gate reads the tool call's command text, so a `codex queue` run from inside a script file is invisible to it — the boundary every shell-level guard shares. The protocol reference and the gate's docstring now say so and require the direct invocation; a test pins both statements.

## Verification

- Full AGENTS.md verification list run in CI shape (isolated `HOME`, no session identity in the environment).
- New tests: the reclaimed-seat case; the boundary statements.
- Acceptance manifest authored for this transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
