### PR TITLE
Serialize synchronous cache verification

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.91.3",
+  "version": "4.91.4",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.91.3",
+  "version": "4.91.4",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.91.4] - 2026-09-03
+
+**A synchronous update no longer mistakes ordinary background guardian work
+for an active release transition.** `cache_guardian.py --doctor` now waits up
+to 120 seconds for the shared transition lock, which covers a complete
+budgeted historical-root restore and serializes the onboarding
+completion check behind a guardian pass already in progress. The continuous
+watcher and explicit `--once` mode remain nonblocking, so background work never
+queues. Persistent publisher contention still fails closed with exit 75 after
+the bounded wait, and historical-root verification is unchanged.
+
 ## [4.91.3] - 2026-09-03
 
 **The release snapshot and the durable guardian now apply one historical-root

--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **One bootstrap now installs and manages the complete public system (September
-2026).** Releases **4.91.0** through **4.91.3** add the stable `synthesis` CLI,
+2026).** Releases **4.91.0** through **4.91.4** add the stable `synthesis` CLI,
 immutable release resolution, full and skills-only profiles, tracked dual-client workspace
 instructions, declarative organization enrollment, transactional desired and
 observed state, six-plane doctor results, and public outcome verification.
 Updates remain explicit. The release gate activates the same content-addressed
 generation that both clients verified. Existing plugin-only installations enter
 that lifecycle without another setup interview, and running older tasks cannot
-invalidate preserved roots merely by creating Python bytecode. See the [4.91.3 release
-notes](CHANGELOG.md).
+invalidate preserved roots merely by creating Python bytecode. The synchronous
+post-update cache check waits through an
+ordinary background guardian pass, while persistent lock contention remains a
+bounded failure. See the [4.91.4 release notes](CHANGELOG.md).
 
 **Peer sessions are addressed by resolver-issued receipts, never by name
 (September 2026).** Releases **4.90.0** through **4.90.3** gate every direct session-to-session

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,17 +1,17 @@
-# AGENT HEURISTIC: closed acceptance universe for the 4.91.3 release-snapshot repair.
+# AGENT HEURISTIC: closed acceptance universe for the 4.91.4 guardian-lock repair.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: synthesis-release-snapshot-bytecode-integrity
+suite: synthesis-cache-guardian-lock-reliability
 membership: closed
-production_entry_point: release.py -> cache_guardian._tree_digest -> preserved Codex plugin roots
+production_entry_point: synthesis update -> onboard.synchronize_codex_history -> cache_guardian --doctor -> shared transition lock
 enforcing_boundary: release.py consumes this transaction-bound closed manifest before publishing the immutable release, installing both clients, and activating the public CLI
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the live old-task update race is verified by the gated publisher after this source acceptance boundary
+unverified_remainder: the real installed update is verified after the gated publisher activates this release
 changed_surfaces:
   - path: .claude-plugin/plugin.json
     cases: [release-contract]
@@ -26,54 +26,24 @@ changed_surfaces:
   - path: skills/synthesis-skills-manager/SKILL.md
     cases: [release-contract]
   - path: skills/synthesis-skills-manager/scripts/cache_guardian.py
-    cases: [guardian-bytecode, guardian-boundary]
+    cases: [guardian-lock-policy, guardian-lock-timeout]
   - path: skills/synthesis-skills-manager/scripts/test_cache_guardian.py
-    cases: [guardian-bytecode, guardian-boundary]
-  - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [bytecode-digest, special-object, refresh-bytecode, atomic-repair, symlink-write-through, repair-rollback, source-repair]
+    cases: [guardian-lock-policy, guardian-lock-timeout]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [release-contract, bytecode-digest, special-object, refresh-bytecode, atomic-repair, symlink-write-through, repair-rollback, source-repair]
+    cases: [release-contract]
 cases:
   - id: release-contract
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_runtime_bytecode_cache_release_contract_is_public_and_coherent
-    motivating_defect: a-follow-on-release-could-ship-disagreeing-version-or-integrity-policy-documentation
-  - id: bytecode-digest
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_cache_guardian_lock_release_contract_is_public_and_coherent
+    motivating_defect: a-follow-on-release-could-ship-disagreeing-version-or-lock-policy-documentation
+  - id: guardian-lock-policy
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_recovery_digest_ignores_client_metadata_but_rejects_unknown_extras
-    motivating_defect: the-publisher-could-reject-hook-generated-bytecode-or-hide-an-unknown-file
-  - id: guardian-bytecode
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_doctor_waits_for_background_guardian_but_once_remains_nonblocking
+    motivating_defect: a-synchronous-update-could-fail-when-ordinary-background-guardian-work-owned-the-lock
+  - id: guardian-lock-timeout
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_runtime_bytecode_does_not_invalidate_historical_source
-    motivating_defect: the-canonical-policy-could-reject-cpython-final-or-atomic-write-bytecode
-  - id: guardian-boundary
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_bytecode_exception_does_not_hide_source_or_unknown_drift
-    motivating_defect: a-wider-temporary-bytecode-pattern-could-mask-source-or-unknown-files
-  - id: special-object
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_recovery_digest_rejects_special_objects
-    motivating_defect: the-shared-digest-adapter-could-erase-the-guardians-special-object-failure
-  - id: refresh-bytecode
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_accepts_runtime_bytecode_change
-    motivating_defect: an-old-hook-could-change-bytecode-between-snapshot-and-restore-and-fail-the-release
-  - id: source-repair
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_repairs_if_existing_preserved_root_changes
-    motivating_defect: the-shared-bytecode-policy-could-stop-repairing-real-source-drift
-  - id: atomic-repair
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_atomically_replaces_unowned_extra
-    motivating_defect: copying-into-a-differing-root-could-leave-untrusted-entries-behind
-  - id: symlink-write-through
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_codex_refresh_does_not_write_through_nested_symlink
-    motivating_defect: a-nested-destination-link-could-redirect-repair-writes-outside-the-cache
-  - id: repair-rollback
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_atomic_cache_repair_rolls_back_failed_verification
-    motivating_defect: a-failed-post-swap-verification-could-strand-the-original-root
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_blocking_cache_lock_wait_is_bounded
+    motivating_defect: a-real-release-transition-could-make-a-synchronous-doctor-wait-without-a-bound
   - id: acceptance-self
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -5,12 +5,20 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.6.2"
+  version: "2.6.3"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
 
 # Synthesis Skills Manager
