### PR TITLE
Add tracked personal instruction overlays

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.93.4",
+  "version": "4.94.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.93.4",
+  "version": "4.94.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.94.0] - 2026-09-04
+
+**A complete organization workspace can now include private personal context
+without leaking it into the shareable organization manifest or leaving it in
+an untracked root file.** `synthesis setup --personal-instruction-source PATH`
+adds one user-owned source after the public and organization layers, records its
+repository and relative path in local desired state, and replays it on update
+and repair. Every repository source must be regular, committed, clean, and
+Git-tracked; traversal, symbolic links, untracked bytes, and working-tree or
+index drift fail closed.
+
+Existing workspace-root instructions remain untouched unless the user selects
+`--adopt-workspace-instructions`. Explicit adoption archives and byte-verifies
+each existing file before activation, records prior digests, modes, paths, and
+time in the receipt, and restores both originals if activation fails after the
+first replacement. The materializer refreshes source provenance even when new
+source identities render identical bytes, and doctor now verifies the source
+commit/digest chain as well as both output digests. synthesis-onboarding 2.2.0
+ships the CLI, desired-state, engine, doctor, schema, documentation, and
+red-first contract coverage as one release.
+
 ## [4.93.4] - 2026-09-04
 
 **Stopped-task conformance now verifies the project selected by causal

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Private instruction context is now a declared, durable organization overlay
+(September 2026).** Release **4.94.0** lets a full organization setup layer one
+user-owned committed source after the public and organization sources without
+placing its repository or path in the shareable organization manifest. The
+source persists in local desired state and is replayed by update and repair.
+Existing unreceipted root instructions remain protected unless the user
+explicitly requests archive-first adoption; partial activation restores both
+client files. Doctor verifies the complete source and output chain. See the
+[4.94.0 release notes](CHANGELOG.md).
+
 **Stopped-task verification now follows the causally selected project copy
 (September 2026).** Release **4.93.4** accepts an equal or newer resolved
 checkout without demanding that recovery preserve the caller's original
@@ -746,6 +756,11 @@ Stable is the default. Use `--channel edge` to follow `main`, or `--pin X.Y.Z`
 for an exact release. Organization enrollment uses `--org-repo URL` or a
 credential-free, time-bounded `--invite FILE`; organization repositories carry
 declarative data and one tracked instruction source, never installer code.
+Users who need private context at the organization workspace root can declare a
+separate committed source with `--personal-instruction-source PATH`. That local
+declaration is not written to the organization repository and update and repair
+continue to enforce it. Existing root instruction files are preserved unless
+the user explicitly selects verified archive-first adoption.
 
 Updates are explicit. Make an update the initiating task's last action, restart
 the selected clients, and verify a fresh lifecycle receipt before treating the

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,24 +1,38 @@
-# AGENT HEURISTIC: authored for the 4.93.4 causal stopped-task alias transaction.
+# AGENT HEURISTIC: authored for the 4.94.0 personal instruction overlay transaction.
 # Fresh per transaction: changed_surfaces must equal the authoritative
 # base-to-head Git diff before release.py can consume the receipt.
 schema: 2
-suite: causal-stopped-task-alias
+suite: personal-instruction-overlay-adoption
 membership: closed
-production_entry_point: skills/synthesis-agent-conformance/scripts/conformance.py
-enforcing_boundary: stopped-task parity requires both native adapters to report one causally selected durable project with the requested project identity, matching phase and status, and an existing controlling plan derived at the selected path
+production_entry_point: skills/synthesis-onboarding/scripts/synthesis_cli.py
+enforcing_boundary: full organization setup accepts only committed provenance-bound instruction sources and may replace existing unreceipted root instructions only through explicit verified archive-first adoption with two-output rollback
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: current-global lifecycle health remains a native runtime observation and cannot be replaced by source or hermetic evidence
+unverified_remainder: live organization review and merge, released-source root adoption, site build-only acceptance, and fresh client lifecycle receipts remain external runtime gates
 changed_surfaces:
-  - path: skills/synthesis-agent-conformance/scripts/conformance.py
-    cases: [causal-stopped-task-alias]
-  - path: skills/synthesis-agent-conformance/scripts/test_conformance.py
-    cases: [causal-stopped-task-alias]
-  - path: skills/synthesis-agent-conformance/SKILL.md
-    cases: [causal-stopped-task-alias]
+  - path: skills/synthesis-onboarding/scripts/system_contract.py
+    cases: [desired-state-schema, source-commit-binding, source-provenance-refresh]
+  - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
+    cases: [personal-source-state-replay, personal-source-preserve-clear]
+  - path: skills/synthesis-onboarding/scripts/onboard.py
+    cases: [personal-source-materialization, explicit-adoption-rollback]
+  - path: skills/synthesis-onboarding/scripts/test_system_contract.py
+    cases: [desired-state-schema, source-commit-binding, source-provenance-refresh]
+  - path: skills/synthesis-onboarding/scripts/test_synthesis_cli.py
+    cases: [personal-source-state-replay, personal-source-preserve-clear]
+  - path: skills/synthesis-onboarding/scripts/test_onboard.py
+    cases: [personal-source-materialization, explicit-adoption-rollback]
+  - path: skills/synthesis-onboarding/references/system-state.schema.json
+    cases: [desired-state-schema]
+  - path: skills/synthesis-onboarding/references/release-capabilities.json
+    cases: [personal-source-materialization]
+  - path: skills/synthesis-onboarding/references/org-manifest.md
+    cases: [personal-source-materialization, explicit-adoption-rollback]
+  - path: skills/synthesis-onboarding/SKILL.md
+    cases: [personal-source-state-replay, personal-source-preserve-clear, explicit-adoption-rollback]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -28,12 +42,36 @@ changed_surfaces:
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
   - path: README.md
-    cases: [release-changelog-parity]
+    cases: [release-changelog-parity, personal-source-materialization]
 cases:
-  - id: causal-stopped-task-alias
+  - id: desired-state-schema
     control_class: acceptance-test
-    fixture: ../synthesis-agent-conformance/scripts/test_conformance.py::test_stopped_handoff_accepts_causally_selected_project_alias
-    motivating_defect: correct-recovery-to-a-causally-newer-checkout-was-rejected-because-its-path-differed-from-the-callers-isolated-worktree
+    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_json_schemas_and_runtime_share_valid_and_invalid_corpora
+    motivating_defect: a-local-personal-source-that-is-not-closed-schema-desired-state-cannot-be-replayed-or-distinguished-from-shareable-organization-data
+  - id: personal-source-state-replay
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_update_replays_persisted_personal_instruction_source
+    motivating_defect: a-setup-only-source-argument-would-disappear-on-update-or-repair-and-silently-remove-private-operating-context
+  - id: personal-source-preserve-clear
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_setup_preserves_personal_source_until_explicit_clear
+    motivating_defect: rerunning-setup-without-repeating-a-local-private-path-could-silently-drop-the-declared-overlay-while-no-explicit-removal-was-requested
+  - id: personal-source-materialization
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_personal_instruction_source_is_materialized_and_receipted
+    motivating_defect: a-tracked-private-source-that-never-enters-the-public-organization-personal-graph-leaves-the-root-instructions-unreproducible
+  - id: explicit-adoption-rollback
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_adoption_rollback_restores_both_existing_outputs
+    motivating_defect: replacing-an-existing-unreceipted-root-without-verified-archives-and-two-file-rollback-can-destroy-the-only-copy-of-user-context
+  - id: source-commit-binding
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_instruction_pair_rejects_uncommitted_untracked_and_symlink_sources
+    motivating_defect: a-receipt-that-hashes-working-tree-bytes-while-naming-an-unrelated-commit-can-certify-content-that-git-never-recorded
+  - id: source-provenance-refresh
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_instruction_pair_refreshes_source_receipt_when_bytes_are_unchanged
+    motivating_defect: identical-rendered-bytes-from-a-new-source-could-leave-the-receipt-pointing-at-the-previous-repository-and-break-desired-state-auditability
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.1.0"
+  version: "2.2.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -37,6 +37,9 @@ After bootstrap, use the installed public command:
 synthesis setup [--profile full|skills-only] [--clients claude,codex]
                 [--channel stable|edge] [--pin X.Y.Z]
                 [--answers PATH] [--org-repo URL | --invite PATH]
