### PR TITLE
Record the SessionStart receipt before context; ignore an unvalidatable pointer; keep the pointer out of the inbox (4.93.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.93.1",
+  "version": "4.93.2",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.93.1",
+  "version": "4.93.2",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.93.2] - 2026-09-03
+
+**A pointer another session left behind can no longer silence a client's
+live receipt, and the inbox never reads it.** The global active-project
+pointer named a project in a worktree eleven commits behind `origin/main`.
+The SessionStart hook validated that pointer for every session on the
+machine, failed closed, and returned before recording its receipt, so no
+Claude session could produce a current transcript-bound receipt while the
+pointer stood; the inbox hook's fallback to the same pointer delivered that
+project's board message to a seatless session working elsewhere.
+
+synthesis-agent-conformance 1.9.2 records the live receipt before it builds
+context — the receipt is evidence that the client delivered the event, and
+nothing that happens afterwards may erase it — and treats a pointer it
+cannot validate as a notice: the session recovers exactly as if no pointer
+were set, the pointer's project is never injected, and failures unrelated
+to the pointer still fail closed. synthesis-project-management 2.12.1
+removes the inbox hook's pointer fallback: only a claimed seat receives
+messages. Tests pin all three behaviors.
+
 ## [4.93.1] - 2026-09-03
 
 **Session start now catches a stale canonical project registry before

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
-**Session start now detects stale project registries before recovery reads
-them (September 2026).** Release **4.93.1** checks the immediately discoverable
-Git-tracked project registries when a root-level task has no active pointer. A
-checkout behind its fetched upstream produces a staleness warning; an
-uncomparable registry produces an `UNKNOWN` result. Project selection remains
-with the causal resolver. See the [4.93.1 release notes](CHANGELOG.md).
+**A pointer left by another session can no longer silence a client's live
+receipt (September 2026).** Release **4.93.2** records the SessionStart
+receipt before building context, ignores with a notice a pointer it cannot
+validate, and keeps the global pointer out of the board inbox. Stale-registry
+detection from 4.93.1 remains; project selection remains with the causal
+resolver. See the [4.93.2 release notes](CHANGELOG.md).
 
 **The installed system now tells the truth about itself (September 2026).**
 Release **4.93.0** makes organization enrollment work from an installed

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.9.1"
+  version: "1.9.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -143,7 +143,7 @@ named-project turn recovers the same state.
 The aggregate `all` command treats a readable active pointer owned by another
 project as non-blocking diagnostic context and verifies stopped-project
 recovery instead. The explicit `pointer` command remains strict for whichever
-project the caller asks it to validate; malformed pointers fail in both modes.
+project the caller asks it to validate; malformed pointers fail in both modes. The SessionStart hook records its live receipt before it builds context, and a pointer it cannot validate is ignored with a notice rather than failing the session: a pointer is another session's cache, never authority for the one starting.
 
 The continuity plane also runs causal project-state recovery. It enumerates
 every registered worktree and ref plus attributed manifests, receipts, pointer,