+
+**Version 2.6.3** (2026-09-03) makes synchronous historical-cache verification
+wait up to 120 seconds for the shared transition lock. This covers a complete
+budgeted historical-root restore and serializes an
+onboarding completion check behind an ordinary background guardian pass instead
+of reporting a false release collision. Watch and `--once` work remain
+nonblocking; persistent publisher contention still fails closed after the
+bounded wait.
 
 **Version 2.6.2** (2026-09-03) makes the publisher and the durable guardian
 consume one canonical integrity policy. The release snapshot and quiet-window
@@ -338,8 +346,11 @@ The sequence, each stage gating the next:
   preceding version is available before older roots during a large recovery.
   The onboarding engine invokes the installed guardian synchronously after a
   Codex refresh and refuses to report success until the invoking task's exact
-  version root and hook targets are present. The watcher continues protecting
-  those roots against later reconciliation after either command exits.
+  version root and hook targets are present. That synchronous doctor waits up
+  to 120 seconds for a guardian pass already holding the transition lock; the
+  watcher and explicit one-shot mode stay nonblocking. The watcher continues
+  protecting those roots against later reconciliation after either command
+  exits.
   The archive has a 512 MiB hard budget and never deletes a historical root
   automatically when that budget is reached; unverifiable cleanup fails the
   release closed. Symlink recovery artifacts and client liveness markers are not

--- a/skills/synthesis-skills-manager/scripts/cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/cache_guardian.py
@@ -45,6 +45,8 @@ BYTECODE_SUFFIXES = frozenset({".pyc", ".pyo"})
 BYTECODE_TEMP_RE = re.compile(r"^.+\.py[co]\.[0-9]+$")
 DEFAULT_INTERVAL_SECONDS = 1.0
 ERROR_RETRY_SECONDS = 10.0
+LOCK_WAIT_TIMEOUT_SECONDS = 120.0
+LOCK_WAIT_INTERVAL_SECONDS = 0.1
 EX_TEMPFAIL = 75
 
 
@@ -53,7 +55,7 @@ class GuardianError(RuntimeError):
 
 
 class GuardianBusy(GuardianError):
-    """The release transition currently owns the shared cache lock."""
+    """Another cache transition currently owns the shared cache lock."""
 
 
 def archive_root(home: Path) -> Path:
@@ -231,16 +233,29 @@ def _cache_lock(home: Path, *, blocking: bool) -> Iterator[None]:
         flags |= os.O_NOFOLLOW
     descriptor = os.open(path, flags, 0o600)
     handle = os.fdopen(descriptor, "a+")
-    operation = fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB)
+    deadline = time.monotonic() + LOCK_WAIT_TIMEOUT_SECONDS if blocking else None
+    acquired = False
     try:
-        try:
-            fcntl.flock(handle.fileno(), operation)
-        except (BlockingIOError, OSError) as exc:
-            raise GuardianBusy("release transition owns the cache lock") from exc
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except BlockingIOError as exc:
+                if deadline is None:
+                    raise GuardianBusy("another cache transition owns the cache lock") from exc
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise GuardianBusy(
+                        "another cache transition held the cache lock for more than "
+                        f"{LOCK_WAIT_TIMEOUT_SECONDS:g} seconds"
+                    ) from exc
+                time.sleep(min(LOCK_WAIT_INTERVAL_SECONDS, remaining))
         yield
     finally:
         try:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            if acquired:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         finally:
             handle.close()
 
@@ -454,7 +469,11 @@ def main(argv: list[str] | None = None) -> int:
     modes.add_argument("--once", action="store_true", help="restore and verify historical roots once")
     modes.add_argument("--watch", action="store_true", help="continuously guard later cache generations")
     modes.add_argument("--install", action="store_true", help="install and start the durable user supervisor")
