### PR TITLE
Restore legacy plugin-only lifecycle migration

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.91.0",
+  "version": "4.91.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.91.0",
+  "version": "4.91.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.91.1] - 2026-09-02
+
+**Existing plugin-only installations now enter the unified lifecycle without a
+second setup interview.** `synthesis update` and `synthesis repair` migrate an
+older receipt only when it proves that no workspace, organization, generated
+resource, adopted repository, or managed entry exists. The migration preserves
+the recorded stable, edge, or exact-pin policy, discovers selected clients from
+their live native-plugin inventories, and records the bounded legacy digest in
+the first authoritative transaction. Ambiguous, malformed, or richer legacy
+state remains fail-closed and requires an explicit `synthesis setup` choice.
+
 ## [4.91.0] - 2026-09-02
 
 **The complete synthesis work system now has one public installer, one stable

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,10 +1,10 @@
-# AGENT HEURISTIC: closed acceptance universe for the 4.91.0 unified onboarding release.
+# AGENT HEURISTIC: closed acceptance universe for the 4.91.1 legacy-update repair.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: unified-synthesis-onboarding-and-lifecycle
+suite: synthesis-onboarding-legacy-update-migration
 membership: closed
-production_entry_point: onboard.sh -> bootstrap.py -> synthesis_cli.py
+production_entry_point: synthesis -> synthesis_cli.py -> onboard.py
 enforcing_boundary: release.py consumes this transaction-bound closed manifest before publishing the immutable release, installing both clients, and activating the public CLI
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
@@ -17,282 +17,62 @@ changed_surfaces:
     cases: [release-identity]
   - path: .codex-plugin/plugin.json
     cases: [release-identity]
-  - path: .github/workflows/validate.yml
-    cases: [release-wiring]
-  - path: AGENTS.md
-    cases: [release-wiring]
   - path: CHANGELOG.md
