### PR TITLE
Unify historical cache integrity policy

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.91.2",
+  "version": "4.91.3",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.91.2",
+  "version": "4.91.3",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.91.3] - 2026-09-03
+
+**The release snapshot and the durable guardian now apply one historical-root
+integrity policy.** The first 4.91.2 release run proved that the guardian could
+accept runtime bytecode while the publisher's pre-refresh snapshot verifier
+still rejected the same changing `.pyc`. The publisher now delegates every
+snapshot, archive, restore, and quiet-window comparison to the guardian's
+narrow policy, including CPython's numeric-suffixed atomic-write files. A
+running older task may continue executing its Python hook during an update.
+Differing roots are replaced as one directory rather than copied through
+untrusted entries, preventing nested links from redirecting repair writes;
+source and unsupported filesystem objects remain integrity failures.
+
 ## [4.91.2] - 2026-09-03
 
 **An older running task can no longer invalidate its own preserved plugin

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **One bootstrap now installs and manages the complete public system (September
-2026).** Releases **4.91.0** through **4.91.2** add the stable `synthesis` CLI,
+2026).** Releases **4.91.0** through **4.91.3** add the stable `synthesis` CLI,
 immutable release resolution, full and skills-only profiles, tracked dual-client workspace
 instructions, declarative organization enrollment, transactional desired and
 observed state, six-plane doctor results, and public outcome verification.
 Updates remain explicit. The release gate activates the same content-addressed
 generation that both clients verified. Existing plugin-only installations enter
 that lifecycle without another setup interview, and running older tasks cannot