--- a/skills/synthesis-agent-conformance/scripts/session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/session_context.py
@@ -550,14 +550,16 @@ def build(
     return "\n".join(lines)
 
 
-def append_inbox(message: str, payload: dict, board: Path, pointer: Path) -> str:
+def append_inbox(message: str, payload: dict, board: Path) -> str:
     """Attach unread board messages for this seat, and for a non-Claude
     client its coordination identity, so the bus is delivered at session
-    start and a Codex session learns the id its receipts are filed under."""
+    start and a Codex session learns the id its receipts are filed under.
+    Only a claimed seat receives messages; the global pointer is another
+    session's cache and is never an address."""
     try:
         from board_inbox import inbox_text
 
-        extra = inbox_text(payload, board=board, pointer=pointer)
+        extra = inbox_text(payload, board=board)
     except Exception as exc:  # the inbox never blocks a session start
         extra = f"Coordination inbox unavailable: {exc}"
     return message + ("\n" + extra if extra else "")
@@ -592,27 +594,46 @@ def main() -> int:
         payload = json.load(sys.stdin)
     except Exception:
         payload = {}
-    try:
-        message = build(
-            args.active_project_file.expanduser(),
-            args.coordination_board.expanduser(),
-            Path(str(payload["cwd"])) if payload.get("cwd") else None,
-        )
-    except Exception as exc:
-        print(f"synthesis project context failed closed: {exc}", file=sys.stderr)
-        return 2
-    message = append_currency_notice(message, payload)
-    message = append_inbox(
-        message,
-        payload,
-        args.coordination_board.expanduser(),
-        args.active_project_file.expanduser(),
-    )
+    # The receipt is evidence that the client delivered this lifecycle event
+    # for this session and plugin root. It is recorded before any context is
+    # built, so a pointer left by another session, a behind worktree, or an
+    # unreadable board can never erase that proof: on 2026-09-03 a foreign
+    # pointer to a worktree eleven commits behind failed this hook closed
+    # before it recorded, and no Claude session on the machine could show a
+    # current receipt.
     try:
         record_live_receipt(payload, args.live_receipt.expanduser())
     except Exception as exc:
         print(f"synthesis live receipt failed closed: {exc}", file=sys.stderr)
         return 2
+    pointer = args.active_project_file.expanduser()
+    board = args.coordination_board.expanduser()
+    cwd = Path(str(payload["cwd"])) if payload.get("cwd") else None
+    try:
+        message = build(pointer, board, cwd)
+    except Exception as exc:
+        if not pointer.is_file():
+            print(f"synthesis project context failed closed: {exc}", file=sys.stderr)
+            return 2
+        # A pointer is a cache written by whichever session last activated a
+        # project; it is not authority for the session starting now. When it
+        # cannot be validated, say so and recover exactly as if it were absent:
+        # its project is never injected, and no session waits on another
+        # task's checkout.
+        ignored = pointer.with_name(pointer.name + ".ignored-by-this-session")
+        try:
+            message = build(ignored, board, cwd)
+        except Exception as inner:
+            print(f"synthesis project context failed closed: {inner}", file=sys.stderr)
+            return 2
+        message = (
+            f"Active-project pointer ignored: {exc}. The pointer is a cache set by "
+            "another session, not authority for this one; resolve the named project "
+            "from the tracked projects/index.yaml through the causal resolver.\n"
+            + message
+        )
+    message = append_currency_notice(message, payload)
+    message = append_inbox(message, payload, board)
 
     if args.format == "codex":
         event = payload.get("hook_event_name", "SessionStart")

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -588,15 +588,29 @@ def test_activate_refuses_stale_record(tmp_path: Path) -> None:
     assert not pointer.exists()
 
 
-def test_payload_parity_reports_broken_pointer(tmp_path: Path) -> None:
+def test_payload_parity_agrees_when_a_broken_pointer_is_ignored(tmp_path: Path) -> None:
+    """A pointer that cannot be validated no longer fails the hook (4.93.2):
+    both client envelopes carry the same ignore notice and the same
+    pointerless recovery context, so parity holds and the defect is visible
+    in the payload rather than in a dead session start."""
     pointer = tmp_path / "active.json"
     pointer.write_text(
         json.dumps({"project": str(tmp_path / "missing-project")}),
         encoding="utf-8",
     )
-    ok, detail = MODULE.payload_parity(pointer)
-    assert not ok
-    assert "payload failed" in detail
+    ok, detail = MODULE.payload_parity(pointer, tmp_path / "no-board.md")
+    assert ok, detail
+    assert "identical context" in detail
+    script = MODULE.SCRIPTS_DIR / "session_context.py"
+    result = MODULE.run(
+        [sys.executable, str(script), "--format", "claude", "--active-project-file", str(pointer),
+         "--coordination-board", str(tmp_path / "no-board.md")],
+        input_text="{}",
+    )
+    assert result.returncode == 0, result.stderr
+    context = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+    assert context.startswith("Active-project pointer ignored: ")
+    assert "No active synthesis project pointer is set." in context
 
 
 def write_stopped_project(tmp_path: Path) -> Path:

--- a/skills/synthesis-agent-conformance/scripts/test_session_context.py
+++ b/skills/synthesis-agent-conformance/scripts/test_session_context.py
@@ -956,3 +956,101 @@ def test_live_receipt_rejects_existing_transcript_for_another_session(
         receipt,
     )
     assert not receipt.exists()
+
+
+
+# --- receipt before context; a pointer is a cache, not authority (4.93.2) -----------------------
+
+def _drive_main(monkeypatch, capsys, tmp_path, *, pointer_text=None, build_error=None):
+    """Run main() in-process with a stubbed receipt recorder and, optionally, a
+    forced context failure; return (exit code, additionalContext, call order)."""
+    import io
+
+    calls: list[str] = []
+    pointer = tmp_path / "active-project.json"
+    if pointer_text is not None:
+        pointer.write_text(pointer_text, encoding="utf-8")
+    real_build = MODULE.build
+
+    def recording_build(pointer_arg, board, cwd, *args, **kwargs):
+        calls.append("build")
+        if build_error is not None:
+            raise build_error
+        return real_build(pointer_arg, board, cwd, *args, **kwargs)
+
+    monkeypatch.setattr(MODULE, "build", recording_build)
+    monkeypatch.setattr(
+        MODULE, "record_live_receipt", lambda payload, destination: calls.append("receipt") or True
+    )
+    monkeypatch.setattr(MODULE, "append_currency_notice", lambda message, payload: message)
+    monkeypatch.setattr(MODULE, "append_inbox", lambda message, payload, board: message)
+    payload = {
+        "hook_event_name": "SessionStart",
+        "session_id": "019fff79-5858-7993-a329-b301bccf5d31",
+        "cwd": str(tmp_path),
+        "source": "resume",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "session_context.py",
+            "--format",
+            "claude",
+            "--active-project-file",
+            str(pointer),
+            "--coordination-board",
+            str(tmp_path / "no-board.md"),
+            "--live-receipt",
+            str(tmp_path / "receipt.json"),
+        ],
+    )
+    code = MODULE.main()
+    out = capsys.readouterr().out.strip()
+    context = json.loads(out)["hookSpecificOutput"]["additionalContext"] if out else ""
+    return code, context, calls
+
+
+def test_main_records_the_receipt_before_building_context(monkeypatch, capsys, tmp_path) -> None:
+    """The receipt proves the client delivered the event; nothing that happens
+    while building context may erase it, so it is recorded first."""
+    code, context, calls = _drive_main(monkeypatch, capsys, tmp_path)
+
+    assert code == 0
+    assert calls[0] == "receipt" and "build" in calls
+    assert "No active synthesis project pointer is set." in context
+
+
+def test_main_ignores_a_pointer_it_cannot_validate_with_a_notice(monkeypatch, capsys, tmp_path) -> None:
+    """2026-09-03: a pointer set by another session named a project in a
+    worktree eleven commits behind; the hook failed closed before recording
+    and every Claude session on the machine lost its receipt. The pointer is
+    a cache: an unvalidatable one is ignored, said so, and never injected."""
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "CONTEXT.md").write_text("**Phase:** 2\n**Status:** Active\n", encoding="utf-8")
+    code, context, calls = _drive_main(
+        monkeypatch, capsys, tmp_path,
+        pointer_text=json.dumps({"project": str(project), "plan": "unknown"}),
+    )
+
+    assert code == 0
+    assert calls == ["receipt", "build", "build"]
+    assert context.startswith("Active-project pointer ignored: ")
+    assert "not authority for this one" in context
+    assert "No active synthesis project pointer is set." in context
+    assert "Active synthesis project" not in context, "the unvalidated pointer's project was injected"
+
+
+def test_main_still_fails_closed_on_a_non_pointer_failure(monkeypatch, capsys, tmp_path) -> None:
+    """Ignoring the pointer must not become ignoring every failure: with no
+    pointer in play, a context failure still exits 2 — after the receipt."""
+    code, context, calls = _drive_main(
+        monkeypatch, capsys, tmp_path,
+        build_error=ValueError("coordination board schema is invalid"),
+    )
+
+    assert code == 2
+    assert calls == ["receipt", "build"]
+    assert context == ""

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,57 +1,82 @@
-# AGENT HEURISTIC: closed acceptance universe for the AR-008 named-project
-# stale-canonical recovery transaction. Fresh per transaction:
-# changed_surfaces must equal the authoritative base-to-head Git diff before
-# release.py can consume the receipt.
+# AGENT HEURISTIC: authored for the 4.93.2 pointer-never-blocks-receipts transaction.
+# Fresh per transaction: changed_surfaces must equal the authoritative
+# base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: project-state-ar008-named-project-recovery-2026-09
+suite: sessionstart-receipt-before-context-and-no-pointer-in-the-inbox
 membership: closed
