### PR TITLE
Strengthen project state and session ownership checks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.93.2",
+  "version": "4.93.3",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.93.2",
+  "version": "4.93.3",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.93.3] - 2026-09-03
+
+**Structured current state can no longer coexist with another current-looking
+prose record, and one session cannot accidentally mutate another session's
+claim.** The semantic doctor now rejects mutable `Current ...`, singular
+`Accepted baseline`, `Next checkpoint`, and `State as of:` surfaces outside a
+structured project's generated block, including reference shards and Setext or
+punctuated headings. Explicitly historical snapshots remain valid. Structured
+state replaces the older body
+marker convention, so the doctor records that check as an explicit skip rather
+than demanding a second current-state authority.
+
+synthesis-project-management 2.13.0 also binds every existing-row `claim`,
+`heartbeat`, and normal `release` mutation to the exact harness seat recorded
+at claim time. A selector parsed from a refused command is address data, not
+mutation authority. Unattributed legacy rows fail closed. Cross-session
+release is a distinct
+`--administrative --reason` operation whose target, caller, time, and reason
+are recorded on the board. synthesis-context-lifecycle 1.19.0 carries the
+matching semantic and doctor contract.
+
 ## [4.93.2] - 2026-09-03
 
 **A pointer another session left behind can no longer silence a client's

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Structured state now has one readable current-state authority (September
+2026).** Release **4.93.3** rejects duplicate current-looking prose outside the
+generated state block while preserving explicitly historical snapshots. It
+also binds existing-row claim changes, heartbeat, and normal release to the
+exact claiming seat; a reason-bearing administrative operation is required to
+release another session. See the
+[4.93.3 release notes](CHANGELOG.md).
+
 **A pointer left by another session can no longer silence a client's live
 receipt (September 2026).** Release **4.93.2** records the SessionStart
 receipt before building context, ignores with a notice a pointer it cannot

--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.18.0"
+  version: "1.19.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -760,14 +760,14 @@ What it checks:
 | Semantic shard | once `reference/` exists: index ≤150, each topic ≤300, every topic linked from the index, and an index actually present (defect if not) |
 | Cross-tier agreement | index.yaml status agrees with the CONTEXT.md header; completed projects carry `completed_date`; indexed projects have directories and vice versa |
 | Freshness | structured current state and the CONTEXT.md header agree exactly with real project Git/session history. A present index.yaml `last_session` is checked as legacy duplicate metadata; a one-day known discrepancy is stale. For a terminal project the question inverts to whether it is still being worked |
-| Semantic current state | `CURRENT_STATE.json` validates; its bounded compiled block agrees with it; a current phase or accepted baseline older than a later release in the same record is a defect |
+| Semantic current state | `CURRENT_STATE.json` validates; its bounded compiled block agrees with it; a current phase or accepted baseline older than a later release in the same record is a defect; structured projects reject a second current-looking prose authority outside the generated block |
 | Durability | tier files are tracked by git; local mode reports recoverable uncommitted or ahead state as warnings; remote mode requires a clean upstream-current branch |
 | Executable state | artifact citations to missing, non-regular, escaped, or symlink-traversing `resources/scripts/` targets warn; existence does not establish correctness |
 | Disclosure | anything unverifiable is reported rather than skipped — unreadable status headers and freshness that cannot be established both surface as findings |
 
 Exit codes follow the guard contract: `0` healthy, `1` defects found, `2` the doctor could not establish ground truth. The third is the important one — an unreadable source or a source outside git exits 2 rather than reporting health, because a check that cannot run must never look like a check that passed.
 
-**Structured operational state (v1.18.0).** Mature projects may carry
+**Structured operational state (v1.19.0).** Mature projects may carry
 `CURRENT_STATE.json` as the authoritative mutable state: project id, phase,
 status, accepted baseline, controlling plan, next actions, last session,
 owning coordination session, Git identity, durable-file hashes, and source
@@ -775,8 +775,14 @@ heads. `CONTEXT.md` remains the human entry point, but its bounded block between
 `synthesis-current-state` markers is compiled from that object. Narrative and
 historical acceptance stay in Markdown. The doctor reports
 `semantic-current-state` when the object is invalid, its compiled block drifts,
-its plan is missing, or prose claims an older current release than later
-evidence in the same record.
+its plan is missing, or mutable current-looking prose appears outside the
+generated block — including `Current ...`, singular `Accepted baseline`,
+`Next checkpoint`, or `State as of:` labels in context or reference shards.
+Historical snapshots remain valid when their headings label them as history.
+For a structured project, the state object, content hashes, and generated block
+replace the older body-marker currency convention; the doctor records that
+check as an explicit structured-state skip rather than demanding a second
+mutable authority.
 
 **The status vocabulary is enforced, not assumed** (v1.13.0). `status` answers
 one question — does this project claim attention — with four values: `active`,

--- a/skills/synthesis-context-lifecycle/scripts/context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_doctor.py
@@ -72,7 +72,7 @@ if str(_PROJECT_STATE_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_PROJECT_STATE_SCRIPTS))
 import project_state  # noqa: E402
 
-DOCTOR_VERSION = "1.9.0"
+DOCTOR_VERSION = "1.10.0"
 
 # Budgets from the tiered context architecture.
 CONTEXT_BUDGET_ACTIVE = 150
