### PR TITLE
Keep aggregate conformance project-scoped

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.92.0",
+  "version": "4.92.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.92.0",
+  "version": "4.92.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.92.1] - 2026-09-03
+
+**One project's active pointer can no longer fail another project's aggregate
+conformance.** When the optional cache names a different project, the aggregate
+path now verifies stopped-project recovery and reports the foreign pointer as
+non-blocking diagnostic evidence. Explicit pointer validation remains strict,
+and malformed pointers still fail closed.
+
 ## [4.92.0] - 2026-09-03
 
 **A named project now resolves from the newest provable coherent state instead

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 ## What's new
 
 **Project recovery now follows evidence across checkouts instead of trusting a
-remembered path (September 2026).** Release **4.92.0** adds causal discovery
+remembered path (September 2026).** Release **4.92.1** adds causal discovery
 across worktrees, refs, attributed interruptions, lifecycle receipts, pointers,
 and claims; structured operational state with a compiled context block;
 semantic freshness checks; and session-bound Stop receipts. Divergence and
 unreadable evidence stay explicit, safe fast-forwarding cannot overwrite
 unrelated work, and one project's autonomous lifecycle can no longer block an
-unrelated session. See the [4.92.0 release notes](CHANGELOG.md).
+unrelated session. The aggregate conformance path also ignores a valid pointer
+owned by a different project while explicit pointer validation stays strict.
+See the [4.92.1 release notes](CHANGELOG.md).
 
 **One bootstrap now installs and manages the complete public system (September
 2026).** Releases **4.91.0** through **4.91.4** add the stable `synthesis` CLI,

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.9.0"
+  version: "1.9.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -139,6 +139,11 @@ no pending manifest and complete branch-head equality with the fetched upstream,
 not merely equality for commits touching the project subdirectory. Then open
 the project in the other client and confirm its SessionStart or first
 named-project turn recovers the same state.