+                [--personal-instruction-source PATH]
+                [--adopt-workspace-instructions]
+                [--clear-personal-instruction-source]
 synthesis update
 synthesis repair
 synthesis status [--json]
@@ -147,9 +150,32 @@ reported with Git's own reason, so a hook refusal is never mislabeled as a
 missing identity. Edit and commit the tracked source, never the workspace
 entry points.
 
-Organization instructions use the same provenance rule: exactly one tracked
-source is materialized as a pair, and both outputs activate or neither does.
-Doctor verifies the source commit, source digest, output digests, and receipt.
+Organization instructions use the same provenance rule. The rendered graph is
+public baseline, exactly one organization source, then an optional user-owned
+personal source. Every repository source must be a committed, clean, regular
+Git-tracked file; untracked, dirty, traversing, and symbolic-link sources are
+refused. Both outputs activate or neither does. Doctor verifies each source
+commit and digest plus both output digests against the receipt.
+
+The optional personal layer is local desired state, never organization data:
+
+```bash
+synthesis setup --profile full --org-repo URL \
+  --personal-instruction-source /absolute/path/to/private-config/.agents/workspace-instructions.md
+```
+
+Setup persists the source repository and relative path, so `synthesis update`
+and `synthesis repair` replay and revalidate it. Omitting the option on a later
+setup preserves the declared source; removing it requires
+`--clear-personal-instruction-source`.
+
+An existing workspace-root `AGENTS.md` or `CLAUDE.md` without an engine receipt
+is preserved by default. After the complete instruction content is represented
+in committed graph sources, `--adopt-workspace-instructions` explicitly archives
+each existing regular file, verifies the archive bytes, and then activates the
+pair. The receipt records archive paths, prior digests, modes, and time. A
+failure after the first activation restores both original outputs while keeping
+the verified archives.
 
 ## Declarative organization enrollment
 
@@ -211,8 +237,9 @@ setting and is never auto-approved.
   transactions, capability IDs, doctor logic, and release descriptors.
 - Organization repository: declarative repositories, welcome text, trusted
   acceptance IDs, and one tracked instruction source.
-- User: credentials, personal policy content, source edits, client restart,
-  and deployment decisions.
+- User: credentials, personal policy content, optional personal instruction
+  source and explicit adoption, source edits, client restart, and deployment
+  decisions.
 
 Unknown fields, unsafe paths, embedded credentials, dirty or wrong-remote
 clones, symlinked release files, and executable organization fields fail closed.

