### PR TITLE
Preserve historical plugin roots during Python hook execution

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.91.1",
+  "version": "4.91.2",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.91.1",
+  "version": "4.91.2",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.91.2] - 2026-09-03
+
+**An older running task can no longer invalidate its own preserved plugin
+root.** Python may create `__pycache__` beside a hook script when the task calls
+that hook from a historical version. The cache guardian now excludes only
+regular Python bytecode directly inside that generated directory from the
+archive comparison. Source changes, unknown files, bytecode outside the
+generated directory, symlinks, and special objects still fail closed. All
+shipped Python lifecycle hooks now run with `-B` to prevent new bytecode writes.
+
 ## [4.91.1] - 2026-09-02
 
 **Existing plugin-only installations now enter the unified lifecycle without a

--- a/README.md
+++ b/README.md
@@ -12,12 +12,14 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **One bootstrap now installs and manages the complete public system (September
-2026).** Release **4.91.0** adds the stable `synthesis` CLI, immutable release
-resolution, full and skills-only profiles, tracked dual-client workspace
+2026).** Releases **4.91.0** through **4.91.2** add the stable `synthesis` CLI,
+immutable release resolution, full and skills-only profiles, tracked dual-client workspace
 instructions, declarative organization enrollment, transactional desired and
 observed state, six-plane doctor results, and public outcome verification.
 Updates remain explicit. The release gate activates the same content-addressed
-generation that both clients verified. See the [4.91.0 release
+generation that both clients verified. Existing plugin-only installations enter
+that lifecycle without another setup interview, and running older tasks cannot
+invalidate preserved roots merely by creating Python bytecode. See the [4.91.2 release
 notes](CHANGELOG.md).
 
 **Peer sessions are addressed by resolver-issued receipts, never by name

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-agent-conformance/scripts/session_context.py --format claude",
+            "command": "python3 -B ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-agent-conformance/scripts/session_context.py --format claude",
             "timeout": 30,
             "statusMessage": "Loading verified synthesis project context"
           }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/board_inbox.py --hook",
+            "command": "python3 -B ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/board_inbox.py --hook",
             "timeout": 10,
             "statusMessage": "Delivering coordination board messages addressed to this session"
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/peer_send_gate.py --gate",
+            "command": "python3 -B ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/peer_send_gate.py --gate",
             "timeout": 15,
             "statusMessage": "Verifying the peer address against a delivery receipt and the coordination board"
           }
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/peer_send_gate.py --gate",
+            "command": "python3 -B ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/peer_send_gate.py --gate",
             "timeout": 15
           }
         ]
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-autopilot/scripts/autopilot_gate.py --gate",
+            "command": "python3 -B ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-autopilot/scripts/autopilot_gate.py --gate",
             "timeout": 15,
             "statusMessage": "Checking autopilot engagements for a continuation"
           }

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,77 +1,75 @@
-# AGENT HEURISTIC: closed acceptance universe for the 4.91.1 legacy-update repair.
+# AGENT HEURISTIC: closed acceptance universe for the 4.91.2 historical-bytecode repair.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: synthesis-onboarding-legacy-update-migration
+suite: synthesis-historical-bytecode-cache-integrity
 membership: closed
-production_entry_point: synthesis -> synthesis_cli.py -> onboard.py
+production_entry_point: release.py -> cache_guardian.py -> preserved Codex plugin roots
 enforcing_boundary: release.py consumes this transaction-bound closed manifest before publishing the immutable release, installing both clients, and activating the public CLI
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: live first-time public and organization user observation, live credential/provider behavior, and deployment of the separately built public sites remain external principal gates
+unverified_remainder: live client cache-replacement timing outside the reproduced old-task update path remains environment-dependent
 changed_surfaces:
   - path: .claude-plugin/plugin.json
-    cases: [release-identity]
+    cases: [release-contract]
   - path: .codex-plugin/plugin.json