@@ -1340,6 +1340,7 @@ def audit_project(
     # their '*State as of:*' markers, because header freshness is necessary
     # but not sufficient: a current header above stale operational sections is
     # a stronger false receipt than an obviously stale file.
+    structured_state = (project_path / project_state.STATE_FILE).is_file()
     for finding in context_currency.audit_project(project_path):
         kind = finding["kind"]
         if kind in ("header-behind-log", "header-field-stale"):
@@ -1350,6 +1351,14 @@ def audit_project(
                 "update the stale header field with context_edit.py set-field",
             )
         elif kind == "body-marker-stale":
+            if structured_state:
+                # CURRENT_STATE.json plus its generated block replaces the
+                # older prose-marker convention. semantic_issues() rejects a
+                # mutable current-state label outside that block, so treating
+                # a leftover marker as a second currency authority would
+                # recreate the duplicated-state defect.
+                audit.skip("body-currency", "structured current state")
+                continue
             audit.add(
                 "body-currency",
                 "defect",
@@ -1363,6 +1372,9 @@ def audit_project(
             # supposed to be final, and adding markers to assert a re-check
             # nobody performed would be the same fiction the item-currency
             # suppression already refuses.
+            if structured_state:
+                audit.skip("body-currency", "structured current state")
+                continue
             if dormant:
                 continue
             audit.add(

--- a/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
@@ -388,6 +388,38 @@ class ContextDoctorTests(unittest.TestCase):
         self.fx.commit("record contradictory state", when="2026-06-01")
         self.assertIn("semantic-current-state", checks_in(self.fx.audit()))
 
+    def test_structured_state_replaces_body_currency_markers(self):
+        project = self.fx.project(
+            "alpha",
+            context="# P\n\n## Handoff history\n\nRelease v0.9.0 was accepted previously.\n",
+            reference="# Reference\n",
+            sessions={"2026-06.md": "### 2026-06-01 — Phase 9 current\n"},
+        )
+        artifacts = project / "resources" / "artifacts"
+        artifacts.mkdir(parents=True)
+        (artifacts / "plan.md").write_text("# Plan\n", encoding="utf-8")
+        self.fx.index(
+            [{"id": "alpha", "status": "active", "last_session": "2026-06-01"}]
+        )
+        self.fx.commit("initial project", when="2026-06-01")
+        cd.project_state.build_operational_state(
+            project,
+            project_id="alpha",
+            phase="Phase 9 release 1.0.0",
+            status="active",
+            controlling_plan="resources/artifacts/plan.md",
+            accepted_baseline="1.0.0",
+            next_actions=["finish"],
+            last_session="2026-06-01",
+            session_id="018f0000-0000-7000-8000-000000000001",
+        )
+        self.fx.commit("compile current state", when="2026-06-01")
+
+        checks = checks_in(self.fx.audit())
+
+        self.assertNotIn("body-currency", checks)
+        self.assertNotIn("semantic-current-state", checks)
+
     def test_stale_context_header_is_caught(self):
         self.fx.project(
             "alpha", context="# P\n\n**Status:** Active\n**Last session:** 2020-01-01\n"

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,34 +1,46 @@
-# AGENT HEURISTIC: authored for the 4.93.2 pointer-never-blocks-receipts transaction.
+# AGENT HEURISTIC: authored for the 4.93.3 single-current-state-and-owned-release transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: sessionstart-receipt-before-context-and-no-pointer-in-the-inbox
+suite: single-current-state-and-owned-release
 membership: closed
-production_entry_point: skills/synthesis-agent-conformance/scripts/session_context.py
-enforcing_boundary: the SessionStart hook records its transcript-bound live receipt before it builds context, ignores with a notice a global pointer it cannot validate instead of failing the session, and the inbox hook delivers only to a claimed seat, never through the global pointer
+production_entry_point: skills/synthesis-project-management/scripts/project_state.py
+enforcing_boundary: structured operational state is the only mutable current-state authority, historical prose is explicitly labeled, every existing-row claim heartbeat and normal release mutation is bound to its claiming seat, and administrative release is reason-bearing and recorded
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: a genuine transcript-bound receipt for a live Claude session under a foreign behind pointer is produced only by a real client SessionStart after this release installs; the hook was reproduced against a scratch receipt path with a fake session id before and after the change
+unverified_remainder: exact-version native lifecycle receipts require genuine client restarts after installation; source and hermetic fixtures do not substitute for those live events
 changed_surfaces:
-  - path: skills/synthesis-agent-conformance/scripts/session_context.py
-    cases: [receipt-before-context, pointer-never-blocks, unrelated-failure-still-closed]
-  - path: skills/synthesis-agent-conformance/scripts/test_session_context.py
-    cases: [receipt-before-context, pointer-never-blocks, unrelated-failure-still-closed]
-  - path: skills/synthesis-agent-conformance/SKILL.md
-    cases: [pointer-never-blocks]
-  - path: skills/synthesis-agent-conformance/scripts/test_conformance.py
-    cases: [payload-parity-with-ignored-pointer]
-  - path: skills/synthesis-project-management/scripts/board_inbox.py
-    cases: [inbox-never-uses-the-pointer]
-  - path: skills/synthesis-project-management/scripts/test_board_inbox.py
-    cases: [inbox-never-uses-the-pointer]
-  - path: skills/synthesis-project-management/SKILL.md
-    cases: [pm-budget]
+  - path: skills/synthesis-project-management/scripts/project_state.py
+    cases: [uncompiled-current-prose-rejected, current-label-normalization, historical-snapshots-allowed]
   - path: skills/synthesis-project-management/scripts/test_project_state.py
-    cases: [release-contract-floors]
+    cases: [uncompiled-current-prose-rejected, current-label-normalization, historical-snapshots-allowed]
+  - path: skills/synthesis-project-management/scripts/coordination.py
+    cases: [claim-bound-to-seat, heartbeat-bound-to-seat, release-bound-to-seat, legacy-selector-fails-closed, administrative-release-recorded]
+  - path: skills/synthesis-project-management/scripts/test_coordination.py
+    cases: [claim-bound-to-seat, heartbeat-bound-to-seat, release-bound-to-seat, legacy-selector-fails-closed, administrative-release-recorded]
+  - path: skills/synthesis-project-management/scripts/test_board_inbox.py
+    cases: [release-bound-to-seat]
+  - path: skills/synthesis-project-management/scripts/test_peer_addressing.py
+    cases: [administrative-release-recorded]
+  - path: skills/synthesis-project-management/scripts/test_peer_send_gate.py
+    cases: [administrative-release-recorded]
+  - path: skills/synthesis-onboarding/scripts/test_onboard.py
+    cases: [sandbox-git-config-isolation]
+  - path: skills/synthesis-project-management/SKILL.md
+    cases: [claim-bound-to-seat, heartbeat-bound-to-seat, release-bound-to-seat, pm-budget]
+  - path: skills/synthesis-project-management/references/parallel-agent-protocol.md
+    cases: [administrative-release-recorded]
+  - path: skills/synthesis-project-management/references/session-identity.md
+    cases: [claim-bound-to-seat, heartbeat-bound-to-seat, release-bound-to-seat]
+  - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
+    cases: [structured-state-replaces-body-markers]
+  - path: skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
+    cases: [structured-state-replaces-body-markers]
+  - path: skills/synthesis-context-lifecycle/SKILL.md
+    cases: [uncompiled-current-prose-rejected]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -40,30 +52,46 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: receipt-before-context
+  - id: uncompiled-current-prose-rejected
     control_class: enforced-gate
-    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_main_records_the_receipt_before_building_context
-    motivating_defect: a-foreign-pointer-to-a-worktree-eleven-commits-behind-silenced-every-claude-receipt-on-the-machine
-  - id: pointer-never-blocks
+    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_structured_state_rejects_uncompiled_current_prose
+    motivating_defect: a-generated-current-state-block-and-two-stale-current-prose-surfaces-passed-the-doctor-in-one-coherent-tree
+  - id: historical-snapshots-allowed
+    control_class: acceptance-test
+    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_structured_state_allows_explicitly_historical_snapshots
+    motivating_defect: semantic-enforcement-that-rejects-history-would-destroy-the-durable-evidence-it-is-meant-to-protect
+  - id: current-label-normalization
     control_class: enforced-gate
-    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_main_ignores_a_pointer_it_cannot_validate_with_a_notice
-    motivating_defect: another-sessions-cache-was-treated-as-authority-for-the-session-starting
-  - id: unrelated-failure-still-closed
-    control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_session_context.py::test_main_still_fails_closed_on_a_non_pointer_failure
-    motivating_defect: ignoring-the-pointer-must-not-become-ignoring-every-failure
-  - id: payload-parity-with-ignored-pointer
-    control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_conformance.py::test_payload_parity_agrees_when_a_broken_pointer_is_ignored
-    motivating_defect: the-stopped-task-payload-check-failed-on-a-foreign-pointer-instead-of-reporting-it
-  - id: inbox-never-uses-the-pointer
+    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_structured_state_rejects_setext_and_punctuated_current_labels
+    motivating_defect: setext-headings-and-trailing-punctuation-bypassed-the-current-state-detector
+  - id: structured-state-replaces-body-markers
     control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_board_inbox.py::test_unseated_session_receives_nothing_even_when_a_global_pointer_names_a_project
-    motivating_defect: the-inbox-fallback-delivered-another-projects-message-to-a-seatless-session
-  - id: release-contract-floors
+    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_structured_state_replaces_body_currency_markers
+    motivating_defect: the-doctor-demanded-an-older-prose-currency-marker-beside-the-structured-authority
+  - id: release-bound-to-seat
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_release_is_bound_to_the_claiming_harness_session
+    motivating_defect: a-refused-claim-id-parsed-from-human-output-released-a-different-live-session
+  - id: claim-bound-to-seat
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_claim_with_existing_id_cannot_take_over_another_session_seat
+    motivating_defect: claim-with-an-existing-selector-could-transfer-the-row-and-its-claims-to-another-client
+  - id: heartbeat-bound-to-seat
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_heartbeat_cannot_take_over_another_session_seat
+    motivating_defect: a-foreign-heartbeat-could-refresh-the-row-and-rewrite-its-seat
+  - id: legacy-selector-fails-closed
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_legacy_selector_only_mutations_fail_closed_without_caller_identity
+    motivating_defect: an-unattributed-row-treated-possession-of-its-display-selector-as-mutation-authority
+  - id: sandbox-git-config-isolation
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent
-    motivating_defect: a-release-contract-that-pins-skill-versions-as-literals-fails-the-first-release-after-it
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_each_sandbox_owns_its_global_git_config
+    motivating_defect: one-onboarding-sandbox-global-hook-install-polluted-the-next-sandbox-and-created-an-order-dependent-failure
+  - id: administrative-release-recorded
+    control_class: enforced-gate
+    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_cross_session_administrative_release_requires_and_records_a_reason
+    motivating_defect: cross-session-release-had-no-separate-authority-or-audit-boundary
   - id: pm-budget
     control_class: acceptance-test
     fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget

--- a/skills/synthesis-onboarding/scripts/test_onboard.py
+++ b/skills/synthesis-onboarding/scripts/test_onboard.py
@@ -85,6 +85,7 @@ class Sandbox:
             "SYNTHESIS_CODEX_BIN": "",
             "GIT_AUTHOR_NAME": "Test User", "GIT_AUTHOR_EMAIL": "test@example.com",
             "GIT_COMMITTER_NAME": "Test User", "GIT_COMMITTER_EMAIL": "test@example.com",
+            "GIT_CONFIG_GLOBAL": str(self.root / "gitconfig"),
             "GIT_CONFIG_NOSYSTEM": "1",
             "GIT_CONFIG_COUNT": "1",
             "GIT_CONFIG_KEY_0": "url.file://%s/.insteadOf" % self.remotes,
@@ -1027,6 +1028,16 @@ class EngineTests(unittest.TestCase):
 
     def statuses(self, data, phase=None):
         return [s["status"] for s in data["steps"] if phase is None or s["phase"] == phase]
+
+    def test_each_sandbox_owns_its_global_git_config(self):
+        other = Sandbox()
+        self.addCleanup(other.cleanup)
+        self.assertEqual(
+            self.box.git_env["GIT_CONFIG_GLOBAL"], str(self.box.root / "gitconfig")
+        )
+        self.assertNotEqual(
+            self.box.git_env["GIT_CONFIG_GLOBAL"], other.git_env["GIT_CONFIG_GLOBAL"]
+        )
 
     def test_install_then_idempotent_rerun(self):
         manifest = self.box.manifest()

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.12.1"
+  version: "2.13.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -227,8 +227,7 @@ Complete task → Update CONTEXT.md → local receipt → Next task
    receipt; confirm attributed state is readable;
    do not create a commit or network push solely because the user is switching
    clients on this machine
-6. **Release coordination claims** — Mark the session released or narrow its
-   claims before pausing or ending
+6. **Release coordination claims** — Mark the session released or narrow its claims before pausing. Existing-row mutations require the claiming seat; cross-session release is administrative and reason-bearing.
 
 ### Cross-Agent Session Coordination
 
@@ -324,7 +323,8 @@ Rules:
    rows remain blocking until explicitly resolved; time alone never transfers
    ownership. Review them on a cadence — `coordination.py stale` surfaces
    quiet claims with physical evidence and prints the release command without
-   ever running it; day-start is the natural place to catch them.
+   running it; day-start is the natural review point. Session ids address rows,
+   not authority: claim changes, heartbeat, and release match the claiming seat; administrative release requires a reason.
 9. **Advisory does not mean optional.** The filesystem cannot stop every tool,
    so the protocol and checkpoint hooks make the shared obligation visible.
 
@@ -357,9 +357,8 @@ or save state by hand:
    `pointer`, and `continuity --readiness local` commands for the project
 8. When changing computers, run `synthesis-mac-sync` remote-handoff mode, then
    verify `continuity --readiness remote`. Day-end performs the same transition.
-9. Release or transfer this session's coordination claims. A normal release
-   recoverably archives an active-project pointer owned by that session; a
-   pointer owned by another session is untouched.
+9. Release or transfer this session's coordination claims. Normal release recoverably archives its session's active-project pointer; another session's pointer is untouched. Normal release is
+   caller-bound; administrative release is distinct and audited.
 
 Resuming from another agent: run `scripts/project_state.py resolve` against the
 Git-tracked index before reading prose. Divergence is `CONFLICT`; unreadable or

--- a/skills/synthesis-project-management/references/parallel-agent-protocol.md
+++ b/skills/synthesis-project-management/references/parallel-agent-protocol.md
@@ -262,13 +262,18 @@ not to another agent's judgment. The user (or a session acting on the user's
 explicit direction, recorded in that session's log) runs:
 
 ```bash
-python3 <root>/scripts/coordination.py release --id <stale-id>
+python3 <root>/scripts/coordination.py release --id <stale-id> \
+  --administrative \
+  --reason "Operator confirmed the abandoned session may be released"
 ```
 
-`release` marks the row released without touching its history; nothing else
-on the board changes. An agent must never administratively release a peer on
-its own initiative — route the request through the board's message log or
-the user, exactly as with any other overlap.
+The administrative path records the target, caller identity, timestamp, and
+reason on the board before it marks the row released. Existing-row `claim`,
+`heartbeat`, and normal `release` mutations are bound to the exact seat
+recorded at claim, so parsing another session's id from a diagnostic cannot
+mutate it. An agent must never administratively release a peer on its own
+initiative — route the request through the board's
+message log or the user, exactly as with any other overlap.
 
 ## Commit authority — check-staged selector precedence
 

--- a/skills/synthesis-project-management/references/session-identity.md
+++ b/skills/synthesis-project-management/references/session-identity.md
@@ -80,6 +80,12 @@ python3 scripts/coordination.py release \
   --session crater-sunset-alone-okay-23906
 ```
 
+Selectors address a row; they do not authorize its mutation. Existing-row
+claim changes, heartbeat, and normal release match the running harness identity
+against the seat recorded when the claim was made. Releasing another session
+is a separate administrative operation that requires
+`--administrative --reason <text>` and records that override on the board.
+
 `coordination.py migrate` upgrades the whole v1/v2 board atomically, assigns
 each historical row a UUIDv7 and both aliases, and preserves its old letter in
 `legacy id`. Messages and history are left intact. Once migrated, canonical

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -1596,6 +1596,17 @@ def command_claim(args) -> int:
             if same_seat:
                 existing_self = same_seat[0]
                 claimed["reused"] = existing_self.identity.compact_id
+        if existing_self is not None:
+            if not active(existing_self):
+                raise RuntimeError(
+                    "session identity is terminal and cannot be reused; omit "
+                    "--session to allocate a new identity"
+                )
+            if not _caller_owns_session(args.board, existing_self):
+                raise RuntimeError(
+                    "caller identity does not own the target session seat; "
+                    "omit --session to allocate a new identity"
+                )
         identity = (
             existing_self.identity
             if existing_self is not None
@@ -1688,6 +1699,10 @@ def command_heartbeat(args) -> int:
             raise RuntimeError(f"session not found: {args.id}")
         if not active(session):
             raise RuntimeError(f"session is not active: {args.id}")
+        if not _caller_owns_session(args.board, session):
+            raise RuntimeError(
+                "caller identity does not own the target session seat"
+            )
         session.heartbeat = timestamp()
         updated["identity"] = session.identity
         return replace_table(content, current)
@@ -1716,18 +1731,103 @@ def command_heartbeat(args) -> int:
     return 0
 
 
+def _caller_owns_session(board: Path, session: Session) -> bool:
+    """Whether the running client identity owns this board session.
+
+    The compact id is an address, not authority. A refused claim may mention a
+    conflicting id in its diagnostic, and shell text processing can capture
+    that id. Every mutation of an existing row therefore binds to the exact
+    harness identity recorded at claim time whenever a seat exists. The host
+    delivery id is used only for a legacy seat that has no exact harness
+    identity.
+    """
+    caller = detect_self()
+    seat = read_seat(board, session.session_uuid)
+    if seat is not None:
+        if seat.harness_session_id:
+            return bool(
+                caller.harness_session_id
+                and caller.harness_session_id == seat.harness_session_id
+                and (
+                    not seat.client
+                    or not caller.client
+                    or seat.client == caller.client
+                )
+            )
+        if seat.host_session_id:
+            return bool(
+                caller.host_session_id
+                and caller.host_session_id == seat.host_session_id
+            )
+        return False
+
+    # Rows created before seat registration remain mutable by their exact board
+    # client ref. Truly legacy rows have neither identity surface, so a bare
+    # selector cannot establish authority and must fail closed.
+    if session.client_ref:
+        try:
+            return detect_client_ref() == session.client_ref
+        except ValueError:
+            return False
+    return False
+
+
+def _append_administrative_release(
+    content: str, session: Session, reason: str, caller: str
+) -> str:
+    marker = re.search(
+        r"(?m)^---[ \t]*\n\n## Protocol(?:[^\n]*)?$",
+        content,
+    )
+    if marker is None:
+        raise RuntimeError("board lacks Protocol boundary")
+    body = (
+        f"### recorded-administrative-release — {timestamp()}\n\n"
+        f"Target session: {session.session_uuid}\n\n"
+        f"Caller identity: {sanitize(caller)}\n\n"
+        f"Reason: {sanitize(reason)}\n\n"
+    )
+    return content[: marker.start()] + body + content[marker.start() :]
+
+
 def command_release(args) -> int:
     released: dict[str, SessionIdentity] = {}
+    administrative = bool(getattr(args, "administrative", False))
+    reason = str(getattr(args, "reason", "") or "").strip()
+    administrative_caller = detect_self().sender_key if administrative else ""
+    if administrative and not reason:
+        print(
+            "coordination release failed: --administrative requires --reason",
+            file=sys.stderr,
+        )
+        return 10
+    if administrative and not administrative_caller:
+        print(
+            "coordination release failed: --administrative requires an "
+            "attributable caller identity",
+            file=sys.stderr,
+        )
+        return 10
 
     def operation(content: str) -> str:
         current = ensure_identities(rows(content))
         session = find_session(current, args.id)
         if session is None:
             raise RuntimeError(f"session not found: {args.id}")
+        if not administrative and not _caller_owns_session(args.board, session):
+            raise RuntimeError(
+                "caller identity does not own the target session seat; "
+                "cross-session release requires --administrative and --reason"
+            )
         session.status = "released"
         session.heartbeat = timestamp()
         released["identity"] = session.identity
-        return replace_table(content, current)
+        updated = replace_table(content, current)
+        if administrative:
+            updated = _append_administrative_release(
+                updated, session, reason, administrative_caller
+            )
+        return updated
 
     try:
         locked_update(args.board, operation)
@@ -2510,6 +2610,15 @@ def parser() -> argparse.ArgumentParser:
     heartbeat.add_argument("--id", "--session", dest="id", required=True)
     release = commands.add_parser("release")
     release.add_argument("--id", "--session", dest="id", required=True)
+    release.add_argument(
+        "--administrative",
+        action="store_true",
+        help="release a different session after explicit operator direction",
+    )
+    release.add_argument(
+        "--reason",
+        help="reason recorded on the board for an administrative release",
+    )
     release.add_argument(
         "--active-project-file", type=Path, default=DEFAULT_ACTIVE_PROJECT
     )

--- a/skills/synthesis-project-management/scripts/project_state.py
+++ b/skills/synthesis-project-management/scripts/project_state.py
@@ -625,6 +625,117 @@ def _content_hashes(project: Path, controlling_plan: str | None = None) -> dict[
     }
 
 
+def _normalized_state_label(value: str) -> str:
+    plain_text = re.sub(r"[*_`]+", "", value)
+    plain_text = re.sub(r"^\s*[-+]\s+", "", plain_text)
+    plain_text = re.sub(r"\s+", " ", plain_text).strip().casefold()
+    return plain_text.strip(" \t:;,.!?—–-")
+
+
+def _is_current_state_label(value: str, *, heading: bool = False) -> bool:
+    normalized = _normalized_state_label(value)
+    prefixes = (
+        "accepted baseline",
+        "next checkpoint",
+        "current accepted",
+        "current baseline",
+        "state as of",
+    )
+    if heading and (
+        normalized == "current" or normalized.startswith("current ")
+    ):
+        return True
+    for prefix in prefixes:
+        if normalized == prefix:
+            return True
+        suffix = normalized[len(prefix) : len(prefix) + 1]
+        if normalized.startswith(prefix) and suffix in {
+            " ",
+            ":",
+            "—",
+            "–",
+            "-",
+        }:
+            return True
+    return False
+
+
+def _uncompiled_current_state_prose(project: Path, context: str) -> list[str]:
+    """Locate mutable current-state labels outside the generated state block.
+
+    A structured project has one operational source and one generated readable
+    projection. Allowing a second heading such as ``Current handoff`` or
+    ``Accepted baseline`` recreates the contradiction that structured state is
+    intended to remove. Historical snapshots remain ordinary Markdown; they
+    are safe when their headings label them as history rather than as current.
+    """
+    marker_start = "<!-- synthesis-current-state:start -->"
+    marker_end = "<!-- synthesis-current-state:end -->"
+    surfaces: list[tuple[str, str]] = [("CONTEXT.md", context)]
+    reference_index = project / "REFERENCE.md"
+    if reference_index.is_file():
+        surfaces.append(
+            (
+                "REFERENCE.md",
+                reference_index.read_text(encoding="utf-8", errors="replace"),
+            )
+        )
+    reference_dir = project / "reference"
+    if reference_dir.is_dir():
+        for path in sorted(reference_dir.rglob("*.md")):
+            if path.is_file():
+                surfaces.append(
+                    (
+                        str(path.relative_to(project)),
+                        path.read_text(encoding="utf-8", errors="replace"),
+                    )
+                )
+
+    findings: list[str] = []
+    for relative, text in surfaces:
+        current_lines: list[int] = []
+        inside_generated = False
+        lines = text.splitlines()
+        for index, line in enumerate(lines):
+            number = index + 1
+            if relative == "CONTEXT.md" and marker_start in line:
+                inside_generated = True
+                continue
+            if relative == "CONTEXT.md" and marker_end in line:
+                inside_generated = False
+                continue
+            if inside_generated:
+                continue
+
+            heading = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*#*\s*$", line)
+            heading_title = heading.group(1) if heading else ""
+            if (
+                not heading_title
+                and line.strip()
+                and index + 1 < len(lines)
+                and re.match(r"^\s{0,3}(?:=+|-+)\s*$", lines[index + 1])
+            ):
+                heading_title = line
+            if heading_title and _is_current_state_label(
+                heading_title, heading=True
+            ):
+                current_lines.append(number)
+                continue
+
+            if _is_current_state_label(line):
+                current_lines.append(number)
+
+        if current_lines:
+            locations = ", ".join(str(number) for number in current_lines)
+            findings.append(
+                "uncompiled current-state prose in "
+                f"{relative} at line(s) {locations}; structured projects must "
+                "keep mutable current claims inside the generated block and "
+                "label other snapshots as history"
+            )
+    return findings
+
+
 def semantic_issues(project: Path) -> list[str]:
     """Return contradictions in operational and human-readable current state."""
     project = project.resolve()
@@ -664,6 +775,7 @@ def semantic_issues(project: Path) -> list[str]:
         current = ".".join(str(part) for part in max(current_versions))
         issues.append(f"current release {current} is older than later recorded release {newest}")
     if state:
+        issues.extend(_uncompiled_current_state_prose(project, context))
         if state.get("project_id") != project.name:
             issues.append("current operational state project id disagrees with its directory")
         plan = (project / str(state.get("controlling_plan", ""))).resolve()

--- a/skills/synthesis-project-management/scripts/test_board_inbox.py
+++ b/skills/synthesis-project-management/scripts/test_board_inbox.py
@@ -19,6 +19,7 @@ import coordination as ENGINE  # noqa: E402
 
 ME_SID = "11111111-1111-4111-8111-111111111111"
 ME_ENV = {"CLAUDECODE": "1", "CLAUDE_CODE_SESSION_ID": ME_SID, "CLAUDE_CODE_HOST_SESSION_ID": "local_me"}
+EARLIER_ENV = {"SYNTHESIS_CLIENT_SESSION_REF": "codex:earlier-seat"}
 
 
 @pytest.fixture(autouse=True)
@@ -67,7 +68,7 @@ def test_project_history_before_the_claim_is_not_delivered_to_a_new_seat(tmp_pat
     its claim is delivered."""
     path = tmp_path / "board.md"
     other = claim(path, "project-o", {}, monkeypatch)
-    earlier = claim(path, "project-m", {}, monkeypatch)
+    earlier = claim(path, "project-m", EARLIER_ENV, monkeypatch)
     assert ENGINE.command_message(args(path, sender=other.compact_id, to="project-m", text="Posted before the seat existed.")) == 0
     assert ENGINE.command_release(args(path, id=earlier.compact_id)) == 0
     text = path.read_text(encoding="utf-8")

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -170,7 +170,10 @@ def test_claim_without_human_supplied_id_allocates_all_identities(tmp_path: Path
     assert session.legacy_id == ""
 
 
-def test_every_identity_form_selects_the_same_session(tmp_path: Path) -> None:
+def test_every_identity_form_selects_the_same_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:identity-forms")
     board = tmp_path / "active-sessions.md"
     request = claim_args(
         board,
@@ -219,8 +222,11 @@ def test_unmatched_strong_selector_does_not_create_a_session(tmp_path: Path) -> 
     assert len(MODULE.rows(board.read_text(encoding="utf-8"))) == 1
 
 
-def test_claim_conflict_message_heartbeat_and_release(tmp_path: Path) -> None:
+def test_claim_conflict_message_heartbeat_and_release(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     board = tmp_path / "coordination" / "active-sessions.md"
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:owner-a")
     first = claim_args(
         board,
         session_id="A",
@@ -230,6 +236,7 @@ def test_claim_conflict_message_heartbeat_and_release(tmp_path: Path) -> None:
     )
     assert MODULE.command_claim(first) == 0
 
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:owner-b")
     second = claim_args(
         board,
         session_id="B",
@@ -244,19 +251,206 @@ def test_claim_conflict_message_heartbeat_and_release(tmp_path: Path) -> None:
     assert "Please release repo/file.md." in board.read_text(encoding="utf-8")
 
     before = MODULE.rows(board.read_text(encoding="utf-8"))[0].heartbeat
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:owner-a")
     assert MODULE.command_heartbeat(args(board, id="A")) == 0
     after = MODULE.rows(board.read_text(encoding="utf-8"))[0].heartbeat
     assert after >= before
 
     assert MODULE.command_release(args(board, id="A")) == 0
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:owner-b")
     assert MODULE.command_claim(second) == 0
     table = MODULE.rows(board.read_text(encoding="utf-8"))
     assert next(row for row in table if row.legacy_id == "A").status == "released"
     assert next(row for row in table if row.legacy_id == "B").status == "active"
 
 
-def test_release_leaves_pointer_without_matching_board_lease(tmp_path: Path) -> None:
+def test_release_is_bound_to_the_claiming_harness_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     board = tmp_path / "coordination" / "active-sessions.md"
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-a")
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local-shared")
+    claim = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="repo/**",
+    )
+    assert MODULE.command_claim(claim) == 0
+
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-b")
+    assert MODULE.command_release(args(board, id="A")) == 10
+    assert MODULE.rows(board.read_text(encoding="utf-8"))[0].status == "active"
+
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-a")
+    assert MODULE.command_release(args(board, id="A")) == 0
+
+
+def test_heartbeat_cannot_take_over_another_session_seat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    board = tmp_path / "coordination" / "active-sessions.md"
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-a")
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local-shared")
+    request = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="repo/**",
+    )
+    assert MODULE.command_claim(request) == 0
+    [before] = MODULE.rows(board.read_text(encoding="utf-8"))
+    seat_before = MODULE.read_seat(board, before.session_uuid)
+    assert seat_before is not None
+
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-b")
+    assert MODULE.command_heartbeat(args(board, id="A")) == 10
+    [after] = MODULE.rows(board.read_text(encoding="utf-8"))
+    seat_after = MODULE.read_seat(board, after.session_uuid)
+    assert after.heartbeat == before.heartbeat
+    assert seat_after is not None
+    assert seat_after.harness_session_id == seat_before.harness_session_id
+    assert MODULE.command_release(args(board, id="A")) == 10
+
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-a")
+    assert MODULE.command_heartbeat(args(board, id="A")) == 0
+    assert MODULE.command_release(args(board, id="A")) == 0
+
+
+def test_claim_with_existing_id_cannot_take_over_another_session_seat(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    board = tmp_path / "coordination" / "active-sessions.md"
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-a")
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local-shared")
+    original = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="repo-a/**",
+    )
+    assert MODULE.command_claim(original) == 0
+    [before] = MODULE.rows(board.read_text(encoding="utf-8"))
+
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-b")
+    takeover = claim_args(
+        board,
+        session_id=before.compact_id,
+        project="project-b",
+        workspace="/tmp/worktree-b @ feature/b",
+        area="repo-b/**",
+    )
+    assert MODULE.command_claim(takeover) == 10
+    [after] = MODULE.rows(board.read_text(encoding="utf-8"))
+    assert after.project == before.project
+    assert after.claims == before.claims
+    seat = MODULE.read_seat(board, after.session_uuid)
+    assert seat is not None and seat.harness_session_id == "harness-a"
+
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-a")
+    assert MODULE.command_claim(original) == 0
+
+
+def test_cross_session_administrative_release_requires_and_records_a_reason(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    board = tmp_path / "coordination" / "active-sessions.md"
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-a")
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local-shared")
+    claim = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="repo/**",
+    )
+    assert MODULE.command_claim(claim) == 0
+
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "harness-b")
+    assert MODULE.command_release(
+        args(board, id="A", administrative=True, reason="")
+    ) == 10
+    assert MODULE.command_release(
+        args(
+            board,
+            id="A",
+            administrative=True,
+            reason="Principal confirmed the abandoned session may be released",
+        )
+    ) == 0
+    text = board.read_text(encoding="utf-8")
+    assert "recorded-administrative-release" in text
+    [released] = MODULE.rows(text)
+    assert released.status == "released"
+    assert f"Target session: {released.session_uuid}" in text
+    assert "Caller identity: cc:harness-b" in text
+    assert "Principal confirmed the abandoned session may be released" in text
+    assert re.search(
+        r"recorded-administrative-release — "
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}",
+        text,
+    )
+
+
+def test_legacy_selector_only_mutations_fail_closed_without_caller_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    board = tmp_path / "coordination" / "active-sessions.md"
+    claim = claim_args(
+        board,
+        session_id="A",
+        project="project-a",
+        workspace="/tmp/worktree-a @ feature/a",
+        area="repo/**",
+    )
+    assert MODULE.command_claim(claim) == 0
+    [active] = MODULE.rows(board.read_text(encoding="utf-8"))
+    assert MODULE.read_seat(board, active.session_uuid) is None
+    assert active.client_ref == ""
+
+    assert MODULE.command_heartbeat(args(board, id="A")) == 10
+    assert MODULE.command_claim(claim) == 10
+    assert MODULE.command_release(args(board, id="A")) == 10
+    assert MODULE.command_release(
+        args(
+            board,
+            id="A",
+            administrative=True,
+            reason="Authorized recovery of an unattributed legacy row",
+        )
+    ) == 10
+    [still_active] = MODULE.rows(board.read_text(encoding="utf-8"))
+    assert still_active.status == "active"
+
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:admin-thread")
+    assert MODULE.command_release(
+        args(
+            board,
+            id="A",
+            administrative=True,
+            reason="Authorized recovery of an unattributed legacy row",
+        )
+    ) == 0
+    text = board.read_text(encoding="utf-8")
+    [released] = MODULE.rows(text)
+    assert released.status == "released"
+    assert f"Target session: {released.session_uuid}" in text
+    assert "Caller identity: codex:admin-thread" in text
+    assert MODULE.command_claim(claim) == 10
+
+
+def test_release_leaves_pointer_without_matching_board_lease(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    board = tmp_path / "coordination" / "active-sessions.md"
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:pointer-owner")
     claim = claim_args(
         board,
         session_id="A",
@@ -695,8 +889,11 @@ def lease_machines(tmp_path: Path, count: int = 2) -> list[Path]:
     return boards
 
 
-def test_lease_shares_claims_across_machines(tmp_path: Path) -> None:
+def test_lease_shares_claims_across_machines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     machine1, machine2 = lease_machines(tmp_path)
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:owner-a")
     first = claim_args(
         machine1,
         session_id="A",
@@ -706,6 +903,7 @@ def test_lease_shares_claims_across_machines(tmp_path: Path) -> None:
     )
     assert MODULE.command_claim(first) == 0
 
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:owner-b")
     conflicting = claim_args(
         machine2,
         session_id="B",
@@ -724,7 +922,9 @@ def test_lease_shares_claims_across_machines(tmp_path: Path) -> None:
     )
     assert MODULE.command_claim(disjoint) == 0
 
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:owner-a")
     assert MODULE.command_release(args(machine1, id="A")) == 0
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:owner-c")
     retried = claim_args(
         machine2,
         session_id="C",
@@ -1158,8 +1358,11 @@ def test_r4_recorded_override_binds_reason_and_paths(
 
 
 def test_r4_inactive_session_is_refused(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:staged-owner")
     root = staged_repository(tmp_path)
     (root / "claimed").mkdir()
     (root / "claimed" / "inside.md").write_text("inside\n", encoding="utf-8")
@@ -1181,6 +1384,7 @@ def test_r4_lease_fence_cannot_resurrect_released_session(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:lease-owner")
     root = staged_repository(tmp_path)
     claimed = root / "claimed"
     claimed.mkdir()
@@ -1514,6 +1718,7 @@ def test_generic_ref_env_overrides_client_specific(tmp_path, monkeypatch):
 
 
 def test_claim_reuses_active_row_for_same_client_seat(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDECODE", "1")
     monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local_feed-beef")
     board = tmp_path / "board.md"
     assert (
@@ -1578,6 +1783,7 @@ def _v3_board(tmp_path):
 
 
 def test_v3_board_keeps_schema_until_explicit_migrate(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDECODE", "1")
     monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "local_feed-beef")
     board = _v3_board(tmp_path)
     assert (
@@ -1979,4 +2185,3 @@ def test_every_command_notes_a_newer_installed_engine(tmp_path):
         capture_output=True, text=True, check=False,
     )
     assert "note: this coordination engine" not in current.stderr
-

--- a/skills/synthesis-project-management/scripts/test_peer_addressing.py
+++ b/skills/synthesis-project-management/scripts/test_peer_addressing.py
@@ -400,7 +400,14 @@ def test_doctor_counts_seats_and_names_orphans(tmp_path, monkeypatch, capsys) ->
     board, sender, target, registry = two_seats(tmp_path, monkeypatch)
     assert ENGINE.command_doctor(args(board)) == 0
     assert "2 seat(s)" in capsys.readouterr().out
-    assert ENGINE.command_release(args(board, id=target.compact_id)) == 0
+    assert ENGINE.command_release(
+        args(
+            board,
+            id=target.compact_id,
+            administrative=True,
+            reason="doctor orphan-seat fixture",
+        )
+    ) == 0
     PA.write_seat(board, session_uuid=target.session_uuid, compact_id=target.compact_id, machine="m1", identity=PA.SelfIdentity(client="claude-code", harness_session_id="orphan"))
     assert ENGINE.command_doctor(args(board)) == 0
     assert "1 without an active row" in capsys.readouterr().out

--- a/skills/synthesis-project-management/scripts/test_peer_send_gate.py
+++ b/skills/synthesis-project-management/scripts/test_peer_send_gate.py
@@ -162,7 +162,14 @@ def test_a_reclaimed_seat_is_not_shadowed_by_its_old_receipt(world, monkeypatch)
     board identity with the same handle; the gate matched the stale receipt
     first and refused a send the fresh receipt authorized."""
     resolve(world)
-    assert ENGINE.command_release(args(world.board, id=world.target.compact_id)) == 0
+    assert ENGINE.command_release(
+        args(
+            world.board,
+            id=world.target.compact_id,
+            administrative=True,
+            reason="reclaimed-seat fixture",
+        )
+    ) == 0
     reclaimed = claim(world.board, "project-t2", TARGET_ENV, monkeypatch)
     for key, value in SENDER_ENV.items():
         monkeypatch.setenv(key, value)
@@ -174,7 +181,14 @@ def test_a_reclaimed_seat_is_not_shadowed_by_its_old_receipt(world, monkeypatch)
 
 def test_released_target_is_refused_even_with_a_receipt(world) -> None:
     resolve(world)
-    assert ENGINE.command_release(args(world.board, id=world.target.compact_id)) == 0
+    assert ENGINE.command_release(
+        args(
+            world.board,
+            id=world.target.compact_id,
+            administrative=True,
+            reason="released-target fixture",
+        )
+    ) == 0
     decision = evaluate(world, payload("mcp__ccd_session_mgmt__send_message", {"session_id": "local_target", "message": body(world)}))
     assert not decision.allow and "no longer an active board row" in decision.reason
 

--- a/skills/synthesis-project-management/scripts/test_project_state.py
+++ b/skills/synthesis-project-management/scripts/test_project_state.py
@@ -42,11 +42,11 @@ def write_project(repo: Path, project_id: str = "alpha", version: str = "1.0.0")
                 "",
                 "[controlling plan](resources/artifacts/plan.md)",
                 "",
-                "## Accepted baseline",
-                f"Current accepted release: v{version}.",
+                "## Baseline history",
+                f"Accepted release snapshot: v{version}.",
                 "",
-                "## Current handoff",
-                f"*State as of: 2026-09-03 (v{version})*",
+                "## Handoff history",
+                f"Snapshot recorded 2026-09-03 (v{version}).",
                 "",
                 "## What's Next",
                 "- [ ] finish",
@@ -313,6 +313,124 @@ def test_internal_version_contradiction_is_semantic_failure(tmp_path: Path) -> N
     context.write_text(context.read_text(encoding="utf-8").replace("**Phase:** release 1.0.0", "**Phase:** current release 1.0.0") + "\nLater release shipped: v4.0.0.\n", encoding="utf-8")
     issues = state.semantic_issues(project)
     assert any("current" in issue.lower() and "4.0.0" in issue for issue in issues)
+
+
+def test_structured_state_rejects_uncompiled_current_prose(tmp_path: Path) -> None:
+    _repo, project = init_repo(tmp_path)
+    context = project / "CONTEXT.md"
+    context.write_text(
+        context.read_text(encoding="utf-8")
+        + "\n## Current handoff\n\n*State as of: 2026-09-03 (v0.9.0 installed)*\n",
+        encoding="utf-8",
+    )
+    reference = project / "reference"
+    reference.mkdir()
+    (reference / "baselines.md").write_text(
+        "# Baselines\n\n## Current reconciled baseline\n\nRelease v0.9.0.\n",
+        encoding="utf-8",
+    )
+    state.build_operational_state(
+        project,
+        project_id="alpha",
+        phase="release 1.0.0",
+        status="active",
+        controlling_plan="resources/artifacts/plan.md",
+        accepted_baseline="1.0.0",
+        next_actions=["finish"],
+        last_session="2026-09-03",
+        session_id="018f0000-0000-7000-8000-000000000001",
+    )
+
+    issues = state.semantic_issues(project)
+
+    assert any(
+        "uncompiled current-state prose" in issue and "CONTEXT.md" in issue
+        for issue in issues
+    )
+    assert any(
+        "uncompiled current-state prose" in issue
+        and "reference/baselines.md" in issue
+        for issue in issues
+    )
+
+
+def test_structured_state_rejects_setext_and_punctuated_current_labels(
+    tmp_path: Path,
+) -> None:
+    _repo, project = init_repo(tmp_path)
+    context = project / "CONTEXT.md"
+    context.write_text(
+        context.read_text(encoding="utf-8")
+        + "\nAccepted baseline:\n------------------\n\nRelease v0.9.0.\n"
+        + "\n## Current handoff:\n\n**State as of — v0.9.0**\n",
+        encoding="utf-8",
+    )
+    reference = project / "reference"
+    reference.mkdir()
+    (reference / "baselines.md").write_text(
+        "# Baselines\n\nNext checkpoint:\n================\n\nRelease v0.9.0.\n",
+        encoding="utf-8",
+    )
+    state.build_operational_state(
+        project,
+        project_id="alpha",
+        phase="release 1.0.0",
+        status="active",
+        controlling_plan="resources/artifacts/plan.md",
+        accepted_baseline="1.0.0",
+        next_actions=["finish"],
+        last_session="2026-09-03",
+        session_id="018f0000-0000-7000-8000-000000000001",
+    )
+
+    issues = state.semantic_issues(project)
+
+    assert any(
+        "uncompiled current-state prose" in issue
+        and "CONTEXT.md" in issue
+        and "line(s) 24, 29, 31" in issue
+        for issue in issues
+    )
+    assert any(
+        "uncompiled current-state prose" in issue
+        and "reference/baselines.md" in issue
+        and "line(s) 3" in issue
+        for issue in issues
+    )
+
+
+def test_structured_state_allows_explicitly_historical_snapshots(tmp_path: Path) -> None:
+    _repo, project = init_repo(tmp_path)
+    context = project / "CONTEXT.md"
+    context.write_text(
+        "# Context\n\n## Handoff history\n\n"
+        "Release v0.9.0 was accepted previously.\n"
+        "current client-health checks were recorded in that historical snapshot.\n",
+        encoding="utf-8",
+    )
+    reference = project / "reference"
+    reference.mkdir()
+    (reference / "baselines.md").write_text(
+        "# Baselines\n\n## Accepted baselines — through 2026-08-18\n\n"
+        "Release v0.9.0.\n",
+        encoding="utf-8",
+    )
+    state.build_operational_state(
+        project,
+        project_id="alpha",
+        phase="release 1.0.0",
+        status="active",
+        controlling_plan="resources/artifacts/plan.md",
+        accepted_baseline="1.0.0",
+        next_actions=["finish"],
+        last_session="2026-09-03",
+        session_id="018f0000-0000-7000-8000-000000000001",
+    )
+
+    assert not any(
+        "uncompiled current-state prose" in issue
+        for issue in state.semantic_issues(project)
+    )
 
 
 def test_checkpoint_requires_context_refresh_after_source_head_changes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- reject duplicate mutable current-state prose outside a structured project's generated block, including Setext and punctuated headings
- bind existing-row claim, heartbeat, and normal release mutations to the claiming seat; record attributable administrative release
- isolate onboarding test sandboxes from shared global Git configuration

## Verification

- 1,312 repository tests passed in one hermetic run
- 204 project-management tests passed
- 188 context-lifecycle tests passed
- 193 onboarding tests passed
- 14/14 transaction-bound acceptance cases passed against the exact 19-path change universe