-    cases: [release-identity, capability-contract]
-  - path: README.md
-    cases: [capability-contract]
-  - path: install.sh
-    cases: [capability-contract]
-  - path: onboard.sh
-    cases: [immutable-bootstrap, self-update, organization-transport, capability-contract]
-  - path: tests/test_installer.sh
-    cases: [capability-contract]
-  - path: skills/synthesis-agent-conformance/scripts/session_context.py
-    cases: [sessionstart-live, live-evidence-grounding, live-content-binding]
-  - path: skills/synthesis-agent-conformance/scripts/test_session_context.py
-    cases: [sessionstart-live, live-content-binding]
-  - path: skills/synthesis-onboarding/SKILL.md
-    cases: [capability-contract]
-  - path: skills/synthesis-onboarding/references/instruction-sources.schema.json
-    cases: [contract-schema, schema-runtime-parity, tracked-instructions]
-  - path: skills/synthesis-onboarding/references/invite.schema.json
-    cases: [contract-schema, schema-runtime-parity, organization-boundary, invite-replay]
-  - path: skills/synthesis-onboarding/references/layers.json
-    cases: [capability-contract]
-  - path: skills/synthesis-onboarding/references/machine-observation.schema.json
-    cases: [contract-schema, runtime-state-schema, transaction-lifecycle]
-  - path: skills/synthesis-onboarding/references/org-manifest.md
-    cases: [organization-boundary, documented-org-contract, organization-policy-update, capability-contract]
-  - path: skills/synthesis-onboarding/references/release-capabilities.json
-    cases: [capability-contract, manifest-schema-agreement]
-  - path: skills/synthesis-onboarding/references/release-descriptor.schema.json
-    cases: [contract-schema, schema-runtime-parity, immutable-release]
-  - path: skills/synthesis-onboarding/references/system-state.schema.json
-    cases: [contract-schema, schema-runtime-parity, runtime-state-schema, transaction-lifecycle]
-  - path: skills/synthesis-onboarding/scripts/bootstrap.py
-    cases: [immutable-bootstrap, immutable-release, immutable-permissions, floating-no-downgrade, self-update, launcher-activation, launcher-dispatch]
-  - path: skills/synthesis-onboarding/scripts/check_capabilities.py
-    cases: [capability-contract, manifest-schema-agreement, documented-org-contract, invite-replay]
-  - path: skills/synthesis-onboarding/scripts/direct_copy.sh
-    cases: [capability-contract]
-  - path: skills/synthesis-onboarding/scripts/kernel_sync.py
-    cases: [tracked-instructions]
-  - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [tracked-instructions, organization-boundary, release-policy-pin, client-combinations, desired-state-selection, repair-policy-stability, auth-failure, historical-cache, floating-no-downgrade, channel-transition, organization-policy-update, idempotent-reconcile, uninstall-truth]
-  - path: skills/synthesis-onboarding/scripts/organization.py
-    cases: [organization-boundary, organization-transport, auth-failure]
-  - path: skills/synthesis-onboarding/scripts/plugin_currency.py
-    cases: [currency-ahead, release-policy-cache]
-  - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
-    cases: [runtime-state-schema, self-update, profile-transition, desired-state-selection, release-policy-pin, channel-transition, pretransfer-purity, organization-policy-update, repair-policy-stability, transaction-lifecycle, idempotent-reconcile, output-parity, resource-rollback, uninstall-truth, outcome-failure]
-  - path: skills/synthesis-onboarding/scripts/system_contract.py
-    cases: [contract-schema, schema-runtime-parity, invite-replay, runtime-state-schema, immutable-release, transaction-lifecycle, interrupted-reentry, concurrency, legacy-migration, launcher-activation, launcher-dispatch, resource-rollback, instruction-drift, live-evidence-grounding, live-content-binding, outcome-provenance, outcome-failure]
-  - path: skills/synthesis-onboarding/scripts/test_bootstrap.py
-    cases: [immutable-bootstrap, immutable-permissions, floating-no-downgrade, self-update]
-  - path: skills/synthesis-onboarding/scripts/test_check_capabilities.py
-    cases: [capability-contract, documented-org-contract]
-  - path: skills/synthesis-onboarding/scripts/test_onboard.py
-    cases: [tracked-instructions, organization-boundary, release-policy-pin, client-combinations, auth-failure, historical-cache, floating-no-downgrade, channel-transition, uninstall-truth]
-  - path: skills/synthesis-onboarding/scripts/test_organization.py
-    cases: [organization-boundary, organization-transport, auth-failure]
-  - path: skills/synthesis-onboarding/scripts/test_plugin_currency.py
-    cases: [currency-ahead, release-policy-cache]
-  - path: skills/synthesis-onboarding/scripts/test_synthesis_cli.py
-    cases: [runtime-state-schema, self-update, profile-transition, desired-state-selection, release-policy-pin, channel-transition, pretransfer-purity, organization-policy-update, repair-policy-stability, transaction-lifecycle, idempotent-reconcile, output-parity, uninstall-truth, outcome-provenance, outcome-failure]
-  - path: skills/synthesis-onboarding/scripts/test_system_contract.py
-    cases: [contract-schema, schema-runtime-parity, invite-replay, runtime-state-schema, immutable-release, transaction-lifecycle, interrupted-reentry, concurrency, legacy-migration, launcher-activation, launcher-dispatch, resource-rollback, instruction-drift, live-evidence-grounding, live-content-binding, outcome-provenance, outcome-failure]
-  - path: skills/synthesis-quick-answers/SKILL.md
-    cases: [quick-answers-contract]
-  - path: skills/synthesis-skills-manager/SKILL.md
-    cases: [release-cli-activation]
-  - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [release-cli-activation, release-tag-authority, historical-cache, release-boundary]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [release-cli-activation, release-tag-authority, historical-cache, release-boundary, release-identity, quick-answers-contract, release-wiring]
+    cases: [release-identity, legacy-update-contract]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [acceptance-self]
+  - path: skills/synthesis-onboarding/SKILL.md
+    cases: [legacy-update-contract, engine-version]
+  - path: skills/synthesis-onboarding/scripts/onboard.py
+    cases: [engine-version]
+  - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
+    cases: [legacy-update-migration, legacy-update-boundary, legacy-client-evidence, legacy-bootstrap-entry, persisted-policy, repair-policy]
+  - path: skills/synthesis-onboarding/scripts/system_contract.py
+    cases: [legacy-update-migration, legacy-update-boundary, legacy-audit]
+  - path: skills/synthesis-onboarding/scripts/test_synthesis_cli.py
+    cases: [engine-version, legacy-update-migration, legacy-update-boundary, legacy-client-evidence, legacy-bootstrap-entry, persisted-policy, repair-policy]
 cases:
-  - id: immutable-release
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_release_descriptor_binds_tag_commit_tree_and_digest
-    motivating_defect: a-channel-name-alone-can-move-between-acquisition-and-execution
-  - id: immutable-bootstrap
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_bootstrap.py::test_materialization_is_content_addressed_and_idempotent
-    motivating_defect: mutable-execution-checkouts-can-change-after-the-user-reviewed-the-bootstrap
-  - id: immutable-permissions
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_bootstrap.py::test_existing_generation_permissions_are_reasserted
-    motivating_defect: a-content-addressed-generation-that-became-writable-remained-writable-on-the-next-reconcile
-  - id: floating-no-downgrade
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_floating_update_never_downgrades_an_ahead_plugin
-    motivating_defect: a-stale-floating-ref-could-replace-a-newer-active-plugin-or-ignore-an-explicit-channel-transition
-  - id: channel-transition
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_setup_rebootstraps_edge_and_pin_back_to_floating_stable
-    motivating_defect: a-policy-blind-ahead guard-could-keep-plugin-and-active-cli-on-different-releases-after-an-explicit-channel-change
-  - id: pretransfer-purity
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_setup_policy_transfer_does_not_run_prior_engine_rollback
-    motivating_defect: a-policy-only-release-transfer-ran-the-prior-engine-through-rollback-before-entering-the-selected-release
-  - id: organization-policy-update
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_org_policy_change_rebootstraps_then_commits_the_new_policy
-    motivating_defect: a-floating-organization-manifest-change-could-update-its-commit-while-the-public-release-policy-remained-stale
-  - id: repair-policy-stability
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_repair_reconciles_recorded_org_policy_without_advancing_it
-    motivating_defect: repair-could-advance-a-floating-organization-policy-and-rebootstrap-instead-of-converging-the-recorded-desired-state
-  - id: self-update
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_bootstrap.py::test_onboard_handoff_consumes_resolution_policy_before_update_cli
-    motivating_defect: the-public-update-command-refreshed-client-plugins-but-left-its-own-active-cli-generation-behind
-  - id: profile-transition
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_profile_transitions_commit_each_selected_policy
-    motivating_defect: changing-between-full-and-skills-only-could-run-without-committing-the-new-selected-profile
-  - id: launcher-activation
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_activation_refuses_launcher_that_spoofs_the_public_marker
-    motivating_defect: a-public-marker-could-forge-launcher-ownership-and-a-failed-two-file-switch-could-split-the-active-release
-  - id: launcher-dispatch
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_managed_launcher_dispatches_through_the_atomic_active_pointer
-    motivating_defect: a-release-independent-launcher-that-failed-to-pass-the-active-descriptor-would-record-development-source-instead-of-published-provenance
-  - id: contract-schema
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_shipped_contract_documents_are_valid
-    motivating_defect: prose-only-state-contracts-drift-between-entry-points
-  - id: schema-runtime-parity
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_json_schemas_and_runtime_share_valid_and_invalid_corpora
-    motivating_defect: shipped-json-schemas-and-runtime-validators-accepted-different-client-source-and-release-shapes
-  - id: desired-state-selection
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_real_full_setup_commits_effective_workspace_layers_and_present_client
-    motivating_defect: setup-committed-pre-engine-placeholders-instead-of-the-workspace-layers-and-present-clients-the-engine-installed
-  - id: runtime-state-schema
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_persisted_state_readers_enforce_closed_runtime_schemas
-    motivating_defect: malformed-persisted-state-passed-the-version-only-reader-and-crashed-later-with-an-uncaught-key-error
-  - id: interrupted-reentry
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_pending_transaction_is_aborted_before_reentry
-    motivating_defect: a-process-interruption-could-leave-a-pending-generation-looking-current-on-the-next-run
-  - id: concurrency
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_concurrent_transactions_preserve_every_generation
-    motivating_defect: concurrent-reconcilers-could-drop-or-reuse-generation-identities
-  - id: transaction-lifecycle
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_uninstall_persists_disabled_state_and_removed_planes
-    motivating_defect: a-removed-system-was-recorded-as-installed-and-had-no-disabled-desired-state
-  - id: resource-rollback
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_failed_transaction_invokes_resource_compensation_before_abort
-    motivating_defect: an-aborted-transaction-left-mutated-resources-behind-while-restoring-only-the-desired-state-file
-  - id: instruction-drift
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_instruction_pair_reports_user_drift_without_clobbering
-    motivating_defect: a-user-edited-client-instruction-output-could-be-overwritten-or-reported-green
-  - id: uninstall-truth
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_uninstall_refuses_to_disable_state_when_removal_is_not_verified
-    motivating_defect: uninstall-and-doctor-reported-removed-while-the-enabled-native-plugin-remained
-  - id: idempotent-reconcile
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_second_reconcile_records_zero_changed_resources
-    motivating_defect: a-second-convergent-run-had-no-public-transaction-evidence-that-it-changed-zero-resources
-  - id: legacy-migration
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_first_generation_records_bounded_legacy_migration_input
-    motivating_defect: the-old-receipt-was-described-as-a-migration-input-but-never-entered-the-authoritative-transaction-history
-  - id: organization-boundary
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_manifest_rejects_repository_selected_commands
-    motivating_defect: organization-data-could-select-local-code-or-escape-a-destination-boundary
-  - id: invite-replay
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_invite_is_bounded_and_cannot_replay
-    motivating_defect: the-public-invite-guide-required-a-nonce-that-the-schema-and-runtime-rejected
-  - id: documented-org-contract
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_check_capabilities.py::test_documented_organization_manifest_is_runtime_valid
-    motivating_defect: the-public-schema-two-example-used-three-shapes-the-runtime-parser-rejected
-  - id: organization-transport
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_organization.py::test_clone_rejects_ambient_https_to_file_transport_rewrite
-    motivating_defect: ambient-git-url-rewriting-converted-a-validated-https-organization-url-into-local-file-execution-input
-  - id: auth-failure
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_auth_failure_is_action_needed_with_help
-    motivating_defect: repository-authentication-failure-could-collapse-into-an-unactionable-generic-install-error
-  - id: tracked-instructions
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_init_workspace_scaffold_and_rerun
-    motivating_defect: workspace-routing-policy-lived-only-in-an-untracked-root-file
-  - id: currency-ahead
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_sessionstart_notice_does_not_request_downgrade_for_floating_channel
-    motivating_defect: stale-floating-evidence-could-instruct-a-newer-installation-to-downgrade
-  - id: release-policy-cache
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_plugin_currency.py::test_live_resolution_is_cached_and_stale_cache_remains_labeled
-    motivating_defect: offline-or-stale-channel-evidence-could-be-presented-as-a-live-authoritative-resolution
-  - id: release-policy-pin
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_setup_rebootstrap_requires_exact_pin_identity_even_at_same_version
-    motivating_defect: an-exact-organization-pin-could-be-overridden-by-a-newer-floating-source-version
-  - id: client-combinations
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_fallback_installs_on_fresh_machine_with_client
-    motivating_defect: the-public-entry-point-could-assume-both-native-clients-or-fail-to-offer-the-declared-direct-copy-adapter
-  - id: historical-cache
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots
-    motivating_defect: a-client-update-could-delete-the-plugin-root-that-an-already-running-task-still-executes
-  - id: sessionstart-live
-    control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_live_receipt_records_real_sessionstart_shape
-    motivating_defect: static-cache-parity-was-mistaken-for-proof-that-a-client-loaded-the-release
-  - id: live-evidence-grounding
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_live_load_rejects_nonexistent_root_unbound_transcript_and_stale_time
-    motivating_defect: nonexistent-plugin-roots-arbitrary-session-identifiers-and-stale-times-could-complete-live-loaded-state
-  - id: live-content-binding
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_live_load_binds_client_root_to_the_release_content_digest
-    motivating_defect: a-valid-looking-sessionstart-receipt-could-complete-live-state-for-plugin-bytes-different-from-the-committed-release
-  - id: outcome-provenance
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_outcome_verification_rejects_non_git_and_untracked_evidence
-    motivating_defect: an-untracked-file-in-a-non-git-directory-could-be-recorded-as-a-verified-user-outcome
-  - id: outcome-failure
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_outcome_verify_refuses_generation_without_live_evidence
-    motivating_defect: a-user-task-could-be-recorded-as-verified-before-any-selected-client-loaded-the-release
-  - id: output-parity
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_public_json_has_one_renderer
-    motivating_defect: child-output-noise-could-corrupt-json-or-create-different-human-and-machine-truth
-  - id: capability-contract
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_check_capabilities.py::test_repository_capabilities_are_consistent
-    motivating_defect: installer-documentation-and-downstream-skills-owned-conflicting-capability-lists
-  - id: manifest-schema-agreement
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_check_capabilities.py::test_repository_capabilities_are_consistent
-    motivating_defect: release-capabilities-advertised-organization-schema-one-while-the-parser-required-schema-two
-  - id: quick-answers-contract
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_quick_answers_self_bootstrap_release_contract_is_public_and_coherent
-    motivating_defect: a-downstream-skill-depended-on-a-plugin-cache-path-and-an-untracked-instruction-file
-  - id: release-cli-activation
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_publisher_activates_cli_through_public_release_verifier
-    motivating_defect: source-publication-and-client-installation-did-not-activate-the-public-cli-generation-users-were-told-to-run
-  - id: release-tag-authority
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_cli_activation_refuses_to_manufacture_a_missing_release_tag
-    motivating_defect: install-only-recovery-could-create-local-release-authority-for-a-dirty-or-unpublished-head
-  - id: release-boundary
-    control_class: enforced-gate
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_main_carries_acceptance_authority_to_publish_boundary
-    motivating_defect: a-green-test-run-unbound-to-the-published-commit-could-authorize-different-bytes
   - id: release-identity
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
-    motivating_defect: supported-client-manifests-and-release-notes-could-name-different-releases
-  - id: release-wiring
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_whole_system_onboarding_release_contract_is_public_and_coherent
+    motivating_defect: a-patch-release-could-publish-disagreeing-native-plugin-identities
+  - id: engine-version
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_agents_verification_list_matches_ci_workflow
-    motivating_defect: documented-and-hosted-required-check-universes-could-drift-silently
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_engine_versions_and_skill_contract_agree
+    motivating_defect: the-public-cli-and-its-engine-could-report-different-contract-versions
+  - id: legacy-update-contract
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_update_migrates_unambiguous_legacy_plugin_only_receipt
+    motivating_defect: the-documented-zero-interview-upgrade-path-did-not-exist-at-runtime
+  - id: legacy-update-migration
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_update_migrates_unambiguous_legacy_plugin_only_receipt
+    motivating_defect: an-existing-plugin-only-user-could-not-run-update-until-repeating-setup
+  - id: legacy-update-boundary
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_legacy_update_refuses_richer_or_malformed_receipts
+    motivating_defect: automatic-migration-could-guess-at-richer-or-malformed-legacy-state
+  - id: legacy-client-evidence
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_legacy_update_refuses_unverifiable_client_inventory
+    motivating_defect: migration-could-select-a-client-without-readable-native-plugin-evidence
+  - id: legacy-bootstrap-entry
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_bootstrap_update_leaves_missing_desired_state_for_legacy_migration
+    motivating_defect: the-active-launcher-refused-before-the-new-migration-path-could-run
+  - id: persisted-policy
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_update_reuses_persisted_policy
+    motivating_defect: the-migration-repair-could-regress-normal-desired-state-updates
+  - id: repair-policy
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_repair_reconciles_recorded_org_policy_without_advancing_it
+    motivating_defect: the-migration-repair-could-regress-recorded-organization-policy
+  - id: legacy-audit
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_first_generation_records_bounded_legacy_migration_input
+    motivating_defect: an-automatic-migration-could-omit-or-overexpose-its-legacy-source-evidence
   - id: acceptance-self
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: an-acceptance-manifest-its-own-runner-cannot-consume-issues-authority-it-never-earned
+    motivating_defect: a-release-manifest-could-claim-closed-membership-with-unmapped-or-invalid-cases

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.0.0"
+  version: "2.0.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -45,6 +45,11 @@ synthesis workspace ensure --name NAME [--remote URL]
 synthesis outcome verify --task TASK --workspace PATH --source-class CLASS
 synthesis uninstall
 ```
+
+`synthesis update` and `synthesis repair` migrate an older plugin-only receipt
+automatically when it contains no workspace, organization, or generated-resource
+state. Richer or unreadable legacy state is never guessed; run `synthesis setup`
+to select the intended profile explicitly.
 
 `install.sh` remains a compatibility entry point. With explicit direct-copy
 targets it invokes the audited copy capability; otherwise it routes through

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -78,7 +78,7 @@ from whole_system import (
     validate_personal_policy,
 )
 
-ENGINE_VERSION = "2.0.0"
+ENGINE_VERSION = "2.0.1"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"

--- a/skills/synthesis-onboarding/scripts/synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/synthesis_cli.py
@@ -29,7 +29,7 @@ from system_contract import (
 )
 
 
-ENGINE_VERSION = "2.0.0"
+ENGINE_VERSION = "2.0.1"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CLI_COMMANDS = (
     "setup",
@@ -489,12 +489,88 @@ def _bootstrap_update(
         return None
     desired = state.read_desired()
     if desired is None:
-        raise ContractError("no desired state exists; run synthesis setup")
+        return None
     if not desired.get("enabled", True):
         raise ContractError("the synthesis system is disabled; run synthesis setup")
     release = desired["release"]
     return _run_release_bootstrap(
         argv, active, release["channel"], release.get("version_pin")
+    )
+
+
+def _legacy_plugin_only_desired(state: SystemState) -> dict[str, Any]:
+    """Migrate only a legacy receipt that proves a plugin-only installation."""
+    legacy = state.legacy_migration_input()
+    if legacy is None:
+        raise ContractError(
+            "no desired or legacy installation state exists; run synthesis setup"
+        )
+
+    valid_fields = (
+        "receipt_version_valid",
+        "profile_valid",
+        "plugin_policy_valid",
+        "layer_choices_valid",
+        "component_choices_valid",
+        "generated_files_valid",
+        "adopted_repositories_valid",
+        "managed_json_entries_valid",
+        "managed_text_entries_valid",
+        "runs_valid",
+    )
+    no_whole_system_state = (
+        legacy.get("profile") in (None, "skills-only")
+        and not legacy.get("personal_workspace_present")
+        and not legacy.get("layer_choices")
+        and not legacy.get("component_choices")
+        and legacy.get("generated_file_count") == 0
+        and legacy.get("adopted_repository_count") == 0
+        and legacy.get("managed_json_entry_count") == 0
+        and legacy.get("managed_text_entry_count") == 0
+        and legacy.get("organization_run_count") == 0
+        and not legacy.get("instruction_state_present")
+        and legacy.get("unknown_field_count") == 0
+    )
+    if (
+        not all(legacy.get(name) is True for name in valid_fields)
+        or not no_whole_system_state
+    ):
+        raise ContractError(
+            "legacy installation contains ambiguous whole-system or organization state; "
+            "run synthesis setup to select the intended profile"
+        )
+
+    clients: list[str] = []
+    uncertain: list[str] = []
+    for client in ("claude", "codex"):
+        binary = onboard.resolve_client(client)
+        if not binary:
+            continue
+        present = onboard.plugin_present(client, binary)
+        if present is None:
+            uncertain.append(client)
+        elif present is True:
+            clients.append(client)
+    if uncertain:
+        raise ContractError(
+            "legacy client plugin inventory is unreadable for: %s; run synthesis setup"
+            % ", ".join(uncertain)
+        )
+    if not clients:
+        raise ContractError(
+            "legacy plugin-only installation has no verifiable installed client plugin; "
+            "run synthesis setup"
+        )
+
+    policy = legacy.get("plugin_policy") or {
+        "channel": "stable",
+        "version_pin": None,
+    }
+    return default_desired_state(
+        "skills-only",
+        clients,
+        policy["channel"],
+        policy.get("version_pin"),
     )
 
 
@@ -669,8 +745,9 @@ def main(
             try:
                 with state.locked():
                     desired = state.read_desired()
+                    migrated_legacy = desired is None
                     if desired is None:
-                        raise ContractError("no desired state exists; run synthesis setup")
+                        desired = _legacy_plugin_only_desired(state)
                     if not desired.get("enabled", True):
                         raise ContractError("the synthesis system is disabled; run synthesis setup")
 
@@ -688,7 +765,9 @@ def main(
                             resolved,
                             args.command,
                             args,
-                            desired_state_path=state.desired_path,
+                            desired_state_path=(
+                                None if migrated_legacy else state.desired_path
+                            ),
                         )
                         if resolved["release"] != desired["release"]:
                             engine_args.append("--policy-transition")

--- a/skills/synthesis-onboarding/scripts/system_contract.py
+++ b/skills/synthesis-onboarding/scripts/system_contract.py
@@ -966,7 +966,7 @@ class SystemState:
         validate_machine_observation(value)
         atomic_write_json(self.observation_path, value)
 
-    def _legacy_migration_input(self) -> dict[str, Any] | None:
+    def legacy_migration_input(self) -> dict[str, Any] | None:
         """Return bounded legacy metadata for the first authoritative generation.
 
         The legacy receipt remains an implementation aid for conffile-safe removal,
@@ -992,31 +992,128 @@ class SystemState:
         if not isinstance(value, dict):
             raise ContractError("legacy onboarding receipt must be an object")
 
-        def choices(name: str) -> dict[str, str]:
-            source = value.get(name) or {}
+        def choices(name: str) -> tuple[dict[str, str], bool]:
+            source = value.get(name)
+            if source is None:
+                return {}, True
             if not isinstance(source, dict):
-                return {}
+                return {}, False
             result: dict[str, str] = {}
             for key, entry in source.items():
                 if not isinstance(key, str) or not isinstance(entry, dict):
-                    continue
+                    return {}, False
                 choice = entry.get("choice")
-                if choice in {"selected", "declined"}:
-                    result[key] = choice
-            return dict(sorted(result.items()))
+                if choice not in {"selected", "declined"}:
+                    return {}, False
+                result[key] = choice
+            return dict(sorted(result.items())), True
+
+        def inventory_count(name: str) -> tuple[int, bool]:
+            source = value.get(name)
+            if source is None:
+                return 0, True
+            if not isinstance(source, dict):
+                return 0, False
+            return len(source), True
+
+        layer_choices, layer_choices_valid = choices("layer_choices")
+        component_choices, component_choices_valid = choices("component_choices")
+        generated_file_count, generated_files_valid = inventory_count("generated_files")
+        adopted_repository_count, adopted_repositories_valid = inventory_count("adopted_repos")
+        managed_json_entry_count, managed_json_entries_valid = inventory_count(
+            "managed_json_entries"
+        )
+        managed_text_entry_count, managed_text_entries_valid = inventory_count(
+            "managed_text_entries"
+        )
+
+        raw_profile = value.get("profile")
+        profile_valid = raw_profile is None or raw_profile in {"full", "skills-only"}
+        receipt_version = value.get("version")
+        receipt_version_valid = (
+            isinstance(receipt_version, int)
+            and not isinstance(receipt_version, bool)
+            and receipt_version in {1, 2}
+        )
+
+        raw_policy = value.get("plugin_policy")
+        plugin_policy_valid = raw_policy is None
+        plugin_policy = None
+        if isinstance(raw_policy, dict) and not set(raw_policy) - {"channel", "version_pin"}:
+            channel = raw_policy.get("channel") or "stable"
+            version_pin = raw_policy.get("version_pin")
+            plugin_policy_valid = (
+                channel in {"stable", "edge"}
+                and (
+                    version_pin is None
+                    or (
+                        isinstance(version_pin, str)
+                        and VERSION_RE.fullmatch(version_pin) is not None
+                    )
+                )
+            )
+            if plugin_policy_valid:
+                plugin_policy = {"channel": channel, "version_pin": version_pin}
+
+        runs = value.get("runs")
+        runs_valid = runs is None or (
+            isinstance(runs, list) and all(isinstance(entry, dict) for entry in runs)
+        )
+        organization_run_count = (
+            sum(1 for entry in runs if entry.get("manifest"))
+            if isinstance(runs, list) and runs_valid
+            else 0
+        )
+        instruction_state_present = any(
+            key in value
+            for key in (
+                "instruction_generation",
+                "instruction_receipt",
+                "kernel_source_sha256",
+            )
+        )
+        known_fields = {
+            "version",
+            "profile",
+            "personal_workspace",
+            "plugin_policy",
+            "layer_choices",
+            "component_choices",
+            "generated_files",
+            "adopted_repos",
+            "managed_json_entries",
+            "managed_text_entries",
+            "runs",
+            "instruction_generation",
+            "instruction_receipt",
+            "kernel_source_sha256",
+        }
 
         return {
             "sha256": file_digest(path),
-            "receipt_version": value.get("version"),
-            "profile": value.get("profile") if value.get("profile") in {"full", "skills-only"} else None,
-            "layer_choices": choices("layer_choices"),
-            "component_choices": choices("component_choices"),
-            "generated_file_count": len(value.get("generated_files") or {})
-            if isinstance(value.get("generated_files") or {}, dict)
-            else 0,
-            "adopted_repository_count": len(value.get("adopted_repos") or {})
-            if isinstance(value.get("adopted_repos") or {}, dict)
-            else 0,
+            "receipt_version": receipt_version,
+            "receipt_version_valid": receipt_version_valid,
+            "profile": raw_profile if profile_valid else None,
+            "profile_valid": profile_valid,
+            "personal_workspace_present": value.get("personal_workspace") is not None,
+            "plugin_policy": plugin_policy,
+            "plugin_policy_valid": plugin_policy_valid,
+            "layer_choices": layer_choices,
+            "layer_choices_valid": layer_choices_valid,
+            "component_choices": component_choices,
+            "component_choices_valid": component_choices_valid,
+            "generated_file_count": generated_file_count,
+            "generated_files_valid": generated_files_valid,
+            "adopted_repository_count": adopted_repository_count,
+            "adopted_repositories_valid": adopted_repositories_valid,
+            "managed_json_entry_count": managed_json_entry_count,
+            "managed_json_entries_valid": managed_json_entries_valid,
+            "managed_text_entry_count": managed_text_entry_count,
+            "managed_text_entries_valid": managed_text_entries_valid,
+            "organization_run_count": organization_run_count,
+            "runs_valid": runs_valid,
+            "instruction_state_present": instruction_state_present,
+            "unknown_field_count": len(set(value) - known_fields),
         }
 
     def run_transaction(
@@ -1059,7 +1156,7 @@ class SystemState:
                 "started_at": utcnow(),
             }
             if not observation["transactions"] and not self.desired_path.exists():
-                legacy = self._legacy_migration_input()
+                legacy = self.legacy_migration_input()
                 if legacy is not None:
                     transaction["details"] = {"legacy_migration_input": legacy}
             observation["transactions"].append(transaction)

--- a/skills/synthesis-onboarding/scripts/test_synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/test_synthesis_cli.py
@@ -76,6 +76,14 @@ def test_help_exposes_every_declared_command(capsys) -> None:
         assert command.split()[0] in help_text
 
 
+def test_engine_versions_and_skill_contract_agree() -> None:
+    skill = (REPO_ROOT / "skills/synthesis-onboarding/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert synthesis_cli.ENGINE_VERSION == synthesis_cli.onboard.ENGINE_VERSION
+    assert 'version: "%s"' % synthesis_cli.ENGINE_VERSION in skill
+
+
 def test_setup_routes_through_one_transaction_and_persists_desired(tmp_path: Path) -> None:
     calls: list[list[str]] = []
 
@@ -439,6 +447,147 @@ def test_update_rejects_malformed_persisted_state_without_running_engine(
     ) == 2
     assert calls == []
     assert "missing keys" in capsys.readouterr().err
+
+
+def test_update_migrates_unambiguous_legacy_plugin_only_receipt(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    state = system_contract.SystemState(home=tmp_path)
+    state.legacy_receipts_path.parent.mkdir(parents=True)
+    state.legacy_receipts_path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "profile": None,
+                "personal_workspace": None,
+                "plugin_policy": {"channel": "stable", "version_pin": "4.90.3"},
+                "layer_choices": {},
+                "component_choices": {},
+                "generated_files": {},
+                "adopted_repos": {},
+                "managed_json_entries": {},
+                "managed_text_entries": {},
+                "runs": [
+                    {
+                        "at": "2026-09-01T00:00:00Z",
+                        "command": "update",
+                        "manifest": None,
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        synthesis_cli.onboard,
+        "resolve_client",
+        lambda client: "/usr/bin/%s" % client,
+    )
+    monkeypatch.setattr(
+        synthesis_cli.onboard,
+        "plugin_present",
+        lambda client, _binary: client == "codex",
+    )
+    calls: list[list[str]] = []
+    assert synthesis_cli.main(
+        ["update", "--json"],
+        state=state,
+        engine_runner=lambda argv: calls.append(argv) or 0,
+    ) == 0
+    assert calls == [[
+        "update", "--clients", "codex", "--channel", "stable",
+        "--version-pin", "4.90.3",
+    ]]
+    desired = state.read_desired()
+    assert desired["profile"] == "skills-only"
+    assert desired["clients"] == ["codex"]
+    assert desired["release"] == {"channel": "stable", "version_pin": "4.90.3"}
+    transaction = state.read_observation()["transactions"][-1]
+    assert transaction["state"] == "committed"
+    assert transaction["details"]["legacy_migration_input"]["sha256"]
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["generation"] == 1
+
+
+def test_legacy_update_refuses_richer_or_malformed_receipts(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    receipts = (
+        {"profile": "full"},
+        {"generated_files": {"/private/resource": {"sha256": "a" * 64}}},
+        {"runs": [{"manifest": "/private/organization-manifest"}]},
+        {"managed_json_entries": []},
+        {"version": 99},
+        {"unknown_state": "present"},
+        {"instruction_generation": 1},
+    )
+    monkeypatch.setattr(
+        synthesis_cli.onboard, "resolve_client", lambda _client: "/bin/client"
+    )
+    monkeypatch.setattr(synthesis_cli.onboard, "plugin_present", lambda *_args: True)
+    for index, extra in enumerate(receipts):
+        state = system_contract.SystemState(home=tmp_path / ("case-%d" % index))
+        state.legacy_receipts_path.parent.mkdir(parents=True)
+        receipt = {
+            "version": 2,
+            "profile": None,
+            "personal_workspace": None,
+            "plugin_policy": {"channel": "stable", "version_pin": None},
+            "layer_choices": {},
+            "component_choices": {},
+            "generated_files": {},
+            "adopted_repos": {},
+            "managed_json_entries": {},
+            "managed_text_entries": {},
+            "runs": [],
+        }
+        receipt.update(extra)
+        state.legacy_receipts_path.write_text(
+            json.dumps(receipt) + "\n", encoding="utf-8"
+        )
+        calls: list[list[str]] = []
+        assert synthesis_cli.main(
+            ["update"], state=state, engine_runner=lambda argv: calls.append(argv) or 0
+        ) == 2
+        assert calls == []
+        assert state.read_desired() is None
+    assert "ambiguous whole-system or organization state" in capsys.readouterr().err
+
+
+def test_legacy_update_refuses_unverifiable_client_inventory(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    state = system_contract.SystemState(home=tmp_path)
+    state.legacy_receipts_path.parent.mkdir(parents=True)
+    state.legacy_receipts_path.write_text(
+        json.dumps({"version": 2, "plugin_policy": {"channel": "stable"}}) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        synthesis_cli.onboard, "resolve_client", lambda _client: "/bin/client"
+    )
+    monkeypatch.setattr(synthesis_cli.onboard, "plugin_present", lambda *_args: None)
+    assert (
+        synthesis_cli.main(
+            ["repair"], state=state, engine_runner=lambda _argv: 0
+        )
+        == 2
+    )
+    assert "inventory is unreadable" in capsys.readouterr().err
+
+
+def test_bootstrap_update_leaves_missing_desired_state_for_legacy_migration(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        synthesis_cli,
+        "_active_release",
+        lambda: {"release_root": str(tmp_path)},
+    )
+    assert synthesis_cli._bootstrap_update(
+        ["update"], system_contract.SystemState(home=tmp_path / "home")
+    ) is None
 
 
 def test_installed_update_transfers_once_through_the_active_bootstrap(


### PR DESCRIPTION
## Summary

- migrate an unambiguous legacy plugin-only receipt into authoritative desired state on `synthesis update` or `synthesis repair`
- preserve its stable, edge, or exact-pin policy and select clients only from readable native-plugin inventories
- refuse richer, malformed, or unverifiable legacy state instead of guessing
- bind the patch to a focused closed acceptance manifest and align the onboarding engine version

## Verification

- full `release.py --check-only` gate passed for 4.91.1 against the 4.91.0 release
- onboarding, conformance, coordination, lifecycle, release-manager, hook, transcript, and knowledge-contract checks passed
- migration success and fail-closed boundaries have dedicated tests