-production_entry_point: native SessionStart hook -> session_context.py build -> bounded workspace registry freshness notice -> named-project causal resolver
-enforcing_boundary: release.py consumes this transaction-bound closed manifest before publishing the immutable release, installing both clients, and activating the public CLI
+production_entry_point: skills/synthesis-agent-conformance/scripts/session_context.py
+enforcing_boundary: the SessionStart hook records its transcript-bound live receipt before it builds context, ignores with a notice a global pointer it cannot validate instead of failing the session, and the inbox hook delivers only to a claimed seat, never through the global pointer
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the real installed AR-008 probe, Codex human trust, current client lifecycle receipts, historical-cache invariants, and the final installed updater are verified after the gated publisher activates this release
+unverified_remainder: a genuine transcript-bound receipt for a live Claude session under a foreign behind pointer is produced only by a real client SessionStart after this release installs; the hook was reproduced against a scratch receipt path with a fake session id before and after the change
 changed_surfaces:
-  - path: .claude-plugin/plugin.json
-    cases: [release-surfaces, release-contract]
-  - path: .codex-plugin/plugin.json
-    cases: [release-surfaces, release-contract]
-  - path: CHANGELOG.md
-    cases: [release-surfaces, release-contract]
-  - path: README.md
-    cases: [release-surfaces, release-contract]
-  - path: skills/synthesis-agent-conformance/SKILL.md
-    cases: [workspace-registry-contract]
   - path: skills/synthesis-agent-conformance/scripts/session_context.py