-invalidate preserved roots merely by creating Python bytecode. See the [4.91.2 release
+invalidate preserved roots merely by creating Python bytecode. See the [4.91.3 release
 notes](CHANGELOG.md).
 
 **Peer sessions are addressed by resolver-issued receipts, never by name

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,17 +1,17 @@
-# AGENT HEURISTIC: closed acceptance universe for the 4.91.2 historical-bytecode repair.
+# AGENT HEURISTIC: closed acceptance universe for the 4.91.3 release-snapshot repair.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: synthesis-historical-bytecode-cache-integrity
+suite: synthesis-release-snapshot-bytecode-integrity
 membership: closed
-production_entry_point: release.py -> cache_guardian.py -> preserved Codex plugin roots
+production_entry_point: release.py -> cache_guardian._tree_digest -> preserved Codex plugin roots
 enforcing_boundary: release.py consumes this transaction-bound closed manifest before publishing the immutable release, installing both clients, and activating the public CLI
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: live client cache-replacement timing outside the reproduced old-task update path remains environment-dependent
+unverified_remainder: the live old-task update race is verified by the gated publisher after this source acceptance boundary
 changed_surfaces:
   - path: .claude-plugin/plugin.json
     cases: [release-contract]
@@ -21,55 +21,59 @@ changed_surfaces:
     cases: [release-contract]
   - path: README.md
     cases: [release-contract]
-  - path: hooks/hooks.json
-    cases: [release-contract, hook-bytecode-prevention]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [acceptance-self]
   - path: skills/synthesis-skills-manager/SKILL.md
     cases: [release-contract]
   - path: skills/synthesis-skills-manager/scripts/cache_guardian.py
-    cases: [runtime-bytecode, bytecode-boundary, nested-bytecode, bytecode-symlink, bytecode-special, special-object, historical-restore]
+    cases: [guardian-bytecode, guardian-boundary]
   - path: skills/synthesis-skills-manager/scripts/test_cache_guardian.py
-    cases: [runtime-bytecode, bytecode-boundary, nested-bytecode, bytecode-symlink, bytecode-special, special-object, hook-bytecode-prevention, historical-restore]
+    cases: [guardian-bytecode, guardian-boundary]
+  - path: skills/synthesis-skills-manager/scripts/release.py
+    cases: [bytecode-digest, special-object, refresh-bytecode, atomic-repair, symlink-write-through, repair-rollback, source-repair]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [release-contract]
+    cases: [release-contract, bytecode-digest, special-object, refresh-bytecode, atomic-repair, symlink-write-through, repair-rollback, source-repair]
 cases:
   - id: release-contract
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_runtime_bytecode_cache_release_contract_is_public_and_coherent
-    motivating_defect: a-patch-release-could-ship-disagreeing-version-documentation-or-bytecode-policy
-  - id: runtime-bytecode
+    motivating_defect: a-follow-on-release-could-ship-disagreeing-version-or-integrity-policy-documentation
+  - id: bytecode-digest
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_recovery_digest_ignores_client_metadata_but_rejects_unknown_extras
+    motivating_defect: the-publisher-could-reject-hook-generated-bytecode-or-hide-an-unknown-file
+  - id: guardian-bytecode
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_runtime_bytecode_does_not_invalidate_historical_source
-    motivating_defect: an-old-task-could-invalidate-its-own-preserved-root-by-running-a-python-hook
-  - id: bytecode-boundary
+    motivating_defect: the-canonical-policy-could-reject-cpython-final-or-atomic-write-bytecode
+  - id: guardian-boundary
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_bytecode_exception_does_not_hide_source_or_unknown_drift
-    motivating_defect: a-bytecode-exclusion-could-mask-source-loose-bytecode-or-unknown-file-drift
-  - id: bytecode-symlink
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_bytecode_exception_refuses_symlinked_cache_directory
-    motivating_defect: an-ignored-cache-directory-could-be-replaced-by-an-unsafe-link
-  - id: nested-bytecode
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_bytecode_exception_does_not_hide_nested_cache_directory
-    motivating_defect: a-generated-directory-exclusion-could-hide-an-unexpected-nested-directory
-  - id: bytecode-special
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_bytecode_exception_refuses_special_cache_entry
-    motivating_defect: an-ignored-bytecode-path-could-hide-a-non-file-object
+    motivating_defect: a-wider-temporary-bytecode-pattern-could-mask-source-or-unknown-files
   - id: special-object
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_tree_digest_refuses_unknown_special_object
-    motivating_defect: the-integrity-digest-could-silently-omit-an-unknown-special-object
-  - id: hook-bytecode-prevention
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_recovery_digest_rejects_special_objects
+    motivating_defect: the-shared-digest-adapter-could-erase-the-guardians-special-object-failure
+  - id: refresh-bytecode
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_shipped_python_hooks_disable_bytecode_writes
-    motivating_defect: shipped-python-hooks-could-continue-mutating-versioned-plugin-roots
-  - id: historical-restore
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_accepts_runtime_bytecode_change
+    motivating_defect: an-old-hook-could-change-bytecode-between-snapshot-and-restore-and-fail-the-release
+  - id: source-repair
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_restore_protects_history_but_never_installs_current
-    motivating_defect: the-bytecode-repair-could-regress-the-original-historical-root-restore-contract
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_repairs_if_existing_preserved_root_changes
+    motivating_defect: the-shared-bytecode-policy-could-stop-repairing-real-source-drift
+  - id: atomic-repair
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_atomically_replaces_unowned_extra
+    motivating_defect: copying-into-a-differing-root-could-leave-untrusted-entries-behind
+  - id: symlink-write-through
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_does_not_write_through_nested_symlink
+    motivating_defect: a-nested-destination-link-could-redirect-repair-writes-outside-the-cache
+  - id: repair-rollback
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_atomic_cache_repair_rolls_back_failed_verification
+    motivating_defect: a-failed-post-swap-verification-could-strand-the-original-root
   - id: acceptance-self
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -5,12 +5,22 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.6.1"
+  version: "2.6.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
 
 # Synthesis Skills Manager
+
+**Version 2.6.2** (2026-09-03) makes the publisher and the durable guardian
+consume one canonical integrity policy. The release snapshot and quiet-window
+verifier now tolerate the same narrowly bounded runtime bytecode as the
+guardian, so an older task can keep invoking its hook throughout a refresh
+without invalidating its preserved root. That boundary includes CPython's
+numeric-suffixed atomic-write files. A differing historical root is replaced
+as one directory instead of copying through untrusted entries, so a nested
+symlink or hard link cannot redirect repair writes outside the cache. All other
+source and filesystem-type checks remain fail-closed.
 
 **Version 2.6.1** (2026-09-03) keeps historical-cache integrity scoped to
 release source even while an older running task executes Python hooks from its

--- a/skills/synthesis-skills-manager/scripts/cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/cache_guardian.py
@@ -23,6 +23,7 @@ import os
 import plistlib
 import re
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -41,6 +42,7 @@ HOOK_PLUGIN_PATH_RE = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\s\"']+)")
 IGNORED_ROOTS = frozenset({".git", ".in_use", ".codex-marketplace-install.json"})
 BYTECODE_CACHE_DIRECTORY = "__pycache__"
 BYTECODE_SUFFIXES = frozenset({".pyc", ".pyo"})