-    cases: [release-identity]
+    cases: [release-contract]
   - path: CHANGELOG.md
-    cases: [release-identity, legacy-update-contract]
+    cases: [release-contract]
+  - path: README.md
+    cases: [release-contract]
+  - path: hooks/hooks.json
+    cases: [release-contract, hook-bytecode-prevention]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [acceptance-self]
-  - path: skills/synthesis-onboarding/SKILL.md
-    cases: [legacy-update-contract, engine-version]
-  - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [engine-version]
-  - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
-    cases: [legacy-update-migration, legacy-update-boundary, legacy-client-evidence, legacy-bootstrap-entry, persisted-policy, repair-policy]
-  - path: skills/synthesis-onboarding/scripts/system_contract.py
-    cases: [legacy-update-migration, legacy-update-boundary, legacy-audit]
-  - path: skills/synthesis-onboarding/scripts/test_synthesis_cli.py
-    cases: [engine-version, legacy-update-migration, legacy-update-boundary, legacy-client-evidence, legacy-bootstrap-entry, persisted-policy, repair-policy]
+  - path: skills/synthesis-skills-manager/SKILL.md
+    cases: [release-contract]
+  - path: skills/synthesis-skills-manager/scripts/cache_guardian.py
+    cases: [runtime-bytecode, bytecode-boundary, nested-bytecode, bytecode-symlink, bytecode-special, special-object, historical-restore]
+  - path: skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+    cases: [runtime-bytecode, bytecode-boundary, nested-bytecode, bytecode-symlink, bytecode-special, special-object, hook-bytecode-prevention, historical-restore]
+  - path: skills/synthesis-skills-manager/scripts/test_release.py
+    cases: [release-contract]
 cases:
-  - id: release-identity
+  - id: release-contract
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_whole_system_onboarding_release_contract_is_public_and_coherent
-    motivating_defect: a-patch-release-could-publish-disagreeing-native-plugin-identities
-  - id: engine-version
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_runtime_bytecode_cache_release_contract_is_public_and_coherent
+    motivating_defect: a-patch-release-could-ship-disagreeing-version-documentation-or-bytecode-policy
+  - id: runtime-bytecode
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_engine_versions_and_skill_contract_agree
-    motivating_defect: the-public-cli-and-its-engine-could-report-different-contract-versions
-  - id: legacy-update-contract
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_runtime_bytecode_does_not_invalidate_historical_source
+    motivating_defect: an-old-task-could-invalidate-its-own-preserved-root-by-running-a-python-hook
+  - id: bytecode-boundary
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_update_migrates_unambiguous_legacy_plugin_only_receipt
-    motivating_defect: the-documented-zero-interview-upgrade-path-did-not-exist-at-runtime
-  - id: legacy-update-migration
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_bytecode_exception_does_not_hide_source_or_unknown_drift
+    motivating_defect: a-bytecode-exclusion-could-mask-source-loose-bytecode-or-unknown-file-drift
+  - id: bytecode-symlink
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_update_migrates_unambiguous_legacy_plugin_only_receipt
-    motivating_defect: an-existing-plugin-only-user-could-not-run-update-until-repeating-setup
-  - id: legacy-update-boundary
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_bytecode_exception_refuses_symlinked_cache_directory
+    motivating_defect: an-ignored-cache-directory-could-be-replaced-by-an-unsafe-link
+  - id: nested-bytecode
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_legacy_update_refuses_richer_or_malformed_receipts
-    motivating_defect: automatic-migration-could-guess-at-richer-or-malformed-legacy-state
-  - id: legacy-client-evidence
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_bytecode_exception_does_not_hide_nested_cache_directory
+    motivating_defect: a-generated-directory-exclusion-could-hide-an-unexpected-nested-directory
+  - id: bytecode-special
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_legacy_update_refuses_unverifiable_client_inventory
-    motivating_defect: migration-could-select-a-client-without-readable-native-plugin-evidence
-  - id: legacy-bootstrap-entry
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_bytecode_exception_refuses_special_cache_entry
+    motivating_defect: an-ignored-bytecode-path-could-hide-a-non-file-object
+  - id: special-object
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_bootstrap_update_leaves_missing_desired_state_for_legacy_migration
-    motivating_defect: the-active-launcher-refused-before-the-new-migration-path-could-run
-  - id: persisted-policy
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_tree_digest_refuses_unknown_special_object
+    motivating_defect: the-integrity-digest-could-silently-omit-an-unknown-special-object
+  - id: hook-bytecode-prevention
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_update_reuses_persisted_policy
-    motivating_defect: the-migration-repair-could-regress-normal-desired-state-updates
-  - id: repair-policy
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_shipped_python_hooks_disable_bytecode_writes
+    motivating_defect: shipped-python-hooks-could-continue-mutating-versioned-plugin-roots
+  - id: historical-restore
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_repair_reconciles_recorded_org_policy_without_advancing_it
-    motivating_defect: the-migration-repair-could-regress-recorded-organization-policy
-  - id: legacy-audit
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_first_generation_records_bounded_legacy_migration_input
-    motivating_defect: an-automatic-migration-could-omit-or-overexpose-its-legacy-source-evidence
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_restore_protects_history_but_never_installs_current
+    motivating_defect: the-bytecode-repair-could-regress-the-original-historical-root-restore-contract
   - id: acceptance-self
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -5,12 +5,19 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.6.0"
+  version: "2.6.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
 
 # Synthesis Skills Manager