-    cases: [ar008-workspace-warning, registry-freshness-unknown]
+    cases: [receipt-before-context, pointer-never-blocks, unrelated-failure-still-closed]
   - path: skills/synthesis-agent-conformance/scripts/test_session_context.py
-    cases: [workspace-registry-contract, ar008-workspace-warning, registry-freshness-unknown]
+    cases: [receipt-before-context, pointer-never-blocks, unrelated-failure-still-closed]
+  - path: skills/synthesis-agent-conformance/SKILL.md
+    cases: [pointer-never-blocks]
+  - path: skills/synthesis-agent-conformance/scripts/test_conformance.py
+    cases: [payload-parity-with-ignored-pointer]
+  - path: skills/synthesis-project-management/scripts/board_inbox.py
+    cases: [inbox-never-uses-the-pointer]
+  - path: skills/synthesis-project-management/scripts/test_board_inbox.py
+    cases: [inbox-never-uses-the-pointer]
+  - path: skills/synthesis-project-management/SKILL.md
+    cases: [pm-budget]
+  - path: skills/synthesis-project-management/scripts/test_project_state.py
+    cases: [release-contract-floors]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
-    cases: [acceptance-self]
+    cases: [shipped-manifest-self-consumption]
+  - path: .claude-plugin/plugin.json
+    cases: [release-manifest-parity]
+  - path: .codex-plugin/plugin.json
+    cases: [release-manifest-parity]
+  - path: CHANGELOG.md
+    cases: [release-changelog-parity]
+  - path: README.md
+    cases: [release-changelog-parity]
 cases:
-  - id: acceptance-self
+  - id: receipt-before-context
+    control_class: enforced-gate
+    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_main_records_the_receipt_before_building_context
+    motivating_defect: a-foreign-pointer-to-a-worktree-eleven-commits-behind-silenced-every-claude-receipt-on-the-machine
+  - id: pointer-never-blocks
+    control_class: enforced-gate
+    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_main_ignores_a_pointer_it_cannot_validate_with_a_notice
+    motivating_defect: another-sessions-cache-was-treated-as-authority-for-the-session-starting
+  - id: unrelated-failure-still-closed
     control_class: acceptance-test
-    fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: a-release-manifest-could-claim-closed-membership-with-unmapped-or-invalid-cases
-  - id: release-surfaces
+    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_main_still_fails_closed_on_a_non_pointer_failure
+    motivating_defect: ignoring-the-pointer-must-not-become-ignoring-every-failure
+  - id: payload-parity-with-ignored-pointer
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_independent_review.py::test_release_surfaces_agree_and_public_commands_are_pinned
-    motivating_defect: versioned-source-surfaces-could-disagree-at-the-release-boundary
-  - id: release-contract
+    fixture: ../synthesis-agent-conformance/scripts/test_conformance.py::test_payload_parity_agrees_when_a_broken_pointer_is_ignored
+    motivating_defect: the-stopped-task-payload-check-failed-on-a-foreign-pointer-instead-of-reporting-it
+  - id: inbox-never-uses-the-pointer
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_board_inbox.py::test_unseated_session_receives_nothing_even_when_a_global_pointer_names_a_project
+    motivating_defect: the-inbox-fallback-delivered-another-projects-message-to-a-seatless-session
+  - id: release-contract-floors
     control_class: acceptance-test
     fixture: ../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent
-    motivating_defect: project-state-release-surfaces-could-advance-without-the-runtime-contract
-  - id: workspace-registry-contract
+    motivating_defect: a-release-contract-that-pins-skill-versions-as-literals-fails-the-first-release-after-it
+  - id: pm-budget
     control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_skill_documents_workspace_registry_freshness_notice
-    motivating_defect: the-public-session-start-contract-could-omit-the-root-registry-freshness-gate-implemented-by-the-hook
-  - id: ar008-workspace-warning
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget
+    motivating_defect: a-restructured-document-must-not-regrow-with-its-next-feature
+  - id: shipped-manifest-self-consumption
     control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_build_without_pointer_warns_when_workspace_registry_is_behind
-    motivating_defect: a-root-level-named-project-start-could-read-a-canonical-record-behind-a-newer-isolated-worktree
-  - id: registry-freshness-unknown
+    fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
+    motivating_defect: an-acceptance-manifest-that-its-own-runner-cannot-consume-issues-authority-it-never-earned
+  - id: release-manifest-parity
     control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_build_without_pointer_marks_uncomparable_registry_unknown
-    motivating_defect: an-uncomparable-project-registry-could-look-current-because-no-staleness-warning-was-emitted
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
+    motivating_defect: a-version-that-reaches-only-one-client-manifest-cannot-be-reliably-installed-or-audited
+  - id: release-changelog-parity
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed
+    motivating_defect: a-release-whose-changelog-disagrees-with-its-manifests-cannot-be-audited-later

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.12.0"
+  version: "2.12.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-project-management/scripts/board_inbox.py
+++ b/skills/synthesis-project-management/scripts/board_inbox.py
@@ -9,6 +9,9 @@ the unread messages addressed to this session's seat (any identity form) or
 to its project, then advances a per-seat watermark. Latency is one turn,
 the same class as the harness's own queue.
 