-    modes.add_argument("--doctor", action="store_true", help="restore once and verify the durable runtime exists")
+    modes.add_argument(
+        "--doctor",
+        action="store_true",
+        help="wait for the cache transition lock, restore once, and verify the durable runtime exists",
+    )
     parser.add_argument("--interval", type=float, default=DEFAULT_INTERVAL_SECONDS)
     args = parser.parse_args(argv)
     try:
@@ -464,7 +483,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.install:
             record = install()
         else:
-            record = restore_once()
+            # A synchronous doctor is a completion gate for onboarding. It
+            # waits through ordinary watcher work instead of turning normal
+            # lock contention into a false update failure. ``--once`` and the
+            # watcher remain nonblocking so background work never queues.
+            record = restore_once(blocking=args.doctor)
             if args.doctor:
                 runtime = runtime_path(Path.home())
                 if not runtime.is_file() or runtime.is_symlink():

--- a/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
@@ -7,6 +7,8 @@ import os
 import plistlib
 import shutil
 import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -257,6 +259,67 @@ def test_release_lock_defers_guardian_without_writing(tmp_path: Path) -> None:
         fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         handle.close()
     assert not guardian.cache_parent(home).exists()
+
+
+def test_doctor_waits_for_background_guardian_but_once_remains_nonblocking(
+    tmp_path: Path,
+) -> None:
+    home = seeded_home(tmp_path)
+    runtime = guardian.runtime_path(home)
+    runtime.parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_text("guardian\n", encoding="utf-8")
+    path = guardian.lock_path(home)
+    handle = path.open("a+")
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    try:
+        once = subprocess.run(
+            [sys.executable, str(SCRIPT), "--once"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=env,
+            check=False,
+        )
+        assert once.returncode == guardian.EX_TEMPFAIL
+
+        doctor = subprocess.Popen(
+            [sys.executable, str(SCRIPT), "--doctor"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+        time.sleep(0.1)
+        assert doctor.poll() is None
+    finally:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+
+    stdout, stderr = doctor.communicate(timeout=5)
+    assert doctor.returncode == 0, stdout + stderr
+    assert json.loads(stdout)["verified"] == 1
+
+
+def test_blocking_cache_lock_wait_is_bounded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = seeded_home(tmp_path)
+    path = guardian.lock_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = path.open("a+")
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    moments = iter((10.0, 131.0))
+    monkeypatch.setattr(guardian.time, "monotonic", lambda: next(moments))
+    try:
+        with pytest.raises(guardian.GuardianBusy, match="more than 120 seconds"):
+            with guardian._cache_lock(home, blocking=True):
+                pytest.fail("contended lock was acquired")
+    finally:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
 
 
 def test_launchd_definition_is_persistent_and_runs_stable_runtime(tmp_path: Path) -> None:

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -775,7 +775,7 @@ def test_delayed_cache_guardian_release_contract_is_public_and_coherent() -> Non
     assert "## [4.77.1]" in changelog
 
 
-def test_runtime_bytecode_cache_release_contract_is_public_and_coherent() -> None:
+def test_cache_guardian_lock_release_contract_is_public_and_coherent() -> None:
     repository = Path(__file__).resolve().parents[3]
     manager = (repository / "skills/synthesis-skills-manager/SKILL.md").read_text(
         encoding="utf-8"
@@ -794,12 +794,12 @@ def test_runtime_bytecode_cache_release_contract_is_public_and_coherent() -> Non
         and hook.get("command", "").startswith("python3 ")
     ]
 
-    assert release.source_version(repository)[0] == "4.91.3"
-    assert release.changelog_top_version(repository) == "4.91.3"
-    assert "Version 2.6.2" in manager and "__pycache__" in manager
-    assert "publisher" in manager and "one canonical integrity policy" in manager
-    assert "running older tasks" in readme
-    assert "## [4.91.3]" in changelog
+    assert release.source_version(repository)[0] == "4.91.4"
+    assert release.changelog_top_version(repository) == "4.91.4"
+    assert "Version 2.6.3" in manager and "wait up to 120 seconds" in manager
+    assert "watcher and explicit one-shot mode stay nonblocking" in manager
+    assert "bounded failure" in readme
+    assert "## [4.91.4]" in changelog
     assert commands and all(command.startswith("python3 -B ") for command in commands)
 
 


### PR DESCRIPTION
A synchronous post-update cache check could collide with the background guardian and return exit 75 even though no release transition remained active.

This change gives doctor mode a bounded 120-second lock wait, keeps watcher and explicit one-shot work nonblocking, and retains exit 75 when contention outlives the bound. The wait covers a complete budgeted historical-root restore.

Verification:
- the subprocess regression failed against 4.91.3 and passes with this change
- lock-timeout and nonblocking controls pass
- manager, onboarding, conformance, instruction, scaffold, capability, acceptance, and repository verification suites pass
- the 4.90.3 peer-addressing source paths are unchanged