--- a/skills/synthesis-onboarding/references/org-manifest.md
+++ b/skills/synthesis-onboarding/references/org-manifest.md
@@ -109,6 +109,19 @@ synthesis setup --profile full --org-repo ssh://git@example.test/example/onboard
 synthesis setup --profile full --invite invitation.json
 ```
 
+A user may add a private personal instruction layer without putting its path or
+repository in this shareable manifest:
+
+```bash
+synthesis setup --profile full \
+  --org-repo ssh://git@example.test/example/onboarding-config.git \
+  --personal-instruction-source /absolute/path/to/private-config/.agents/workspace-instructions.md
+```
+
+The engine stores that declaration only in local desired state. Update and
+repair replay it. A later setup preserves it unless the user explicitly passes
+`--clear-personal-instruction-source`.
+
 An invite carries the repository URL, optional exact commit, issuance time,
 expiry no more than seven days later, and a nonce. It carries no credential.
 The engine records successful use and rejects replay. Repository authentication
@@ -133,11 +146,20 @@ an executable manifest field is rejected.
 
 ## Instruction provenance
 
-The declared source must be a regular Git-tracked file in the organization
-configuration repository. The engine records its repository, commit, relative
-path, and digest, then activates identical `AGENTS.md` and `CLAUDE.md` outputs
-as one transaction. If either target collides or activation fails, neither new
-output remains active. Doctor verifies both output digests against the receipt.
+The declared source must be a regular, committed, clean Git-tracked file in the
+organization configuration repository. The engine records its repository,
+commit, relative path, and digest. It renders the public baseline first, then
+the organization source, then the optional user-local personal source, and
+activates identical `AGENTS.md` and `CLAUDE.md` outputs as one transaction. If
+either target collides or activation fails, neither new output remains active.
+Doctor verifies source commits and digests plus both output digests against the
+receipt.
+
+Existing workspace-root instruction files remain untouched unless the user
+passes `--adopt-workspace-instructions`. Adoption accepts regular files only,
+archives and byte-verifies them before activation, and records their archive
+paths and digests in the local receipt. A partial activation restores both
+original files; the archives remain available.
 
 ## Public capability ownership
 

--- a/skills/synthesis-onboarding/references/release-capabilities.json
+++ b/skills/synthesis-onboarding/references/release-capabilities.json
@@ -80,6 +80,11 @@
   "invite_schema_version": 1,
   "instruction_sources_schema_version": 1,
   "instruction_source": "ai-knowledge-{workspace}/.agents/workspace-AGENTS.md",
+  "organization_instruction_graph": {
+    "roles": ["public", "organization", "personal"],
+    "personal_role": "optional-user-local-desired-state",
+    "existing_output_adoption": "explicit-archive-first"
+  },
   "restart_rule": "Update is the initiating task's last action; a fresh client lifecycle receipt establishes live-loaded state.",
   "public_acceptance_tasks": [
     {

--- a/skills/synthesis-onboarding/references/system-state.schema.json
+++ b/skills/synthesis-onboarding/references/system-state.schema.json
@@ -30,6 +30,27 @@
       }
     },
     "personal_workspace": {"type": ["string", "null"], "pattern": "^[a-z0-9][a-z0-9-]{0,62}$"},
+    "personal_instruction_source": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["repository", "path"],
+          "properties": {
+            "repository": {
+              "type": "string",
+              "pattern": "^/(?!.*(?:^|/)\\.\\.(?:/|$)).+"
+            },
+            "path": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+            }
+          }
+        }
+      ]
+    },
     "personal_configuration": {
       "oneOf": [
         {"type": "null"},
@@ -141,6 +162,18 @@
       "if": {"properties": {"organizations": {"minItems": 1}}, "required": ["organizations"]},
       "then": {"properties": {"layers": {"properties": {"organization": {"const": "selected"}}}}},
       "else": {"properties": {"layers": {"properties": {"organization": {"const": "declined"}}}}}
+    },
+    {
+      "if": {
+        "required": ["personal_instruction_source"],
+        "properties": {"personal_instruction_source": {"type": "object"}}
+      },
+      "then": {
+        "properties": {
+          "profile": {"const": "full"},
+          "organizations": {"minItems": 1}
+        }
+      }
     }
   ]
 }

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -45,12 +45,15 @@ from plugin_currency import (
 from system_contract import (
     ContractError,
     DriftError,
+    describe_personal_instruction_source,
     file_digest,
     materialize_instruction_pair,
+    personal_instruction_source_path,
     public_source_identity,
     validate_desired_state,
     validate_org_manifest,
     validate_repository_url,
+    verify_instruction_source_receipt,
 )
 from whole_system import (
     CAPTURE_TEMPLATE_REL,
@@ -79,7 +82,7 @@ from whole_system import (
     validate_personal_policy,
 )
 
-ENGINE_VERSION = "2.1.0"
+ENGINE_VERSION = "2.2.0"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"
@@ -1526,7 +1529,54 @@ def phase_kbs(report, manifest, receipts, dry_run):
                     report.add("knowledge-base", CHANGED, "wired %s repo-local pre-commit protection" % name)
 
 
-def phase_workspace(report, manifest, receipts, dry_run):
+def archive_existing_workspace_instructions(workspace):
+    workspace = Path(workspace)
+    archive_root = (
+        STATE_DIR
+        / "backups"
+        / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        / "workspace-instructions"
+    )
+    metadata = {}
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        target = workspace / name
+        if not target.exists() and not target.is_symlink():
+            continue
+        if target.is_symlink() or not target.is_file():
+            raise ContractError(
+                "existing workspace instruction output is not a regular file: %s"
+                % name
+            )
+        content = target.read_bytes()
+        digest = hashlib.sha256(content).hexdigest()
+        archive_root.mkdir(parents=True, exist_ok=True)
+        destination = archive_root / name
+        if destination.exists() or destination.is_symlink():
+            raise ContractError("workspace instruction archive collision: %s" % name)
+        shutil.copy2(target, destination)
+        if (
+            not destination.is_file()
+            or destination.is_symlink()
+            or destination.read_bytes() != content
+        ):
+            raise ContractError("workspace instruction archive verification failed: %s" % name)
+        metadata[name] = {
+            "archive_path": str(destination),
+            "sha256": digest,
+            "mode": oct(target.stat().st_mode & 0o777),
+            "archived_at": utcnow(),
+        }
+    return metadata
+
+
+def phase_workspace(
+    report,
+    manifest,
+    receipts,
+    dry_run,
+    personal_instruction_source=None,
+    adopt_existing=False,
+):
     workspace = manifest["org"]["workspace"]
     ws_dir = WORKSPACES_ROOT / workspace
     manifest_path = Path(manifest["_path"])
@@ -1540,34 +1590,66 @@ def phase_workspace(report, manifest, receipts, dry_run):
     except ContractError as exc:
         report.add("workspace", ERROR, "public instruction source is unavailable: %s" % exc)
         return
+    source_roots = {"public": source_root(), "organization": org_root}
+    sources = [
+        {
+            "role": "public",
+            "path": "skills/synthesis-onboarding/references/kernel.example.md",
+            "required": True,
+        },
+        {
+            "role": "organization",
+            "path": manifest["instruction_sources"][0]["path"],
+            "required": manifest["instruction_sources"][0].get("required", True),
+        },
+    ]
+    if personal_instruction_source is not None:
+        try:
+            personal_descriptor = describe_personal_instruction_source(
+                Path(personal_instruction_source)
+            )
+        except ContractError as exc:
+            report.add("workspace", ERROR, str(exc))
+            return
+        source_roots["personal"] = Path(personal_descriptor["repository"])
+        sources.append(
+            {
+                "role": "personal",
+                "path": personal_descriptor["path"],
+                "required": True,
+            }
+        )
     graph = {
         "schema_version": 1,
-        "sources": [
-            {
-                "role": "public",
-                "path": "skills/synthesis-onboarding/references/kernel.example.md",
-                "required": True,
-            },
-            {
-                "role": "organization",
-                "path": manifest["instruction_sources"][0]["path"],
-                "required": manifest["instruction_sources"][0].get("required", True),
-            },
-        ],
+        "sources": sources,
         "output": "AGENTS.md",
         "claude_adapter": "CLAUDE.md",
     }
     previous = receipts.data.get("instruction_receipt")
-    if previous is None and any((ws_dir / name).exists() for name in ("AGENTS.md", "CLAUDE.md")):
+    existing = any(
+        (ws_dir / name).exists() or (ws_dir / name).is_symlink()
+        for name in ("AGENTS.md", "CLAUDE.md")
+    )
+    if previous is None and existing and not adopt_existing:
         report.add("workspace", ERROR, "workspace instructions exist without a source receipt; preserved")
         return
     if dry_run:
-        report.add("workspace", CHANGED, "would materialize tracked AGENTS.md and CLAUDE.md sources")
+        if previous is None and existing and adopt_existing:
+            report.add(
+                "workspace",
+                CHANGED,
+                "would archive existing workspace instructions and materialize tracked AGENTS.md and CLAUDE.md sources",
+            )
+        else:
+            report.add("workspace", CHANGED, "would materialize tracked AGENTS.md and CLAUDE.md sources")
         return
+    adopted_outputs = {}
     try:
+        if previous is None and existing and adopt_existing:
+            adopted_outputs = archive_existing_workspace_instructions(ws_dir)
         receipt = materialize_instruction_pair(
             graph,
-            {"public": source_root(), "organization": org_root},
+            source_roots,
             ws_dir,
             generation=int(receipts.data.get("instruction_generation", 0)) + 1,
             previous_receipt=previous,
@@ -1576,6 +1658,8 @@ def phase_workspace(report, manifest, receipts, dry_run):
     except (ContractError, DriftError, OSError) as exc:
         report.add("workspace", ERROR, str(exc))
         return
+    if adopted_outputs:
+        receipt["adopted_outputs"] = adopted_outputs
     receipts.data["instruction_generation"] = receipt["generation"]
     receipts.data["instruction_receipt"] = receipt
     for target in (ws_dir / "AGENTS.md", ws_dir / "CLAUDE.md"):
@@ -2735,6 +2819,51 @@ def doctor(report, manifest, clients_wanted, policy, desired_state=None):
             else:
                 report.add("doctor", OK, "knowledge base %s present at %s" % (kb["name"], repo_path))
         receipt = receipts.data.get("instruction_receipt") or {}
+        source_errors = []
+        source_receipts = receipt.get("sources") or []
+        for entry in source_receipts:
+            try:
+                verify_instruction_source_receipt(entry)
+            except (ContractError, DriftError, OSError) as exc:
+                source_errors.append(str(exc))
+        expected_personal = (
+            (desired_state or {}).get("personal_instruction_source")
+            if desired_state is not None
+            else None
+        )
+        actual_personal = next(
+            (
+                source
+                for source in source_receipts
+                if isinstance(source, dict) and source.get("role") == "personal"
+            ),
+            None,
+        )
+        if expected_personal is not None:
+            if actual_personal is None or any(
+                actual_personal.get(field) != expected_personal.get(field)
+                for field in ("repository", "path")
+            ):
+                source_errors.append(
+                    "personal instruction receipt differs from desired state"
+                )
+        elif desired_state is not None and actual_personal is not None:
+            source_errors.append(
+                "personal instruction receipt exists outside desired state"
+            )
+        if source_errors:
+            report.add(
+                "doctor",
+                ERROR,
+                "workspace instruction source drift: %s"
+                % "; ".join(source_errors),
+            )
+        else:
+            report.add(
+                "doctor",
+                OK,
+                "tracked workspace instruction sources match their receipts",
+            )
         outputs = receipt.get("outputs") or {}
         output_errors = []
         for name in ("AGENTS.md", "CLAUDE.md"):
@@ -3172,6 +3301,16 @@ def build_parser():
     )
     parser.add_argument("--with-personal-workspace", metavar="NAME",
                         help="also scaffold a personal ai-knowledge-<NAME> workspace during install")
+    parser.add_argument(
+        "--personal-instruction-source",
+        type=Path,
+        help="optional user-owned Git-tracked instruction source layered after organization instructions",
+    )
+    parser.add_argument(
+        "--adopt-workspace-instructions",
+        action="store_true",
+        help="archive and replace an existing unreceipted workspace instruction pair",
+    )
     parser.add_argument("--dry-run", action="store_true", help="show what would change; touch nothing")
     parser.add_argument("--no-plugin-cli", action="store_true",
                         help="skip client plugin CLIs; use file-copy fallback")
@@ -3201,6 +3340,31 @@ def main(argv=None):
         except (ValueError, OSError) as exc:
             report.add("manifest", ERROR, str(exc))
             return finish(report, args, 2)
+    if (args.personal_instruction_source or args.adopt_workspace_instructions) and not manifest:
+        report.add(
+            "workspace",
+            ERROR,
+            "personal instruction sources and workspace adoption require an organization manifest",
+        )
+        return finish(report, args, 2)
+    personal_instruction_source = args.personal_instruction_source
+    if desired_state is not None:
+        desired_source_path = personal_instruction_source_path(
+            desired_state.get("personal_instruction_source")
+        )
+        if desired_source_path is not None:
+            if (
+                personal_instruction_source is not None
+                and personal_instruction_source.expanduser().resolve()
+                != desired_source_path.resolve()
+            ):
+                report.add(
+                    "workspace",
+                    ERROR,
+                    "personal instruction source differs from persisted desired state",
+                )
+                return finish(report, args, 2)
+            personal_instruction_source = desired_source_path
 
     try:
         manifest_policy = policy_from_manifest(manifest, channel_override=args.channel)
@@ -3311,7 +3475,14 @@ def main(argv=None):
     if manifest:
         phase_org_skills(report, manifest, receipts, args.dry_run)
         phase_kbs(report, manifest, receipts, args.dry_run)
-        phase_workspace(report, manifest, receipts, args.dry_run)
+        phase_workspace(
+            report,
+            manifest,
+            receipts,
+            args.dry_run,
+            personal_instruction_source=personal_instruction_source,
+            adopt_existing=args.adopt_workspace_instructions,
+        )
     if args.with_personal_workspace:
         init_workspace(report, receipts, args.with_personal_workspace, args.dry_run)
     if args.command == "init":

--- a/skills/synthesis-onboarding/scripts/synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/synthesis_cli.py
@@ -25,8 +25,10 @@ from system_contract import (
     SystemState,
     active_release_descriptor,
     consume_invite,
+    describe_personal_instruction_source,
     default_desired_state,
     json_digest,
+    personal_instruction_source_path,
     validate_invite,
     validate_desired_state,
     validate_repository_url,
@@ -35,7 +37,7 @@ from system_contract import (
 )
 
 
-ENGINE_VERSION = "2.1.0"
+ENGINE_VERSION = "2.2.0"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CLI_COMMANDS = (
     "setup",
@@ -84,6 +86,22 @@ def build_parser() -> argparse.ArgumentParser:
     setup.add_argument("--org-repo")
     setup.add_argument("--invite", type=Path)
     setup.add_argument("--no-services", action="store_true")
+    personal_source = setup.add_mutually_exclusive_group()
+    personal_source.add_argument(
+        "--personal-instruction-source",
+        type=Path,
+        help="user-owned Git-tracked instructions to layer after organization instructions",
+    )
+    personal_source.add_argument(
+        "--clear-personal-instruction-source",
+        action="store_true",
+        help="remove a previously declared personal instruction layer",
+    )
+    setup.add_argument(
+        "--adopt-workspace-instructions",
+        action="store_true",
+        help="archive and replace an existing unreceipted workspace instruction pair",
+    )
     _common_output(setup)
 
     for name in ("update", "repair"):
@@ -624,6 +642,13 @@ def _engine_args(
         translated.extend(["--answers", str(args.answers)])
     if getattr(args, "no_services", False):
         translated.append("--no-services")
+    personal_source = personal_instruction_source_path(
+        desired.get("personal_instruction_source")
+    )
+    if personal_source is not None:
+        translated.extend(["--personal-instruction-source", str(personal_source)])
+    if getattr(args, "adopt_workspace_instructions", False):
+        translated.append("--adopt-workspace-instructions")
     if desired_state_path is not None:
         translated.extend(["--desired-state", str(desired_state_path)])
     return translated
@@ -1036,6 +1061,28 @@ def main(
                     return _run_release_bootstrap(
                         argv, active, probe["release"]["channel"], args.pin
                     )
+            if (
+                args.personal_instruction_source
+                or args.clear_personal_instruction_source
+                or args.adopt_workspace_instructions
+            ) and (not repository or args.profile != "full"):
+                raise ContractError(
+                    "personal instruction configuration requires an organization and the full profile"
+                )
+            if args.clear_personal_instruction_source and args.adopt_workspace_instructions:
+                raise ContractError(
+                    "workspace instruction adoption cannot clear the personal instruction source"
+                )
+            personal_instruction_source = None
+            if repository and args.profile == "full":
+                if args.personal_instruction_source:
+                    personal_instruction_source = describe_personal_instruction_source(
+                        args.personal_instruction_source
+                    )
+                elif not args.clear_personal_instruction_source and previous_desired:
+                    personal_instruction_source = previous_desired.get(
+                        "personal_instruction_source"
+                    )
             request = {
                 "schema_version": 1,
                 "profile": args.profile,
@@ -1044,6 +1091,8 @@ def main(
                 "version_pin": args.pin,
                 "organization_repository": repository,
                 "organization_commit": expected_commit,
+                "personal_instruction_source": personal_instruction_source,
+                "adopt_workspace_instructions": args.adopt_workspace_instructions,
             }
 
             def setup_operation(_transaction: dict[str, Any]) -> dict[str, Any]:
@@ -1083,6 +1132,7 @@ def main(
                     channel=channel,
                     version_pin=version_pin,
                     organizations=organizations,
+                    personal_instruction_source=personal_instruction_source,
                 )
                 active = _active_release()
                 if active and not _active_matches_policy(active, desired):
@@ -1117,6 +1167,9 @@ def main(
                         personal_configuration=selection[
                             "personal_configuration"
                         ],
+                        personal_instruction_source=desired.get(
+                            "personal_instruction_source"
+                        ),
                     )
                 if invite:
                     consume_invite(invite, state, already_locked=True)

--- a/skills/synthesis-onboarding/scripts/system_contract.py
+++ b/skills/synthesis-onboarding/scripts/system_contract.py
@@ -750,6 +750,7 @@ def default_desired_state(
     organizations: list[dict[str, str]] | None = None,
     personal_workspace: str | None = None,
     personal_configuration: dict[str, Any] | None = None,
+    personal_instruction_source: dict[str, str] | None = None,
     enabled: bool = True,
 ) -> dict[str, Any]:
     if profile not in ("full", "skills-only"):
@@ -764,6 +765,15 @@ def default_desired_state(
         safe_identifier(personal_workspace, "personal workspace")
     personal_configuration = validate_personal_configuration(personal_configuration)
     organization_entries = organizations or []
+    personal_instruction_source = validate_personal_instruction_source(
+        personal_instruction_source
+    )
+    if personal_instruction_source is not None and (
+        profile != "full" or not organization_entries
+    ):
+        raise ContractError(
+            "a personal instruction source requires a full organization setup"
+        )
     if layers is None:
         selected = set(PROFILE_LAYERS[profile])
         if profile == "full" and organization_entries:
@@ -780,6 +790,7 @@ def default_desired_state(
         "release": {"channel": channel, "version_pin": version_pin},
         "personal_workspace": personal_workspace,
         "personal_configuration": personal_configuration,
+        "personal_instruction_source": personal_instruction_source,
         "layers": dict(sorted(layers.items())),
         "organizations": organization_entries,
     }
@@ -790,7 +801,8 @@ def validate_desired_state(value: Any) -> dict[str, Any]:
     value = _require_mapping(value, "desired state")
     allowed = {
         "schema_version", "enabled", "profile", "clients", "release",
-        "personal_workspace", "personal_configuration", "layers", "organizations",
+        "personal_workspace", "personal_configuration", "personal_instruction_source",
+        "layers", "organizations",
     }
     required = {
         "schema_version", "enabled", "profile", "clients", "release",
@@ -831,6 +843,9 @@ def validate_desired_state(value: Any) -> dict[str, Any]:
     configuration = validate_personal_configuration(
         value.get("personal_configuration")
     )
+    instruction_source = validate_personal_instruction_source(
+        value.get("personal_instruction_source")
+    )
     if profile == "full" and (workspace is None or configuration is None):
         raise ContractError(
             "full desired state requires a personal workspace and configuration"
@@ -854,6 +869,12 @@ def validate_desired_state(value: Any) -> dict[str, Any]:
         raise ContractError("desired state supports at most one organization")
     if profile == "skills-only" and organizations:
         raise ContractError("skills-only desired state cannot enroll an organization")
+    if instruction_source is not None and (
+        profile != "full" or not organizations
+    ):
+        raise ContractError(
+            "a personal instruction source requires a full organization setup"
+        )
     selected_layers = set(PROFILE_LAYERS[profile])
     if profile == "full" and organizations:
         selected_layers.add("organization")
@@ -877,6 +898,65 @@ def validate_desired_state(value: Any) -> dict[str, Any]:
         if not HEX40_RE.fullmatch(str(entry.get("commit") or "")):
             raise ContractError("desired state organization commit is invalid")
     return value
+
+
+def validate_personal_instruction_source(value: Any) -> dict[str, str] | None:
+    if value is None:
+        return None
+    value = _require_mapping(value, "desired state personal instruction source")
+    fields = {"repository", "path"}
+    _reject_unknown(value, fields, "desired state personal instruction source")
+    if set(value) != fields:
+        raise ContractError("desired state personal instruction source is incomplete")
+    repository = value.get("repository")
+    if not isinstance(repository, str) or not repository:
+        raise ContractError(
+            "desired state personal instruction source repository must be an absolute path"
+        )
+    repository_path = Path(repository)
+    if not repository_path.is_absolute() or repository_path != Path(
+        os.path.normpath(repository)
+    ):
+        raise ContractError(
+            "desired state personal instruction source repository must be an absolute normalized path"
+        )
+    relative = safe_relative_path(
+        value.get("path"), "desired state personal instruction source path"
+    )
+    return {"repository": str(repository_path), "path": relative}
+
+
+def personal_instruction_source_path(value: Any) -> Path | None:
+    source = validate_personal_instruction_source(value)
+    if source is None:
+        return None
+    return contained_path(
+        Path(source["repository"]),
+        source["path"],
+        "personal instruction source",
+    )
+
+
+def describe_personal_instruction_source(path: Path) -> dict[str, str]:
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    if candidate.is_symlink() or not candidate.is_file():
+        raise ContractError("personal instruction source must be a regular file")
+    candidate = candidate.resolve()
+    root_text = _git(candidate.parent, "rev-parse", "--show-toplevel")
+    root = Path(root_text).resolve()
+    if root.is_symlink() or not root.is_dir():
+        raise ContractError("personal instruction source repository is unavailable")
+    try:
+        relative = candidate.relative_to(root).as_posix()
+    except ValueError as exc:
+        raise ContractError(
+            "personal instruction source is outside its Git repository"
+        ) from exc
+    relative = safe_relative_path(relative, "personal instruction source path")
+    _tracked_source(root, relative)
+    return {"repository": str(root), "path": relative}
 
 
 def validate_personal_configuration(value: Any) -> dict[str, Any] | None:
@@ -1734,8 +1814,56 @@ def _tracked_source(
     )
     if proc.returncode:
         raise ContractError("instruction source is not Git-tracked: %s" % relative)
+    if _git(root, "status", "--porcelain=v1", "--", relative):
+        raise ContractError(
+            "instruction source has uncommitted changes: %s" % relative
+        )
     commit = _git(root, "rev-parse", "HEAD^{commit}")
     return path, commit, file_digest(path)
+
+
+def verify_instruction_source_receipt(value: Any) -> dict[str, str]:
+    value = _require_mapping(value, "instruction source receipt")
+    fields = {"role", "repository", "commit", "path", "sha256"}
+    _reject_unknown(value, fields, "instruction source receipt")
+    if set(value) != fields:
+        raise ContractError("instruction source receipt is incomplete")
+    role = value.get("role")
+    if role not in {"public", "organization", "personal"}:
+        raise ContractError("instruction source receipt role is invalid")
+    repository = value.get("repository")
+    if not isinstance(repository, str) or not Path(repository).is_absolute():
+        raise ContractError("instruction source receipt repository is invalid")
+    commit = str(value.get("commit") or "")
+    digest = str(value.get("sha256") or "")
+    if not HEX40_RE.fullmatch(commit) or not HEX64_RE.fullmatch(digest):
+        raise ContractError("instruction source receipt identity is invalid")
+    relative = safe_relative_path(value.get("path"), "instruction source receipt path")
+    root = Path(repository)
+    path = contained_path(root, relative, "instruction source receipt path")
+    if not path.is_file() or path.is_symlink() or file_digest(path) != digest:
+        raise DriftError("instruction source bytes drifted: %s" % role)
+    if role != "public":
+        git_root = Path(_git(root, "rev-parse", "--show-toplevel")).resolve()
+        if git_root != root.resolve():
+            raise ContractError("instruction source repository root drifted: %s" % role)
+        if _git(root, "status", "--porcelain=v1", "--", relative):
+            raise DriftError("instruction source has uncommitted changes: %s" % role)
+        proc = subprocess.run(
+            ["git", "-C", str(root), "show", "%s:%s" % (commit, relative)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if proc.returncode or hashlib.sha256(proc.stdout).hexdigest() != digest:
+            raise DriftError("instruction source commit no longer binds bytes: %s" % role)
+    return {
+        "role": role,
+        "repository": str(root.resolve()),
+        "commit": commit,
+        "path": relative,
+        "sha256": digest,
+    }
 
 
 def _restore_file(path: Path, previous: tuple[bool, bytes, int]) -> None:
@@ -1812,7 +1940,12 @@ def materialize_instruction_pair(
             if required:
                 raise
             continue
-        text = path.read_text(encoding="utf-8").strip()
+        try:
+            text = path.read_text(encoding="utf-8").strip()
+        except UnicodeError as exc:
+            raise ContractError(
+                "instruction source is not valid UTF-8: %s" % relative
+            ) from exc
         parts.extend(["", "## %s" % role.title(), "", text])
         source_receipts.append(
             {
@@ -1832,6 +1965,8 @@ def materialize_instruction_pair(
             for target in targets
         ):
             unchanged = dict(previous_receipt)
+            unchanged["sources"] = source_receipts
+            unchanged["verified_at"] = utcnow()
             unchanged["unchanged"] = True
             return unchanged
     previous = []

--- a/skills/synthesis-onboarding/scripts/test_onboard.py
+++ b/skills/synthesis-onboarding/scripts/test_onboard.py
@@ -6,6 +6,7 @@ HOME with local bare repositories standing in for org remotes — no network,
 no client CLIs, no writes outside the sandbox.
 """
 
+import hashlib
 import json
 import os
 import shutil
@@ -140,6 +141,18 @@ class Sandbox:
         sh(["git", "-C", str(self.org_config), "init", "-q", "-b", "main"], env=self.git_env)
         self._commit_all(self.org_config, "seed org config")
         return self.org_config
+
+    def personal_instruction_source(self):
+        repo = self.root / "personal-config"
+        source = repo / ".agents" / "workspace-instructions.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(
+            "Use the private personal context only for this user's work.\n",
+            encoding="utf-8",
+        )
+        sh(["git", "-C", str(repo), "init", "-q", "-b", "main"], env=self.git_env)
+        self._commit_all(repo, "seed personal config")
+        return source
 
     def manifest(self, kb_primary=None):
         lines = [
@@ -1088,6 +1101,152 @@ class EngineTests(unittest.TestCase):
         data, _ = self.box.run_json("install", "--manifest", str(manifest), expect=1)
         self.assertEqual(self.box.ws_agents.read_text(), edited)
         self.assertIn("error", self.statuses(data, "workspace"))
+
+    def test_personal_instruction_source_is_materialized_and_receipted(self):
+        manifest = self.box.manifest()
+        personal = self.box.personal_instruction_source()
+        self.box.run_json(
+            "install",
+            "--manifest",
+            str(manifest),
+            "--personal-instruction-source",
+            str(personal),
+            expect=0,
+        )
+        rendered = self.box.ws_agents.read_text(encoding="utf-8")
+        self.assertIn("## Public", rendered)
+        self.assertIn("## Organization", rendered)
+        self.assertIn("## Personal", rendered)
+        self.assertIn("private personal context", rendered)
+        receipt = json.loads(
+            (
+                self.box.home / ".synthesis" / "onboarding" / "receipts.json"
+            ).read_text(encoding="utf-8")
+        )["instruction_receipt"]
+        self.assertEqual(
+            [source["role"] for source in receipt["sources"]],
+            ["public", "organization", "personal"],
+        )
+        personal_receipt = receipt["sources"][-1]
+        self.assertEqual(personal_receipt["path"], ".agents/workspace-instructions.md")
+        self.assertEqual(
+            personal_receipt["repository"], str(personal.parents[1].resolve())
+        )
+
+        personal.write_text(
+            "Use newer committed private personal context.\n", encoding="utf-8"
+        )
+        self.box._commit_all(personal.parents[1], "update personal config")
+        data, _ = self.box.run_json(
+            "doctor",
+            "--manifest",
+            str(manifest),
+            "--personal-instruction-source",
+            str(personal),
+            expect=1,
+        )
+        self.assertTrue(
+            any(
+                "workspace instruction source drift" in step["detail"]
+                for step in data["steps"]
+            )
+        )
+
+    def test_existing_unreceipted_workspace_pair_requires_explicit_adoption(self):
+        manifest = self.box.manifest()
+        workspace = self.box.home / "workspaces" / "exampleco"
+        workspace.mkdir(parents=True)
+        agents = workspace / "AGENTS.md"
+        claude = workspace / "CLAUDE.md"
+        agents.write_text("# Existing agents\n", encoding="utf-8")
+        claude.write_text("# Existing claude\n", encoding="utf-8")
+        data, _ = self.box.run_json(
+            "install", "--manifest", str(manifest), expect=1
+        )
+        self.assertEqual(agents.read_text(encoding="utf-8"), "# Existing agents\n")
+        self.assertEqual(claude.read_text(encoding="utf-8"), "# Existing claude\n")
+        self.assertTrue(
+            any("without a source receipt" in step["detail"] for step in data["steps"])
+        )
+
+    def test_explicit_adoption_archives_existing_pair_before_activation(self):
+        manifest = self.box.manifest()
+        personal = self.box.personal_instruction_source()
+        workspace = self.box.home / "workspaces" / "exampleco"
+        workspace.mkdir(parents=True)
+        originals = {
+            "AGENTS.md": b"# Existing agents\n",
+            "CLAUDE.md": b"# Existing claude\n",
+        }
+        for name, content in originals.items():
+            (workspace / name).write_bytes(content)
+        self.box.run_json(
+            "install",
+            "--manifest",
+            str(manifest),
+            "--personal-instruction-source",
+            str(personal),
+            "--adopt-workspace-instructions",
+            expect=0,
+        )
+        receipt = json.loads(
+            (
+                self.box.home / ".synthesis" / "onboarding" / "receipts.json"
+            ).read_text(encoding="utf-8")
+        )["instruction_receipt"]
+        adopted = receipt["adopted_outputs"]
+        self.assertEqual(set(adopted), set(originals))
+        for name, content in originals.items():
+            archive = Path(adopted[name]["archive_path"])
+            self.assertTrue(archive.is_file())
+            self.assertEqual(archive.read_bytes(), content)
+            self.assertEqual(
+                adopted[name]["sha256"], hashlib.sha256(content).hexdigest()
+            )
+        self.assertIn("## Personal", (workspace / "AGENTS.md").read_text())
+
+    def test_adoption_rollback_restores_both_existing_outputs(self):
+        manifest_path = self.box.manifest()
+        manifest = onboard.load_manifest(manifest_path)
+        personal = self.box.personal_instruction_source()
+        workspace = self.box.home / "workspaces" / "exampleco"
+        workspace.mkdir(parents=True)
+        originals = {
+            "AGENTS.md": b"old agents\n",
+            "CLAUDE.md": b"old claude\n",
+        }
+        for name, content in originals.items():
+            (workspace / name).write_bytes(content)
+        report = onboard.Report(as_json=True)
+        state_dir = self.box.home / ".synthesis" / "onboarding"
+        receipts = onboard.Receipts(state_dir / "receipts.json")
+        original_materialize = onboard.materialize_instruction_pair
+
+        def fail_after_first(*args, **kwargs):
+            kwargs["fail_after_first"] = True
+            return original_materialize(*args, **kwargs)
+
+        with (
+            patch.object(onboard, "materialize_instruction_pair", fail_after_first),
+            patch.object(onboard, "WORKSPACES_ROOT", self.box.home / "workspaces"),
+            patch.object(onboard, "STATE_DIR", state_dir),
+        ):
+            onboard.phase_workspace(
+                report,
+                manifest,
+                receipts,
+                False,
+                personal_instruction_source=personal,
+                adopt_existing=True,
+            )
+        self.assertIn("error", self.statuses({"steps": report.steps}, "workspace"))
+        for name, content in originals.items():
+            self.assertEqual((workspace / name).read_bytes(), content)
+        self.assertNotIn("instruction_receipt", receipts.data)
+        archives = list(
+            (self.box.home / ".synthesis" / "onboarding" / "backups").rglob("*")
+        )
+        self.assertTrue(any(path.is_file() for path in archives))
 
     def test_manifest_rejects_repository_selected_migration_actions(self):
         path = self.box.manifest()

--- a/skills/synthesis-onboarding/scripts/test_synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/test_synthesis_cli.py
@@ -435,6 +435,156 @@ def test_update_reuses_persisted_policy(tmp_path: Path) -> None:
     ]]
 
 
+def test_update_replays_persisted_personal_instruction_source(tmp_path: Path) -> None:
+    state = system_contract.SystemState(home=tmp_path)
+    desired = system_contract.default_desired_state(
+        profile="full",
+        clients=["codex"],
+        channel="stable",
+        organizations=[
+            {
+                "repository": "https://example.test/org/config.git",
+                "manifest_path": ".agents/onboarding.yaml",
+                "commit_policy": "pinned",
+                "commit": "1" * 40,
+            }
+        ],
+        personal_workspace="example-user",
+        personal_configuration=full_configuration(),
+        personal_instruction_source={
+            "repository": "/workspaces/example/private-config",
+            "path": ".agents/workspace-instructions.md",
+        },
+    )
+    args = synthesis_cli.build_parser().parse_args(["update"])
+    assert synthesis_cli._engine_args(
+        desired, "update", args, desired_state_path=state.desired_path
+    ) == [
+        "update",
+        "--clients",
+        "codex",
+        "--channel",
+        "stable",
+        "--personal-instruction-source",
+        "/workspaces/example/private-config/.agents/workspace-instructions.md",
+        "--desired-state",
+        str(state.desired_path),
+    ]
+
+
+def test_setup_rejects_personal_instruction_adoption_without_organization(
+    tmp_path: Path, capsys
+) -> None:
+    source = tmp_path / "private-config" / ".agents" / "workspace-instructions.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("Personal.\n", encoding="utf-8")
+    commit_fixture_repo(source.parents[1])
+    calls: list[list[str]] = []
+    assert synthesis_cli.main(
+        [
+            "setup",
+            "--profile",
+            "full",
+            "--clients",
+            "codex",
+            "--personal-instruction-source",
+            str(source),
+            "--adopt-workspace-instructions",
+        ],
+        state=system_contract.SystemState(home=tmp_path / "home"),
+        engine_runner=lambda argv: calls.append(argv) or 0,
+    ) == 2
+    assert calls == []
+    assert "requires an organization" in capsys.readouterr().err
+
+
+def test_setup_preserves_personal_source_until_explicit_clear(
+    tmp_path: Path, monkeypatch
+) -> None:
+    state = system_contract.SystemState(home=tmp_path / "home")
+    repository = "https://example.test/org/config.git"
+    organization_entry = {
+        "repository": repository,
+        "manifest_path": ".agents/onboarding.yaml",
+        "commit_policy": "floating",
+        "commit": "1" * 40,
+    }
+    personal_source = {
+        "repository": "/workspaces/example/private-config",
+        "path": ".agents/workspace-instructions.md",
+    }
+    previous = system_contract.default_desired_state(
+        "full",
+        ["codex"],
+        "stable",
+        organizations=[organization_entry],
+        personal_workspace="example-user",
+        personal_configuration=full_configuration(),
+        personal_instruction_source=personal_source,
+    )
+    state.run_transaction("setup", previous, lambda _tx: {})
+    org_root = tmp_path / "org"
+    (org_root / ".agents").mkdir(parents=True)
+    monkeypatch.setattr(
+        synthesis_cli.organization,
+        "acquire_repository",
+        lambda *_args, **_kwargs: (org_root, "1" * 40),
+    )
+    monkeypatch.setattr(
+        synthesis_cli.onboard,
+        "load_manifest",
+        lambda _path: {"ecosystem": {"clients": ["codex"], "channel": "stable"}},
+    )
+    selected = system_contract.default_desired_state(
+        "full",
+        ["codex"],
+        "stable",
+        organizations=[organization_entry],
+        personal_workspace="example-user",
+        personal_configuration=full_configuration(),
+    )
+    calls: list[list[str]] = []
+
+    def engine(argv: list[str]) -> dict:
+        calls.append(argv)
+        return {
+            "engine": "fixture",
+            "counts": {"changed": 0},
+            "effective_selection": {
+                key: selected[key]
+                for key in (
+                    "profile",
+                    "clients",
+                    "personal_workspace",
+                    "personal_configuration",
+                    "layers",
+                )
+            },
+            "exit": 0,
+        }
+
+    base = [
+        "setup",
+        "--profile",
+        "full",
+        "--clients",
+        "codex",
+        "--org-repo",
+        repository,
+    ]
+    assert synthesis_cli.main(base, state=state, engine_runner=engine) == 0
+    assert "--personal-instruction-source" in calls[-1]
+    assert state.read_desired()["personal_instruction_source"] == personal_source
+
+    assert synthesis_cli.main(
+        base + ["--clear-personal-instruction-source"],
+        state=state,
+        engine_runner=engine,
+    ) == 0
+    assert "--personal-instruction-source" not in calls[-1]
+    assert state.read_desired()["personal_instruction_source"] is None
+
+
 def test_update_rejects_malformed_persisted_state_without_running_engine(
     tmp_path: Path, capsys
 ) -> None:

--- a/skills/synthesis-onboarding/scripts/test_system_contract.py
+++ b/skills/synthesis-onboarding/scripts/test_system_contract.py
@@ -176,10 +176,58 @@ def test_json_schemas_and_runtime_share_valid_and_invalid_corpora(
     desired_validator = Draft202012Validator(contracts["desired"])
     desired_validator.validate(valid_full)
     system_contract.validate_desired_state(valid_full)
+    legacy_without_personal_source = {
+        key: value
+        for key, value in valid_full.items()
+        if key != "personal_instruction_source"
+    }
+    desired_validator.validate(legacy_without_personal_source)
+    system_contract.validate_desired_state(legacy_without_personal_source)
+    organization = {
+        "repository": "https://example.test/org/config.git",
+        "manifest_path": ".agents/onboarding.yaml",
+        "commit_policy": "pinned",
+        "commit": "1" * 40,
+    }
+    with_personal_source = system_contract.default_desired_state(
+        "full",
+        ["codex"],
+        "stable",
+        personal_workspace="example-user",
+        personal_configuration=full_configuration,
+        organizations=[organization],
+        personal_instruction_source={
+            "repository": "/workspaces/example/private-config",
+            "path": ".agents/workspace-instructions.md",
+        },
+    )
+    desired_validator.validate(with_personal_source)
+    system_contract.validate_desired_state(with_personal_source)
     invalid_state_shapes = [
         system_contract.default_desired_state("full", ["codex"], "stable"),
         {**desired, "layers": {}},
         {**desired, "layers": {**desired["layers"], "unknown": "declined"}},
+        {
+            **valid_full,
+            "personal_instruction_source": {
+                "repository": "/workspaces/example/private-config",
+                "path": ".agents/workspace-instructions.md",
+            },
+        },
+        {
+            **with_personal_source,
+            "personal_instruction_source": {
+                "repository": "relative/private-config",
+                "path": ".agents/workspace-instructions.md",
+            },
+        },
+        {
+            **with_personal_source,
+            "personal_instruction_source": {
+                "repository": "/workspaces/example/../private-config",
+                "path": ".agents/workspace-instructions.md",
+            },
+        },
         {
             **valid_full,
             "organizations": [
@@ -785,6 +833,120 @@ def test_instruction_pair_reports_user_drift_without_clobbering(tmp_path: Path) 
             previous_receipt=receipt,
         )
     assert (workspace / "AGENTS.md").read_text(encoding="utf-8") == "user edit\n"
+
+
+def test_instruction_pair_refreshes_source_receipt_when_bytes_are_unchanged(
+    tmp_path: Path,
+) -> None:
+    graph = {
+        "schema_version": 1,
+        "sources": [
+            {"role": "personal", "path": "instructions.md", "required": True}
+        ],
+        "output": "AGENTS.md",
+        "claude_adapter": "CLAUDE.md",
+    }
+    sources = []
+    for name in ("source-a", "source-b"):
+        source = tmp_path / name
+        source.mkdir()
+        git(source, "init", "-q", "-b", "main")
+        (source / "instructions.md").write_text("Same bytes.\n", encoding="utf-8")
+        git(source, "add", "instructions.md")
+        git(source, "commit", "-q", "-m", "source")
+        sources.append(source)
+    workspace = tmp_path / "workspace"
+    first = system_contract.materialize_instruction_pair(
+        graph, {"personal": sources[0]}, workspace, generation=1
+    )
+    second = system_contract.materialize_instruction_pair(
+        graph,
+        {"personal": sources[1]},
+        workspace,
+        generation=2,
+        previous_receipt=first,
+    )
+    assert second["unchanged"] is True
+    assert second["generation"] == 1
+    assert second["sources"][0]["repository"] == str(sources[1].resolve())
+    assert second["verified_at"]
+
+
+def test_instruction_pair_rejects_uncommitted_untracked_and_symlink_sources(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    git(source, "init", "-q", "-b", "main")
+    tracked = source / "instructions.md"
+    tracked.write_text("Committed instructions.\n", encoding="utf-8")
+    git(source, "add", "instructions.md")
+    git(source, "commit", "-q", "-m", "source")
+    graph = {
+        "schema_version": 1,
+        "sources": [
+            {"role": "personal", "path": "instructions.md", "required": True}
+        ],
+        "output": "AGENTS.md",
+        "claude_adapter": "CLAUDE.md",
+    }
+
+    tracked.write_text("Dirty instructions.\n", encoding="utf-8")
+    with pytest.raises(system_contract.ContractError, match="uncommitted"):
+        system_contract.materialize_instruction_pair(
+            graph, {"personal": source}, tmp_path / "dirty-workspace", generation=1
+        )
+    tracked.write_text("Committed instructions.\n", encoding="utf-8")
+
+    untracked = source / "untracked.md"
+    untracked.write_text("Untracked.\n", encoding="utf-8")
+    untracked_graph = {
+        **graph,
+        "sources": [
+            {"role": "personal", "path": "untracked.md", "required": True}
+        ],
+    }
+    with pytest.raises(system_contract.ContractError, match="not Git-tracked"):
+        system_contract.materialize_instruction_pair(
+            untracked_graph,
+            {"personal": source},
+            tmp_path / "untracked-workspace",
+            generation=1,
+        )
+
+    link = source / "linked.md"
+    link.symlink_to(tracked.name)
+    link_graph = {
+        **graph,
+        "sources": [
+            {"role": "personal", "path": "linked.md", "required": True}
+        ],
+    }
+    with pytest.raises(system_contract.ContractError, match="symbolic link"):
+        system_contract.materialize_instruction_pair(
+            link_graph,
+            {"personal": source},
+            tmp_path / "link-workspace",
+            generation=1,
+        )
+
+    binary = source / "binary.md"
+    binary.write_bytes(b"\xff\xfe")
+    git(source, "add", "binary.md")
+    git(source, "commit", "-q", "-m", "binary source")
+    binary_graph = {
+        **graph,
+        "sources": [
+            {"role": "personal", "path": "binary.md", "required": True}
+        ],
+    }
+    with pytest.raises(system_contract.ContractError, match="valid UTF-8"):
+        system_contract.materialize_instruction_pair(
+            binary_graph,
+            {"personal": source},
+            tmp_path / "binary-workspace",
+            generation=1,
+        )
 
 
 def test_invite_is_bounded_and_cannot_replay(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

Full organization setup could materialize public and organization instructions, but it had no declared path for user-owned tracked context. That left existing root instructions outside desired state and made update or repair unable to reproduce the complete workspace.

## What changed

- Add one optional user-local instruction source after the public and organization layers, persisted in desired state and replayed by update and repair.
- Preserve unreceipted root files by default. Explicit adoption archives and byte-verifies them before activation and restores both outputs after a partial failure.
- Reject untracked, dirty, traversing, symbolic-link, and non-UTF-8 sources. Bind each receipt to bytes present in the recorded Git commit.
- Refresh source provenance when an identity changes without changing rendered bytes, and verify source plus output drift in doctor.
- Update the public CLI, schemas, capability contract, guides, release notes, and red-first fixtures together.

## Verification

- 202 onboarding tests passed.
- Closed acceptance matched all 15 changed paths; 10 of 10 defect-pinned cases passed.
- The full repository run reached 1,300 passing tests; the 22 environment-blocked cases passed in the exact affected suites under hermetic Git and loopback conditions (49 of 49 in those suites).
- The gated release check passed every required preflight, test, compile, and acceptance step. Nothing was published by the gate.