### PR TITLE
Add causal project-state recovery

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.91.4",
+  "version": "4.92.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.91.4",
+  "version": "4.92.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.92.0] - 2026-09-03
+
+**A named project now resolves from the newest provable coherent state instead
+of whichever checkout a task remembered.** The recovery engine inventories
+canonical and isolated worktrees, refs, attributed dirty files, lifecycle
+manifests and receipts, pointers, and active claims. Equality and ancestry can
+select a winner; divergence is `CONFLICT`, failed evidence is `UNKNOWN`, and a
+safe canonical fast-forward requires clean tracked/index state plus an
+untracked-collision proof.
+
+Mature projects can now make mutable operational state structured and compile
+the bounded human-readable block from it. The context doctor detects semantic
+release contradictions and exact one-day staleness. Stop binds a clean handoff
+receipt to the active session, project, claim, Git identity, durable hashes,
+and source heads, while interrupted work remains recoverable from automatic
+manifests. Autonomous engagement records are likewise session- and
+project-bound, so unrelated work can never become a global Stop blocker.
+
 ## [4.91.4] - 2026-09-03
 
 **A synchronous update no longer mistakes ordinary background guardian work

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Project recovery now follows evidence across checkouts instead of trusting a
+remembered path (September 2026).** Release **4.92.0** adds causal discovery
+across worktrees, refs, attributed interruptions, lifecycle receipts, pointers,
+and claims; structured operational state with a compiled context block;
+semantic freshness checks; and session-bound Stop receipts. Divergence and
+unreadable evidence stay explicit, safe fast-forwarding cannot overwrite
+unrelated work, and one project's autonomous lifecycle can no longer block an
+unrelated session. See the [4.92.0 release notes](CHANGELOG.md).
+
 **One bootstrap now installs and manages the complete public system (September
 2026).** Releases **4.91.0** through **4.91.4** add the stable `synthesis` CLI,
 immutable release resolution, full and skills-only profiles, tracked dual-client workspace

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -55,6 +55,12 @@
             "command": "python3 -B ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-autopilot/scripts/autopilot_gate.py --gate",
             "timeout": 15,
             "statusMessage": "Checking autopilot engagements for a continuation"
+          },
+          {
+            "type": "command",
+            "command": "python3 -B ${CLAUDE_PLUGIN_ROOT}/skills/synthesis-project-management/scripts/project_state.py hook",
+            "timeout": 30,
+            "statusMessage": "Binding durable project state to this lifecycle event"
           }
         ]
       }

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.8.0"
+  version: "1.9.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -139,6 +139,14 @@ no pending manifest and complete branch-head equality with the fetched upstream,
 not merely equality for commits touching the project subdirectory. Then open
 the project in the other client and confirm its SessionStart or first
 named-project turn recovers the same state.
+
+The continuity plane also runs causal project-state recovery. It enumerates
+every registered worktree and ref plus attributed manifests, receipts, pointer,
+and claims; selects only by equality or ancestry; and reports `CONFLICT` or
+`UNKNOWN` separately from a successful local recovery. Source, installed,
+live, continuity, and capability verdicts remain independent—a matching cache
+cannot compensate for a stale loaded registry, and an unavailable remote
+cannot become a green continuity result.
 
 ### 5. Close the loop
 

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -63,6 +63,7 @@ from live_receipt import (
     transcript_binds_session,
 )
 from project_context import next_actions, record_freshness
+from project_state import resolve_project as resolve_durable_project
 from pointer_lock import locked_pointer
 from coordination_schema import SCHEMA_VERSION as COORDINATION_SCHEMA_VERSION
 
