### PR TITLE
Make stopped-task parity follow causal project selection

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.93.3",
+  "version": "4.93.4",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.93.3",
+  "version": "4.93.4",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.93.4] - 2026-09-04
+
+**Stopped-task conformance now verifies the project selected by causal
+recovery instead of requiring the caller's original worktree pathname.** A
+clean isolated checkout and a newer canonical checkout can carry the same
+project tree; recovery correctly chooses the causally newer repository state,
+but the prior parity assertion treated that path change as a missing payload.
+
+synthesis-agent-conformance 1.9.3 extracts the selected durable project from
+the shared adapter payload, requires the requested project identity, derives
+the controlling plan at the selected path, and keeps phase and status equality
+checks. The separate project-state recovery check continues to prove causal
+selection. A red-first two-worktree fixture and a real installed-shape probe
+cover the motivating topology.
+
 ## [4.93.3] - 2026-09-03
 
 **Structured current state can no longer coexist with another current-looking

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Stopped-task verification now follows the causally selected project copy
+(September 2026).** Release **4.93.4** accepts an equal or newer resolved
+checkout without demanding that recovery preserve the caller's original
+worktree pathname. It still requires the same project identity, phase, status,
+and controlling plan, while the separate resolver check proves causal
+selection. See the [4.93.4 release notes](CHANGELOG.md).
+
 **Structured state now has one readable current-state authority (September
 2026).** Release **4.93.3** rejects duplicate current-looking prose outside the
 generated state block while preserving explicitly historical snapshots. It

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.9.2"
+  version: "1.9.3"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-agent-conformance/scripts/conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/conformance.py
@@ -1843,11 +1843,39 @@ def stopped_payload_parity(
     if normalized["claude"] != normalized["codex"]:
         return False, "Claude and Codex stopped-task payloads diverge"
     message = contexts["codex"]
+    selected_match = re.search(
+        r"^Stopped synthesis project discovered from the task directory: (.+)\.$",
+        message,
+        re.MULTILINE,
+    )
+    if not selected_match:
+        return False, "stopped-task payload does not name the selected project"
+    try:
+        selected_project = Path(selected_match.group(1)).expanduser().resolve(strict=True)
+    except OSError as exc:
+        return False, f"selected stopped-task project is unreadable: {exc}"
+    if selected_project.name != project.resolve().name:
+        return False, (
+            "stopped-task payload selected a different project: "
+            f"expected={project.resolve().name}; selected={selected_project.name}"
+        )
+
+    plan = str(summary.get("plan", "unknown"))
+    if plan != "unknown":
+        try:
+            relative_plan = Path(plan).resolve(strict=True).relative_to(project.resolve())
+        except (OSError, ValueError) as exc:
+            return False, f"input project's controlling plan is invalid: {exc}"
+        selected_plan = selected_project / relative_plan
+        if not selected_plan.is_file():
+            return False, f"selected project's controlling plan is missing: {selected_plan}"
+        plan = str(selected_plan)
+
     expected = [
-        str(project.resolve()),
+        f"Stopped synthesis project discovered from the task directory: {selected_project}.",
         f"Current phase: {summary.get('phase', 'unknown')}.",
         f"Current status: {summary.get('status', 'unknown')}.",
-        f"Controlling plan: {summary.get('plan', 'unknown')}.",
+        f"Controlling plan: {plan}.",
     ]
     missing = [value for value in expected if value not in message]
     if missing:

--- a/skills/synthesis-agent-conformance/scripts/test_conformance.py
+++ b/skills/synthesis-agent-conformance/scripts/test_conformance.py
@@ -666,6 +666,81 @@ def test_stopped_handoff_passes_without_active_pointer(tmp_path: Path) -> None:
     assert named["handoff.pointer-cache"].ok
 
 
+def test_stopped_handoff_accepts_causally_selected_project_alias(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The resolver may select a newer checkout whose project tree is equal.
+
+    Adapter parity must verify that selected durable project, not require the
+    caller's isolated-worktree pathname to survive reconciliation.
+    """
+    synthesis_home = tmp_path / "synthesis-home"
+    synthesis_home.mkdir()
+    monkeypatch.setenv("SYNTHESIS_HOME", str(synthesis_home))
+    project = write_stopped_project(tmp_path)
+    repo = project.parents[1]
+    (repo / "projects" / "index.yaml").write_text(
+        "- id: demo\n  status: paused\n",
+        encoding="utf-8",
+    )
+    (project / "sessions" / "2026-09.md").write_text(
+        "# September 2026\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "add",
+            "projects/index.yaml",
+            "projects/demo/sessions/2026-09.md",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-qm", "add project registry"],
+        check=True,
+    )
+    isolated = tmp_path / "isolated"
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "feature/isolated",
+            str(isolated),
+            "HEAD",
+        ],
+        check=True,
+    )
+    (repo / "unrelated.txt").write_text("newer repository state\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "unrelated.txt"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-qm", "advance canonical checkout"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "update-ref", "refs/remotes/origin/main", "HEAD"],
+        check=True,
+    )
+
+    isolated_project = isolated / "projects" / "demo"
+    checks = MODULE.handoff_checks(
+        isolated_project,
+        tmp_path / "missing-pointer.json",
+        tmp_path / "missing-board.md",
+    )
+
+    named = {check.name: check for check in checks}
+    assert named["handoff.stopped-task-payload"].ok
+
+
 def test_aggregate_pointer_scope_accepts_documented_cache_absence(
     tmp_path: Path,
 ) -> None:

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,46 +1,24 @@
-# AGENT HEURISTIC: authored for the 4.93.3 single-current-state-and-owned-release transaction.
+# AGENT HEURISTIC: authored for the 4.93.4 causal stopped-task alias transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: single-current-state-and-owned-release
+suite: causal-stopped-task-alias
 membership: closed
-production_entry_point: skills/synthesis-project-management/scripts/project_state.py
-enforcing_boundary: structured operational state is the only mutable current-state authority, historical prose is explicitly labeled, every existing-row claim heartbeat and normal release mutation is bound to its claiming seat, and administrative release is reason-bearing and recorded
+production_entry_point: skills/synthesis-agent-conformance/scripts/conformance.py
+enforcing_boundary: stopped-task parity requires both native adapters to report one causally selected durable project with the requested project identity, matching phase and status, and an existing controlling plan derived at the selected path
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: exact-version native lifecycle receipts require genuine client restarts after installation; source and hermetic fixtures do not substitute for those live events
+unverified_remainder: current-global lifecycle health remains a native runtime observation and cannot be replaced by source or hermetic evidence
 changed_surfaces:
-  - path: skills/synthesis-project-management/scripts/project_state.py
-    cases: [uncompiled-current-prose-rejected, current-label-normalization, historical-snapshots-allowed]
-  - path: skills/synthesis-project-management/scripts/test_project_state.py
-    cases: [uncompiled-current-prose-rejected, current-label-normalization, historical-snapshots-allowed]
-  - path: skills/synthesis-project-management/scripts/coordination.py
-    cases: [claim-bound-to-seat, heartbeat-bound-to-seat, release-bound-to-seat, legacy-selector-fails-closed, administrative-release-recorded]
-  - path: skills/synthesis-project-management/scripts/test_coordination.py
-    cases: [claim-bound-to-seat, heartbeat-bound-to-seat, release-bound-to-seat, legacy-selector-fails-closed, administrative-release-recorded]
-  - path: skills/synthesis-project-management/scripts/test_board_inbox.py
-    cases: [release-bound-to-seat]
-  - path: skills/synthesis-project-management/scripts/test_peer_addressing.py
-    cases: [administrative-release-recorded]
-  - path: skills/synthesis-project-management/scripts/test_peer_send_gate.py
-    cases: [administrative-release-recorded]
-  - path: skills/synthesis-onboarding/scripts/test_onboard.py
-    cases: [sandbox-git-config-isolation]
-  - path: skills/synthesis-project-management/SKILL.md
-    cases: [claim-bound-to-seat, heartbeat-bound-to-seat, release-bound-to-seat, pm-budget]
-  - path: skills/synthesis-project-management/references/parallel-agent-protocol.md
-    cases: [administrative-release-recorded]
-  - path: skills/synthesis-project-management/references/session-identity.md
-    cases: [claim-bound-to-seat, heartbeat-bound-to-seat, release-bound-to-seat]
-  - path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
-    cases: [structured-state-replaces-body-markers]
-  - path: skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
-    cases: [structured-state-replaces-body-markers]
-  - path: skills/synthesis-context-lifecycle/SKILL.md
-    cases: [uncompiled-current-prose-rejected]
+  - path: skills/synthesis-agent-conformance/scripts/conformance.py
+    cases: [causal-stopped-task-alias]
+  - path: skills/synthesis-agent-conformance/scripts/test_conformance.py
+    cases: [causal-stopped-task-alias]
+  - path: skills/synthesis-agent-conformance/SKILL.md
+    cases: [causal-stopped-task-alias]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -52,50 +30,10 @@ changed_surfaces:
   - path: README.md
     cases: [release-changelog-parity]
 cases:
-  - id: uncompiled-current-prose-rejected
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_structured_state_rejects_uncompiled_current_prose
-    motivating_defect: a-generated-current-state-block-and-two-stale-current-prose-surfaces-passed-the-doctor-in-one-coherent-tree
-  - id: historical-snapshots-allowed
+  - id: causal-stopped-task-alias
     control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_structured_state_allows_explicitly_historical_snapshots
-    motivating_defect: semantic-enforcement-that-rejects-history-would-destroy-the-durable-evidence-it-is-meant-to-protect
-  - id: current-label-normalization
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_structured_state_rejects_setext_and_punctuated_current_labels
-    motivating_defect: setext-headings-and-trailing-punctuation-bypassed-the-current-state-detector
-  - id: structured-state-replaces-body-markers
-    control_class: enforced-gate
-    fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::ContextDoctorTests::test_structured_state_replaces_body_currency_markers
-    motivating_defect: the-doctor-demanded-an-older-prose-currency-marker-beside-the-structured-authority
-  - id: release-bound-to-seat
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_release_is_bound_to_the_claiming_harness_session
-    motivating_defect: a-refused-claim-id-parsed-from-human-output-released-a-different-live-session
-  - id: claim-bound-to-seat
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_claim_with_existing_id_cannot_take_over_another_session_seat
-    motivating_defect: claim-with-an-existing-selector-could-transfer-the-row-and-its-claims-to-another-client
-  - id: heartbeat-bound-to-seat
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_heartbeat_cannot_take_over_another_session_seat
-    motivating_defect: a-foreign-heartbeat-could-refresh-the-row-and-rewrite-its-seat
-  - id: legacy-selector-fails-closed
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_legacy_selector_only_mutations_fail_closed_without_caller_identity
-    motivating_defect: an-unattributed-row-treated-possession-of-its-display-selector-as-mutation-authority
-  - id: sandbox-git-config-isolation
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_each_sandbox_owns_its_global_git_config
-    motivating_defect: one-onboarding-sandbox-global-hook-install-polluted-the-next-sandbox-and-created-an-order-dependent-failure
-  - id: administrative-release-recorded
-    control_class: enforced-gate
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_cross_session_administrative_release_requires_and_records_a_reason
-    motivating_defect: cross-session-release-had-no-separate-authority-or-audit-boundary
-  - id: pm-budget
-    control_class: acceptance-test
-    fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget
-    motivating_defect: a-restructured-document-must-not-regrow-with-its-next-feature
+    fixture: ../synthesis-agent-conformance/scripts/test_conformance.py::test_stopped_handoff_accepts_causally_selected_project_alias
+    motivating_defect: correct-recovery-to-a-causally-newer-checkout-was-rejected-because-its-path-differed-from-the-callers-isolated-worktree
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
@@ -103,7 +41,7 @@ cases:
   - id: release-manifest-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
-    motivating_defect: a-version-that-reaches-only-one-client-manifest-cannot-be-reliably-installed-or-audited
+    motivating_defect: a-version-that-reaches-only-one-client-manifest-cannot-be-reliably-installed-or-audited-later
   - id: release-changelog-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed


### PR DESCRIPTION
## Summary
- validate the project chosen by causal recovery instead of requiring the caller worktree path
- derive the controlling plan from the selected durable project
- add a two-worktree regression fixture and a closed release acceptance contract

## Verification
- full governed release preflight
- 162 conformance tests
- 92 release and acceptance tests
- real installed-shape handoff probe