+
+**Version 2.6.1** (2026-09-03) keeps historical-cache integrity scoped to
+release source even while an older running task executes Python hooks from its
+versioned root. The guardian excludes only regular `.pyc` or `.pyo` files
+directly inside a real `__pycache__` directory; unknown files, loose bytecode,
+links, special objects, and source changes remain integrity failures. Shipped
+Python hooks also use `-B` so current runtimes do not create bytecode there.
 
 **Version 2.6.0** (2026-09-02) makes public CLI activation part of the same
 gated release transaction as source publication and dual-client verification.

--- a/skills/synthesis-skills-manager/scripts/cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/cache_guardian.py
@@ -39,6 +39,8 @@ LABEL = "org.synthesisengineering.synthesis-skills-cache-guardian"
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 HOOK_PLUGIN_PATH_RE = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\s\"']+)")
 IGNORED_ROOTS = frozenset({".git", ".in_use", ".codex-marketplace-install.json"})
+BYTECODE_CACHE_DIRECTORY = "__pycache__"
+BYTECODE_SUFFIXES = frozenset({".pyc", ".pyo"})
 DEFAULT_INTERVAL_SECONDS = 1.0
 ERROR_RETRY_SECONDS = 10.0
 EX_TEMPFAIL = 75
@@ -88,11 +90,41 @@ def _version_roots(parent: Path) -> dict[str, Path]:
     }
 
 
+def _is_ignorable_bytecode(path: Path, relative_path: Path) -> bool:
+    """Ignore only regular Python bytecode in a real ``__pycache__`` directory.
+
+    Hooks execute from immutable historical plugin roots. Python may create a
+    sibling cache directory as a runtime side effect, but arbitrary files,
+    nested directories, links, and special objects inside that directory must
+    still change the integrity result or fail closed.
+    """
+    if (
+        relative_path.name == BYTECODE_CACHE_DIRECTORY
+        and relative_path.parts.count(BYTECODE_CACHE_DIRECTORY) == 1
+    ):
+        if path.is_symlink() or not path.is_dir():
+            raise GuardianError(
+                f"unsafe Python bytecode cache directory: {relative_path}"
+            )
+        return True
+    if (
+        relative_path.parent.name == BYTECODE_CACHE_DIRECTORY
+        and relative_path.parts.count(BYTECODE_CACHE_DIRECTORY) == 1
+        and relative_path.suffix in BYTECODE_SUFFIXES
+    ):
+        if path.is_symlink() or not path.is_file():
+            raise GuardianError(f"unsafe Python bytecode cache entry: {relative_path}")
+        return True
+    return False
+
+
 def _tree_digest(root: Path) -> str:
     digest = hashlib.sha256()
     for path in sorted(root.rglob("*"), key=lambda item: str(item.relative_to(root))):
         relative_path = path.relative_to(root)
         if relative_path.parts and relative_path.parts[0] in IGNORED_ROOTS:
+            continue
+        if _is_ignorable_bytecode(path, relative_path):
             continue
         relative = str(relative_path).encode("utf-8")
         if path.is_symlink():
@@ -101,6 +133,8 @@ def _tree_digest(root: Path) -> str:
             digest.update(b"D\0" + relative)
         elif path.is_file():
             digest.update(b"F\0" + relative + b"\0" + path.read_bytes())
+        else:
+            raise GuardianError(f"unsupported cache entry type: {relative_path}")
     return digest.hexdigest()
 
 

--- a/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
@@ -120,12 +120,123 @@ def test_differing_existing_history_fails_closed_without_overwrite(
     assert target.read_text(encoding="utf-8") == "do not erase\n"
 
 
+def test_runtime_bytecode_does_not_invalidate_historical_source(
+    tmp_path: Path,
+) -> None:
+    home = seeded_home(tmp_path)
+    guardian.restore_once(home)
+    target = (
+        guardian.cache_parent(home)
+        / "4.73.0"
+        / "skills/synthesis-autopilot/scripts/__pycache__/autopilot_gate.cpython-312.pyc"
+    )
+    target.parent.mkdir()
+    target.write_bytes(b"runtime bytecode\n")
+
+    record = guardian.restore_once(home)
+
+    assert record["verified"] == 1
+    assert target.read_bytes() == b"runtime bytecode\n"
+
+
+@pytest.mark.parametrize(
+    ("relative", "content"),
+    [
+        ("skills/synthesis-autopilot/scripts/autopilot_gate.py", "changed source\n"),
+        ("skills/synthesis-autopilot/scripts/autopilot_gate.pyc", "loose bytecode\n"),
+        ("skills/synthesis-autopilot/scripts/__pycache__/unexpected.txt", "unknown\n"),
+    ],
+)
+def test_bytecode_exception_does_not_hide_source_or_unknown_drift(
+    tmp_path: Path, relative: str, content: str
+) -> None:
+    home = seeded_home(tmp_path)
+    guardian.restore_once(home)
+    target = guardian.cache_parent(home) / "4.73.0" / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+    with pytest.raises(guardian.GuardianError, match="differs from archive"):
+        guardian.restore_once(home)
+
+
+def test_bytecode_exception_refuses_symlinked_cache_directory(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    guardian.restore_once(home)
+    scripts = (
+        guardian.cache_parent(home) / "4.73.0" / "skills/synthesis-autopilot/scripts"
+    )
+    (scripts / "__pycache__").symlink_to(".")
+
+    with pytest.raises(
+        guardian.GuardianError, match="unsafe Python bytecode cache directory"
+    ):
+        guardian.restore_once(home)
+
+
+def test_bytecode_exception_does_not_hide_nested_cache_directory(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    guardian.restore_once(home)
+    nested = (
+        guardian.cache_parent(home)
+        / "4.73.0"
+        / "skills/synthesis-autopilot/scripts/__pycache__/__pycache__"
+    )
+    nested.mkdir(parents=True)
+
+    with pytest.raises(guardian.GuardianError, match="differs from archive"):
+        guardian.restore_once(home)
+
+
+def test_bytecode_exception_refuses_special_cache_entry(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    guardian.restore_once(home)
+    target = (
+        guardian.cache_parent(home)
+        / "4.73.0"
+        / "skills/synthesis-autopilot/scripts/__pycache__/unsafe.pyc"
+    )
+    target.parent.mkdir()
+    os.mkfifo(target)
+
+    with pytest.raises(
+        guardian.GuardianError, match="unsafe Python bytecode cache entry"
+    ):
+        guardian.restore_once(home)
+
+
+def test_tree_digest_refuses_unknown_special_object(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    guardian.restore_once(home)
+    target = guardian.cache_parent(home) / "4.73.0" / "unexpected.pipe"
+    os.mkfifo(target)
+
+    with pytest.raises(guardian.GuardianError, match="unsupported cache entry type"):
+        guardian.restore_once(home)
+
+
 def test_unsafe_archive_symlink_is_refused(tmp_path: Path) -> None:
     home = seeded_home(tmp_path)
     (guardian.archive_root(home) / "4.73.0" / "escape").symlink_to("../../outside")
 
     with pytest.raises(guardian.GuardianError, match="unsafe archive symlink"):
         guardian.restore_once(home)
+
+
+def test_shipped_python_hooks_disable_bytecode_writes() -> None:
+    repository = Path(__file__).resolve().parents[3]
+    payload = json.loads((repository / "hooks/hooks.json").read_text(encoding="utf-8"))
+    commands = [
+        hook["command"]
+        for registrations in payload["hooks"].values()
+        for registration in registrations
+        for hook in registration["hooks"]
+        if hook.get("type") == "command"
+        and hook.get("command", "").startswith("python3 ")
+    ]
+
+    assert commands
+    assert all(command.startswith("python3 -B ") for command in commands)
 
 
 def test_release_lock_defers_guardian_without_writing(tmp_path: Path) -> None:

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -775,6 +775,33 @@ def test_delayed_cache_guardian_release_contract_is_public_and_coherent() -> Non
     assert "## [4.77.1]" in changelog
 
 
+def test_runtime_bytecode_cache_release_contract_is_public_and_coherent() -> None:
+    repository = Path(__file__).resolve().parents[3]
+    manager = (repository / "skills/synthesis-skills-manager/SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    changelog = (repository / "CHANGELOG.md").read_text(encoding="utf-8")
+    readme = (repository / "README.md").read_text(encoding="utf-8")
+    hook_payload = json.loads(
+        (repository / "hooks/hooks.json").read_text(encoding="utf-8")
+    )
+    commands = [
+        hook["command"]
+        for registrations in hook_payload["hooks"].values()
+        for registration in registrations
+        for hook in registration["hooks"]
+        if hook.get("type") == "command"
+        and hook.get("command", "").startswith("python3 ")
+    ]
+
+    assert release.source_version(repository)[0] == "4.91.2"
+    assert release.changelog_top_version(repository) == "4.91.2"
+    assert "Version 2.6.1" in manager and "__pycache__" in manager
+    assert "running older tasks" in readme
+    assert "## [4.91.2]" in changelog
+    assert commands and all(command.startswith("python3 -B ") for command in commands)
+
+
 def test_whole_system_onboarding_release_contract_is_public_and_coherent() -> None:
     repository = Path(__file__).resolve().parents[3]
     onboarding = (repository / "skills/synthesis-onboarding/SKILL.md").read_text(


### PR DESCRIPTION
## Summary

- exclude only regular Python bytecode directly inside a real `__pycache__` directory from historical-root integrity comparisons
- keep source changes, unknown files, nested cache directories, loose bytecode, links, and special objects fail-closed
- run shipped Python lifecycle hooks with `-B` to prevent new bytecode writes

## Verification

- gated release check-only suite passed
- closed 10-surface acceptance suite passed all 10 cases
- independent adversarial review passed after adding special-object coverage
- candidate guardian verified 81 real historical roots while the running old task continued creating bytecode