+
+The aggregate `all` command treats a readable active pointer owned by another
+project as non-blocking diagnostic context and verifies stopped-project
+recovery instead. The explicit `pointer` command remains strict for whichever
+project the caller asks it to validate; malformed pointers fail in both modes.
 
 The continuity plane also runs causal project-state recovery. It enumerates
 every registered worktree and ref plus attributed manifests, receipts, pointer,

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -2094,6 +2094,33 @@ def pointer_checks(
     command accepts its documented absence and validates stopped-task handoff
     instead; an existing malformed pointer still fails in both scopes.
     """
+    if not require_pointer and pointer.exists():
+        try:
+            scoped_payload = json.loads(pointer.read_text(encoding="utf-8"))
+            scoped_project = scoped_payload.get("project")
+            if not scoped_project:
+                raise ValueError("missing project")
+            if Path(str(scoped_project)).expanduser().resolve() != project.resolve():
+                stopped_pointer = (
+                    project / ".synthesis-stopped-pointer-must-not-exist.json"
+                )
+                checks = handoff_checks(
+                    project,
+                    stopped_pointer,
+                    coordination_board,
+                )
+                add(
+                    checks,
+                    "pointer.scope",
+                    True,
+                    f"active pointer belongs to unrelated project: {scoped_project}",
+                    required=False,
+                )
+                return checks
+        except (OSError, ValueError, TypeError, json.JSONDecodeError):
+            # Existing malformed pointers remain failures in aggregate mode;
+            # only a readable, explicitly different project is non-blocking.
+            pass
     checks = handoff_checks(project, pointer, coordination_board)
     if not require_pointer and not pointer.exists():
         return checks

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -675,6 +675,51 @@ def test_aggregate_pointer_scope_accepts_documented_cache_absence(
     assert not {check.name: check for check in explicit}["pointer.schema"].ok
 
 
+def test_aggregate_pointer_scope_ignores_unrelated_project_state(
+    tmp_path: Path,
+) -> None:
+    project = write_stopped_project(tmp_path)
+    unrelated = tmp_path / "projects" / "unrelated-project"
+    unrelated.mkdir(parents=True)
+    pointer = tmp_path / "active.json"
+    pointer.write_text(
+        json.dumps(
+            {
+                "project": str(unrelated),
+                "phase": "stale unrelated phase",
+                "status": "blocked",
+                "plan": str(unrelated / "missing-plan.md"),
+                "activated_at": "2026-01-01T00:00:00+00:00",
+                "source": "fixture",
+                "worktree": str(tmp_path / "deleted-worktree"),
+                "branch": "feature/unrelated",
+                "source_commit": "0" * 40,
+                "owner_session": "019fff79-5858-7993-a329-b301bccf5d62",
+                "owner_lease": "https://example.test/coordination.git",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    aggregate = MODULE.pointer_checks(
+        project,
+        pointer,
+        tmp_path / "missing-board.md",
+        require_pointer=False,
+    )
+    explicit = MODULE.pointer_checks(
+        project,
+        pointer,
+        tmp_path / "missing-board.md",
+    )
+
+    assert all(check.ok for check in aggregate if check.required)
+    named = {check.name: check for check in aggregate}
+    assert named["pointer.scope"].ok
+    assert "unrelated project" in named["pointer.scope"].detail
+    assert not all(check.ok for check in explicit if check.required)
+
+
 def test_local_continuity_recovers_interrupted_attributed_edits(tmp_path: Path) -> None:
     project, _stale = clone_pair_with_project(tmp_path)
     context = project / "CONTEXT.md"

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,8 +1,8 @@
-# Closed acceptance universe for the project-state reliability release.
+# Closed acceptance universe for the project-isolation corrective release.
 schema: 2
-suite: synthesis-project-state-reliability
+suite: synthesis-project-state-pointer-isolation
 membership: closed
-production_entry_point: named-project resolution, SessionStart recovery, context doctor, lifecycle Stop, and autopilot Stop gate
+production_entry_point: aggregate conformance with an optional active-project pointer
 enforcing_boundary: release.py consumes this transaction-bound manifest before publishing, installation, and stable activation
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
@@ -19,67 +19,25 @@ changed_surfaces:
     cases: [release-contract]
   - path: README.md
     cases: [release-contract]
-  - path: hooks/hooks.json
-    cases: [release-contract, lifecycle-stop]
   - path: skills/synthesis-agent-conformance/SKILL.md
-    cases: [session-recovery, release-contract]
+    cases: [pointer-isolation, release-contract]
   - path: skills/synthesis-agent-conformance/scripts/conformance.py
-    cases: [session-recovery]
-  - path: skills/synthesis-agent-conformance/scripts/session_context.py
-    cases: [session-recovery]
-  - path: skills/synthesis-agent-conformance/scripts/test_session_context.py
-    cases: [session-recovery]
-  - path: skills/synthesis-autopilot/SKILL.md
-    cases: [scoped-autopilot, release-contract]
-  - path: skills/synthesis-autopilot/scripts/autopilot_gate.py
-    cases: [scoped-autopilot]
-  - path: skills/synthesis-autopilot/scripts/test_autopilot_gate.py
-    cases: [scoped-autopilot]
-  - path: skills/synthesis-context-lifecycle/SKILL.md
-    cases: [semantic-doctor, release-contract]
-  - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
-    cases: [semantic-doctor]
-  - path: skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
-    cases: [semantic-doctor]
+    cases: [pointer-isolation]
+  - path: skills/synthesis-agent-conformance/scripts/test_conformance.py
+    cases: [pointer-isolation]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [acceptance-self]
-  - path: skills/synthesis-project-management/SKILL.md
-    cases: [resolver-matrix, release-contract]
-  - path: skills/synthesis-project-management/references/project-state-recovery.md
-    cases: [resolver-matrix]
-  - path: skills/synthesis-project-management/scripts/project_state.py
-    cases: [resolver-matrix, lifecycle-stop]
   - path: skills/synthesis-project-management/scripts/test_project_state.py
-    cases: [resolver-matrix, lifecycle-stop, release-contract]
-  - path: skills/synthesis-repo-guard/SKILL.md
-    cases: [lifecycle-stop, release-contract]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
     cases: [release-contract]
 cases:
-  - id: resolver-matrix
+  - id: pointer-isolation
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_canonical_behind_isolated_worktree_selects_newer_without_mutation
-    motivating_defect: a-resumed-project-could-select-whichever-clean-checkout-a-task-remembered
-  - id: lifecycle-stop
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_lifecycle_hook_refuses_semantically_incomplete_stop
-    motivating_defect: a-clean-handoff-receipt-could-outlive-semantic-project-state-or-source-heads
-  - id: semantic-doctor
-    control_class: enforced-gate
-    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests
-    motivating_defect: structurally-valid-prose-could-contradict-later-release-evidence-and-still-report-healthy
-  - id: session-recovery
-    control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_stopped_project_recovery_reads_newer_isolated_worktree
-    motivating_defect: session-start-could-read-a-behind-canonical-checkout-without-inventorying-isolated-state
-  - id: scoped-autopilot
-    control_class: enforced-gate
-    fixture: ../synthesis-autopilot/scripts/test_autopilot_gate.py::test_foreign_live_engagement_never_blocks_this_session
-    motivating_defect: one-projects-engagement-could-globally-block-an-unrelated-session
+    fixture: ../synthesis-agent-conformance/scripts/test_conformance.py::test_aggregate_pointer_scope_ignores_unrelated_project_state
+    motivating_defect: a-valid-pointer-owned-by-one-project-could-fail-an-unrelated-projects-aggregate-conformance
   - id: release-contract
     control_class: acceptance-test
     fixture: ../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent
-    motivating_defect: release-version-documentation-hook-and-skill-contracts-could-disagree
+    motivating_defect: release-version-documentation-and-skill-contracts-could-disagree
   - id: acceptance-self
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-project-management/scripts/test_project_state.py
+++ b/skills/synthesis-project-management/scripts/test_project_state.py
@@ -549,9 +549,9 @@ def test_project_state_reliability_release_contract_is_coherent() -> None:
         json.loads((root / path).read_text(encoding="utf-8"))["version"]
         for path in (".claude-plugin/plugin.json", ".codex-plugin/plugin.json")
     }
-    assert versions == {"4.92.0"}
-    assert "## [4.92.0] - 2026-09-03" in (root / "CHANGELOG.md").read_text(encoding="utf-8")
-    assert "Release **4.92.0**" in (root / "README.md").read_text(encoding="utf-8")
+    assert versions == {"4.92.1"}
+    assert "## [4.92.1] - 2026-09-03" in (root / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "Release **4.92.1**" in (root / "README.md").read_text(encoding="utf-8")
     hooks = json.loads((root / "hooks" / "hooks.json").read_text(encoding="utf-8"))
     commands = [
         hook["command"]
@@ -562,7 +562,7 @@ def test_project_state_reliability_release_contract_is_coherent() -> None:
     expected = {
         "synthesis-project-management": "2.12.0",
         "synthesis-context-lifecycle": "1.18.0",
-        "synthesis-agent-conformance": "1.9.0",
+        "synthesis-agent-conformance": "1.9.1",
         "synthesis-autopilot": "2.1.0",
         "synthesis-repo-guard": "2.4.0",
     }


### PR DESCRIPTION
## Summary

- treat a readable active pointer for another project as non-blocking diagnostic context in aggregate conformance
- preserve strict explicit pointer validation and malformed-pointer failures
- add a live-derived regression fixture and exact closed acceptance manifest

## Verification

- 240 focused tests pass
- full gated release preflight passes
- live aggregate run reports the unrelated pointer as scoped diagnostic evidence