### PR TITLE
Update local handoff validation

### DIFF
--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,0 +1,26 @@
+name: Repo guard
+
+on:
+  pull_request:
+    paths:
+      - 'skills/synthesis-repo-guard/**'
+      - '.github/workflows/repo-guard.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'skills/synthesis-repo-guard/**'
+      - '.github/workflows/repo-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  checkpoint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install pytest pyyaml
+      - run: python -m pytest skills/synthesis-repo-guard/test_checkpoint_sync.py skills/synthesis-repo-guard/test_deleted_paths.py -q

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,86 +1,67 @@
-# AGENT HEURISTIC: authored for the 4.94.0 personal instruction overlay transaction.
-# Fresh per transaction: changed_surfaces must equal the authoritative
-# base-to-head Git diff before release.py can consume the receipt.
+# AGENT HEURISTIC: closed acceptance for this local handoff transaction.
+# The release boundary supplies and verifies the authoritative Git change base.
 schema: 2
-suite: personal-instruction-overlay-adoption
+suite: deleted-child-directory-handoff
 membership: closed
-production_entry_point: skills/synthesis-onboarding/scripts/synthesis_cli.py
-enforcing_boundary: full organization setup accepts only committed provenance-bound instruction sources and may replace existing unreceipted root instructions only through explicit verified archive-first adoption with two-output rollback
+production_entry_point: skills/synthesis-repo-guard/checkpoint_sync.py
+enforcing_boundary: local handoff attributes missing children only to a verified live repository and refuses unsafe ancestry or unavailable repository identity
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: live organization review and merge, released-source root adoption, site build-only acceptance, and fresh client lifecycle receipts remain external runtime gates
+unverified_remainder: released installation and the genuine client Stop handoff remain external runtime gates
 changed_surfaces:
-  - path: skills/synthesis-onboarding/scripts/system_contract.py
-    cases: [desired-state-schema, source-commit-binding, source-provenance-refresh]
-  - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
-    cases: [personal-source-state-replay, personal-source-preserve-clear]
-  - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [personal-source-materialization, explicit-adoption-rollback]
-  - path: skills/synthesis-onboarding/scripts/test_system_contract.py
-    cases: [desired-state-schema, source-commit-binding, source-provenance-refresh]
-  - path: skills/synthesis-onboarding/scripts/test_synthesis_cli.py
-    cases: [personal-source-state-replay, personal-source-preserve-clear]
-  - path: skills/synthesis-onboarding/scripts/test_onboard.py
-    cases: [personal-source-materialization, explicit-adoption-rollback]
-  - path: skills/synthesis-onboarding/references/system-state.schema.json
-    cases: [desired-state-schema]
-  - path: skills/synthesis-onboarding/references/release-capabilities.json
-    cases: [personal-source-materialization]
-  - path: skills/synthesis-onboarding/references/org-manifest.md
-    cases: [personal-source-materialization, explicit-adoption-rollback]
-  - path: skills/synthesis-onboarding/SKILL.md
-    cases: [personal-source-state-replay, personal-source-preserve-clear, explicit-adoption-rollback]
+  - path: skills/synthesis-repo-guard/checkpoint_sync.py
+    cases: [deleted-child, nested-children, missing-repository, symlink-ancestry, missing-worktree, unavailable-inventory, missing-file-receipt, verified-retirement]
+  - path: skills/synthesis-repo-guard/test_deleted_paths.py
+    cases: [deleted-child, nested-children, missing-repository, symlink-ancestry, missing-worktree, unavailable-inventory, missing-file-receipt, checkpoint-ci]
+  - path: skills/synthesis-repo-guard/test_checkpoint_sync.py
+    cases: [verified-retirement]
+  - path: skills/synthesis-repo-guard/SKILL.md
+    cases: [deleted-child, missing-worktree, missing-file-receipt]
+  - path: .github/workflows/repo-guard.yml
+    cases: [checkpoint-ci]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
-  - path: .claude-plugin/plugin.json
-    cases: [release-manifest-parity]
-  - path: .codex-plugin/plugin.json
-    cases: [release-manifest-parity]
-  - path: CHANGELOG.md
-    cases: [release-changelog-parity]
-  - path: README.md
-    cases: [release-changelog-parity, personal-source-materialization]
 cases:
-  - id: desired-state-schema
+  - id: deleted-child
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_json_schemas_and_runtime_share_valid_and_invalid_corpora
-    motivating_defect: a-local-personal-source-that-is-not-closed-schema-desired-state-cannot-be-replayed-or-distinguished-from-shareable-organization-data
-  - id: personal-source-state-replay
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_removed_cache_parent_still_resolves_its_repository
+    motivating_defect: deleting-a-generated-file-and-its-parent-must-not-prevent-handoff-of-an-available-repository
+  - id: nested-children
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_update_replays_persisted_personal_instruction_source
-    motivating_defect: a-setup-only-source-argument-would-disappear-on-update-or-repair-and-silently-remove-private-operating-context
-  - id: personal-source-preserve-clear
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_missing_multiple_child_directories_resolve_inside_live_repository
+    motivating_defect: cleanup-may-remove-multiple-child-directories
+  - id: missing-repository
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_setup_preserves_personal_source_until_explicit_clear
-    motivating_defect: rerunning-setup-without-repeating-a-local-private-path-could-silently-drop-the-declared-overlay-while-no-explicit-removal-was-requested
-  - id: personal-source-materialization
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_missing_repository_does_not_resolve_from_unrelated_workspace
+    motivating_defect: recovery-must-not-invent-a-repository-for-a-missing-workspace
+  - id: symlink-ancestry
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_personal_instruction_source_is_materialized_and_receipted
-    motivating_defect: a-tracked-private-source-that-never-enters-the-public-organization-personal-graph-leaves-the-root-instructions-unreproducible
-  - id: explicit-adoption-rollback
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_symlink_ancestor_is_not_a_repository_boundary
+    motivating_defect: resolving-symlinks-first-can-borrow-another-repository-identity
+  - id: missing-worktree
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_adoption_rollback_restores_both_existing_outputs
-    motivating_defect: replacing-an-existing-unreceipted-root-without-verified-archives-and-two-file-rollback-can-destroy-the-only-copy-of-user-context
-  - id: source-commit-binding
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_missing_registered_nested_worktree_cannot_fall_into_parent_repo
+    motivating_defect: missing-nested-worktrees-must-not-be-attributed-to-the-enclosing-repository
+  - id: unavailable-inventory
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_instruction_pair_rejects_uncommitted_untracked_and_symlink_sources
-    motivating_defect: a-receipt-that-hashes-working-tree-bytes-while-naming-an-unrelated-commit-can-certify-content-that-git-never-recorded
-  - id: source-provenance-refresh
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_deleted_path_resolution_fails_when_worktree_inventory_is_unavailable
+    motivating_defect: required-worktree-inventory-must-not-fail-open
+  - id: missing-file-receipt
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_instruction_pair_refreshes_source_receipt_when_bytes_are_unchanged
-    motivating_defect: identical-rendered-bytes-from-a-new-source-could-leave-the-receipt-pointing-at-the-previous-repository-and-break-desired-state-auditability
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_local_receipt_preserves_missing_file_evidence_without_restoring_it
+    motivating_defect: receipts-must-preserve-deleted-file-evidence-and-pending-attribution
+  - id: checkpoint-ci
+    control_class: acceptance-test
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_checkpoint_ci_runs_both_regression_modules
+    motivating_defect: repository-local-tests-need-a-declared-ci-path
+  - id: verified-retirement
+    control_class: acceptance-test
+    fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_reconcile_retired_worktree_repairs_prior_removal
+    motivating_defect: repository-lookup-changes-must-preserve-the-evidence-bearing-retirement-transaction
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: an-acceptance-manifest-that-its-own-runner-cannot-consume-issues-authority-it-never-earned
-  - id: release-manifest-parity
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
-    motivating_defect: a-version-that-reaches-only-one-client-manifest-cannot-be-reliably-installed-or-audited-later
-  - id: release-changelog-parity
-    control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed
-    motivating_defect: a-release-whose-changelog-disagrees-with-its-manifests-cannot-be-audited-later
+    motivating_defect: a-manifest-that-its-own-runner-cannot-consume-cannot-support-release-acceptance

--- a/skills/synthesis-repo-guard/SKILL.md
+++ b/skills/synthesis-repo-guard/SKILL.md
@@ -86,8 +86,12 @@ Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`)
 - Manifest writers, Stop receipts, remote flushes, and worktree retirement use
   one lifecycle lock. Retirement pins a freshly fetched remote-tracking
   commit, fsyncs a resumable intent before removal, invalidates old receipts,
-  and completes idempotently after interruption. A missing path without this
-  proof remains a fail-closed Stop error.
+  and completes idempotently after interruption. A missing worktree without
+  this proof remains a fail-closed Stop error. Deleted files and child
+  directories within a verified live repository are recorded as missing,
+  without restoring them or discarding their pending attribution. Resolution
+  refuses symlink ancestry, unavailable worktree inventory and a missing
+  registered nested worktree rather than borrowing the enclosing repository.
 - A distinct commit author identifies batched remote-context commits.
 - Divergence leaves the exact commit and manifest local and reports the
   block. Never rebase or force-push.

--- a/skills/synthesis-repo-guard/SKILL.md
+++ b/skills/synthesis-repo-guard/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.4.0"
+  version: "2.4.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-repo-guard/checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/checkpoint_sync.py
@@ -479,9 +479,33 @@ def summarize_paths(paths: list[str], limit: int = 3) -> str:
 
 
 def repo_root_for_path(path: Path) -> Path | None:
+    path = lexical_absolute(path)
+    # Keep lexical ancestry until symlinks have been rejected. Resolving first
+    # would silently attribute a pending path to the link target's repository.
+    if any(part.is_symlink() for part in (path, *path.parents)):
+        return None
     probe = path if path.is_dir() else path.parent
+    crossed_missing_parent = False
+    while not probe.is_dir():
+        if probe.exists() or probe == probe.parent:
+            return None
+        crossed_missing_parent = True
+        probe = probe.parent
     rc, output, _ = git(probe, "rev-parse", "--show-toplevel")
-    return Path(output).resolve() if rc == 0 and output else None
+    if rc != 0 or not output:
+        return None
+    root = Path(output).resolve()
+    if not root.is_dir() or not path_is_within(path, root):
+        return None
+    if crossed_missing_parent:
+        roots, error = listed_worktree_roots(root)
+        if error or root not in roots:
+            return None
+        # A missing registered nested worktree needs retirement reconciliation,
+        # not evidence incorrectly attributed to its enclosing repository.
+        if any(other != root and path_is_within(path, other) for other in roots):
+            return None
+    return root
 
 
 def path_is_within(path: Path, root: Path) -> bool:

--- a/skills/synthesis-repo-guard/test_checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/test_checkpoint_sync.py
@@ -28,7 +28,9 @@ def command(*args: str, cwd: Path | None = None) -> str:
 def repository(tmp_path: Path) -> tuple[Path, Path, dict]:
     remote = tmp_path / "remote.git"
     repo = tmp_path / "repo"
-    command("git", "init", "--bare", "-q", str(remote))
+    # Retirement fixtures name origin/main; do not inherit a runner-specific
+    # default branch when constructing their synthetic remote.
+    command("git", "init", "--bare", "-q", "-b", "main", str(remote))
     command("git", "clone", "-q", str(remote), str(repo))
     command("git", "config", "user.name", "Test", cwd=repo)
     command("git", "config", "user.email", "test@example.com", cwd=repo)

--- a/skills/synthesis-repo-guard/test_deleted_paths.py
+++ b/skills/synthesis-repo-guard/test_deleted_paths.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 SPEC = importlib.util.spec_from_file_location(
     "deleted_path_checkpoint", Path(__file__).with_name("checkpoint_sync.py")
@@ -26,6 +27,14 @@ def repo(tmp_path):
     root.mkdir()
     git(root, "init", "-b", "main")
     return root.resolve()
+
+
+def test_checkpoint_ci_runs_both_regression_modules():
+    source = Path(__file__).resolve().parents[2]
+    workflow = yaml.safe_load((source / ".github/workflows/repo-guard.yml").read_text())
+    runs = [step.get("run", "") for step in workflow["jobs"]["checkpoint"]["steps"]]
+    assert "python -m pytest skills/synthesis-repo-guard/test_checkpoint_sync.py skills/synthesis-repo-guard/test_deleted_paths.py -q" in runs
+    assert workflow["permissions"] == {"contents": "read"}
 
 
 def test_removed_cache_parent_still_resolves_its_repository(tmp_path):

--- a/skills/synthesis-repo-guard/test_deleted_paths.py
+++ b/skills/synthesis-repo-guard/test_deleted_paths.py
@@ -1,0 +1,115 @@
+"""Deleted child directories must not erase a valid repository boundary."""
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SPEC = importlib.util.spec_from_file_location(
+    "deleted_path_checkpoint", Path(__file__).with_name("checkpoint_sync.py")
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def git(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args], check=True,
+                          capture_output=True, text=True).stdout.strip()
+
+
+def repo(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    git(root, "init", "-b", "main")
+    return root.resolve()
+
+
+def test_removed_cache_parent_still_resolves_its_repository(tmp_path):
+    root = repo(tmp_path)
+    target = root / "scripts" / "__pycache__" / "fixture.pyc"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"generated fixture")
+    assert MODULE.repo_root_for_path(target) == root  # positive control
+    target.unlink()
+    target.parent.rmdir()
+    assert MODULE.repo_root_for_path(target) == root
+    assert MODULE.file_evidence(target)["state"] == "deleted-or-missing"
+    assert not target.parent.exists()
+
+
+def test_missing_multiple_child_directories_resolve_inside_live_repository(tmp_path):
+    root = repo(tmp_path)
+    assert MODULE.repo_root_for_path(root / "removed" / "children" / "file") == root
+
+
+def test_missing_repository_does_not_resolve_from_unrelated_workspace(tmp_path):
+    root = repo(tmp_path)
+    assert MODULE.repo_root_for_path(root / "present") == root
+    assert MODULE.repo_root_for_path(tmp_path / "missing-repository" / "file") is None
+
+
+@pytest.mark.parametrize("dangling", [False, True])
+def test_symlink_ancestor_is_not_a_repository_boundary(tmp_path, dangling):
+    root = repo(tmp_path)
+    alias = tmp_path / "alias"
+    alias.symlink_to(root / "missing" if dangling else root, target_is_directory=True)
+    assert MODULE.repo_root_for_path(alias / "file") is None
+
+
+def test_missing_registered_nested_worktree_cannot_fall_into_parent_repo(tmp_path):
+    root = repo(tmp_path)
+    nested = root / "nested"
+    git(root, "worktree", "add", "--orphan", "-b", "nested", str(nested))
+    assert MODULE.repo_root_for_path(nested / "file") == nested
+    # Model interruption, not the sanctioned retirement workflow. This exact
+    # synthetic directory is inside this test's freshly created repository.
+    assert nested.parent == root and (nested / ".git").is_file()
+    shutil.rmtree(nested)
+    assert MODULE.repo_root_for_path(nested / "removed" / "file") is None
+
+
+def test_deleted_path_resolution_fails_when_worktree_inventory_is_unavailable(tmp_path, monkeypatch):
+    root = repo(tmp_path)
+    monkeypatch.setattr(MODULE, "listed_worktree_roots", lambda _repo: ([], "unavailable"))
+    assert MODULE.repo_root_for_path(root / "missing-parent" / "file") is None
+
+
+def test_local_receipt_preserves_missing_file_evidence_without_restoring_it(tmp_path, monkeypatch):
+    root = repo(tmp_path)
+    target = root / "scripts" / "removed" / "cache.pyc"
+    (root / "scripts").mkdir()
+    state = tmp_path / "state"
+    pending = state / "pending"
+    pending.mkdir(parents=True)
+    monkeypatch.setattr(MODULE, "STATE_DIR", state)
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    monkeypatch.setattr(MODULE, "LOCAL_HANDOFF_DIR", state / "receipts")
+    manifest = MODULE.pending_manifest_path("deleted-path-fixture")
+    content = {"schema_version": 2, "session_id": "deleted-path-fixture",
+               "paths": [str(target)], "remote_paths": []}
+    manifest.write_text(json.dumps(content))
+    original_git = MODULE.git
+
+    def fixture_git(path, *args, **kwargs):
+        # This fixture tests file resolution/receipt semantics, not commits.
+        # Real Git resolves the repository; fixed read-only HEAD metadata
+        # avoids creating commits in the synthetic repository.
+        if args == ("branch", "--show-current"):
+            return 0, "main", ""
+        if args == ("rev-parse", "HEAD"):
+            return 0, "a" * 40, ""
+        return original_git(path, *args, **kwargs)
+
+    monkeypatch.setattr(MODULE, "git", fixture_git)
+    results, observed = MODULE.local_handoff_checkpoint(
+        {"session_id": "deleted-path-fixture", "cwd": str(root)}, MODULE.DEFAULTS
+    )
+    assert observed == manifest
+    assert results[0]["action"] == "local-ready"
+    assert results[0]["file_evidence"] == [{"path": str(target), "state": "deleted-or-missing"}]
+    assert json.loads(manifest.read_text()) == content
+    assert not target.parent.exists()


### PR DESCRIPTION
## Changes

Resolve deleted child directories through their verified live repository. Preserve missing-file evidence and pending attribution; do not recreate paths or discard manifests. Reject symlink ancestry, failed worktree inventory and missing registered nested worktrees.

Add eight regression cases and a dedicated checkpoint CI job.

## Evidence

- Regression run before correction: four failures and four passing controls.
- Corrected targeted tests: eight passed.
- Read-only diagnostic against the reported missing path: correct repository, deleted-or-missing evidence, parent remains absent.
- Broader local suite: eleven passed; twenty failed at synthetic seed commits because the host coordination guard requires exact temporary-worktree claims. No guard was disabled. The dedicated CI job runs these tests in the standard runner environment.

This is a source review request, not an installation receipt or release acceptance. Release integration remains with the current release owner.