+BYTECODE_TEMP_RE = re.compile(r"^.+\.py[co]\.[0-9]+$")
 DEFAULT_INTERVAL_SECONDS = 1.0
 ERROR_RETRY_SECONDS = 10.0
 EX_TEMPFAIL = 75
@@ -107,12 +109,17 @@ def _is_ignorable_bytecode(path: Path, relative_path: Path) -> bool:
                 f"unsafe Python bytecode cache directory: {relative_path}"
             )
         return True
-    if (
-        relative_path.parent.name == BYTECODE_CACHE_DIRECTORY
-        and relative_path.parts.count(BYTECODE_CACHE_DIRECTORY) == 1
-        and relative_path.suffix in BYTECODE_SUFFIXES
-    ):
-        if path.is_symlink() or not path.is_file():
+    if relative_path.parent.name == BYTECODE_CACHE_DIRECTORY and (
+        relative_path.suffix in BYTECODE_SUFFIXES
+        or BYTECODE_TEMP_RE.fullmatch(relative_path.name) is not None
+    ) and relative_path.parts.count(BYTECODE_CACHE_DIRECTORY) == 1:
+        try:
+            mode = path.lstat().st_mode
+        except FileNotFoundError:
+            # CPython atomically replaces its numeric-suffixed temporary file;
+            # disappearance between rglob and lstat is that expected boundary.
+            return True
+        if not stat.S_ISREG(mode):
             raise GuardianError(f"unsafe Python bytecode cache entry: {relative_path}")
         return True
     return False

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -75,6 +75,8 @@ except ImportError:  # pragma: no cover - resolved at runtime in the repo
         return shutil.which(name)
 
 from bootstrap import materialize_release
+from cache_guardian import GuardianError as CacheGuardianError
+from cache_guardian import _tree_digest as _guardian_tree_digest
 from system_contract import ContractError, activate_cli, atomic_write_json
 
 
@@ -108,9 +110,6 @@ DEFAULT_COORDINATION_BOARD = (
 )
 DEFAULT_ACTIVE_PROJECT_POINTER = Path.home() / ".synthesis" / "active-project.json"
 HOOK_PLUGIN_PATH_RE = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\s\"']+)")
-RECOVERY_DIGEST_IGNORED_ROOTS = frozenset(
-    {".git", ".in_use", ".codex-marketplace-install.json"}
-)
 CODEX_CACHE_ARCHIVE_BUDGET_BYTES = 512 * 1024 * 1024
 CODEX_CACHE_QUIET_SECONDS = 10.0
 CODEX_CACHE_SETTLE_TIMEOUT_SECONDS = 60.0