+Only a claimed seat receives messages: the global active-project pointer is
+another session's cache, never an address.
+
 For a Codex session it also states the session's coordination identity,
 because a Codex shell carries no thread id: the agent exports it as
 ``SYNTHESIS_CLIENT_SESSION_REF`` so claims and receipts are filed under the
@@ -38,16 +41,6 @@ from peer_addressing import (  # noqa: E402
 )
 
 DEFAULT_BOARD = Path.home() / ".synthesis" / "coordination" / "active-sessions.md"
-DEFAULT_POINTER = Path.home() / ".synthesis" / "active-project.json"
-
-
-def pointer_project(pointer: Path) -> str:
-    try:
-        data = json.loads(pointer.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return ""
-    project = data.get("project") if isinstance(data, dict) else None
-    return Path(str(project)).name if project else ""
 
 
 def identity_forms_for(board: Path, identity: SelfIdentity) -> tuple[set[str], str, str, str]:
@@ -86,10 +79,15 @@ def inbox_text(
     payload: dict,
     *,
     board: Path = DEFAULT_BOARD,
-    pointer: Path = DEFAULT_POINTER,
     environ: dict[str, str] | None = None,
     mark: bool = True,
 ) -> str:
+    """Messages for this session's claimed seat, or nothing.
+
+    A session without a seat has no address. The global active-project
+    pointer is another session's cache and is never consulted: on
+    2026-09-03 a fallback to it delivered one project's message to a
+    seatless session working on a different project."""
     identity = identity_from_hook(payload, environ)
     key = identity.sender_key
     if not key:
@@ -100,11 +98,7 @@ def inbox_text(
         return ""
     forms, project, _compact, started = identity_forms_for(board, identity)
     if not forms:
-        project = pointer_project(pointer)
-        started = ""
-    if not forms and not project:
-        notice = identity_notice(identity)
-        return notice
+        return identity_notice(identity)
     messages = unread_messages(
         text, board=board, sender_key=key, identity_forms=forms, project=project, since=started
     )
@@ -118,7 +112,6 @@ def inbox_text(
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
     parser.add_argument("--board", type=Path, default=DEFAULT_BOARD)
-    parser.add_argument("--active-project-file", type=Path, default=DEFAULT_POINTER)
     parser.add_argument("--hook", action="store_true", help="read the hook payload on stdin and emit hook JSON")
     parser.add_argument("--no-mark", action="store_true", help="do not advance the watermark")
     args = parser.parse_args()
@@ -132,7 +125,7 @@ def main() -> int:
         if not isinstance(payload, dict):
             payload = {}
     try:
-        text = inbox_text(payload, board=board, pointer=args.active_project_file.expanduser(), mark=not args.no_mark)
+        text = inbox_text(payload, board=board, mark=not args.no_mark)
     except Exception as exc:  # never block a prompt on inbox trouble; say what failed
         text = f"Coordination inbox could not be read: {exc}"
     if not text:

--- a/skills/synthesis-project-management/scripts/test_board_inbox.py
+++ b/skills/synthesis-project-management/scripts/test_board_inbox.py
@@ -54,11 +54,11 @@ def board(tmp_path, monkeypatch):
 
 def test_inbox_delivers_once_to_the_named_seat(board, tmp_path) -> None:
     payload = {"session_id": ME_SID, "hook_event_name": "UserPromptSubmit", "cwd": "/tmp"}
-    text = INBOX.inbox_text(payload, board=board, pointer=tmp_path / "pointer.json", environ=ME_ENV)
+    text = INBOX.inbox_text(payload, board=board, environ=ME_ENV)
     assert "2 unread message(s)" in text
     assert "Handoff: the review is yours." in text and "For every project-m session." in text
     assert "Not for me." not in text
-    assert INBOX.inbox_text(payload, board=board, pointer=tmp_path / "pointer.json", environ=ME_ENV) == ""
+    assert INBOX.inbox_text(payload, board=board, environ=ME_ENV) == ""
 
 
 def test_project_history_before_the_claim_is_not_delivered_to_a_new_seat(tmp_path, monkeypatch) -> None:
@@ -75,28 +75,31 @@ def test_project_history_before_the_claim_is_not_delivered_to_a_new_seat(tmp_pat
     path.write_text(text, encoding="utf-8")
     me = claim(path, "project-m", ME_ENV, monkeypatch)
     assert ENGINE.command_message(args(path, sender=other.compact_id, to="project-m", text="Posted after the claim.")) == 0
-    delivered = INBOX.inbox_text({"session_id": ME_SID}, board=path, pointer=tmp_path / "pointer.json", environ=ME_ENV)
+    delivered = INBOX.inbox_text({"session_id": ME_SID}, board=path, environ=ME_ENV)
     assert "Posted after the claim." in delivered
     assert "Posted before the seat existed." not in delivered
     assert "1 unread message(s)" in delivered
     assert me.project == "project-m"
 
 
-def test_unseated_session_gets_project_messages_from_the_active_pointer(board, tmp_path) -> None:
+def test_unseated_session_receives_nothing_even_when_a_global_pointer_names_a_project(board, tmp_path) -> None:
+    """2026-09-03: the fallback to the global active-project pointer delivered
+    another project's message to a seatless session. The pointer is another
+    session's cache; without a seat there is no address."""
     pointer = tmp_path / "pointer.json"
     pointer.write_text(json.dumps({"project": "/kb/projects/project-m"}), encoding="utf-8")
     stranger = {"CLAUDECODE": "1", "CLAUDE_CODE_SESSION_ID": "99999999-9999-4999-8999-999999999999"}
-    text = INBOX.inbox_text({"session_id": stranger["CLAUDE_CODE_SESSION_ID"]}, board=board, pointer=pointer, environ=stranger)
-    assert "For every project-m session." in text and "Handoff" not in text
+    assert INBOX.inbox_text({"session_id": stranger["CLAUDE_CODE_SESSION_ID"]}, board=board, environ=stranger) == ""
+    assert not hasattr(INBOX, "pointer_project"), "the pointer fallback must not exist"
 
 
 def test_codex_session_learns_its_identity(board, tmp_path) -> None:
-    text = INBOX.inbox_text({"session_id": "0a0a0a0a-1b1b-4c1c-8d1d-2e2e2e2e2e2e"}, board=board, pointer=tmp_path / "pointer.json", environ={"CODEX_HOME": "/x"})
+    text = INBOX.inbox_text({"session_id": "0a0a0a0a-1b1b-4c1c-8d1d-2e2e2e2e2e2e"}, board=board, environ={"CODEX_HOME": "/x"})
     assert "SYNTHESIS_CLIENT_SESSION_REF=codex:0a0a0a0a-1b1b-4c1c-8d1d-2e2e2e2e2e2e" in text
 
 
 def test_no_session_id_means_silence(board, tmp_path) -> None:
-    assert INBOX.inbox_text({}, board=board, pointer=tmp_path / "pointer.json", environ={}) == ""
+    assert INBOX.inbox_text({}, board=board, environ={}) == ""
 
 
 def test_hook_process_emits_additional_context_json_or_nothing(board, tmp_path) -> None:
@@ -104,12 +107,12 @@ def test_hook_process_emits_additional_context_json_or_nothing(board, tmp_path) 
     env = {k: v for k, v in os.environ.items() if not k.startswith("CLAUDE") and k != "SYNTHESIS_CLIENT_SESSION_REF"}
     env.update(ME_ENV)
     payload = json.dumps({"session_id": ME_SID, "hook_event_name": "UserPromptSubmit"})
-    first = subprocess.run([sys.executable, str(script), "--board", str(board), "--active-project-file", str(tmp_path / "pointer.json"), "--hook"], input=payload, capture_output=True, text=True, env=env)
+    first = subprocess.run([sys.executable, str(script), "--board", str(board), "--hook"], input=payload, capture_output=True, text=True, env=env)
     assert first.returncode == 0, first.stderr
     data = json.loads(first.stdout)
     assert data["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
     assert "2 unread message(s)" in data["hookSpecificOutput"]["additionalContext"]
-    second = subprocess.run([sys.executable, str(script), "--board", str(board), "--active-project-file", str(tmp_path / "pointer.json"), "--hook"], input=payload, capture_output=True, text=True, env=env)
+    second = subprocess.run([sys.executable, str(script), "--board", str(board), "--hook"], input=payload, capture_output=True, text=True, env=env)
     assert second.returncode == 0 and second.stdout == ""
 
 

--- a/skills/synthesis-project-management/scripts/test_project_state.py
+++ b/skills/synthesis-project-management/scripts/test_project_state.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -562,13 +563,20 @@ def test_project_state_reliability_release_contract_is_coherent() -> None:
         for hook in group["hooks"]
     ]
     assert any(command.endswith("project_state.py hook") for command in commands)
-    expected = {
-        "synthesis-project-management": "2.12.0",
-        "synthesis-context-lifecycle": "1.18.0",
-        "synthesis-agent-conformance": "1.9.1",
-        "synthesis-autopilot": "2.1.0",
-        "synthesis-repo-guard": "2.4.0",
+    # The reliability tranche shipped these skills at these versions; later
+    # releases may bump any of them, so the contract is a floor, never a
+    # literal to re-pin by hand (a hand-pinned literal broke the first
+    # release after this test was written).
+    floors = {
+        "synthesis-project-management": (2, 12, 0),
+        "synthesis-context-lifecycle": (1, 18, 0),
+        "synthesis-agent-conformance": (1, 9, 1),
+        "synthesis-autopilot": (2, 1, 0),
+        "synthesis-repo-guard": (2, 4, 0),
     }
-    for skill, version in expected.items():
+    for skill, floor in floors.items():
         text = (root / "skills" / skill / "SKILL.md").read_text(encoding="utf-8")
-        assert f'version: "{version}"' in text
+        match = re.search(r'^\s*version:\s*"(\d+)\.(\d+)\.(\d+)"\s*$', text, re.M)
+        assert match, f"{skill} declares no semantic version"
+        declared = tuple(int(part) for part in match.groups())
+        assert declared >= floor, f"{skill} {declared} is below the reliability floor {floor}"


### PR DESCRIPTION
## Summary

A global active-project pointer set by one session named a project in a worktree eleven commits behind `origin/main`. The plugin's SessionStart hook validated that pointer for every session on the machine, failed closed, and returned before recording its receipt, so no Claude session could produce a current transcript-bound receipt. The inbox hook's fallback to the same pointer delivered another project's board message to a seatless session.

- **Receipt before context.** `session_context.py` records the live receipt first. The receipt is evidence that the client delivered the lifecycle event; a bad pointer, a behind worktree, or an unreadable board can no longer erase it.
- **A pointer is a cache, not authority.** A pointer the hook cannot validate is ignored with a notice, and the session recovers exactly as if no pointer were set (registry freshness notices, named-project recovery through the causal resolver). Its project is never injected. Failures unrelated to the pointer still fail closed.
- **The inbox never uses the pointer.** `board_inbox.py` delivers only to a claimed seat; a seatless session receives nothing.

## Verification

- Full AGENTS.md verification list run in CI shape (isolated `HOME`, no session identity in the environment).
- New tests: receipt recorded before context; invalid pointer ignored with a notice and exit 0; non-pointer failure still exits 2 with the receipt recorded; seatless inbox delivers nothing.
- The real hook was reproduced against a scratch receipt path with a fake session id before the change (fails closed on the live pointer) and after it (records and recovers).
- Acceptance manifest authored for this transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