@@ -1761,6 +1762,42 @@ def handoff_checks(
     return checks
 
 
+def project_state_recovery_checks(
+    project: Path,
+    coordination_board: Path = DEFAULT_COORDINATION_BOARD,
+) -> list[Check]:
+    """Report causal incoming recovery separately from other continuity gates."""
+    checks: list[Check] = []
+    index = project.parent / "index.yaml"
+    report = resolve_durable_project(
+        project.name,
+        index,
+        repo_guard_root=DEFAULT_REPO_GUARD_STATE,
+        checkpoint_receipt_root=(
+            Path.home() / ".synthesis" / "project-state" / "receipts"
+        ),
+        coordination_board=coordination_board if coordination_board.is_file() else None,
+        pointer=DEFAULT_ACTIVE_PROJECT,
+        fetch=True,
+        refresh_coordination=coordination_board.is_file(),
+    )
+    acceptable = report.status in {"PASS", "LOCAL_RECOVERABLE"}
+    detail = (
+        f"{report.status}: head={report.selected_head or 'none'}; "
+        f"path={report.selected_path or 'ref-only'}"
+    )
+    if report.issues:
+        detail += "; " + "; ".join(report.issues)
+    add(
+        checks,
+        "continuity.project-state-recovery",
+        acceptable,
+        detail,
+        outcome=report.status,
+    )
+    return checks
+
+
 def stopped_payload_parity(
     project: Path,
     summary: dict[str, object],
@@ -2436,6 +2473,12 @@ def main() -> int:
     elif args.command == "all":
         checks.extend(
             coordination_checks(args.coordination_board.expanduser(), required=False)
+        )
+    if args.command in {"pointer", "handoff", "continuity", "all"} and args.project:
+        checks.extend(
+            project_state_recovery_checks(
+                args.project.resolve(), args.coordination_board.expanduser()
+            )
         )
     if args.command == "activate":
         if not args.project:

--- a/skills/synthesis-agent-conformance/scripts/session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/session_context.py
@@ -44,6 +44,7 @@ if str(ONBOARDING_SCRIPTS_DIR) not in sys.path:
 
 from project_context import extract, next_actions, record_freshness
 from active_project import load_and_validate
+from project_state import STATE_FILE, resolve_project, semantic_issues
 from coordination_schema import display_id, parse_table_rows, row_identity
 from live_receipt import (
     claude_root_transcript_path,
@@ -365,12 +366,54 @@ def linked_plan(project: Path, context: str) -> Path | None:
     return project / match.group(1) if match else None
 
 
+def reconciled_project(project: Path) -> tuple[Path, list[str]]:
+    """Resolve a project across worktrees and refs before reading its prose."""
+    index = project.parent / "index.yaml"
+    if not index.is_file():
+        return project, []
+    synthesis_home = Path(os.environ.get("SYNTHESIS_HOME", str(Path.home() / ".synthesis")))
+    board = synthesis_home / "coordination" / "active-sessions.md"
+    pointer = synthesis_home / "active-project.json"
+    report = resolve_project(
+        project.name,
+        index,
+        repo_guard_root=synthesis_home / "repo-guard",
+        checkpoint_receipt_root=synthesis_home / "project-state" / "receipts",
+        coordination_board=board if board.is_file() else None,
+        pointer=pointer,
+        fetch=True,
+        fast_forward_canonical=True,
+        refresh_coordination=board.is_file(),
+    )
+    if report.status not in {"PASS", "LOCAL_RECOVERABLE"}:
+        raise ValueError(
+            f"project-state reconciliation is {report.status}: "
+            + "; ".join(report.issues)
+        )
+    if report.selected_path is None:
+        raise ValueError(
+            "newer project state is proven but has no safe readable worktree; "
+            f"selected head={report.selected_head} tree={report.selected_tree}"
+        )
+    return Path(report.selected_path), report.issues
+
+
 def append_project_context(lines: list[str], project: Path, *, label: str) -> None:
+    project, recovery_issues = reconciled_project(project)
     context_path = project / "CONTEXT.md"
     context = context_path.read_text(encoding="utf-8")
-    phase = extract(context, "Phase")
-    status = extract(context, "Status")
-    plan = linked_plan(project, context)
+    semantic = semantic_issues(project)
+    if semantic:
+        raise ValueError("semantic current-state failure: " + "; ".join(semantic))
+    state_path = project / STATE_FILE
+    state = json.loads(state_path.read_text(encoding="utf-8")) if state_path.is_file() else {}
+    phase = str(state.get("phase") or extract(context, "Phase"))
+    status = str(state.get("status") or extract(context, "Status"))
+    plan = (
+        project / str(state["controlling_plan"])
+        if state.get("controlling_plan")
+        else linked_plan(project, context)
+    )
     if plan is not None and not plan.is_file():
         raise FileNotFoundError(f"active plan is missing: {plan}")
     lines.extend(
@@ -384,7 +427,9 @@ def append_project_context(lines: list[str], project: Path, *, label: str) -> No
     fresh, freshness_detail = record_freshness(project)
     if not fresh:
         lines.append(f"RECORD STALENESS WARNING: {freshness_detail}.")
-    actions = next_actions(context)
+    for issue in recovery_issues:
+        lines.append(f"PROJECT RECOVERY NOTE: {issue}.")
+    actions = list(state.get("next_actions") or next_actions(context))
     if actions:
         lines.append("Recorded next actions:")
         lines.extend(f"- {action}" for action in actions)
@@ -426,7 +471,9 @@ def build(
         else:
             lines.append(
                 "Stopped-task recovery remains available: when the user names a "
-                "synthesis project, resolve it from the git-tracked projects/index.yaml "
+                "synthesis project, run the project-state resolver from the current "
+                "synthesis-project-management skill against the git-tracked "
+                "projects/index.yaml before reading any project prose "
                 "and run the Session Start Protocol automatically; never ask the user "
                 "to run a context-lifecycle command or save state manually. One "
                 "exception to automatic resolution: if the named project contradicts "

--- a/skills/synthesis-agent-conformance/scripts/test_session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/test_session_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 import time
 from datetime import datetime, timedelta, timezone
@@ -129,7 +130,8 @@ def test_build_without_pointer_explains_automatic_named_project_recovery(
     message = MODULE.build(tmp_path / "missing-pointer.json", tmp_path / "no-board.md")
 
     assert "No active synthesis project pointer is set." in message
-    assert "resolve it from the git-tracked projects/index.yaml" in message
+    assert "project-state resolver" in message
+    assert "projects/index.yaml" in message
     assert "never ask the user to run a context-lifecycle command" in message
 
 
@@ -181,6 +183,52 @@ def test_build_discovers_stopped_project_from_cwd(tmp_path: Path, monkeypatch) -
     assert "Current status: Active." in message
     assert f"Controlling plan: {plan}." in message
     assert "Resume from durable state" in message
+
+
+def test_stopped_project_recovery_reads_newer_isolated_worktree(tmp_path: Path, monkeypatch) -> None:
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True)
+    for key, value in (("user.email", "fixture@example.invalid"), ("user.name", "Fixture"), ("core.hooksPath", "/dev/null")):
+        subprocess.run(["git", "-C", str(repo), "config", key, value], check=True)
+    project = repo / "projects" / "alpha"
+    plan = project / "resources" / "artifacts" / "plan.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Plan\n", encoding="utf-8")
+    (project / "sessions").mkdir()
+    (project / "REFERENCE.md").write_text("# Reference\n", encoding="utf-8")
+    (project / "CONTEXT.md").write_text(
+        "# Alpha\n\n**Phase:** Older\n**Status:** Active\n"
+        "**Last session:** 2026-09-02\n\n"
+        "[plan](resources/artifacts/plan.md)\n\n"
+        "## What's Next\n\n- [ ] old action\n",
+        encoding="utf-8",
+    )
+    (repo / "projects" / "index.yaml").write_text(
+        "projects:\n  - id: alpha\n    status: active\n    last_session: '2026-09-02'\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "-C", str(repo), "add", "projects"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "initial"], check=True, capture_output=True)
+    newer = tmp_path / "newer"
+    subprocess.run(["git", "-C", str(repo), "worktree", "add", "-b", "feature/newer", str(newer)], check=True, capture_output=True)
+    newer_context = newer / "projects" / "alpha" / "CONTEXT.md"
+    newer_context.write_text(
+        newer_context.read_text(encoding="utf-8")
+        .replace("**Phase:** Older", "**Phase:** Newer")
+        .replace("old action", "new action"),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "-C", str(newer), "add", "projects/alpha/CONTEXT.md"], check=True)
+    subprocess.run(["git", "-C", str(newer), "commit", "-m", "advance"], check=True, capture_output=True)
+    monkeypatch.setattr(MODULE, "record_freshness", lambda path: (True, "current"))
+
+    lines: list[str] = []
+    MODULE.append_project_context(lines, project, label="Recovered project")
+    message = "\n".join(lines)
+
+    assert f"Recovered project: {newer / 'projects' / 'alpha'}." in message
+    assert "Current phase: Newer." in message
+    assert "new action" in message
 
 
 def test_build_rejects_incomplete_or_unleased_pointer(

--- a/skills/synthesis-autopilot/SKILL.md
+++ b/skills/synthesis-autopilot/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-thinking-framework", "synthesis-context-lifecycle", "synthesis-checkpoint", "synthesis-anti-shortcuts", "synthesis-grounding-discipline", "synthesis-implementation-integrity", "synthesis-project-management", "synthesis-adversarial-review", "synthesis-decision-packet"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.0.0"
+  version: "2.1.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -144,9 +144,12 @@ alerted blocker (`autopilot_gate.py blocker ... --alerted`) nor an honest
 close (`autopilot_gate.py close --goals-met | --incomplete <reason>`). The
 cycle ledger is mechanical too: `autopilot_gate.py cycle` refuses to record
 a wake that advanced nothing and names no external wait — there is no way
-to log a bare spin. An engagement abandoned by a dead session blocks the
-next session's stop BY DESIGN: abandonment must be loud, and the block
-message carries the honest close command.
+to log a bare spin. Registration binds the engagement to the active
+coordination-session UUID, project, exact claim, and native client-session
+reference. The Stop gate blocks only the owning session. It probes the board
+before reporting a foreign engagement's claim state, but foreign work—live,
+inactive, or unknown—never globally blocks an unrelated project or forces that
+session to adjudicate somebody else's completion.
 
 ## The Plan File
 

--- a/skills/synthesis-autopilot/scripts/autopilot_gate.py
+++ b/skills/synthesis-autopilot/scripts/autopilot_gate.py
@@ -21,9 +21,9 @@ unfinished is refused unless the agent has done one of three legal things:
      reason.
 
 All three outs are satisfiable by the agent alone, so the gate can fail
-closed without deadlocking a session. An abandoned engagement from an
-earlier session blocks later stops BY DESIGN — abandonment must be loud;
-the block message carries the exact command to close it out honestly.
+closed without deadlocking a session. An engagement is bound to its
+coordination seat, project, and client-session identity. A live or abandoned
+engagement owned by another session never blocks an unrelated session.
 
 Runaway control lives in `cycle`: recording a wake that advanced nothing
 requires a named external wait (`--waiting-on`). There is no way to record
@@ -50,12 +50,13 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
-ENGINE_VERSION = "1.0.0"
+ENGINE_VERSION = "1.1.0"
 
 
 def state_dir() -> Path:
@@ -97,19 +98,115 @@ def load_for_plan(plan: str) -> tuple[Path, dict]:
     return path, load(path)
 
 
+def _board_rows(path: Path) -> list[dict[str, str]]:
+    text = path.read_text(encoding="utf-8")
+    header = None
+    rows: list[dict[str, str]] = []
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if header is None and "session uuid" in {cell.lower() for cell in cells}:
+            header = [cell.lower() for cell in cells]
+            continue
+        if header is None or all(set(cell) <= {"-", ":"} for cell in cells):
+            continue
+        if len(cells) == len(header):
+            rows.append(dict(zip(header, cells)))
+    if header is None:
+        raise ValueError("coordination board has no active-session table")
+    return rows
+
+
+def _project_from_plan(plan: str) -> str:
+    parts = Path(plan).resolve().parts
+    if "projects" in parts:
+        index = len(parts) - 1 - list(reversed(parts)).index("projects")
+        if index + 1 < len(parts):
+            return parts[index + 1]
+    return ""
+
+
+def _registration_identity(plan: str) -> tuple[str, str, str, Path, dict[str, str]]:
+    session_id = (
+        os.environ.get("AUTOPILOT_GATE_SESSION_ID")
+        or os.environ.get("SYNTHESIS_COORDINATION_SESSION")
+        or ""
+    ).strip()
+    project_id = (
+        os.environ.get("AUTOPILOT_GATE_PROJECT_ID") or _project_from_plan(plan)
+    ).strip()
+    client_ref = os.environ.get("SYNTHESIS_CLIENT_SESSION_REF", "").strip()
+    board = Path(os.environ.get(
+        "AUTOPILOT_GATE_COORDINATION_BOARD",
+        os.path.expanduser("~/.synthesis/coordination/active-sessions.md"),
+    )).resolve()
+    if not session_id or not project_id or not client_ref:
+        raise ValueError(
+            "registration requires session, project, and client-session identity"
+        )
+    matches = [
+        row for row in _board_rows(board)
+        if row.get("session uuid") == session_id
+        and row.get("project") == project_id
+        and row.get("client session ref") == client_ref
+        and row.get("status", "").lower() == "active"
+    ]
+    if len(matches) != 1:
+        raise ValueError("registration requires exactly one matching active coordination claim")
+    plan_path = str(Path(plan).resolve())
+    row = matches[0]
+    coverage = row.get("claimed areas (advisory lock)", "") + " " + row.get("workspace(s) / branch", "")
+    project_root = str(Path(plan_path).parent.parent.parent)
+    roots = [
+        str(Path(token.strip().removesuffix("/**").removesuffix("/*")).resolve())
+        for token in re.split(r"(?:<br>|[,;\s]+)", coverage)
+        if token.strip().startswith("/")
+    ]
+    if plan_path not in coverage and project_root not in coverage and not any(
+        plan_path == root or plan_path.startswith(root.rstrip("/") + "/")
+        for root in roots
+    ):
+        raise ValueError("active coordination claim does not cover the autopilot plan")
+    return session_id, project_id, client_ref, board, row
+
+
 def cmd_register(plan: str, mission: str, horizon: str) -> int:
     if not mission.strip():
         print("register: --mission must describe what done means",
               file=sys.stderr)
         return 2
+    try:
+        session_id, project_id, client_ref, board, claim = _registration_identity(plan)
+    except (OSError, ValueError) as exc:
+        print(f"register: coordination claim binding failed: {exc}", file=sys.stderr)
+        return 2
     path = entry_path(plan)
     if path.exists() and load(path).get("status") == "active":
-        print(f"engagement already active for this plan: {path}")
+        data = load(path)
+        data.update({
+            "session_id": session_id,
+            "project_id": project_id,
+            "client_session_ref": client_ref,
+            "coordination_board": str(board),
+            "claim_hash": hashlib.sha256(
+                json.dumps(claim, sort_keys=True).encode()
+            ).hexdigest(),
+        })
+        save(path, data)
+        print(f"engagement binding refreshed for this plan: {path}")
         return 0
     save(path, {
         "plan": os.path.abspath(os.path.expanduser(plan)),
         "mission": mission.strip(),
         "horizon": horizon,
+        "session_id": session_id,
+        "project_id": project_id,
+        "client_session_ref": client_ref,
+        "coordination_board": str(board),
+        "claim_hash": hashlib.sha256(
+            json.dumps(claim, sort_keys=True).encode()
+        ).hexdigest(),
         "engaged_at": now_iso(),
         "status": "active",
         "goals_met": False,
@@ -203,11 +300,60 @@ def cmd_close(plan: str, goals_met: bool, incomplete: str | None) -> int:
     return 0
 
 
+def _caller_identity(payload: dict) -> tuple[set[str], str]:
+    identities = {
+        str(payload.get(key) or "").strip()
+        for key in ("session_id", "root_task_uuid", "task_id")
+    }
+    configured = os.environ.get("SYNTHESIS_CLIENT_SESSION_REF", "").strip()
+    if configured:
+        identities.add(configured)
+        identities.add(configured.rsplit(":", 1)[-1])
+    return {value for value in identities if value}, str(payload.get("cwd") or "")
+
+
+def _owned_by_caller(data: dict, identities: set[str], cwd: str) -> bool:
+    session_id = str(data.get("session_id") or "")
+    client_ref = str(data.get("client_session_ref") or "")
+    if session_id in identities or client_ref in identities:
+        return True
+    if client_ref and client_ref.rsplit(":", 1)[-1] in identities:
+        return True
+    plan = str(data.get("plan") or "")
+    return (
+        not session_id
+        and not client_ref
+        and bool(cwd)
+        and plan.startswith(str(Path(cwd).resolve()) + os.sep)
+    )
+
+
+def _foreign_claim_state(data: dict) -> str:
+    try:
+        board = Path(str(data.get("coordination_board") or ""))
+        session_id = str(data.get("session_id") or "")
+        project_id = str(data.get("project_id") or "")
+        if not board.is_file() or not session_id:
+            return "UNKNOWN"
+        rows = _board_rows(board)
+        return "ACTIVE" if any(
+            row.get("session uuid") == session_id
+            and row.get("project") == project_id
+            and row.get("status", "").lower() == "active"
+            for row in rows
+        ) else "INACTIVE"
+    except Exception:
+        return "UNKNOWN"
+
+
 def gate() -> int:
     try:
-        json.load(sys.stdin)  # payload read; content not needed for the rule
+        payload = json.load(sys.stdin)
+        if not isinstance(payload, dict):
+            payload = {}
     except Exception:
-        pass  # a stop gate must still evaluate registry state
+        payload = {}
+    identities, cwd = _caller_identity(payload)
     root = state_dir()
     if not root.is_dir():
         return 0
@@ -223,6 +369,15 @@ def gate() -> int:
             return 2
         if data.get("status") != "active" or data.get("goals_met"):
             continue
+        if not _owned_by_caller(data, identities, cwd):
+            state = _foreign_claim_state(data)
+            print(
+                "autopilot-gate: foreign engagement does not block this "
+                f"session (project={data.get('project_id') or 'unknown'}, "
+                f"session={data.get('session_id') or 'legacy'}, claim={state})",
+                file=sys.stderr,
+            )
+            continue
         if data.get("continuation") or data.get("blocker"):
             continue
         offenders.append(
@@ -231,7 +386,7 @@ def gate() -> int:
         return 0
     me = os.path.basename(__file__)
     print(
-        "autopilot-gate BLOCKED: this session is stopping while an autopilot "
+        "autopilot-gate BLOCKED: this session owns an autopilot "
         "engagement is active, unfinished, and has NO continuation — the "
         "exact shape of the overnight silent-idle failure. Engagements: "
         + "; ".join(offenders) + ". Before stopping, do exactly one: "
@@ -240,9 +395,8 @@ def gate() -> int:
         f"(2) alert the principal and record the blocker ({me} blocker "
         "--plan P --reason ... --alerted), or "
         f"(3) close the engagement honestly ({me} close --plan P "
-        "--goals-met | --incomplete REASON). An engagement another session "
-        "abandoned blocks here BY DESIGN — close it honestly rather than "
-        "deleting its record.",
+        "--goals-met | --incomplete REASON). Foreign engagements are reported "
+        "separately and never block this session.",
         file=sys.stderr,
     )
     return 2

--- a/skills/synthesis-autopilot/scripts/test_autopilot_gate.py
+++ b/skills/synthesis-autopilot/scripts/test_autopilot_gate.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -20,9 +21,24 @@ sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
 
 
-def run_cli(tmp_path: Path, *args: str, stdin: str = "{}"):
-    env = {**__import__("os").environ,
-           "AUTOPILOT_GATE_STATE_DIR": str(tmp_path)}
+def run_cli(tmp_path: Path, *args: str, stdin: str = "{}", env_extra=None):
+    board = tmp_path / "board.md"
+    if not board.exists():
+        board.write_text(
+            "| Session UUID | Compact ID | Speakable ID | Client session ref | Project | Workspace(s) / branch | Claimed areas (advisory lock) | Context role | Started | Heartbeat | Status |\n"
+            "|---|---|---|---|---|---|---|---|---|---|---|\n"
+            "| session-a | s-aaaa-bbbb-cccc | words-1 | tool:session-a | alpha | /tmp/p | /tmp/p/** | owner | 2026-09-03T12:00:00-04:00 | 2026-09-03T12:00:00-04:00 | active |\n",
+            encoding="utf-8",
+        )
+    env = {
+        **os.environ,
+        "AUTOPILOT_GATE_STATE_DIR": str(tmp_path / "engagements"),
+        "AUTOPILOT_GATE_SESSION_ID": "session-a",
+        "AUTOPILOT_GATE_PROJECT_ID": "alpha",
+        "AUTOPILOT_GATE_COORDINATION_BOARD": str(board),
+        "SYNTHESIS_CLIENT_SESSION_REF": "tool:session-a",
+        **(env_extra or {}),
+    }
     return subprocess.run([sys.executable, str(MODULE_PATH), *args],
                           input=stdin, capture_output=True, text=True,
                           env=env)
@@ -42,7 +58,7 @@ def test_gate_blocks_active_engagement_without_continuation(tmp_path) -> None:
     """The overnight failure, encoded: active + unfinished + nothing
     scheduled must refuse the stop."""
     register(tmp_path)
-    done = run_cli(tmp_path, "--gate")
+    done = run_cli(tmp_path, "--gate", stdin='{"session_id":"session-a"}')
     assert done.returncode == 2
     assert "silent-idle" in done.stderr
     assert "continuation" in done.stderr
@@ -82,10 +98,48 @@ def test_gate_passes_after_honest_close(tmp_path: Path) -> None:
 
 
 def test_unreadable_record_fails_closed(tmp_path: Path) -> None:
-    (tmp_path / "broken.json").write_text("{not json", encoding="utf-8")
+    root = tmp_path / "engagements"
+    root.mkdir(parents=True)
+    (root / "broken.json").write_text("{not json", encoding="utf-8")
     done = run_cli(tmp_path, "--gate")
     assert done.returncode == 2
     assert "unreadable" in done.stderr
+
+
+def test_registration_is_bound_to_session_project_claim_and_client_ref(tmp_path: Path) -> None:
+    register(tmp_path)
+    records = list((tmp_path / "engagements").glob("*.json"))
+    assert len(records) == 1
+    payload = json.loads(records[0].read_text(encoding="utf-8"))
+    assert payload["session_id"] == "session-a"
+    assert payload["project_id"] == "alpha"
+    assert payload["client_session_ref"] == "tool:session-a"
+    assert payload["claim_hash"]
+
+
+def test_foreign_live_engagement_never_blocks_this_session(tmp_path: Path) -> None:
+    register(tmp_path)
+    done = run_cli(
+        tmp_path,
+        "--gate",
+        stdin='{"session_id":"session-b"}',
+        env_extra={"SYNTHESIS_CLIENT_SESSION_REF": "tool:session-b"},
+    )
+    assert done.returncode == 0
+
+
+def test_registration_without_matching_claim_fails_closed(tmp_path: Path) -> None:
+    done = run_cli(
+        tmp_path,
+        "register",
+        "--plan",
+        "/tmp/p/plan.md",
+        "--mission",
+        "finish",
+        env_extra={"AUTOPILOT_GATE_SESSION_ID": "missing"},
+    )
+    assert done.returncode == 2
+    assert "claim" in done.stderr.lower()
 
 
 def test_bare_spin_cannot_be_recorded(tmp_path: Path) -> None:

--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.17.0"
+  version: "1.18.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -759,12 +759,24 @@ What it checks:
 | Budgets | CONTEXT.md ≤150 active / ≤80 completed; REFERENCE.md ≤300 (warning). A standing project (`bounded: false`) over budget is told to shard, not to narrow its scope |
 | Semantic shard | once `reference/` exists: index ≤150, each topic ≤300, every topic linked from the index, and an index actually present (defect if not) |
 | Cross-tier agreement | index.yaml status agrees with the CONTEXT.md header; completed projects carry `completed_date`; indexed projects have directories and vice versa |
-| Freshness | index.yaml `last_session` and the CONTEXT.md header agree with real git history. Applies to live projects; for a terminal one the question inverts to whether it is still being worked |
+| Freshness | structured current state and the CONTEXT.md header agree exactly with real project Git/session history. A present index.yaml `last_session` is checked as legacy duplicate metadata; a one-day known discrepancy is stale. For a terminal project the question inverts to whether it is still being worked |
+| Semantic current state | `CURRENT_STATE.json` validates; its bounded compiled block agrees with it; a current phase or accepted baseline older than a later release in the same record is a defect |
 | Durability | tier files are tracked by git; local mode reports recoverable uncommitted or ahead state as warnings; remote mode requires a clean upstream-current branch |
 | Executable state | artifact citations to missing, non-regular, escaped, or symlink-traversing `resources/scripts/` targets warn; existence does not establish correctness |
 | Disclosure | anything unverifiable is reported rather than skipped — unreadable status headers and freshness that cannot be established both surface as findings |
 
 Exit codes follow the guard contract: `0` healthy, `1` defects found, `2` the doctor could not establish ground truth. The third is the important one — an unreadable source or a source outside git exits 2 rather than reporting health, because a check that cannot run must never look like a check that passed.
+
+**Structured operational state (v1.18.0).** Mature projects may carry
+`CURRENT_STATE.json` as the authoritative mutable state: project id, phase,
+status, accepted baseline, controlling plan, next actions, last session,
+owning coordination session, Git identity, durable-file hashes, and source
+heads. `CONTEXT.md` remains the human entry point, but its bounded block between
+`synthesis-current-state` markers is compiled from that object. Narrative and
+historical acceptance stay in Markdown. The doctor reports
+`semantic-current-state` when the object is invalid, its compiled block drifts,
+its plan is missing, or prose claims an older current release than later
+evidence in the same record.
 
 **The status vocabulary is enforced, not assumed** (v1.13.0). `status` answers
 one question — does this project claim attention — with four values: `active`,

--- a/skills/synthesis-context-lifecycle/scripts/context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_doctor.py
@@ -63,7 +63,16 @@ from pathlib import Path
 # missing the doctor must fail loudly rather than silently skip a check.
 import context_currency
 
-DOCTOR_VERSION = "1.8.1"
+_PROJECT_STATE_SCRIPTS = (
+    Path(__file__).resolve().parents[2]
+    / "synthesis-project-management"
+    / "scripts"
+)
+if str(_PROJECT_STATE_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_STATE_SCRIPTS))
+import project_state  # noqa: E402
+
+DOCTOR_VERSION = "1.9.0"
 
 # Budgets from the tiered context architecture.
 CONTEXT_BUDGET_ACTIVE = 150
@@ -85,9 +94,10 @@ REFERENCE_TOPIC_BUDGET = 300
 # working-memory file.
 REFERENCE_EXPECTED_AFTER_SESSIONS = 2
 
-# How far index.yaml's last_session may lag the project's newest commit before
-# it is stale rather than merely rounded.
-LAST_SESSION_TOLERANCE_DAYS = 1
+# Current-state dates are exact safety evidence. A known one-day discrepancy is
+# stale, not rounding; tolerating it allowed a newer project commit to coexist
+# with a green resumption record.
+LAST_SESSION_TOLERANCE_DAYS = 0
 
 # A commit touching more than this many distinct projects is repo-wide
 # maintenance, not a work session on any one of them.
@@ -806,6 +816,7 @@ CHECKS = [
     "completed-date",
     "last-session-freshness",
     "context-header-freshness",
+    "semantic-current-state",
     "header-currency",
     "body-currency",
     "uncommitted-context",
@@ -950,6 +961,15 @@ def audit_project(
 
     context_text = read_text(context_path)
     context_lines = len(context_text.splitlines())
+
+    for issue in project_state.semantic_issues(project_path):
+        audit.add(
+            "semantic-current-state",
+            "defect",
+            issue,
+            "reconcile current state from Git and lifecycle evidence, then "
+            "regenerate the bounded current-state block",
+        )
 
     if not context_text.strip():
         audit.add(

--- a/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
@@ -359,6 +359,35 @@ class ContextDoctorTests(unittest.TestCase):
         self.fx.commit("real work", when="2026-06-01")
         self.assertIn("last-session-freshness", checks_in(self.fx.audit()))
 
+    def test_one_day_known_staleness_is_not_tolerated(self):
+        self.fx.project(
+            "alpha",
+            context="# P\n\n**Status:** Active\n**Last session:** 2026-06-01\n",
+        )
+        self.fx.index(
+            [{"id": "alpha", "status": "active", "last_session": "2026-06-01"}]
+        )
+        self.fx.commit("real work", when="2026-06-02")
+        checks = checks_in(self.fx.audit())
+        self.assertIn("last-session-freshness", checks)
+        self.assertIn("context-header-freshness", checks)
+
+    def test_current_release_older_than_later_recorded_release_is_caught(self):
+        self.fx.project(
+            "alpha",
+            context=(
+                "# P\n\n**Phase:** current release 1.0.0\n**Status:** Active\n"
+                "**Last session:** 2026-06-01\n\n"
+                "Current accepted release: v1.0.0.\n"
+                "Later release shipped: v4.0.0.\n"
+            ),
+        )
+        self.fx.index(
+            [{"id": "alpha", "status": "active", "last_session": "2026-06-01"}]
+        )
+        self.fx.commit("record contradictory state", when="2026-06-01")
+        self.assertIn("semantic-current-state", checks_in(self.fx.audit()))
+
     def test_stale_context_header_is_caught(self):
         self.fx.project(
             "alpha", context="# P\n\n**Status:** Active\n**Last session:** 2020-01-01\n"

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,17 +1,15 @@
-# AGENT HEURISTIC: closed acceptance universe for the 4.91.4 guardian-lock repair.
-# Fresh per transaction: changed_surfaces must equal the authoritative
-# base-to-head Git diff before release.py can consume the receipt.
+# Closed acceptance universe for the project-state reliability release.
 schema: 2
-suite: synthesis-cache-guardian-lock-reliability
+suite: synthesis-project-state-reliability
 membership: closed
-production_entry_point: synthesis update -> onboard.synchronize_codex_history -> cache_guardian --doctor -> shared transition lock
-enforcing_boundary: release.py consumes this transaction-bound closed manifest before publishing the immutable release, installing both clients, and activating the public CLI
+production_entry_point: named-project resolution, SessionStart recovery, context doctor, lifecycle Stop, and autopilot Stop gate
+enforcing_boundary: release.py consumes this transaction-bound manifest before publishing, installation, and stable activation
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the real installed update is verified after the gated publisher activates this release
+unverified_remainder: a genuinely new external-runtime lifecycle event remains a separate live-plane acceptance condition
 changed_surfaces:
   - path: .claude-plugin/plugin.json
     cases: [release-contract]
@@ -21,30 +19,66 @@ changed_surfaces:
     cases: [release-contract]
   - path: README.md
     cases: [release-contract]
+  - path: hooks/hooks.json
+    cases: [release-contract, lifecycle-stop]
+  - path: skills/synthesis-agent-conformance/SKILL.md
+    cases: [session-recovery, release-contract]
+  - path: skills/synthesis-agent-conformance/scripts/conformance.py
+    cases: [session-recovery]
+  - path: skills/synthesis-agent-conformance/scripts/session_context.py
+    cases: [session-recovery]
+  - path: skills/synthesis-agent-conformance/scripts/test_session_context.py
+    cases: [session-recovery]
+  - path: skills/synthesis-autopilot/SKILL.md
+    cases: [scoped-autopilot, release-contract]
+  - path: skills/synthesis-autopilot/scripts/autopilot_gate.py
+    cases: [scoped-autopilot]
+  - path: skills/synthesis-autopilot/scripts/test_autopilot_gate.py
+    cases: [scoped-autopilot]
+  - path: skills/synthesis-context-lifecycle/SKILL.md
+    cases: [semantic-doctor, release-contract]
+  - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
+    cases: [semantic-doctor]
+  - path: skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
+    cases: [semantic-doctor]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [acceptance-self]
-  - path: skills/synthesis-skills-manager/SKILL.md
-    cases: [release-contract]
-  - path: skills/synthesis-skills-manager/scripts/cache_guardian.py
-    cases: [guardian-lock-policy, guardian-lock-timeout]
-  - path: skills/synthesis-skills-manager/scripts/test_cache_guardian.py
-    cases: [guardian-lock-policy, guardian-lock-timeout]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [release-contract]
+  - path: skills/synthesis-project-management/SKILL.md
+    cases: [resolver-matrix, release-contract]
+  - path: skills/synthesis-project-management/references/project-state-recovery.md
+    cases: [resolver-matrix]
+  - path: skills/synthesis-project-management/scripts/project_state.py
+    cases: [resolver-matrix, lifecycle-stop]
+  - path: skills/synthesis-project-management/scripts/test_project_state.py
+    cases: [resolver-matrix, lifecycle-stop, release-contract]
+  - path: skills/synthesis-repo-guard/SKILL.md
+    cases: [lifecycle-stop, release-contract]
 cases:
+  - id: resolver-matrix
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_canonical_behind_isolated_worktree_selects_newer_without_mutation
+    motivating_defect: a-resumed-project-could-select-whichever-clean-checkout-a-task-remembered
+  - id: lifecycle-stop
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_lifecycle_hook_refuses_semantically_incomplete_stop
+    motivating_defect: a-clean-handoff-receipt-could-outlive-semantic-project-state-or-source-heads
+  - id: semantic-doctor
+    control_class: enforced-gate
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests
+    motivating_defect: structurally-valid-prose-could-contradict-later-release-evidence-and-still-report-healthy
+  - id: session-recovery
+    control_class: acceptance-test
+    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_stopped_project_recovery_reads_newer_isolated_worktree
+    motivating_defect: session-start-could-read-a-behind-canonical-checkout-without-inventorying-isolated-state
+  - id: scoped-autopilot
+    control_class: enforced-gate
+    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_foreign_live_engagement_never_blocks_this_session
+    motivating_defect: one-projects-engagement-could-globally-block-an-unrelated-session
   - id: release-contract
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_cache_guardian_lock_release_contract_is_public_and_coherent
-    motivating_defect: a-follow-on-release-could-ship-disagreeing-version-or-lock-policy-documentation
-  - id: guardian-lock-policy
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_doctor_waits_for_background_guardian_but_once_remains_nonblocking
-    motivating_defect: a-synchronous-update-could-fail-when-ordinary-background-guardian-work-owned-the-lock
-  - id: guardian-lock-timeout
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_blocking_cache_lock_wait_is_bounded
-    motivating_defect: a-real-release-transition-could-make-a-synchronous-doctor-wait-without-a-bound
+    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent
+    motivating_defect: release-version-documentation-hook-and-skill-contracts-could-disagree
   - id: acceptance-self
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: a-release-manifest-could-claim-closed-membership-with-unmapped-or-invalid-cases
+    motivating_defect: a-closed-release-manifest-could-omit-a-changed-surface-or-reference-an-invalid-case

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -53,6 +53,8 @@ changed_surfaces:
     cases: [resolver-matrix, lifecycle-stop, release-contract]
   - path: skills/synthesis-repo-guard/SKILL.md
     cases: [lifecycle-stop, release-contract]
+  - path: skills/synthesis-skills-manager/scripts/test_release.py
+    cases: [release-contract]
 cases:
   - id: resolver-matrix
     control_class: acceptance-test

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.11.2"
+  version: "2.12.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -137,9 +137,8 @@ Full rationale:
 
 ### 1. Project Index (`index.yaml`)
 
-Single source of truth for all projects. Status is a field, not a folder:
-`active` (being worked), `paused`, `ongoing` (no defined end state),
-`completed` (+ `completed_date`, `outcome`, `key_result`), `archived`.
+Discovery index for all projects. Status is a field, not a folder: `active`
+(being worked), `paused`, `ongoing`, `completed`, or `archived`.
 
 ```yaml
 projects:
@@ -148,13 +147,13 @@ projects:
     status: active
     description: Brief description of what this project accomplishes
     tags: [tag1, tag2]
-    last_session: YYYY-MM-DD
 ```
 
 Full multi-status example:
 [references/records-and-conventions.md](references/records-and-conventions.md).
-**Update when:** session end (update `last_session`), project status changes,
-new project added.
+**Update when:** project status changes or a project is added. For structured
+projects, derive session currency; a present stale `last_session` is evidence,
+not truth. Details: [references/project-state-recovery.md](references/project-state-recovery.md).
 
 ### 2. Tiered Context Architecture
 
@@ -194,8 +193,6 @@ work. Full rules and the canonical convention:
 [references/records-and-conventions.md](references/records-and-conventions.md)
 and the synthesis-context-lifecycle skill.
 
----
-
 ## The Protocol
 
 ### During Work
@@ -212,19 +209,22 @@ Complete task → Update CONTEXT.md → local receipt → Next task
    `~/.synthesis/coordination/active-sessions.md` exists, read it before any
    write and register or refresh this session's project, worktree, branch,
    context role, and claims
-2. **Read CONTEXT.md** — Understand current state before touching code
-3. **Check line count** — If CONTEXT.md >150 lines, archive before starting work
-4. **Read REFERENCE.md** — If it exists and the task needs reference details
-5. **Search lessons/** — `grep` for relevant past experiences
-6. **Check related projects** — Look at `related:` tags in index.yaml
+2. **Resolve before reading** — Run `scripts/project_state.py resolve` against the Git-tracked index; use only its causally selected state.
+3. **Read the selected state** — Read `CURRENT_STATE.json`, CONTEXT.md, the linked plan, REFERENCE.md, and latest session; validate hashes and semantics.
+4. **Check line count** — If CONTEXT.md >150 lines, archive before starting work
+5. **Read REFERENCE.md** — If it exists and the task needs reference details
+6. **Search lessons/** — `grep` for relevant past experiences
+7. **Check related projects** — Look at `related:` tags in index.yaml
 
 ### Session End
 
 1. **Final CONTEXT.md update** — Ensure all sections current (≤150 lines)
 2. **Archive if needed** — Move old sessions to sessions/, stable facts to REFERENCE.md
 3. **Attribute if warranted** — If multiple agents/models contributed materially, end the session-log entry with Attribution line(s) (see Agent Attribution)
-4. **Update index.yaml** — Set `last_session` date
-5. **Verify local continuity** — Confirm session-attributed state is readable;
+4. **Refresh structured state** — Regenerate `CURRENT_STATE.json` and its
+   compiled block after every meaningful source phase.
+5. **Verify local continuity** — Require the session- and claim-bound Stop
+   receipt; confirm attributed state is readable;
    do not create a commit or network push solely because the user is switching
    clients on this machine
 6. **Release coordination claims** — Mark the session released or narrow its
@@ -361,11 +361,11 @@ or save state by hand:
    recoverably archives an active-project pointer owned by that session; a
    pointer owned by another session is untouched.
 
-Resuming from another agent: resolve the named project through the
-git-tracked `projects/index.yaml`, read `CONTEXT.md` and the linked plan,
-and inspect Git status and diff before acting — working-tree truth
-supersedes cached project prose. Pointer semantics and cross-computer
-recovery preconditions:
+Resuming from another agent: run `scripts/project_state.py resolve` against the
+Git-tracked index before reading prose. Divergence is `CONFLICT`; unreadable or
+unreachable evidence is `UNKNOWN`. Full evidence, ordering, safe-fast-forward,
+and receipt contract: [references/project-state-recovery.md](references/project-state-recovery.md).
+Pointer semantics and cross-computer recovery preconditions:
 [references/parallel-agent-protocol.md](references/parallel-agent-protocol.md)
 ("Resuming and the active-project pointer").
 

--- a/skills/synthesis-project-management/references/project-state-recovery.md
+++ b/skills/synthesis-project-management/references/project-state-recovery.md
@@ -1,0 +1,59 @@
+# Project-state recovery
+
+`scripts/project_state.py resolve` discovers a named project's state across the
+canonical checkout, registered isolated worktrees, local and remote refs,
+attributed dirty paths, lifecycle manifests and receipts, the active-project
+pointer, and coordination claims. Each candidate records its worktree or ref,
+project-touching commit, project tree, timestamp, dirty-path hashes, and owning
+session where one is provable.
+
+Equality and Git ancestry are the only ordering evidence. Timestamps describe
+observations but never select a winner. A dirty state extends its exact base
+commit; if a newer committed project state exists, the two are divergent until
+reconciled. Two distinct attributed dirty states are also divergent. Missing
+worktrees, unreadable evidence, and failed fetches are `UNKNOWN`; divergent
+states are `CONFLICT`; an attributed interruption is `LOCAL_RECOVERABLE`.
+
+A canonical checkout may fast-forward automatically only when its current head
+is an ancestor of the selected head, tracked and staged state are clean, no
+untracked path would be overwritten, and the selected project still exists
+after the move. Otherwise the resolver reports the exact fresher source without
+mutating unrelated state.
+
+Structured projects store mutable operational truth in `CURRENT_STATE.json`:
+phase, status, accepted baseline, controlling plan, next actions, last session,
+owning coordination session, repository/project identity, durable Markdown
+hashes, and source-repository heads. The bounded current-state block in
+CONTEXT.md is compiled from it; narrative and historical acceptance remain
+Markdown.
+
+Use the same executable to create and verify that state; do not hand-edit the
+compiled block:
+
+```bash
+python3 scripts/project_state.py build \
+  --project /absolute/project/path --project-id example \
+  --phase "implementation" --status active \
+  --controlling-plan resources/artifacts/plan.md \
+  --accepted-baseline 1.2.3 --next-action "Run acceptance" \
+  --last-session 2026-09-03 --session-id SESSION_UUID \
+  --source-head /absolute/source/repository=COMMIT
+
+python3 scripts/project_state.py checkpoint \
+  --project /absolute/project/path --session-id SESSION_UUID \
+  --coordination-board /absolute/active-sessions.md \
+  --receipt-root /absolute/project-state/receipts \
+  --source-head /absolute/source/repository=COMMIT
+```
+
+Every repeated `--source-head` is resolved to a commit before the state or
+receipt is issued. `validate` accepts the same source bindings. A changed
+source head invalidates the prior clean receipt instead of being treated as a
+fresh handoff.
+
+The lifecycle hook first refreshes the coordination lease, then issues a clean
+receipt only when the event matches one active coordination seat and its
+project, state, claim, Git identity, durable hashes, and live source heads all
+validate. An interrupted event retains the file-attributed pending manifest
+and remains recoverable, but never receives a clean receipt. Foreign project
+sessions never block one another.

--- a/skills/synthesis-project-management/scripts/project_state.py
+++ b/skills/synthesis-project-management/scripts/project_state.py
@@ -1,0 +1,1202 @@
+#!/usr/bin/env python3
+"""Resolve, validate, and checkpoint durable synthesis project state.
+
+The public API is provider-neutral. Native lifecycle adapters pass their event
+envelopes to this module; evidence discovery, ordering, and receipt validation
+remain shared.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any, Iterable
+
+
+STATE_FILE = "CURRENT_STATE.json"
+STATE_SCHEMA = 1
+RECEIPT_SCHEMA = 1
+_VERSION_RE = re.compile(r"(?<![0-9])v?(\d+)\.(\d+)\.(\d+)(?![0-9])", re.I)
+_DATE_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
+
+
+class ProjectStateError(RuntimeError):
+    """A required evidence source was unreadable or mutually inconsistent."""
+
+
+@dataclass
+class Candidate:
+    source: str
+    project_path: str | None
+    worktree: str | None
+    ref: str | None
+    head: str
+    project_tree: str
+    timestamp: str
+    dirty_files: list[dict[str, str]] = field(default_factory=list)
+    session_id: str | None = None
+
+
+@dataclass
+class RecoveryReport:
+    project_id: str
+    status: str
+    selected_path: str | None
+    selected_head: str | None
+    selected_tree: str | None
+    candidates: list[Candidate]
+    issues: list[str]
+    planes: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _run(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True
+    )
+    if check and result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip() or "git command failed"
+        raise ProjectStateError(detail)
+    return result
+
+
+def _sha_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha_file(path: Path) -> str:
+    return _sha_bytes(path.read_bytes())
+
+
+def _atomic_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    os.replace(temporary, path)
+
+
+def _atomic_text(path: Path, value: str) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(value, encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProjectStateError(f"unreadable JSON evidence {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ProjectStateError(f"JSON evidence is not an object: {path}")
+    return payload
+
+
+def _repository_root(path: Path) -> Path:
+    result = _run(path, "rev-parse", "--show-toplevel")
+    return Path(result.stdout.strip()).resolve()
+
+
+def _common_git_dir(repo: Path) -> Path:
+    raw = Path(_run(repo, "rev-parse", "--git-common-dir").stdout.strip())
+    return (repo / raw).resolve() if not raw.is_absolute() else raw.resolve()
+
+
+def _index_entry(text: str, project_id: str) -> str:
+    matches = list(re.finditer(rf"(?m)^\s*-?\s*id:\s*['\"]?{re.escape(project_id)}['\"]?\s*$", text))
+    if len(matches) != 1:
+        raise ProjectStateError(
+            f"index must contain exactly one project id {project_id!r}; found {len(matches)}"
+        )
+    start = matches[0].start()
+    following = re.search(r"(?m)^\s*-?\s*id:\s*", text[matches[0].end() :])
+    end = matches[0].end() + following.start() if following else len(text)
+    return text[start:end]
+
+
+def _latest_session_date(project: Path) -> str | None:
+    dates: list[str] = []
+    sessions = project / "sessions"
+    if sessions.is_dir():
+        for path in sessions.glob("*.md"):
+            for line in path.read_text(
+                encoding="utf-8", errors="replace"
+            ).splitlines():
+                if re.match(r"^#{2,6}\s+", line):
+                    dates.extend(_DATE_RE.findall(line))
+    context = project / "CONTEXT.md"
+    if context.is_file():
+        for line in context.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.lower().startswith("**last session:"):
+                dates.extend(_DATE_RE.findall(line))
+    return max(dates) if dates else None
+
+
+def _worktrees(repo: Path) -> list[tuple[Path, str, str | None]]:
+    text = _run(repo, "worktree", "list", "--porcelain").stdout
+    records: list[tuple[Path, str, str | None]] = []
+    for block in text.strip().split("\n\n") if text.strip() else []:
+        values: dict[str, str] = {}
+        for line in block.splitlines():
+            key, _, value = line.partition(" ")
+            values[key] = value
+        if values.get("worktree") and values.get("HEAD"):
+            records.append(
+                (Path(values["worktree"]).resolve(), values["HEAD"], values.get("branch"))
+            )
+    return records
+
+
+def _latest_project_commit(repo: Path, ref: str, relative: str) -> str | None:
+    result = _run(repo, "log", "-1", "--format=%H", ref, "--", relative, check=False)
+    value = result.stdout.strip()
+    return value if result.returncode == 0 and value else None
+
+
+def _tree_at(repo: Path, ref: str, relative: str) -> str | None:
+    result = _run(repo, "rev-parse", f"{ref}:{relative}", check=False)
+    value = result.stdout.strip()
+    return value if result.returncode == 0 and value else None
+
+
+def _timestamp(repo: Path, ref: str) -> str:
+    result = _run(repo, "show", "-s", "--format=%cI", ref, check=False)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _dirty_project_files(worktree: Path, relative: str) -> list[dict[str, str]]:
+    result = _run(
+        worktree,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+        "--",
+        relative,
+    )
+    found: list[dict[str, str]] = []
+    for line in result.stdout.splitlines():
+        if len(line) < 4:
+            continue
+        name = line[3:].split(" -> ")[-1]
+        path = (worktree / name).resolve()
+        digest = _sha_file(path) if path.is_file() else "deleted"
+        found.append({"path": str(path), "status": line[:2], "sha256": digest})
+    return sorted(found, key=lambda item: item["path"])
+
+
+def _manifest_inventory(
+    root: Path | None,
+    checkpoint_receipt_root: Path | None = None,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    issues: list[str] = []
+    found: list[dict[str, Any]] = []
+    directories: list[tuple[str, Path]] = []
+    if root is not None:
+        directories.extend(
+            (("manifest", root / "pending"), ("receipt", root / "local-handoff"))
+        )
+    if checkpoint_receipt_root is not None:
+        directories.append(("checkpoint-receipt", checkpoint_receipt_root))
+    for kind, directory in directories:
+        if not directory.exists():
+            continue
+        if not directory.is_dir():
+            issues.append(f"unreadable {kind} directory: {directory}")
+            continue
+        for path in sorted(directory.glob("*.json")):
+            try:
+                payload = _load_json(path)
+            except ProjectStateError as exc:
+                issues.append(str(exc))
+                continue
+            payload["_kind"] = kind
+            payload["_path"] = str(path.resolve())
+            payload["_timestamp"] = datetime.fromtimestamp(
+                path.stat().st_mtime, tz=timezone.utc
+            ).isoformat()
+            found.append(payload)
+    return found, issues
+
+
+def _manifest_for_dirty(
+    dirty: list[dict[str, str]], manifests: Iterable[dict[str, Any]]
+) -> str | None:
+    dirty_paths = {item["path"]: item["sha256"] for item in dirty}
+    for manifest in manifests:
+        if manifest.get("_kind") != "manifest":
+            continue
+        paths = {str(Path(value).resolve()) for value in manifest.get("paths", []) if isinstance(value, str)}
+        if not set(dirty_paths).issubset(paths):
+            continue
+        claimed_hashes = {
+            str(Path(key).resolve()): value
+            for key, value in (manifest.get("path_hashes") or {}).items()
+            if isinstance(key, str) and isinstance(value, str)
+        }
+        if claimed_hashes and any(claimed_hashes.get(path) != digest for path, digest in dirty_paths.items()):
+            continue
+        return str(manifest.get("session_id") or "") or None
+    return None
+
+
+def _candidate_from_metadata(
+    kind: str,
+    payload: dict[str, Any],
+    fallback: Candidate,
+) -> Candidate:
+    return Candidate(
+        source=kind,
+        project_path=None,
+        worktree=None,
+        ref=None,
+        head=str(payload.get("head") or payload.get("git_head") or fallback.head),
+        project_tree=str(payload.get("project_tree") or fallback.project_tree),
+        timestamp=str(payload.get("updated_at") or payload.get("created_at") or payload.get("_timestamp") or ""),
+        session_id=str(payload.get("session_id")) if payload.get("session_id") else None,
+    )
+
+
+def _parse_board_rows(path: Path) -> list[dict[str, str]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ProjectStateError(f"coordination board unreadable: {exc}") from exc
+    lines = text.splitlines()
+    header: list[str] | None = None
+    rows: list[dict[str, str]] = []
+    for line in lines:
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if header is None and "session uuid" in {cell.lower() for cell in cells}:
+            header = [cell.lower() for cell in cells]
+            continue
+        if header is None or all(set(cell) <= {"-", ":"} for cell in cells):
+            continue
+        if len(cells) == len(header):
+            rows.append(dict(zip(header, cells)))
+    if header is None:
+        raise ProjectStateError("coordination board has no active-session table")
+    return rows
+
+
+def _refresh_coordination_board(path: Path) -> str | None:
+    helper = Path(__file__).with_name("coordination.py")
+    result = subprocess.run(
+        [sys.executable, str(helper), "--board", str(path), "status", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+        env=os.environ.copy(),
+    )
+    if result.returncode:
+        return "coordination lease refresh failed: " + (
+            result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        )
+    try:
+        payload = json.loads(result.stdout)
+        lease = payload["lease"]
+        problems = payload["problems"]
+    except (KeyError, TypeError, json.JSONDecodeError) as exc:
+        return f"coordination lease refresh returned invalid evidence: {exc}"
+    if problems:
+        return "coordination board is invalid after refresh: " + "; ".join(map(str, problems))
+    if not lease.get("configured") or not lease.get("refreshed") or lease.get("error"):
+        return "coordination lease refresh failed: " + str(
+            lease.get("error") or "remote authority was not refreshed"
+        )
+    return None
+
+
+def _is_ancestor(repo: Path, older: str, newer: str) -> bool:
+    return _run(repo, "merge-base", "--is-ancestor", older, newer, check=False).returncode == 0
+
+
+def _safe_fast_forward(
+    repo: Path,
+    target_ref: str,
+    expected_project_head: str,
+    expected_project_tree: str,
+    relative: str,
+) -> tuple[bool, str | None]:
+    current = _run(repo, "rev-parse", "HEAD").stdout.strip()
+    upstream = _run(
+        repo, "rev-parse", "--symbolic-full-name", "@{upstream}", check=False
+    )
+    if upstream.returncode or upstream.stdout.strip() != target_ref:
+        return False, "selected remote ref is not the canonical branch upstream"
+    target = _run(repo, "rev-parse", f"{target_ref}^{{commit}}").stdout.strip()
+    if _latest_project_commit(repo, target_ref, relative) != expected_project_head:
+        return False, "selected project commit no longer matches its remote ref"
+    if _tree_at(repo, target_ref, relative) != expected_project_tree:
+        return False, "selected project tree no longer matches its remote ref"
+    if current == target:
+        return True, None
+    if not _is_ancestor(repo, current, target):
+        return False, "canonical checkout cannot fast-forward to selected state"
+    if _run(repo, "diff", "--quiet", check=False).returncode or _run(
+        repo, "diff", "--cached", "--quiet", check=False
+    ).returncode:
+        return False, "canonical checkout has tracked or staged changes"
+    changed = set(_run(repo, "diff", "--name-only", current, target).stdout.splitlines())
+    untracked = {
+        line[3:]
+        for line in _run(repo, "status", "--porcelain=v1", "--untracked-files=all").stdout.splitlines()
+        if line.startswith("?? ")
+    }
+    if changed & untracked:
+        return False, "canonical fast-forward would overwrite untracked paths"
+    result = _run(repo, "merge", "--ff-only", target, check=False)
+    if result.returncode:
+        return False, result.stderr.strip() or "fast-forward failed"
+    if _tree_at(repo, "HEAD", relative) != expected_project_tree:
+        return False, "fast-forward did not produce the selected project tree"
+    return True, None
+
+
+def resolve_project(
+    project_id: str,
+    index_path: Path,
+    *,
+    repo_guard_root: Path | None = None,
+    checkpoint_receipt_root: Path | None = None,
+    coordination_board: Path | None = None,
+    pointer: Path | None = None,
+    fetch: bool = True,
+    fast_forward_canonical: bool = False,
+    refresh_coordination: bool = False,
+) -> RecoveryReport:
+    """Discover all local/remote project evidence and select only by proof."""
+    index_path = index_path.resolve()
+    issues: list[str] = []
+    candidates: list[Candidate] = []
+    try:
+        index_text = index_path.read_text(encoding="utf-8")
+        entry = _index_entry(index_text, project_id)
+        repo = _repository_root(index_path.parent)
+    except (OSError, ProjectStateError) as exc:
+        return RecoveryReport(project_id, "UNKNOWN", None, None, None, [], [str(exc)], {"continuity": "UNKNOWN"})
+    relative = str((index_path.parent / project_id).resolve().relative_to(repo))
+
+    if fetch:
+        fetched = _run(repo, "fetch", "--all", "--prune", check=False)
+        if fetched.returncode:
+            issues.append(f"fetch failed: {fetched.stderr.strip() or fetched.stdout.strip()}")
+        fetch_succeeded = fetched.returncode == 0
+    else:
+        fetch_succeeded = False
+
+    worktree_records = _worktrees(repo)
+    registered = {str(path) for path, _head, _branch in worktree_records}
+    metadata_root = _common_git_dir(repo) / "worktrees"
+    if metadata_root.is_dir():
+        for metadata in metadata_root.iterdir():
+            marker = metadata / "gitdir"
+            if not marker.is_file():
+                issues.append(f"missing worktree registration target for {metadata.name}")
+                continue
+            target_git = Path(marker.read_text(encoding="utf-8").strip())
+            target = target_git.parent.resolve()
+            if not target.exists() or str(target) not in registered:
+                issues.append(f"missing worktree registered at {target}")
+
+    manifests, manifest_issues = _manifest_inventory(
+        repo_guard_root, checkpoint_receipt_root
+    )
+    issues.extend(manifest_issues)
+    authoritative: list[Candidate] = []
+    for worktree, _repository_head, branch in worktree_records:
+        project = worktree / relative
+        if not project.is_dir():
+            continue
+        project_head = _latest_project_commit(worktree, "HEAD", relative)
+        tree = _tree_at(worktree, "HEAD", relative)
+        if not project_head or not tree:
+            continue
+        dirty = _dirty_project_files(worktree, relative)
+        owner = _manifest_for_dirty(dirty, manifests) if dirty else None
+        candidate = Candidate(
+            source="canonical" if worktree == repo else "worktree",
+            project_path=str(project.resolve()),
+            worktree=str(worktree),
+            ref=branch,
+            head=project_head,
+            project_tree=tree,
+            timestamp=_timestamp(worktree, project_head),
+            dirty_files=dirty,
+            session_id=owner,
+        )
+        authoritative.append(candidate)
+        candidates.append(candidate)
+        if worktree == repo:
+            candidates.append(Candidate(**{**asdict(candidate), "source": "worktree"}))
+
+    refs = _run(repo, "for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes").stdout.splitlines()
+    for ref in refs:
+        if ref.endswith("/HEAD"):
+            continue
+        project_head = _latest_project_commit(repo, ref, relative)
+        tree = _tree_at(repo, ref, relative)
+        if not project_head or not tree:
+            continue
+        candidates.append(
+            Candidate("ref", None, None, ref, project_head, tree, _timestamp(repo, project_head))
+        )
+
+    if not authoritative:
+        return RecoveryReport(project_id, "UNKNOWN", None, None, None, candidates, issues + ["no readable project worktree"], {"continuity": "UNKNOWN"})
+    fallback = authoritative[0]
+    related_sessions = {
+        str(payload.get("session_id"))
+        for payload in manifests
+        if payload.get("_kind") == "manifest"
+        and (
+            project_id in json.dumps(payload, sort_keys=True)
+            or any(
+                str(Path(path).resolve()).startswith(str((repo / relative).resolve()))
+                for path in payload.get("paths", [])
+                if isinstance(path, str)
+            )
+        )
+    }
+    for payload in manifests:
+        material = json.dumps(payload, sort_keys=True)
+        paths = [str(value) for value in payload.get("paths", []) if isinstance(value, str)]
+        if (
+            project_id in material
+            or any(str(Path(path).resolve()).startswith(str((repo / relative).resolve())) for path in paths)
+            or str(payload.get("session_id")) in related_sessions
+        ):
+            candidates.append(_candidate_from_metadata(str(payload["_kind"]), payload, fallback))
+
+    if pointer is not None and pointer.exists():
+        try:
+            payload = _load_json(pointer)
+            target = payload.get("project") or payload.get("project_path") or payload.get("path")
+            if target and Path(str(target)).resolve().is_dir():
+                candidates.append(_candidate_from_metadata("pointer", payload, fallback))
+            else:
+                issues.append(f"active-project pointer is stale: {pointer}")
+        except ProjectStateError as exc:
+            issues.append(str(exc))
+
+    if coordination_board is not None:
+        if refresh_coordination:
+            try:
+                refresh_issue = _refresh_coordination_board(coordination_board)
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                refresh_issue = f"coordination lease refresh failed: {exc}"
+            if refresh_issue:
+                issues.append(refresh_issue)
+        try:
+            for row in _parse_board_rows(coordination_board):
+                if row.get("status", "").lower() != "active" or row.get("project") != project_id:
+                    continue
+                payload = {"session_id": row.get("session uuid"), "updated_at": row.get("heartbeat")}
+                candidates.append(_candidate_from_metadata("claim", payload, fallback))
+        except ProjectStateError as exc:
+            issues.append(str(exc))
+
+    latest = _latest_session_date(repo / relative)
+    recorded_match = re.search(r"(?m)^\s*last_session:\s*['\"]?([^'\"\s]+)", entry)
+    recorded = recorded_match.group(1) if recorded_match else None
+    if latest and recorded and recorded != latest:
+        issues.append(f"index last_session {recorded} is stale; derived value is {latest}")
+
+    dirty_candidates = [candidate for candidate in authoritative if candidate.dirty_files]
+    unattributed = [candidate for candidate in dirty_candidates if not candidate.session_id]
+    if unattributed:
+        issues.append("dirty project files lack an exact attributed manifest")
+        status = "CONFLICT"
+        selected = None
+    elif dirty_candidates and any(
+        dirty.head != other.head and _is_ancestor(repo, dirty.head, other.head)
+        for dirty in dirty_candidates
+        for other in candidates
+        if other.source in {"canonical", "worktree", "ref"}
+    ):
+        issues.append("attributed dirty project state extends an older head than a newer committed project state")
+        status = "CONFLICT"
+        selected = None
+    elif dirty_candidates:
+        signatures = {
+            _sha_bytes(json.dumps(candidate.dirty_files, sort_keys=True).encode())
+            for candidate in dirty_candidates
+        }
+        if len(signatures) != 1:
+            issues.append("divergent attributed dirty project states")
+            status = "CONFLICT"
+            selected = None
+        else:
+            status = "LOCAL_RECOVERABLE"
+            selected = dirty_candidates[0]
+    else:
+        unique: dict[tuple[str, str], Candidate] = {}
+        for candidate in candidates:
+            if candidate.source in {"canonical", "worktree", "ref"}:
+                unique.setdefault((candidate.head, candidate.project_tree), candidate)
+        maximal: list[Candidate] = []
+        for candidate in unique.values():
+            if any(
+                candidate.head != other.head and _is_ancestor(repo, candidate.head, other.head)
+                for other in unique.values()
+            ):
+                continue
+            maximal.append(candidate)
+        trees = {candidate.project_tree for candidate in maximal}
+        if len(trees) > 1:
+            status = "CONFLICT"
+            selected = None
+            issues.append("divergent project states have no provable causal ordering")
+        elif maximal:
+            status = "PASS"
+            target = maximal[0]
+            matching_paths = [
+                item for item in authoritative if item.project_tree == target.project_tree
+            ]
+            selected = matching_paths[0] if matching_paths else target
+            if fast_forward_canonical and selected.project_path is None:
+                if not fetch_succeeded:
+                    ok, reason = False, "automatic fast-forward requires a successful fetch"
+                elif not selected.ref or not selected.ref.startswith("refs/remotes/"):
+                    ok, reason = False, "selected state is not a fetched remote ref"
+                else:
+                    ok, reason = _safe_fast_forward(
+                        repo,
+                        selected.ref,
+                        selected.head,
+                        selected.project_tree,
+                        relative,
+                    )
+                if ok:
+                    selected = Candidate(
+                        "canonical", str((repo / relative).resolve()), str(repo), None,
+                        selected.head, selected.project_tree, selected.timestamp,
+                    )
+                else:
+                    issues.append(f"automatic fast-forward refused: {reason}")
+        else:
+            status = "UNKNOWN"
+            selected = None
+            issues.append("no committed project state could be ordered")
+
+    if any(issue.startswith(("fetch failed", "unreadable", "coordination board", "coordination lease", "missing worktree")) for issue in issues) and status not in {"CONFLICT", "LOCAL_RECOVERABLE"}:
+        status = "UNKNOWN"
+    planes = {"continuity": "PASS" if status == "PASS" else status}
+    return RecoveryReport(
+        project_id,
+        status,
+        selected.project_path if selected else None,
+        selected.head if selected else None,
+        selected.project_tree if selected else None,
+        candidates,
+        issues,
+        planes,
+    )
+
+
+def _version(value: str) -> tuple[int, int, int] | None:
+    match = _VERSION_RE.search(value)
+    return tuple(int(part) for part in match.groups()) if match else None
+
+
+def _content_hashes(project: Path, controlling_plan: str | None = None) -> dict[str, str]:
+    paths = [path for path in project.rglob("*.md") if path.is_file()]
+    if controlling_plan:
+        plan = (project / controlling_plan).resolve()
+        if project.resolve() not in plan.parents or not plan.is_file():
+            raise ProjectStateError("controlling plan must be a readable file inside the project")
+        paths.append(plan)
+    return {
+        str(path.resolve().relative_to(project.resolve())): _sha_file(path)
+        for path in sorted(set(paths))
+    }
+
+
+def semantic_issues(project: Path) -> list[str]:
+    """Return contradictions in operational and human-readable current state."""
+    project = project.resolve()
+    context_path = project / "CONTEXT.md"
+    if not context_path.is_file():
+        return ["current context is missing"]
+    context = context_path.read_text(encoding="utf-8", errors="replace")
+    issues: list[str] = []
+    state_path = project / STATE_FILE
+    state: dict[str, Any] | None = None
+    if state_path.exists():
+        try:
+            state = _load_json(state_path)
+            if state.get("schema_version") != STATE_SCHEMA:
+                issues.append("current operational state schema is unsupported")
+            for key in (
+                "project_id", "phase", "status", "controlling_plan", "accepted_baseline",
+                "next_actions", "last_session", "session_id", "content_hashes",
+                "repository", "project_path", "git_head", "project_tree",
+                "source_heads", "updated_at",
+            ):
+                if key not in state:
+                    issues.append(f"current operational state lacks {key}")
+        except ProjectStateError as exc:
+            issues.append(str(exc))
+    current_text: list[str] = []
+    for line in context.splitlines():
+        lowered = line.lower()
+        if lowered.startswith("**phase:") or "current accepted" in lowered or "current baseline" in lowered:
+            current_text.append(line)
+    if state:
+        current_text.extend([str(state.get("phase", "")), str(state.get("accepted_baseline", ""))])
+    current_versions = [item for value in current_text if (item := _version(value))]
+    all_versions = [tuple(int(part) for part in match.groups()) for match in _VERSION_RE.finditer(context)]
+    if current_versions and all_versions and max(current_versions) < max(all_versions):
+        newest = ".".join(str(part) for part in max(all_versions))
+        current = ".".join(str(part) for part in max(current_versions))
+        issues.append(f"current release {current} is older than later recorded release {newest}")
+    if state:
+        if state.get("project_id") != project.name:
+            issues.append("current operational state project id disagrees with its directory")
+        plan = (project / str(state.get("controlling_plan", ""))).resolve()
+        if project not in plan.parents or not plan.is_file():
+            issues.append("current controlling plan is missing or escapes the project")
+        hashes = state.get("content_hashes")
+        if isinstance(hashes, dict):
+            try:
+                if hashes != _content_hashes(
+                    project, str(state.get("controlling_plan") or "")
+                ):
+                    issues.append("durable project files changed after current state was written")
+            except ProjectStateError as exc:
+                issues.append(str(exc))
+        else:
+            issues.append("current operational state content hashes are malformed")
+        latest = _latest_session_date(project)
+        if latest and state.get("last_session") != latest:
+            issues.append(
+                f"current operational state last session {state.get('last_session')} "
+                f"is stale; derived value is {latest}"
+            )
+        marker_start = "<!-- synthesis-current-state:start -->"
+        marker_end = "<!-- synthesis-current-state:end -->"
+        if marker_start in context or marker_end in context:
+            expected = render_context_current_state(project, state)
+            match = re.search(
+                re.escape(marker_start) + r".*?" + re.escape(marker_end), context, re.S
+            )
+            if not match or match.group(0) != expected:
+                issues.append("compiled current-state block disagrees with operational state")
+    return issues
+
+
+def _git_identity(project: Path) -> tuple[Path, str, str, str]:
+    repo = _repository_root(project)
+    relative = str(project.resolve().relative_to(repo))
+    head = _run(repo, "rev-parse", "HEAD").stdout.strip()
+    tree = _tree_at(repo, "HEAD", relative) or "UNCOMMITTED"
+    return repo, relative, head, tree
+
+
+def build_operational_state(
+    project: Path,
+    *,
+    project_id: str,
+    phase: str,
+    status: str,
+    controlling_plan: str,
+    accepted_baseline: str,
+    next_actions: list[str],
+    last_session: str,
+    session_id: str,
+    source_heads: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Write the machine-readable current state from explicit current facts."""
+    project = project.resolve()
+    if project.name != project_id:
+        raise ProjectStateError("project id does not match the project directory")
+    repo, relative, head, tree = _git_identity(project)
+    plan = (project / controlling_plan).resolve()
+    if project not in plan.parents or not plan.is_file():
+        raise ProjectStateError("controlling plan must be a readable file inside the project")
+    if not next_actions or not all(isinstance(item, str) and item.strip() for item in next_actions):
+        raise ProjectStateError("next_actions must contain at least one substantive action")
+    payload: dict[str, Any] = {
+        "schema_version": STATE_SCHEMA,
+        "project_id": project_id,
+        "phase": phase,
+        "status": status,
+        "controlling_plan": controlling_plan,
+        "accepted_baseline": accepted_baseline,
+        "next_actions": next_actions,
+        "last_session": last_session,
+        "session_id": session_id,
+        "repository": str(repo),
+        "project_path": relative,
+        "git_head": head,
+        "project_tree": tree,
+        "source_heads": dict(sorted((source_heads or {}).items())),
+        "content_hashes": {},
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    compile_context(project, payload)
+    payload["content_hashes"] = _content_hashes(project, controlling_plan)
+    _atomic_json(project / STATE_FILE, payload)
+    return payload
+
+
+def render_context_current_state(project: Path, state: dict[str, Any]) -> str:
+    """Compile the bounded current-state block used by human readers."""
+    actions = "\n".join(f"- {item}" for item in state.get("next_actions", []))
+    return "\n".join(
+        [
+            "<!-- synthesis-current-state:start -->",
+            f"**Phase:** {state.get('phase', '')}",
+            f"**Status:** {state.get('status', '')}",
+            f"**Last session:** {state.get('last_session', '')}",
+            f"**Accepted baseline:** {state.get('accepted_baseline', '')}",
+            f"**Controlling plan:** [{state.get('controlling_plan', '')}]({state.get('controlling_plan', '')})",
+            "**Next actions:**",
+            actions,
+            "<!-- synthesis-current-state:end -->",
+        ]
+    )
+
+
+def compile_context(project: Path, state: dict[str, Any]) -> None:
+    """Replace or introduce the generated current-state block atomically."""
+    context_path = project.resolve() / "CONTEXT.md"
+    context = context_path.read_text(encoding="utf-8")
+    start = "<!-- synthesis-current-state:start -->"
+    end = "<!-- synthesis-current-state:end -->"
+    block = render_context_current_state(project, state)
+    has_start, has_end = start in context, end in context
+    if has_start != has_end:
+        raise ProjectStateError("CONTEXT.md has an incomplete current-state marker pair")
+    if has_start:
+        updated = re.sub(
+            re.escape(start) + r".*?" + re.escape(end), block, context, count=1, flags=re.S
+        )
+    else:
+        lines = context.splitlines()
+        if not lines or not lines[0].startswith("#"):
+            raise ProjectStateError("CONTEXT.md needs a leading heading before compilation")
+        remaining = lines[1:]
+        while remaining and not remaining[0].strip():
+            remaining.pop(0)
+        while remaining and re.match(r"^\*\*(Phase|Status|Last session):\*\*", remaining[0], re.I):
+            remaining.pop(0)
+        while remaining and not remaining[0].strip():
+            remaining.pop(0)
+        updated = lines[0] + "\n\n" + block + "\n\n" + "\n".join(remaining)
+        if context.endswith("\n"):
+            updated += "\n"
+    _atomic_text(context_path, updated)
+
+
+def _working_digest(project: Path) -> str:
+    entries: list[tuple[str, str]] = []
+    for path in sorted(item for item in project.rglob("*") if item.is_file()):
+        if ".git" in path.parts:
+            continue
+        entries.append((str(path.relative_to(project)), _sha_file(path)))
+    return _sha_bytes(json.dumps(entries, separators=(",", ":")).encode())
+
+
+def _active_claim(path: Path, session_id: str, project_id: str, project: Path) -> dict[str, str]:
+    rows = _parse_board_rows(path)
+    matches = [
+        row for row in rows
+        if row.get("session uuid") == session_id
+        and row.get("project") == project_id
+        and row.get("status", "").lower() == "active"
+    ]
+    if len(matches) != 1:
+        raise ProjectStateError("checkpoint requires exactly one active matching session claim")
+    row = matches[0]
+    workspace = row.get("workspace(s) / branch", "")
+    claimed = row.get("claimed areas (advisory lock)", "")
+    repo = str(_repository_root(project))
+    if repo not in workspace and str(project) not in claimed and project.name not in claimed:
+        raise ProjectStateError("active session claim does not cover the project worktree")
+    return row
+
+
+def _receipt_path(receipt_root: Path, session_id: str, project_id: str) -> Path:
+    name = _sha_bytes(f"{session_id}\0{project_id}".encode()) + ".json"
+    return receipt_root / name
+
+
+def checkpoint_project(
+    project: Path,
+    *,
+    session_id: str,
+    coordination_board: Path,
+    receipt_root: Path,
+    source_heads: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Issue a clean checkpoint only when state, claim, Git, and hashes bind."""
+    project = project.resolve()
+    state = _load_json(project / STATE_FILE)
+    project_id = str(state.get("project_id") or "")
+    if state.get("schema_version") != STATE_SCHEMA or not project_id:
+        raise ProjectStateError("current operational state is invalid")
+    if state.get("session_id") != session_id:
+        raise ProjectStateError("current operational state belongs to a different session")
+    problems = semantic_issues(project)
+    current_hashes = _content_hashes(project, str(state.get("controlling_plan") or ""))
+    if current_hashes != state.get("content_hashes"):
+        problems.append("durable project files changed after current state was written")
+    if dict(sorted((source_heads or {}).items())) != state.get("source_heads", {}):
+        problems.append("source heads changed after current state was written")
+    if problems:
+        raise ProjectStateError("; ".join(problems))
+    claim = _active_claim(coordination_board.resolve(), session_id, project_id, project)
+    _repo, _relative, head, tree = _git_identity(project)
+    payload: dict[str, Any] = {
+        "receipt_schema": RECEIPT_SCHEMA,
+        "session_id": session_id,
+        "project_id": project_id,
+        "project": str(project),
+        "git_head": head,
+        "project_tree": tree,
+        "working_digest": _working_digest(project),
+        "state_hash": _sha_file(project / STATE_FILE),
+        "content_hashes": current_hashes,
+        "source_heads": dict(sorted((source_heads or {}).items())),
+        "claim_hash": _sha_bytes(json.dumps(claim, sort_keys=True).encode()),
+        "writer_adapter": os.environ.get("SYNTHESIS_LIFECYCLE_ADAPTER", "shared"),
+        "validated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    path = _receipt_path(receipt_root.resolve(), session_id, project_id)
+    _atomic_json(path, payload)
+    payload["receipt_path"] = str(path)
+    return payload
+
+
+def validate_checkpoint(
+    project: Path,
+    *,
+    session_id: str,
+    coordination_board: Path,
+    receipt_root: Path,
+    source_heads: dict[str, str] | None = None,
+) -> tuple[str, list[str]]:
+    """Validate an outgoing receipt without turning missing evidence green."""
+    project = project.resolve()
+    try:
+        state = _load_json(project / STATE_FILE)
+    except ProjectStateError as exc:
+        return "UNKNOWN", [str(exc)]
+    project_id = str(state.get("project_id") or "")
+    path = _receipt_path(receipt_root.resolve(), session_id, project_id)
+    if not path.is_file():
+        return "LOCAL_RECOVERABLE", ["no clean checkpoint receipt exists"]
+    try:
+        receipt = _load_json(path)
+        claim = _active_claim(coordination_board.resolve(), session_id, project_id, project)
+    except ProjectStateError as exc:
+        return "UNKNOWN", [str(exc)]
+    problems: list[str] = []
+    if receipt.get("receipt_schema") != RECEIPT_SCHEMA:
+        problems.append("checkpoint receipt schema is unsupported")
+    if receipt.get("session_id") != session_id or receipt.get("project_id") != project_id:
+        problems.append("checkpoint receipt identity mismatch")
+    requested_sources = dict(sorted((source_heads or {}).items()))
+    if requested_sources != receipt.get("source_heads", {}):
+        return "FAIL", ["source heads differ from the clean checkpoint"]
+    if _sha_file(project / STATE_FILE) != receipt.get("state_hash"):
+        problems.append("current operational state differs from the clean checkpoint")
+    if _content_hashes(project, str(state.get("controlling_plan") or "")) != receipt.get("content_hashes"):
+        problems.append("durable project files differ from the clean checkpoint")
+    if _working_digest(project) != receipt.get("working_digest"):
+        problems.append("project working state differs from the clean checkpoint")
+    if _sha_bytes(json.dumps(claim, sort_keys=True).encode()) != receipt.get("claim_hash"):
+        problems.append("coordination claim differs from the clean checkpoint")
+    return ("LOCAL_RECOVERABLE", problems) if problems else ("PASS", [])
+
+
+def _row_for_event(rows: list[dict[str, str]], payload: dict[str, Any]) -> dict[str, str] | None:
+    event_ids = {
+        str(payload.get(key) or "").strip()
+        for key in ("session_id", "root_task_uuid", "task_id")
+    }
+    configured = os.environ.get("SYNTHESIS_CLIENT_SESSION_REF", "").strip()
+    if configured:
+        event_ids.update({configured, configured.rsplit(":", 1)[-1]})
+    matches = []
+    for row in rows:
+        if row.get("status", "").lower() != "active":
+            continue
+        client_ref = row.get("client session ref", "")
+        if (
+            client_ref in event_ids
+            or client_ref.rsplit(":", 1)[-1] in event_ids
+            or row.get("session uuid", "") in event_ids
+        ):
+            matches.append(row)
+    if len(matches) > 1:
+        raise ProjectStateError("lifecycle event matches multiple active coordination seats")
+    return matches[0] if matches else None
+
+
+def _project_from_claim(row: dict[str, str]) -> Path | None:
+    project_id = row.get("project", "")
+    if not project_id:
+        return None
+    paths: list[Path] = []
+    cells = (
+        row.get("claimed areas (advisory lock)", "")
+        + ","
+        + row.get("workspace(s) / branch", "")
+    )
+    for raw in re.split(r"(?:<br>|,)", cells):
+        value = raw.strip().split(" @ ", 1)[0].removesuffix("/**").removesuffix("/")
+        if not value.startswith("/"):
+            continue
+        path = Path(value)
+        marker = ("projects", project_id)
+        parts = path.parts
+        for index in range(len(parts) - 1):
+            if tuple(parts[index : index + 2]) == marker:
+                paths.append(Path(*parts[: index + 2]))
+        paths.append(path / "projects" / project_id)
+    existing = sorted(
+        {path.resolve() for path in paths if (path / STATE_FILE).is_file()},
+        key=lambda item: (len(str(item)), str(item)),
+    )
+    if len(existing) > 1:
+        matching = []
+        for path in existing:
+            try:
+                if _load_json(path / STATE_FILE).get("session_id") == row.get("session uuid"):
+                    matching.append(path)
+            except ProjectStateError:
+                continue
+        if len(matching) == 1:
+            return matching[0]
+        raise ProjectStateError("active claim names multiple structured project states")
+    return existing[0] if existing else None
+
+
+def _live_source_heads(state: dict[str, Any]) -> dict[str, str]:
+    live: dict[str, str] = {}
+    for raw in (state.get("source_heads") or {}):
+        root = Path(str(raw)).resolve()
+        live[str(raw)] = _run(root, "rev-parse", "HEAD").stdout.strip()
+    return live
+
+
+def checkpoint_hook(
+    payload: dict[str, Any],
+    *,
+    coordination_board: Path,
+    receipt_root: Path,
+    refresh_coordination: bool = True,
+) -> tuple[str, list[str]]:
+    """Bind a lifecycle event to its seat and issue an exact clean receipt."""
+    try:
+        if refresh_coordination:
+            refresh_issue = _refresh_coordination_board(coordination_board.resolve())
+            if refresh_issue:
+                return "FAIL", [refresh_issue]
+        row = _row_for_event(_parse_board_rows(coordination_board.resolve()), payload)
+        if row is None:
+            cwd = Path(str(payload.get("cwd") or ".")).resolve()
+            for candidate in (cwd, *cwd.parents):
+                if (candidate / STATE_FILE).is_file():
+                    return "UNKNOWN", ["structured project has no matching active coordination seat"]
+            return "NOT_APPLICABLE", []
+        project = _project_from_claim(row)
+        if project is None:
+            return "NOT_APPLICABLE", []
+        state = _load_json(project / STATE_FILE)
+        session_id = row.get("session uuid", "")
+        source_heads = _live_source_heads(state)
+        checkpoint_project(
+            project,
+            session_id=session_id,
+            coordination_board=coordination_board,
+            receipt_root=receipt_root,
+            source_heads=source_heads,
+        )
+        return validate_checkpoint(
+            project,
+            session_id=session_id,
+            coordination_board=coordination_board,
+            receipt_root=receipt_root,
+            source_heads=source_heads,
+        )
+    except (OSError, ProjectStateError) as exc:
+        return "FAIL", [str(exc)]
+
+
+def _source_head_args(values: list[str]) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for value in values:
+        path, separator, head = value.partition("=")
+        if not separator or not path.strip() or not head.strip():
+            raise ProjectStateError(
+                "source heads must use an absolute-path=commit value"
+            )
+        root = Path(path).expanduser().resolve()
+        if not root.is_absolute() or not root.is_dir():
+            raise ProjectStateError(f"source repository is unreadable: {root}")
+        resolved = _run(root, "rev-parse", f"{head.strip()}^{{commit}}").stdout.strip()
+        parsed[str(root)] = resolved
+    return parsed
+
+
+def _add_source_heads(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--source-head",
+        action="append",
+        default=[],
+        metavar="ABSOLUTE_PATH=COMMIT",
+        help="bind one implementation source repository (repeatable)",
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    resolve = sub.add_parser("resolve")
+    resolve.add_argument("--project-id", required=True)
+    resolve.add_argument("--index", required=True, type=Path)
+    resolve.add_argument("--repo-guard-root", type=Path)
+    resolve.add_argument("--checkpoint-receipt-root", type=Path)
+    resolve.add_argument("--coordination-board", type=Path)
+    resolve.add_argument("--pointer", type=Path)
+    resolve.add_argument("--no-fetch", action="store_true")
+    resolve.add_argument("--fast-forward-canonical", action="store_true")
+    resolve.add_argument("--no-coordination-refresh", action="store_true")
+    semantic = sub.add_parser("semantic")
+    semantic.add_argument("--project", required=True, type=Path)
+    build = sub.add_parser("build")
+    build.add_argument("--project", required=True, type=Path)
+    build.add_argument("--project-id", required=True)
+    build.add_argument("--phase", required=True)
+    build.add_argument("--status", required=True)
+    build.add_argument("--controlling-plan", required=True)
+    build.add_argument("--accepted-baseline", required=True)
+    build.add_argument("--next-action", action="append", required=True)
+    build.add_argument("--last-session", required=True)
+    build.add_argument("--session-id", required=True)
+    _add_source_heads(build)
+    checkpoint = sub.add_parser("checkpoint")
+    checkpoint.add_argument("--project", required=True, type=Path)
+    checkpoint.add_argument("--session-id", required=True)
+    checkpoint.add_argument("--coordination-board", required=True, type=Path)
+    checkpoint.add_argument("--receipt-root", required=True, type=Path)
+    _add_source_heads(checkpoint)
+    validate = sub.add_parser("validate")
+    validate.add_argument("--project", required=True, type=Path)
+    validate.add_argument("--session-id", required=True)
+    validate.add_argument("--coordination-board", required=True, type=Path)
+    validate.add_argument("--receipt-root", required=True, type=Path)
+    _add_source_heads(validate)
+    hook = sub.add_parser("hook")
+    hook.add_argument(
+        "--coordination-board",
+        type=Path,
+        default=Path.home() / ".synthesis" / "coordination" / "active-sessions.md",
+    )
+    hook.add_argument(
+        "--receipt-root",
+        type=Path,
+        default=Path.home() / ".synthesis" / "project-state" / "receipts",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "resolve":
+        report = resolve_project(
+            args.project_id,
+            args.index,
+            repo_guard_root=args.repo_guard_root,
+            checkpoint_receipt_root=args.checkpoint_receipt_root,
+            coordination_board=args.coordination_board,
+            pointer=args.pointer,
+            fetch=not args.no_fetch,
+            fast_forward_canonical=args.fast_forward_canonical,
+            refresh_coordination=(
+                args.coordination_board is not None and not args.no_coordination_refresh
+            ),
+        )
+        print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+        return 0 if report.status in {"PASS", "LOCAL_RECOVERABLE"} else 1
+    if args.command == "semantic":
+        issues = semantic_issues(args.project)
+        print(json.dumps({"status": "PASS" if not issues else "FAIL", "issues": issues}, indent=2))
+        return 0 if not issues else 1
+    if args.command == "build":
+        try:
+            payload = build_operational_state(
+                args.project,
+                project_id=args.project_id,
+                phase=args.phase,
+                status=args.status,
+                controlling_plan=args.controlling_plan,
+                accepted_baseline=args.accepted_baseline,
+                next_actions=args.next_action,
+                last_session=args.last_session,
+                session_id=args.session_id,
+                source_heads=_source_head_args(args.source_head),
+            )
+        except (OSError, ProjectStateError) as exc:
+            print(json.dumps({"status": "FAIL", "issues": [str(exc)]}, indent=2))
+            return 1
+        print(json.dumps({"status": "PASS", "state": payload}, indent=2))
+        return 0
+    if args.command == "checkpoint":
+        try:
+            payload = checkpoint_project(
+                args.project,
+                session_id=args.session_id,
+                coordination_board=args.coordination_board,
+                receipt_root=args.receipt_root,
+                source_heads=_source_head_args(args.source_head),
+            )
+        except (OSError, ProjectStateError) as exc:
+            print(json.dumps({"status": "FAIL", "issues": [str(exc)]}, indent=2))
+            return 1
+        print(json.dumps({"status": "PASS", "receipt": payload}, indent=2))
+        return 0
+    if args.command == "hook":
+        try:
+            payload = json.loads(sys.stdin.read() or "{}")
+            if not isinstance(payload, dict):
+                raise ValueError("hook payload is not an object")
+        except (json.JSONDecodeError, ValueError) as exc:
+            print(json.dumps({"status": "UNKNOWN", "issues": [str(exc)]}))
+            return 2
+        verdict, issues = checkpoint_hook(
+            payload,
+            coordination_board=args.coordination_board,
+            receipt_root=args.receipt_root,
+        )
+        print(json.dumps({"status": verdict, "issues": issues}))
+        return 0 if verdict in {"PASS", "NOT_APPLICABLE"} else 2
+    verdict, issues = validate_checkpoint(
+        args.project,
+        session_id=args.session_id,
+        coordination_board=args.coordination_board,
+        receipt_root=args.receipt_root,
+        source_heads=_source_head_args(args.source_head),
+    )
+    print(json.dumps({"status": verdict, "issues": issues}, indent=2))
+    return 0 if verdict == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/synthesis-project-management/scripts/test_project_state.py
+++ b/skills/synthesis-project-management/scripts/test_project_state.py
@@ -1,0 +1,571 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import project_state as state
+
+
+def run(*args: str, cwd: Path) -> str:
+    result = subprocess.run(args, cwd=cwd, capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def write_project(repo: Path, project_id: str = "alpha", version: str = "1.0.0") -> Path:
+    project = repo / "projects" / project_id
+    (project / "sessions").mkdir(parents=True, exist_ok=True)
+    (project / "resources" / "artifacts").mkdir(parents=True, exist_ok=True)
+    (repo / "projects" / "index.yaml").write_text(
+        f"- id: {project_id}\n  status: active\n  last_session: '2026-09-01'\n",
+        encoding="utf-8",
+    )
+    (project / "REFERENCE.md").write_text("# Reference\n", encoding="utf-8")
+    (project / "sessions" / "2026-09.md").write_text(
+        "### 2026-09-03 — current\n", encoding="utf-8"
+    )
+    (project / "resources" / "artifacts" / "plan.md").write_text(
+        "# Plan\n", encoding="utf-8"
+    )
+    (project / "CONTEXT.md").write_text(
+        "\n".join(
+            [
+                "# Context",
+                "",
+                f"**Phase:** release {version}",
+                "**Status:** Active",
+                "**Last session:** 2026-09-03",
+                "",
+                "[controlling plan](resources/artifacts/plan.md)",
+                "",
+                "## Accepted baseline",
+                f"Current accepted release: v{version}.",
+                "",
+                "## Current handoff",
+                f"*State as of: 2026-09-03 (v{version})*",
+                "",
+                "## What's Next",
+                "- [ ] finish",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return project
+
+
+def init_repo(root: Path, version: str = "1.0.0") -> tuple[Path, Path]:
+    remote = root / "remote.git"
+    repo = root / "repo"
+    hooks = root / "fixture-hooks"
+    hooks.mkdir()
+    run("git", "init", "--bare", str(remote), cwd=root)
+    run("git", "init", "-b", "main", str(repo), cwd=root)
+    run("git", "config", "user.email", "fixture@example.invalid", cwd=repo)
+    run("git", "config", "user.name", "Fixture", cwd=repo)
+    run("git", "config", "core.hooksPath", str(hooks), cwd=repo)
+    project = write_project(repo, version=version)
+    run("git", "add", "projects", cwd=repo)
+    run("git", "commit", "-m", "Initial project state", cwd=repo)
+    run("git", "remote", "add", "origin", str(remote), cwd=repo)
+    run("git", "push", "-u", "origin", "main", cwd=repo)
+    run("git", "symbolic-ref", "HEAD", "refs/heads/main", cwd=remote)
+    return repo, project
+
+
+def commit_version(repo: Path, project: Path, version: str) -> str:
+    text = (project / "CONTEXT.md").read_text(encoding="utf-8")
+    text = text.replace("v1.0.0", f"v{version}").replace("release 1.0.0", f"release {version}")
+    (project / "CONTEXT.md").write_text(text, encoding="utf-8")
+    run("git", "add", str(project.relative_to(repo)), cwd=repo)
+    run("git", "commit", "-m", "Advance project state", cwd=repo)
+    return run("git", "rev-parse", "HEAD", cwd=repo)
+
+
+def board(path: Path, rows: list[tuple[str, str, str, str]]) -> Path:
+    header = (
+        "# Board\nLease: file:///fixture\n\n## Active sessions\n\n"
+        "| Session UUID | Compact ID | Speakable ID | Client session ref | Project | "
+        "Workspace(s) / branch | Claimed areas (advisory lock) | Context role | Started | Heartbeat | Status |\n"
+        "|---|---|---|---|---|---|---|---|---|---|---|\n"
+    )
+    body = "".join(
+        f"| {session} | {compact} | words-1 | tool:{session} | {project} | {workspace} | "
+        f"{workspace}/projects/{project}/** | owner | 2026-09-03T12:00:00-04:00 | 2026-09-03T12:00:00-04:00 | active |\n"
+        for session, compact, project, workspace in rows
+    )
+    path.write_text(header + body + "\n## Messages\n\n## Protocol\n", encoding="utf-8")
+    return path
+
+
+def sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_positive_controls_discover_canonical_worktree_ref_manifest_receipt_pointer_and_claim(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    state_root = tmp_path / "state"
+    (state_root / "pending").mkdir(parents=True)
+    (state_root / "local-handoff").mkdir(parents=True)
+    manifest = {"schema_version": 2, "session_id": "session-a", "paths": [str(project / "CONTEXT.md")]}
+    (state_root / "pending" / (hashlib.sha256(b"session-a").hexdigest() + ".json")).write_text(json.dumps(manifest), encoding="utf-8")
+    (state_root / "local-handoff" / (hashlib.sha256(b"session-a").hexdigest() + ".json")).write_text(json.dumps({"session_id": "session-a", "readiness": "LOCAL_READY", "results": []}), encoding="utf-8")
+    checkpoint_receipts = tmp_path / "checkpoint-receipts"
+    checkpoint_receipts.mkdir()
+    (checkpoint_receipts / "bound.json").write_text(
+        json.dumps({"session_id": "session-a", "project_id": "alpha"}),
+        encoding="utf-8",
+    )
+    pointer = tmp_path / "active.json"
+    pointer.write_text(json.dumps({"project": str(project)}), encoding="utf-8")
+    claims = board(tmp_path / "board.md", [("018f0000-0000-7000-8000-000000000001", "s-abcd-efgh-jkmn", "alpha", str(repo))])
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", repo_guard_root=state_root, checkpoint_receipt_root=checkpoint_receipts, coordination_board=claims, pointer=pointer, fetch=False)
+    assert {item.source for item in report.candidates} >= {"canonical", "worktree", "ref", "manifest", "receipt", "checkpoint-receipt", "pointer", "claim"}
+
+
+def test_canonical_behind_isolated_worktree_selects_newer_without_mutation(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    worktree = tmp_path / "newer"
+    run("git", "worktree", "add", "-b", "feature/newer", str(worktree), cwd=repo)
+    newer_project = worktree / "projects" / "alpha"
+    newer = commit_version(worktree, newer_project, "2.0.0")
+    original = run("git", "rev-parse", "HEAD", cwd=repo)
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", fetch=False)
+    assert report.status == "PASS"
+    assert report.selected_path == str(newer_project.resolve())
+    assert report.selected_head == newer
+    assert run("git", "rev-parse", "HEAD", cwd=repo) == original
+
+
+def test_safe_fast_forward_preserves_unrelated_untracked_file(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    peer = tmp_path / "peer"
+    run("git", "clone", str(tmp_path / "remote.git"), str(peer), cwd=tmp_path)
+    run("git", "config", "user.email", "fixture@example.invalid", cwd=peer)
+    run("git", "config", "user.name", "Fixture", cwd=peer)
+    run("git", "config", "core.hooksPath", str(tmp_path / "fixture-hooks"), cwd=peer)
+    newer = commit_version(peer, peer / "projects" / "alpha", "2.0.0")
+    run("git", "push", "origin", "main", cwd=peer)
+    unrelated = repo / "notes.local"
+    unrelated.write_text("preserve\n", encoding="utf-8")
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", fetch=True, fast_forward_canonical=True)
+    assert report.selected_head == newer
+    assert unrelated.read_text(encoding="utf-8") == "preserve\n"
+
+
+def test_fast_forward_refuses_non_upstream_local_ref(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    worktree = tmp_path / "newer"
+    run("git", "worktree", "add", "-b", "feature/newer", str(worktree), cwd=repo)
+    newer_project = worktree / "projects" / "alpha"
+    newer = commit_version(worktree, newer_project, "2.0.0")
+    run("git", "worktree", "remove", str(worktree), cwd=repo)
+    original = run("git", "rev-parse", "HEAD", cwd=repo)
+    report = state.resolve_project(
+        "alpha",
+        repo / "projects" / "index.yaml",
+        fetch=True,
+        fast_forward_canonical=True,
+    )
+    assert report.selected_head == newer
+    assert report.selected_path is None
+    assert any("not a fetched remote ref" in issue for issue in report.issues)
+    assert run("git", "rev-parse", "HEAD", cwd=repo) == original
+
+
+def test_local_ahead_is_selected_and_remote_ahead_is_selected_after_fetch(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    local = commit_version(repo, project, "2.0.0")
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", fetch=False)
+    assert report.selected_head == local
+    run("git", "reset", "--hard", "origin/main", cwd=repo)
+    peer = tmp_path / "peer"
+    run("git", "clone", str(tmp_path / "remote.git"), str(peer), cwd=tmp_path)
+    run("git", "config", "user.email", "fixture@example.invalid", cwd=peer)
+    run("git", "config", "user.name", "Fixture", cwd=peer)
+    run("git", "config", "core.hooksPath", str(tmp_path / "fixture-hooks"), cwd=peer)
+    remote = commit_version(peer, peer / "projects" / "alpha", "3.0.0")
+    run("git", "push", "origin", "main", cwd=peer)
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", fetch=True)
+    assert report.selected_head == remote
+
+
+def test_diverged_project_states_fail_closed(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    run("git", "checkout", "-b", "feature/a", cwd=repo)
+    commit_version(repo, project, "2.0.0")
+    run("git", "checkout", "main", cwd=repo)
+    commit_version(repo, project, "3.0.0")
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", fetch=False)
+    assert report.status == "CONFLICT"
+    assert any("diverg" in issue.lower() for issue in report.issues)
+
+
+def test_deleted_registered_worktree_is_reported_not_ignored(tmp_path: Path) -> None:
+    repo, _project = init_repo(tmp_path)
+    raw_gitdir = Path(run("git", "rev-parse", "--git-common-dir", cwd=repo))
+    gitdir = (repo / raw_gitdir).resolve() if not raw_gitdir.is_absolute() else raw_gitdir.resolve()
+    metadata = gitdir / "worktrees" / "gone"
+    metadata.mkdir(parents=True)
+    (metadata / "gitdir").write_text(str(tmp_path / "gone" / ".git") + "\n", encoding="utf-8")
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", fetch=False)
+    assert report.status == "UNKNOWN"
+    assert any("missing worktree" in issue.lower() for issue in report.issues)
+
+
+def test_dirty_attributed_project_file_is_local_recoverable(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    context = project / "CONTEXT.md"
+    context.write_text(context.read_text(encoding="utf-8") + "interrupted\n", encoding="utf-8")
+    state_root = tmp_path / "state"
+    pending = state_root / "pending"
+    pending.mkdir(parents=True)
+    session = "session-a"
+    payload = {"schema_version": 2, "session_id": session, "paths": [str(context)], "path_hashes": {str(context): sha(context)}}
+    (pending / (hashlib.sha256(session.encode()).hexdigest() + ".json")).write_text(json.dumps(payload), encoding="utf-8")
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", repo_guard_root=state_root, fetch=False)
+    assert report.status == "LOCAL_RECOVERABLE"
+    assert report.selected_path == str(project.resolve())
+
+
+def test_dirty_state_on_older_head_conflicts_with_newer_committed_state(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    newer_worktree = tmp_path / "newer"
+    run("git", "worktree", "add", "-b", "feature/newer", str(newer_worktree), cwd=repo)
+    commit_version(newer_worktree, newer_worktree / "projects" / "alpha", "2.0.0")
+    context = project / "CONTEXT.md"
+    context.write_text(context.read_text(encoding="utf-8") + "interrupted\n", encoding="utf-8")
+    state_root = tmp_path / "state"
+    pending = state_root / "pending"
+    pending.mkdir(parents=True)
+    session = "session-a"
+    payload = {
+        "schema_version": 2,
+        "session_id": session,
+        "paths": [str(context)],
+        "path_hashes": {str(context): sha(context)},
+    }
+    (pending / (hashlib.sha256(session.encode()).hexdigest() + ".json")).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+    report = state.resolve_project(
+        "alpha", repo / "projects" / "index.yaml", repo_guard_root=state_root, fetch=False
+    )
+    assert report.status == "CONFLICT"
+    assert any("older" in issue.lower() for issue in report.issues)
+
+
+def test_two_attributed_dirty_worktrees_with_different_hashes_conflict(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    other = tmp_path / "other"
+    run("git", "worktree", "add", "-b", "feature/other", str(other), cwd=repo)
+    paths = [project / "CONTEXT.md", other / "projects" / "alpha" / "CONTEXT.md"]
+    paths[0].write_text(paths[0].read_text(encoding="utf-8") + "a\n", encoding="utf-8")
+    paths[1].write_text(paths[1].read_text(encoding="utf-8") + "b\n", encoding="utf-8")
+    root = tmp_path / "state" / "pending"
+    root.mkdir(parents=True)
+    for index, path in enumerate(paths):
+        session = f"session-{index}"
+        payload = {"schema_version": 2, "session_id": session, "paths": [str(path)], "path_hashes": {str(path): sha(path)}}
+        (root / (hashlib.sha256(session.encode()).hexdigest() + ".json")).write_text(json.dumps(payload), encoding="utf-8")
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", repo_guard_root=root.parent, fetch=False)
+    assert report.status == "CONFLICT"
+
+
+def test_absent_pointer_does_not_block_and_stale_pointer_cannot_override(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", pointer=tmp_path / "absent.json", fetch=False)
+    assert report.selected_path == str(project.resolve())
+    stale = tmp_path / "stale.json"
+    stale.write_text(json.dumps({"project": str(tmp_path / "gone")}), encoding="utf-8")
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", pointer=stale, fetch=False)
+    assert report.selected_path == str(project.resolve())
+    assert any("pointer" in issue.lower() for issue in report.issues)
+
+
+def test_stale_index_date_is_derived_as_a_warning_not_selected_truth(tmp_path: Path) -> None:
+    repo, _project = init_repo(tmp_path)
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", fetch=False)
+    assert report.status == "PASS"
+    assert any("last_session" in issue and "2026-09-03" in issue for issue in report.issues)
+
+
+def test_future_date_in_session_body_does_not_advance_derived_session(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    (project / "sessions" / "2026-09.md").write_text(
+        "### 2026-09-03 — current\n\nNext review: 2026-09-30.\n",
+        encoding="utf-8",
+    )
+    report = state.resolve_project(
+        "alpha", repo / "projects" / "index.yaml", fetch=False
+    )
+    assert any("derived value is 2026-09-03" in issue for issue in report.issues)
+    assert not any("2026-09-30" in issue for issue in report.issues)
+
+
+def test_internal_version_contradiction_is_semantic_failure(tmp_path: Path) -> None:
+    _repo, project = init_repo(tmp_path)
+    context = project / "CONTEXT.md"
+    context.write_text(context.read_text(encoding="utf-8").replace("**Phase:** release 1.0.0", "**Phase:** current release 1.0.0") + "\nLater release shipped: v4.0.0.\n", encoding="utf-8")
+    issues = state.semantic_issues(project)
+    assert any("current" in issue.lower() and "4.0.0" in issue for issue in issues)
+
+
+def test_checkpoint_requires_context_refresh_after_source_head_changes(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    claims = board(tmp_path / "board.md", [("018f0000-0000-7000-8000-000000000001", "s-abcd-efgh-jkmn", "alpha", str(repo))])
+    receipt_root = tmp_path / "receipts"
+    source = tmp_path / "source"
+    source.mkdir()
+    run("git", "init", "-b", "main", cwd=source)
+    run("git", "config", "user.email", "fixture@example.invalid", cwd=source)
+    run("git", "config", "user.name", "Fixture", cwd=source)
+    run("git", "config", "core.hooksPath", str(tmp_path / "fixture-hooks"), cwd=source)
+    (source / "code.txt").write_text("one\n", encoding="utf-8")
+    run("git", "add", "code.txt", cwd=source)
+    run("git", "commit", "-m", "source one", cwd=source)
+    head = run("git", "rev-parse", "HEAD", cwd=source)
+    state.build_operational_state(project, project_id="alpha", phase="release 1.0.0", status="active", controlling_plan="resources/artifacts/plan.md", accepted_baseline="1.0.0", next_actions=["finish"], last_session="2026-09-03", session_id="018f0000-0000-7000-8000-000000000001", source_heads={str(source): head})
+    state.checkpoint_project(project, session_id="018f0000-0000-7000-8000-000000000001", coordination_board=claims, receipt_root=receipt_root, source_heads={str(source): head})
+    (source / "code.txt").write_text("two\n", encoding="utf-8")
+    run("git", "add", "code.txt", cwd=source)
+    run("git", "commit", "-m", "source two", cwd=source)
+    newer = run("git", "rev-parse", "HEAD", cwd=source)
+    verdict, issues = state.validate_checkpoint(project, session_id="018f0000-0000-7000-8000-000000000001", coordination_board=claims, receipt_root=receipt_root, source_heads={str(source): newer})
+    assert verdict == "FAIL"
+    assert any("source" in issue.lower() for issue in issues)
+
+
+def test_operational_state_compiles_and_validates_bounded_context(tmp_path: Path) -> None:
+    _repo, project = init_repo(tmp_path)
+    payload = state.build_operational_state(
+        project,
+        project_id="alpha",
+        phase="release 1.0.0",
+        status="active",
+        controlling_plan="resources/artifacts/plan.md",
+        accepted_baseline="1.0.0",
+        next_actions=["finish"],
+        last_session="2026-09-03",
+        session_id="018f0000-0000-7000-8000-000000000001",
+    )
+    context = (project / "CONTEXT.md").read_text(encoding="utf-8")
+    assert context.count("<!-- synthesis-current-state:start -->") == 1
+    assert "**Phase:** release 1.0.0" in context
+    assert not state.semantic_issues(project)
+    (project / "CONTEXT.md").write_text(
+        context.replace("**Phase:** release 1.0.0", "**Phase:** release 0.9.0", 1),
+        encoding="utf-8",
+    )
+    assert any("compiled" in issue for issue in state.semantic_issues(project))
+    assert any("changed after" in issue for issue in state.semantic_issues(project))
+    assert payload["content_hashes"]["CONTEXT.md"] != sha(project / "CONTEXT.md")
+
+
+def test_semantic_state_detects_stale_hashed_reference(tmp_path: Path) -> None:
+    _repo, project = init_repo(tmp_path)
+    state.build_operational_state(
+        project,
+        project_id="alpha",
+        phase="release 1.0.0",
+        status="active",
+        controlling_plan="resources/artifacts/plan.md",
+        accepted_baseline="1.0.0",
+        next_actions=["finish"],
+        last_session="2026-09-03",
+        session_id="018f0000-0000-7000-8000-000000000001",
+    )
+    (project / "REFERENCE.md").write_text("# Reference\n\nchanged\n", encoding="utf-8")
+    assert any("changed after" in issue for issue in state.semantic_issues(project))
+
+
+@pytest.mark.parametrize("writer,receiver", [("adapter-a", "adapter-b"), ("adapter-b", "adapter-a")])
+def test_handoff_directions_share_one_receipt_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    writer: str,
+    receiver: str,
+) -> None:
+    repo, project = init_repo(tmp_path)
+    session = "018f0000-0000-7000-8000-000000000001"
+    claims = board(tmp_path / "board.md", [(session, "s-abcd-efgh-jkmn", "alpha", str(repo))])
+    receipt_root = tmp_path / "receipts"
+    state.build_operational_state(project, project_id="alpha", phase="release 1.0.0", status="active", controlling_plan="resources/artifacts/plan.md", accepted_baseline="1.0.0", next_actions=["finish"], last_session="2026-09-03", session_id=session)
+    monkeypatch.setenv("SYNTHESIS_LIFECYCLE_ADAPTER", writer)
+    receipt = state.checkpoint_project(project, session_id=session, coordination_board=claims, receipt_root=receipt_root)
+    assert receipt["writer_adapter"] == writer
+    monkeypatch.setenv("SYNTHESIS_LIFECYCLE_ADAPTER", receiver)
+    verdict, issues = state.validate_checkpoint(project, session_id=session, coordination_board=claims, receipt_root=receipt_root)
+    assert (verdict, issues) == ("PASS", [])
+
+
+def test_clean_stop_passes_and_interrupted_stop_is_recoverable_not_clean(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    session = "018f0000-0000-7000-8000-000000000001"
+    claims = board(tmp_path / "board.md", [(session, "s-abcd-efgh-jkmn", "alpha", str(repo))])
+    receipts = tmp_path / "receipts"
+    state.build_operational_state(project, project_id="alpha", phase="release 1.0.0", status="active", controlling_plan="resources/artifacts/plan.md", accepted_baseline="1.0.0", next_actions=["finish"], last_session="2026-09-03", session_id=session)
+    state.checkpoint_project(project, session_id=session, coordination_board=claims, receipt_root=receipts)
+    assert state.validate_checkpoint(project, session_id=session, coordination_board=claims, receipt_root=receipts)[0] == "PASS"
+    (project / "REFERENCE.md").write_text("interrupted\n", encoding="utf-8")
+    assert state.validate_checkpoint(project, session_id=session, coordination_board=claims, receipt_root=receipts)[0] == "LOCAL_RECOVERABLE"
+
+
+def test_unrelated_dirty_and_staged_files_survive_recovery(tmp_path: Path) -> None:
+    repo, _project = init_repo(tmp_path)
+    (repo / "unrelated.txt").write_text("staged\n", encoding="utf-8")
+    run("git", "add", "unrelated.txt", cwd=repo)
+    (repo / "other.local").write_text("dirty\n", encoding="utf-8")
+    before = run("git", "status", "--porcelain=v1", cwd=repo)
+    state.resolve_project("alpha", repo / "projects" / "index.yaml", fetch=False, fast_forward_canonical=True)
+    assert run("git", "status", "--porcelain=v1", cwd=repo) == before
+
+
+def test_unrelated_project_session_does_not_block_checkpoint(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    session = "018f0000-0000-7000-8000-000000000001"
+    claims = board(tmp_path / "board.md", [(session, "s-abcd-efgh-jkmn", "alpha", str(repo)), ("018f0000-0000-7000-8000-000000000002", "s-npqr-stuv-wxyz", "beta", str(tmp_path / "elsewhere"))])
+    state.build_operational_state(project, project_id="alpha", phase="release 1.0.0", status="active", controlling_plan="resources/artifacts/plan.md", accepted_baseline="1.0.0", next_actions=["finish"], last_session="2026-09-03", session_id=session)
+    receipt = state.checkpoint_project(project, session_id=session, coordination_board=claims, receipt_root=tmp_path / "receipts")
+    assert receipt["session_id"] == session
+
+
+def test_unreachable_remote_is_unknown_not_green(tmp_path: Path) -> None:
+    repo, _project = init_repo(tmp_path)
+    run("git", "remote", "set-url", "origin", str(tmp_path / "missing.git"), cwd=repo)
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", fetch=True)
+    assert report.status == "UNKNOWN"
+    assert any("fetch" in issue.lower() for issue in report.issues)
+
+
+def test_unreachable_coordination_lease_is_unknown_not_green(tmp_path: Path) -> None:
+    repo, _project = init_repo(tmp_path)
+    claims = board(
+        tmp_path / "board.md",
+        [("018f0000-0000-7000-8000-000000000001", "s-abcd-efgh-jkmn", "alpha", str(repo))],
+    )
+    report = state.resolve_project(
+        "alpha",
+        repo / "projects" / "index.yaml",
+        coordination_board=claims,
+        fetch=False,
+        refresh_coordination=True,
+    )
+    assert report.status == "UNKNOWN"
+    assert any("lease refresh" in issue.lower() for issue in report.issues)
+
+
+def test_installed_newer_than_loaded_registry_is_a_live_plane_failure(tmp_path: Path) -> None:
+    repo, _project = init_repo(tmp_path)
+    report = state.resolve_project("alpha", repo / "projects" / "index.yaml", fetch=False)
+    report.planes.update({"source": "PASS", "installed": "PASS", "live": "FAIL"})
+    assert report.selected_path is not None
+    assert report.planes == {"source": "PASS", "installed": "PASS", "live": "FAIL", "continuity": "PASS"}
+
+
+def test_lifecycle_hook_issues_session_bound_clean_receipt(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    session = "018f0000-0000-7000-8000-000000000001"
+    claims = board(tmp_path / "board.md", [(session, "s-abcd-efgh-jkmn", "alpha", str(repo))])
+    receipts = tmp_path / "receipts"
+    state.build_operational_state(
+        project,
+        project_id="alpha",
+        phase="release 1.0.0",
+        status="active",
+        controlling_plan="resources/artifacts/plan.md",
+        accepted_baseline="1.0.0",
+        next_actions=["finish"],
+        last_session="2026-09-03",
+        session_id=session,
+    )
+    verdict, issues = state.checkpoint_hook(
+        {"session_id": session, "cwd": str(repo)},
+        coordination_board=claims,
+        receipt_root=receipts,
+        refresh_coordination=False,
+    )
+    assert (verdict, issues) == ("PASS", [])
+    receipt = json.loads(next(receipts.glob("*.json")).read_text(encoding="utf-8"))
+    assert receipt["session_id"] == session
+    assert receipt["project_id"] == "alpha"
+
+
+def test_lifecycle_hook_refuses_semantically_incomplete_stop(tmp_path: Path) -> None:
+    repo, project = init_repo(tmp_path)
+    session = "018f0000-0000-7000-8000-000000000001"
+    claims = board(tmp_path / "board.md", [(session, "s-abcd-efgh-jkmn", "alpha", str(repo))])
+    state.build_operational_state(
+        project,
+        project_id="alpha",
+        phase="release 1.0.0",
+        status="active",
+        controlling_plan="resources/artifacts/plan.md",
+        accepted_baseline="1.0.0",
+        next_actions=["finish"],
+        last_session="2026-09-03",
+        session_id=session,
+    )
+    (project / "CONTEXT.md").write_text("# stale after work\n", encoding="utf-8")
+    verdict, issues = state.checkpoint_hook(
+        {"session_id": session, "cwd": str(repo)},
+        coordination_board=claims,
+        receipt_root=tmp_path / "receipts",
+        refresh_coordination=False,
+    )
+    assert verdict == "FAIL"
+    assert any("changed" in issue for issue in issues)
+
+
+def test_lifecycle_hook_fails_closed_when_lease_cannot_refresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _project = init_repo(tmp_path)
+    session = "018f0000-0000-7000-8000-000000000001"
+    claims = board(
+        tmp_path / "board.md",
+        [(session, "s-abcd-efgh-jkmn", "alpha", str(repo))],
+    )
+    monkeypatch.setattr(
+        state,
+        "_refresh_coordination_board",
+        lambda _path: "coordination lease refresh failed: fixture outage",
+    )
+    verdict, issues = state.checkpoint_hook(
+        {"session_id": session, "cwd": str(repo)},
+        coordination_board=claims,
+        receipt_root=tmp_path / "receipts",
+    )
+    assert verdict == "FAIL"
+    assert issues == ["coordination lease refresh failed: fixture outage"]
+
+
+def test_project_state_reliability_release_contract_is_coherent() -> None:
+    root = Path(__file__).resolve().parents[3]
+    versions = {
+        json.loads((root / path).read_text(encoding="utf-8"))["version"]
+        for path in (".claude-plugin/plugin.json", ".codex-plugin/plugin.json")
+    }
+    assert versions == {"4.92.0"}
+    assert "## [4.92.0] - 2026-09-03" in (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "Release **4.92.0**" in (root / "README.md").read_text(encoding="utf-8")
+    hooks = json.loads((root / "hooks" / "hooks.json").read_text(encoding="utf-8"))
+    commands = [
+        hook["command"]
+        for group in hooks["hooks"]["Stop"]
+        for hook in group["hooks"]
+    ]
+    assert any(command.endswith("project_state.py hook") for command in commands)
+    expected = {
+        "synthesis-project-management": "2.12.0",
+        "synthesis-context-lifecycle": "1.18.0",
+        "synthesis-agent-conformance": "1.9.0",
+        "synthesis-autopilot": "2.1.0",
+        "synthesis-repo-guard": "2.4.0",
+    }
+    for skill, version in expected.items():
+        text = (root / "skills" / skill / "SKILL.md").read_text(encoding="utf-8")
+        assert f'version: "{version}"' in text

--- a/skills/synthesis-repo-guard/SKILL.md
+++ b/skills/synthesis-repo-guard/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.3.0"
+  version: "2.4.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -186,6 +186,13 @@ optional session-end verification:
 Each client session has its own hashed pending manifest under
 `~/.synthesis/repo-guard/pending/`. Multiple agents can therefore coexist
 without one hook committing, publishing, or overwriting another session's files.
+
+For projects that adopt `CURRENT_STATE.json`, the plugin's provider-neutral
+Stop gate composes this file-level evidence with synthesis project management's
+semantic checkpoint. A clean project handoff receipt is issued only when the
+current coordination seat, project id, Git identity, durable-file hashes, and
+recorded source heads all match. An interrupted task still relies on the
+pending manifest and reports `LOCAL_RECOVERABLE`; it is never mislabeled clean.
 
 ### Cursor (`.cursor/settings.json`)
 

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -794,8 +794,12 @@ def test_cache_guardian_lock_release_contract_is_public_and_coherent() -> None:
         and hook.get("command", "").startswith("python3 ")
     ]
 
-    assert release.source_version(repository)[0] == "4.91.4"
-    assert release.changelog_top_version(repository) == "4.91.4"
+    # This is a historical feature contract. Current release metadata must
+    # agree without pinning every later release to the version that introduced
+    # the feature.
+    current = release.source_version(repository)[0]
+    assert current is not None
+    assert release.changelog_top_version(repository) == current
     assert "Version 2.6.3" in manager and "wait up to 120 seconds" in manager
     assert "watcher and explicit one-shot mode stay nonblocking" in manager
     assert "bounded failure" in readme


### PR DESCRIPTION
Adds a provider-neutral resolver for coherent project state across worktrees, refs, attributed interruptions, lifecycle evidence, pointers, and active claims. Introduces structured operational state with a compiled context block, semantic freshness checks, exact session-bound checkpoint receipts, and project-scoped autonomous stop gating. The closed acceptance matrix covers clean and interrupted handoffs, divergence, stale metadata, remote outages, concurrent sessions, safe fast-forward invariants, and positive discovery controls. The governed prepublication suite passes at the submitted head.