@@ -571,23 +570,11 @@ def refresh_stable_path(
 
 
 def _tree_digest(root: Path) -> str:
-    """Hash recovery-owned paths and bytes, excluding client-managed metadata."""
-    digest = hashlib.sha256()
-    for path in sorted(root.rglob("*"), key=lambda item: str(item.relative_to(root))):
-        relative_path = path.relative_to(root)
-        if (
-            relative_path.parts
-            and relative_path.parts[0] in RECOVERY_DIGEST_IGNORED_ROOTS
-        ):
-            continue
-        relative = str(relative_path).encode("utf-8")
-        if path.is_symlink():
-            digest.update(b"L\0" + relative + b"\0" + os.readlink(path).encode("utf-8"))
-        elif path.is_dir():
-            digest.update(b"D\0" + relative)
-        elif path.is_file():
-            digest.update(b"F\0" + relative + b"\0" + path.read_bytes())
-    return digest.hexdigest()
+    """Use the guardian's one canonical historical-root integrity policy."""
+    try:
+        return _guardian_tree_digest(root)
+    except CacheGuardianError as exc:
+        raise OSError(str(exc)) from exc
 
 
 def codex_cache_archive() -> Path:
@@ -941,6 +928,57 @@ def _remove_transition_backup(backup: Path) -> None:
     shutil.rmtree(resolved)
 
 
+def _remove_cache_transition_tree(path: Path, parent: Path, prefix: str) -> None:
+    if not path.exists() and not path.is_symlink():
+        return
+    if path.parent != parent or not path.name.startswith(prefix) or path.is_symlink():
+        raise OSError(f"refusing unsafe cache-transition cleanup target: {path}")
+    shutil.rmtree(path)
+
+
+def _replace_cache_root(source: Path, destination: Path, parent: Path) -> None:
+    """Replace a differing root without following any destination entry."""
+    if destination.parent != parent or parent.is_symlink():
+        raise OSError(f"refusing unsafe cache-repair boundary: {destination}")
+    staging_prefix = f".release-repair-{destination.name}-"
+    displaced_prefix = f".release-displaced-{destination.name}-"
+    nonce = f"{os.getpid()}-{time.time_ns()}"
+    staging = parent / f"{staging_prefix}{nonce}"
+    displaced = parent / f"{displaced_prefix}{nonce}"
+    moved = False
+    installed = False
+    try:
+        shutil.copytree(source, staging, symlinks=True)
+        if _tree_digest(source) != _tree_digest(staging):
+            raise OSError(f"staged repair differs from snapshot: {source}")
+        if destination.is_symlink() or not destination.is_dir():
+            raise OSError(f"version root has an unsafe type: {destination}")
+        os.rename(destination, displaced)
+        moved = True
+        os.rename(staging, destination)
+        installed = True
+        if _tree_digest(source) != _tree_digest(destination):
+            raise OSError(f"atomically repaired root differs from snapshot: {destination}")
+    except OSError as exc:
+        rollback_error: OSError | None = None
+        if moved:
+            try:
+                if installed and (destination.exists() or destination.is_symlink()):
+                    os.rename(destination, staging)
+                if displaced.exists() or displaced.is_symlink():
+                    os.rename(displaced, destination)
+            except OSError as rollback_exc:
+                rollback_error = rollback_exc
+        if rollback_error is not None:
+            raise OSError(
+                f"cache-root repair failed ({exc}); rollback failed ({rollback_error})"
+            ) from exc
+        raise
+    finally:
+        _remove_cache_transition_tree(staging, parent, staging_prefix)
+    _remove_cache_transition_tree(displaced, parent, displaced_prefix)
+
+
 def _restore_codex_caches_once(
     snapshot: CodexCacheSnapshot,
 ) -> tuple[set[str], set[str]]:
@@ -960,7 +998,7 @@ def _restore_codex_caches_once(
         elif not destination.is_dir():
             raise OSError(f"version root is not a directory: {destination}")
         elif _tree_digest(source) != _tree_digest(destination):
-            shutil.copytree(source, destination, dirs_exist_ok=True, symlinks=True)
+            _replace_cache_root(source, destination, parent)
             repaired.add(version)
         if _tree_digest(source) != _tree_digest(destination):
             raise OSError(f"version root changed during refresh: {destination}")

--- a/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
@@ -132,11 +132,14 @@ def test_runtime_bytecode_does_not_invalidate_historical_source(
     )
     target.parent.mkdir()
     target.write_bytes(b"runtime bytecode\n")
+    temporary = target.with_name(f"{target.name}.123456789")
+    temporary.write_bytes(b"CPython atomic-write staging\n")
 
     record = guardian.restore_once(home)
 
     assert record["verified"] == 1
     assert target.read_bytes() == b"runtime bytecode\n"
+    assert temporary.read_bytes() == b"CPython atomic-write staging\n"
 
 
 @pytest.mark.parametrize(
@@ -145,6 +148,8 @@ def test_runtime_bytecode_does_not_invalidate_historical_source(
         ("skills/synthesis-autopilot/scripts/autopilot_gate.py", "changed source\n"),
         ("skills/synthesis-autopilot/scripts/autopilot_gate.pyc", "loose bytecode\n"),
         ("skills/synthesis-autopilot/scripts/__pycache__/unexpected.txt", "unknown\n"),
+        ("skills/synthesis-autopilot/scripts/__pycache__/hook.pyc.tmp", "unknown\n"),
+        ("skills/synthesis-autopilot/scripts/__pycache__/hook.pyc.notdigits", "unknown\n"),
     ],
 )
 def test_bytecode_exception_does_not_hide_source_or_unknown_drift(

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -794,11 +794,12 @@ def test_runtime_bytecode_cache_release_contract_is_public_and_coherent() -> Non
         and hook.get("command", "").startswith("python3 ")
     ]
 
-    assert release.source_version(repository)[0] == "4.91.2"
-    assert release.changelog_top_version(repository) == "4.91.2"
-    assert "Version 2.6.1" in manager and "__pycache__" in manager
+    assert release.source_version(repository)[0] == "4.91.3"
+    assert release.changelog_top_version(repository) == "4.91.3"
+    assert "Version 2.6.2" in manager and "__pycache__" in manager
+    assert "publisher" in manager and "one canonical integrity policy" in manager
     assert "running older tasks" in readme
-    assert "## [4.91.2]" in changelog
+    assert "## [4.91.3]" in changelog
     assert commands and all(command.startswith("python3 -B ") for command in commands)
 
 
@@ -1037,11 +1038,27 @@ def test_recovery_digest_ignores_client_metadata_but_rejects_unknown_extras(
     (installed / ".codex-marketplace-install.json").write_text(
         '{"revision":"fixture"}\n', encoding="utf-8"
     )
+    bytecode = installed / "skills/example/__pycache__/hook.cpython-312.pyc"
+    bytecode.parent.mkdir()
+    bytecode.write_bytes(b"first runtime bytecode\n")
+    temporary = bytecode.with_name(f"{bytecode.name}.123456789")
+    temporary.write_bytes(b"CPython atomic-write staging\n")
 
+    assert release._tree_digest(expected) == release._tree_digest(installed)
+    bytecode.write_bytes(b"changed while the release ran\n")
     assert release._tree_digest(expected) == release._tree_digest(installed)
 
     (installed / "unexpected").write_text("unowned\n", encoding="utf-8")
     assert release._tree_digest(expected) != release._tree_digest(installed)
+
+
+def test_recovery_digest_rejects_special_objects(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    os.mkfifo(root / "unexpected.pipe")
+
+    with pytest.raises(OSError, match="unsupported cache entry type"):
+        release._tree_digest(root)
 
 
 # --- install sequencing ----------------------------------------------------
@@ -1480,7 +1497,39 @@ def test_codex_refresh_repairs_if_existing_preserved_root_changes(
     assert "repaired 1" in restore.detail
 
 
-def test_codex_refresh_fails_if_unowned_extra_survives_repair(
+def test_codex_refresh_accepts_runtime_bytecode_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_parent = tmp_path / "codex-cache"
+    old_root = cache_parent / "4.74.0"
+    old_root.mkdir(parents=True)
+    (old_root / "owned").write_text("before\n", encoding="utf-8")
+    bytecode = old_root / "skills/example/__pycache__/hook.cpython-312.pyc"
+    bytecode.parent.mkdir(parents=True)
+    bytecode.write_bytes(b"before runtime\n")
+
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(release, "resolve_client_binary", lambda name: "/fake/codex")
+
+    def run(command, **_kwargs):
+        if command[1:3] == ["plugin", "add"]:
+            temporary = bytecode.with_name(f"{bytecode.name}.123456789")
+            temporary.write_bytes(b"CPython atomic-write staging\n")
+            bytecode.write_bytes(b"changed during refresh\n")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(release, "run", run)
+    result = release.Result()
+
+    assert release.refresh_client("codex", result, dry_run=False) is True
+    restore = next(
+        step for step in result.steps if step.name == "install.codex.cache-restore"
+    )
+    assert restore.ok is True
+    assert bytecode.read_bytes() == b"changed during refresh\n"
+
+
+def test_codex_refresh_atomically_replaces_unowned_extra(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     cache_parent = tmp_path / "codex-cache"
@@ -1498,12 +1547,60 @@ def test_codex_refresh_fails_if_unowned_extra_survives_repair(
 
     monkeypatch.setattr(release, "run", run)
     result = release.Result()
-    assert release.refresh_client("codex", result, dry_run=False) is False
+    assert release.refresh_client("codex", result, dry_run=False) is True
     restore = next(
         step for step in result.steps if step.name == "install.codex.cache-restore"
     )
-    assert restore.ok is False
-    assert "recovery copy kept" in restore.detail
+    assert restore.ok is True
+    assert not (old_root / "unexpected").exists()
+
+
+def test_codex_refresh_does_not_write_through_nested_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cache_parent = tmp_path / "codex-cache"
+    old_root = cache_parent / "4.74.0"
+    package = old_root / "pkg"
+    package.mkdir(parents=True)
+    outside = tmp_path / "outside.py"
+    outside.write_text("outside sentinel\n", encoding="utf-8")
+    (package / "module.py").symlink_to(outside)
+    backup = tmp_path / "synthesis-codex-cache-fixture"
+    trusted = backup / "4.74.0" / "pkg/module.py"
+    trusted.parent.mkdir(parents=True)
+    trusted.write_text("trusted source\n", encoding="utf-8")
+    snapshot = release.CodexCacheSnapshot(backup, ("4.74.0",))
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache_parent)
+    monkeypatch.setattr(
+        release, "_remove_transition_backup", lambda path: shutil.rmtree(path)
+    )
+    result = release.Result()
+
+    assert release.restore_codex_caches(snapshot, result)
+    assert outside.read_text(encoding="utf-8") == "outside sentinel\n"
+    repaired = old_root / "pkg/module.py"
+    assert repaired.is_file() and not repaired.is_symlink()
+    assert repaired.read_text(encoding="utf-8") == "trusted source\n"
+
+
+def test_atomic_cache_repair_rolls_back_failed_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    parent = tmp_path / "cache"
+    source = tmp_path / "snapshot" / "4.74.0"
+    destination = parent / "4.74.0"
+    source.mkdir(parents=True)
+    destination.mkdir(parents=True)
+    (source / "marker").write_text("trusted\n", encoding="utf-8")
+    (destination / "marker").write_text("original\n", encoding="utf-8")
+    digests = iter(("staged", "staged", "source", "changed"))
+    monkeypatch.setattr(release, "_tree_digest", lambda _path: next(digests))
+
+    with pytest.raises(OSError, match="atomically repaired root differs"):
+        release._replace_cache_root(source, destination, parent)
+
+    assert (destination / "marker").read_text(encoding="utf-8") == "original\n"
+    assert not list(parent.glob(".release-*-4.74.0-*"))
 
 
 def test_codex_refresh_does_not_run_when_cache_snapshot_fails(


### PR DESCRIPTION
## Summary

- make the publisher and cache guardian use one canonical tree-integrity policy
- permit only recognized CPython bytecode artifacts inside a single cache directory while rejecting source, unknown, nested, linked, and special objects
- replace divergent cache roots by verified directory swap with rollback, preventing writes through untrusted destination links
- run Python lifecycle hooks without persistent bytecode writes

## Verification

- gated release preflight: PASS
- manager and release tests: 113 passed
- closed acceptance manifest: 11 cases passed
- independent adversarial review: PASS