### PR TITLE
Add additive organization enrollment

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.94.0",
+  "version": "4.95.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.94.0",
+  "version": "4.95.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.github/workflows/repo-guard.yml
+++ b/.github/workflows/repo-guard.yml
@@ -1,0 +1,26 @@
+name: Repo guard
+
+on:
+  pull_request:
+    paths:
+      - 'skills/synthesis-repo-guard/**'
+      - '.github/workflows/repo-guard.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'skills/synthesis-repo-guard/**'
+      - '.github/workflows/repo-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  checkpoint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install pytest pyyaml
+      - run: python -m pytest skills/synthesis-repo-guard/test_checkpoint_sync.py skills/synthesis-repo-guard/test_deleted_paths.py -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Cross-source collisions and edited copies fail closed; unchanged legacy copies
 require byte verification against their recorded Git revision. Organization
 copies never trigger public-plugin fallback retirement in an unselected client.
 Organization copies are not mistaken for duplicate public-plugin skills.
+Top-level and nested organization skill layouts have one unambiguous inventory;
+existing shared copies are adopted only after source-commit byte verification.
 Onboarding 2.3.0 includes schema, CLI, engine, recovery, ownership, and
 producer/consumer regression coverage.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.95.0] - 2026-09-04
+
+**Additive organization enrollment preserves an existing personal installation.**
+`synthesis enroll --org-repo URL` (or a time-bounded invite) supports saved full
+and skills-only profiles, retaining personal configuration, clients, and release
+policy. The organization and optional tracked personal instruction overlay are
+saved for update, repair, and doctor. Conflicting policies, organization
+replacement, and workspace collisions fail before generation.
+
+Exact-target journals restore generated instructions, selected skill copies,
+ownership receipts, and invite state after an engine, doctor, or commit failure,
+including interrupted and cross-device recovery. Existing knowledge clones are
+adopted without pulls or configuration changes; required pre-commit protection
+must be present. Skills-only repair preserves independent personal receipt
+metadata. Doctor refuses unfinished enrollment. Per-copy journals persist ownership
+before later phases can fail, and repair restores the recorded organization
+revision without fetching or resetting personal configuration.
+
+Organization copy ownership now survives source removal and uninstall.
+Cross-source collisions and edited copies fail closed; unchanged legacy copies
+require byte verification against their recorded Git revision. Organization
+copies never trigger public-plugin fallback retirement in an unselected client.
+Organization copies are not mistaken for duplicate public-plugin skills.
+Onboarding 2.3.0 includes schema, CLI, engine, recovery, ownership, and
+producer/consumer regression coverage.
+
+Repo-guard 2.4.1 resolves deleted child directories inside a verified live
+repository without losing pending attribution. Missing worktrees, symlink
+ancestry, and unavailable worktree inventory still fail closed. Dedicated
+checkpoint CI covers the deleted-path and retirement fixtures.
+
 ## [4.94.0] - 2026-09-04
 
 **A complete organization workspace can now include private personal context

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Add an organization without resetting an existing installation (September
+2026).** Release **4.95.0** adds `synthesis enroll` for saved full or skills-only
+installations. It preserves personal configuration, selected clients, and release
+policy while registering the organization for future updates. Exact-target
+recovery journals protect generated instructions, selected organization skill
+copies, receipts, and invite use. Replay, doctor, and uninstall enforce the same
+ownership boundaries.
+
 **Private instruction context is now a declared, durable organization overlay
 (September 2026).** Release **4.94.0** lets a full organization setup layer one
 user-owned committed source after the public and organization sources without
@@ -748,12 +756,15 @@ synthesis status
 synthesis doctor
 synthesis update
 synthesis repair
+synthesis enroll --org-repo URL
 synthesis workspace ensure --name my-workspace
 synthesis uninstall --purge
 ```
 
 Stable is the default. Use `--channel edge` to follow `main`, or `--pin X.Y.Z`
-for an exact release. Organization enrollment uses `--org-repo URL` or a
+for an exact release. New users can include an organization in full setup;
+existing users use `synthesis enroll` without reinitializing personal layers.
+Organization enrollment uses `--org-repo URL` or a
 credential-free, time-bounded `--invite FILE`; organization repositories carry
 declarative data and one tracked instruction source, never installer code.
 Users who need private context at the organization workspace root can declare a

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -21,9 +21,9 @@ changed_surfaces:
   - path: skills/synthesis-onboarding/scripts/organization.py
     cases: [enrollment-regressions]
   - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [engine-personal-preservation, enrollment-regressions, replay-after-failure, removed-org-source, legacy-copy-ownership]
+    cases: [engine-personal-preservation, enrollment-regressions, replay-after-failure, removed-org-source, legacy-copy-ownership, shared-layout-adoption, mixed-layout-refusal]
   - path: skills/synthesis-onboarding/scripts/direct_copy.sh
-    cases: [selected-client-preservation, cli-engine-boundary]
+    cases: [selected-client-preservation, cli-engine-boundary, shared-layout-adoption, mixed-layout-refusal]
   - path: skills/synthesis-onboarding/scripts/test_additive_enrollment.py
     cases: [enrollment-regressions]
   - path: skills/synthesis-onboarding/references/system-state.schema.json
@@ -149,3 +149,11 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_journal_creation_publishes_only_complete_identity
     motivating_defect: partially-written-journal-identity-prevents-recovery-before-any-target-was-mutated
+  - id: shared-layout-adoption
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_flat_shared_repository_adoption_proves_source_bytes
+    motivating_defect: top-level-shared-skill-copies-are-not-inventoried-or-safely-adopted
+  - id: mixed-layout-refusal
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_mixed_organization_skill_layout_refuses_before_copies
+    motivating_defect: mixed-source-layouts-make-engine-inventory-and-copy-capability-disagree

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,38 +1,43 @@
-# AGENT HEURISTIC: authored for the 4.94.0 personal instruction overlay transaction.
-# Fresh per transaction: changed_surfaces must equal the authoritative
-# base-to-head Git diff before release.py can consume the receipt.
+# AGENT HEURISTIC: authored for the 4.95.0 additive enrollment transaction.
+# Closed membership is checked against the complete committed release diff.
 schema: 2
-suite: personal-instruction-overlay-adoption
+suite: additive-organization-enrollment
 membership: closed
 production_entry_point: skills/synthesis-onboarding/scripts/synthesis_cli.py
-enforcing_boundary: full organization setup accepts only committed provenance-bound instruction sources and may replace existing unreceipted root instructions only through explicit verified archive-first adoption with two-output rollback
+enforcing_boundary: additive enrollment preserves personal selection and journals exact generated resources through commit recovery replay doctor and uninstall
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: live organization review and merge, released-source root adoption, site build-only acceptance, and fresh client lifecycle receipts remain external runtime gates
+unverified_remainder: live organization adoption build-only site refresh terminal updater and genuine client lifecycle receipts remain runtime gates
 changed_surfaces:
   - path: skills/synthesis-onboarding/scripts/system_contract.py
-    cases: [desired-state-schema, source-commit-binding, source-provenance-refresh]
+    cases: [additive-schema, enrollment-regressions]
   - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
-    cases: [personal-source-state-replay, personal-source-preserve-clear]
+    cases: [additive-selection, enrollment-regressions]
+  - path: skills/synthesis-onboarding/scripts/enrollment.py
+    cases: [enrollment-regressions, partial-copy-rollback, copy-recovery-binding, premutation-copy-recovery, journal-publication]
+  - path: skills/synthesis-onboarding/scripts/organization.py
+    cases: [enrollment-regressions]
   - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [personal-source-materialization, explicit-adoption-rollback]
-  - path: skills/synthesis-onboarding/scripts/test_system_contract.py
-    cases: [desired-state-schema, source-commit-binding, source-provenance-refresh]
-  - path: skills/synthesis-onboarding/scripts/test_synthesis_cli.py
-    cases: [personal-source-state-replay, personal-source-preserve-clear]
-  - path: skills/synthesis-onboarding/scripts/test_onboard.py
-    cases: [personal-source-materialization, explicit-adoption-rollback]
+    cases: [engine-personal-preservation, enrollment-regressions, replay-after-failure, removed-org-source, legacy-copy-ownership]
+  - path: skills/synthesis-onboarding/scripts/direct_copy.sh
+    cases: [selected-client-preservation, cli-engine-boundary]
+  - path: skills/synthesis-onboarding/scripts/test_additive_enrollment.py
+    cases: [enrollment-regressions]
   - path: skills/synthesis-onboarding/references/system-state.schema.json
-    cases: [desired-state-schema]
+    cases: [additive-schema]
+  - path: skills/synthesis-onboarding/references/machine-observation.schema.json
+    cases: [additive-schema, enrollment-regressions]
   - path: skills/synthesis-onboarding/references/release-capabilities.json
-    cases: [personal-source-materialization]
+    cases: [capability-contract]
+  - path: skills/synthesis-onboarding/scripts/check_capabilities.py
+    cases: [capability-contract]
   - path: skills/synthesis-onboarding/references/org-manifest.md
-    cases: [personal-source-materialization, explicit-adoption-rollback]
+    cases: [capability-contract, engine-personal-preservation]
   - path: skills/synthesis-onboarding/SKILL.md
-    cases: [personal-source-state-replay, personal-source-preserve-clear, explicit-adoption-rollback]
+    cases: [engine-version-contract, additive-selection]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
   - path: .claude-plugin/plugin.json
@@ -42,45 +47,105 @@ changed_surfaces:
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
   - path: README.md
-    cases: [release-changelog-parity, personal-source-materialization]
+    cases: [release-changelog-parity, capability-contract]
+  - path: skills/synthesis-onboarding/scripts/test_synthesis_cli.py
+    cases: [recorded-org-repair, engine-version-contract]
+  - path: skills/synthesis-repo-guard/checkpoint_sync.py
+    cases: [deleted-path-handoff, missing-worktree-boundary]
+  - path: skills/synthesis-repo-guard/test_checkpoint_sync.py
+    cases: [checkpoint-ci-binding]
+  - path: skills/synthesis-repo-guard/test_deleted_paths.py
+    cases: [deleted-path-handoff, missing-worktree-boundary, checkpoint-ci-binding]
+  - path: skills/synthesis-repo-guard/SKILL.md
+    cases: [deleted-path-handoff, missing-worktree-boundary]
+  - path: .github/workflows/repo-guard.yml
+    cases: [checkpoint-ci-binding]
 cases:
-  - id: desired-state-schema
+  - id: additive-schema
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_json_schemas_and_runtime_share_valid_and_invalid_corpora
-    motivating_defect: a-local-personal-source-that-is-not-closed-schema-desired-state-cannot-be-replayed-or-distinguished-from-shareable-organization-data
-  - id: personal-source-state-replay
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_skills_only_overlay_matches_runtime_and_schema
+    motivating_defect: an-organization-tied-to-full-profile-forces-unrelated-personal-initialization
+  - id: additive-selection
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_update_replays_persisted_personal_instruction_source
-    motivating_defect: a-setup-only-source-argument-would-disappear-on-update-or-repair-and-silently-remove-private-operating-context
-  - id: personal-source-preserve-clear
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_enroll_preserves_base_and_replays_overlay
+    motivating_defect: setup-reinitializes-personal-state-and-engine-only-install-omits-future-updates
+  - id: engine-personal-preservation
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_setup_preserves_personal_source_until_explicit_clear
-    motivating_defect: rerunning-setup-without-repeating-a-local-private-path-could-silently-drop-the-declared-overlay-while-no-explicit-removal-was-requested
-  - id: personal-source-materialization
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_real_engine_enroll_and_repair_preserve_personal_files_and_receipts
+    motivating_defect: routing-tests-alone-do-not-prove-personal-preservation-through-real-repair-and-uninstall
+  - id: selected-client-preservation
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_personal_instruction_source_is_materialized_and_receipted
-    motivating_defect: a-tracked-private-source-that-never-enters-the-public-organization-personal-graph-leaves-the-root-instructions-unreproducible
-  - id: explicit-adoption-rollback
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_organization_copy_never_retires_unselected_clients
+    motivating_defect: organization-copy-retired-unselected-client-copies-as-public-plugin-fallbacks
+  - id: enrollment-regressions
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_adoption_rollback_restores_both_existing_outputs
-    motivating_defect: replacing-an-existing-unreceipted-root-without-verified-archives-and-two-file-rollback-can-destroy-the-only-copy-of-user-context
-  - id: source-commit-binding
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_nested_copy_recovery_precedes_outer_enrollment_rollback
+    motivating_defect: recovering-outer-enrollment-before-interrupted-inner-copy-restores-the-wrong-generation
+  - id: capability-contract
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_instruction_pair_rejects_uncommitted_untracked_and_symlink_sources
-    motivating_defect: a-receipt-that-hashes-working-tree-bytes-while-naming-an-unrelated-commit-can-certify-content-that-git-never-recorded
-  - id: source-provenance-refresh
+    fixture: ../synthesis-onboarding/scripts/test_check_capabilities.py::test_repository_capabilities_are_consistent
+    motivating_defect: public-install-surfaces-can-advertise-unimplemented-commands-or-profile-layers
+  - id: engine-version-contract
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_instruction_pair_refreshes_source_receipt_when_bytes_are_unchanged
-    motivating_defect: identical-rendered-bytes-from-a-new-source-could-leave-the-receipt-pointing-at-the-previous-repository-and-break-desired-state-auditability
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_engine_versions_and_skill_contract_agree
+    motivating_defect: installed-guidance-and-engine-versions-can-disagree-across-clients
   - id: shipped-manifest-self-consumption
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: an-acceptance-manifest-that-its-own-runner-cannot-consume-issues-authority-it-never-earned
+    motivating_defect: an-acceptance-manifest-must-be-consumed-by-its-own-runner
   - id: release-manifest-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
-    motivating_defect: a-version-that-reaches-only-one-client-manifest-cannot-be-reliably-installed-or-audited-later
+    motivating_defect: a-version-reaching-only-one-client-cannot-be-installed-or-audited-reliably
   - id: release-changelog-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed
-    motivating_defect: a-release-whose-changelog-disagrees-with-its-manifests-cannot-be-audited-later
+    motivating_defect: release-changelog-and-manifest-disagreement-prevents-reliable-audit
+  - id: cli-engine-boundary
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_real_cli_enroll_reaches_engine_and_preserves_personal_state
+    motivating_defect: organization-copies-mistaken-for-public-plugin-duplicates-abort-real-cli-enrollment
+  - id: replay-after-failure
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_failed_later_phase_keeps_copied_skills_repairable
+    motivating_defect: a-later-phase-failure-strands-copied-skills-with-old-ownership-receipts
+  - id: partial-copy-rollback
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_partial_organization_copy_restores_exact_receipts_and_skill_bytes
+    motivating_defect: partial-copy-failure-corrupts-owned-skills-before-repair
+  - id: recorded-org-repair
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_repair_restores_recorded_org_commit_without_fetch_or_personal_setup
+    motivating_defect: failed-update-leaves-managed-org-cache-at-an-uncommitted-desired-revision
+  - id: removed-org-source
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_removing_entire_org_source_retires_exact_owned_inventory
+    motivating_defect: removed-organization-sources-leave-unowned-runtime-copies
+  - id: legacy-copy-ownership
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_legacy_org_copy_adoption_verifies_recorded_source_bytes
+    motivating_defect: legacy-provenance-alone-can-overwrite-edited-private-bytes
+  - id: copy-recovery-binding
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_copy_journal_diagnostic_is_read_only_and_recovery_is_bound
+    motivating_defect: diagnostic-or-unbound-recovery-can-overwrite-unrelated-receipts
+  - id: deleted-path-handoff
+    control_class: acceptance-test
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_local_receipt_preserves_missing_file_evidence_without_restoring_it
+    motivating_defect: deleted-parent-prevents-durable-handoff-of-an-existing-repository
+  - id: missing-worktree-boundary
+    control_class: acceptance-test
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_missing_registered_nested_worktree_cannot_fall_into_parent_repo
+    motivating_defect: ancestor-resolution-can-misattribute-a-missing-nested-worktree
+  - id: checkpoint-ci-binding
+    control_class: acceptance-test
+    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_checkpoint_ci_runs_both_regression_modules
+    motivating_defect: retirement-and-deleted-path-regressions-need-hosted-execution
+  - id: premutation-copy-recovery
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_empty_copy_journal_recovers_before_any_target_mutation
+    motivating_defect: interruption-or-backup-failure-before-receipt-capture-strands-all-future-mutations
+  - id: journal-publication
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_journal_creation_publishes_only_complete_identity
+    motivating_defect: partially-written-journal-identity-prevents-recovery-before-any-target-was-mutated

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.2.0"
+  version: "2.3.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -40,6 +40,10 @@ synthesis setup [--profile full|skills-only] [--clients claude,codex]
                 [--personal-instruction-source PATH]
                 [--adopt-workspace-instructions]
                 [--clear-personal-instruction-source]
+synthesis enroll --org-repo URL | --invite PATH
+                 [--personal-instruction-source PATH]
+                 [--adopt-workspace-instructions]
+                 [--clear-personal-instruction-source]
 synthesis update
 synthesis repair
 synthesis status [--json]
@@ -79,7 +83,8 @@ the same bootstrap and stable CLI.
 - `full` selects skills, session context, hooks and gates, agent kernel,
   runtime engines, coordination, doctors and conformance, personal policy,
   knowledge bases, and lifecycle. Organization enrollment is conditional.
-- `skills-only` selects skills, session context, and lifecycle.
+- `skills-only` selects skills, session context, and lifecycle. Additive
+  organization enrollment is available without selecting any personal layers.
 
 Each selected layer ends as verified or non-green. A declined layer is not
 silently reported as installed merely because plugin source contains its code.
@@ -185,8 +190,42 @@ execute an installer. Shared skill repositories are copied through the public
 engine's fixed direct-copy capability. Knowledge repositories are cloned or
 updated only when their exact remote and cleanliness checks pass.
 
-Enroll with `synthesis setup --org-repo URL`, or use a credential-free,
-time-bounded invite file. Invites are validated before mutation, expire within
+For a new installation, use `synthesis setup --org-repo URL`. For an existing
+enabled full or skills-only installation, use `synthesis enroll --org-repo URL`.
+Enrollment preserves the base profile, personal workspace, configuration, layer
+choices, selected clients, and release policy. It adds only the organization
+overlay and an explicitly selected personal instruction source; it never calls
+the personal initializer or reinstalls the public plugin.
+
+The organization's client and release requirements must match the saved
+selection. Conflicts, a different organization, or a workspace collision are
+refused. The saved additive mode and workspace identity apply to update, repair,
+and doctor too. Skills-only repair does not rewrite independently managed
+personal layers or their receipt metadata. Full repair continues to reconcile
+its already-selected personal layers.
+
+Enrollment journals exact generated targets before mutation. Engine, doctor,
+or state-commit failure restores instructions, selected skill copies, ownership
+receipts, and invite use. Mutating commands recover interrupted enrollment;
+doctor remains non-green until recovery finishes. Verified archives, organization
+source caches, and new knowledge clones are retained. Existing knowledge clones
+are adopted without pulling or changing their configuration during enrollment;
+required executable pre-commit protection must already be configured.
+
+Organization skill ownership is checked before every replay. Changed private
+copies are preserved; unchanged legacy copies can be adopted only after their
+bytes match their recorded Git revision. Removed skills and removed sources are
+archived using exact ownership receipts. Uninstall consumes that inventory and
+reports edited retained copies as non-green.
+
+Each organization copy commits its ownership receipt before a later phase can
+fail. A partial copy restores both the previous bytes and receipt. Interrupted
+copy recovery precedes outer enrollment rollback; doctor only reports pending
+recovery. Repair returns a clean managed organization cache to its recorded
+commit without fetching, then replays the saved selection.
+
+Either setup or enrollment can use a credential-free, time-bounded invite file.
+Invites are validated before mutation, expire within
 seven days, may pin the organization commit, and are protected against replay.
 See `references/org-manifest.md` and `references/invite.schema.json`. A
 schema-1 manifest is refused before any mutation with a message naming the

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -190,6 +190,11 @@ execute an installer. Shared skill repositories are copied through the public
 engine's fixed direct-copy capability. Knowledge repositories are cloned or
 updated only when their exact remote and cleanliness checks pass.
 
+The copy capability accepts either `skills/<name>/SKILL.md` or top-level
+`<name>/SKILL.md` organization repositories, never both layouts at once.
+Existing shared copies require matching repository identity and exact source
+bytes at their recorded commit before enrollment can adopt their ownership.
+
 For a new installation, use `synthesis setup --org-repo URL`. For an existing
 enabled full or skills-only installation, use `synthesis enroll --org-repo URL`.
 Enrollment preserves the base profile, personal workspace, configuration, layer

--- a/skills/synthesis-onboarding/references/machine-observation.schema.json
+++ b/skills/synthesis-onboarding/references/machine-observation.schema.json
@@ -25,7 +25,7 @@
           "transaction_id": {"type": "string", "pattern": "^[0-9a-f]{32}$"},
           "generation": {"type": "integer", "minimum": 1},
           "state": {"enum": ["pending", "committed", "aborted"]},
-          "command": {"enum": ["setup", "update", "repair", "workspace-ensure", "uninstall"]},
+          "command": {"enum": ["setup", "enroll", "update", "repair", "workspace-ensure", "uninstall"]},
           "desired_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
           "committed_desired_digest": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
           "release": {"$ref": "release-descriptor.schema.json"},

--- a/skills/synthesis-onboarding/references/org-manifest.md
+++ b/skills/synthesis-onboarding/references/org-manifest.md
@@ -104,10 +104,28 @@ and destination escapes are refused.
 
 ## Enrollment
 
+First-time full-system installation:
+
 ```bash
 synthesis setup --profile full --org-repo ssh://git@example.test/example/onboarding-config.git
 synthesis setup --profile full --invite invitation.json
 ```
+
+Add the organization to an existing installation without reinitializing its
+personal kernel, policies, or runtimes:
+
+```bash
+synthesis enroll --org-repo ssh://git@example.test/example/onboarding-config.git
+synthesis enroll --invite invitation.json
+```
+
+Additive enrollment supports either saved profile, preserves the selected
+clients and release policy, and records the organization for future update,
+repair, and doctor. Its manifest must agree with that installation's client,
+channel, and exact-pin selection. A conflicting policy, different organization,
+or changed workspace identity is refused rather than taking over personal
+configuration. Existing knowledge repositories are adopted without a pull or
+configuration change; required pre-commit protection must already be configured.
 
 A user may add a private personal instruction layer without putting its path or
 repository in this shareable manifest:
@@ -118,8 +136,9 @@ synthesis setup --profile full \
   --personal-instruction-source /absolute/path/to/private-config/.agents/workspace-instructions.md
 ```
 
-The engine stores that declaration only in local desired state. Update and
-repair replay it. A later setup preserves it unless the user explicitly passes
+The same personal-source and archive-first adoption options are available on
+`synthesis enroll`. The engine stores that declaration only in local desired
+state. Update and repair replay it. A later setup or enrollment preserves it unless the user explicitly passes
 `--clear-personal-instruction-source`.
 
 An invite carries the repository URL, optional exact commit, issuance time,

--- a/skills/synthesis-onboarding/references/release-capabilities.json
+++ b/skills/synthesis-onboarding/references/release-capabilities.json
@@ -6,6 +6,7 @@
     "name": "synthesis",
     "commands": [
       "setup",
+      "enroll",
       "update",
       "repair",
       "status",
@@ -38,7 +39,7 @@
       "primary": false,
       "bootstrap_arguments": ["setup", "--profile", "skills-only"],
       "selected_layers": ["skills", "session-context", "lifecycle"],
-      "conditional_layers": []
+      "conditional_layers": ["organization"]
     }
   },
   "release_policy": {

--- a/skills/synthesis-onboarding/references/system-state.schema.json
+++ b/skills/synthesis-onboarding/references/system-state.schema.json
@@ -104,8 +104,11 @@
           "repository": {"type": "string", "minLength": 1},
           "manifest_path": {"const": ".agents/onboarding.yaml"},
           "commit_policy": {"enum": ["floating", "pinned"]},
-          "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"}
-        }
+          "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+          "mode": {"const": "additive"},
+          "workspace": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]{0,62}$"}
+        },
+        "dependentRequired": {"mode": ["workspace"], "workspace": ["mode"]}
       }
     }
   },
@@ -139,7 +142,7 @@
       "then": {
         "properties": {
           "personal_configuration": {"type": "null"},
-          "organizations": {"maxItems": 0},
+          "organizations": {"items": {"required": ["mode", "workspace"]}},
           "layers": {
             "properties": {
               "skills": {"const": "selected"},
@@ -150,7 +153,6 @@
               "coordination": {"const": "declined"},
               "doctors-conformance": {"const": "declined"},
               "personal-policy": {"const": "declined"},
-              "organization": {"const": "declined"},
               "knowledge-bases": {"const": "declined"},
               "lifecycle": {"const": "selected"}
             }
@@ -170,7 +172,6 @@
       },
       "then": {
         "properties": {
-          "profile": {"const": "full"},
           "organizations": {"minItems": 1}
         }
       }

--- a/skills/synthesis-onboarding/scripts/check_capabilities.py
+++ b/skills/synthesis-onboarding/scripts/check_capabilities.py
@@ -80,6 +80,8 @@ def validate(repo_root: Path) -> None:
             raise CapabilityError("profile %s names an unknown layer" % profile)
     if capabilities["profiles"]["full"]["conditional_layers"] != ["organization"]:
         raise CapabilityError("organization must be the full profile's only conditional layer")
+    if capabilities["profiles"]["skills-only"]["conditional_layers"] != ["organization"]:
+        raise CapabilityError("skills-only must expose the additive organization layer")
 
     component_paths = {entry["path"] for entry in components["installers"]}
     for path in ("install.sh", "onboard.sh"):
@@ -96,6 +98,7 @@ def validate(repo_root: Path) -> None:
         "synthesis update",
         "synthesis doctor",
         "synthesis workspace ensure",
+        "synthesis enroll",
     ):
         _require(readme, fragment, "README.md")
 

--- a/skills/synthesis-onboarding/scripts/direct_copy.sh
+++ b/skills/synthesis-onboarding/scripts/direct_copy.sh
@@ -168,6 +168,9 @@ retire_direct_copies() {
 }
 
 retire_plugin_fallbacks() {
+    # Native public plugins do not contain organization skills. Never retire
+    # those copies, especially in a runtime outside the selected target set.
+    [ "$SOURCE_TYPE" = "public" ] || return 0
     if claude_plugin_installed; then
         retire_direct_copies "$USER_HOME/.claude/skills"
     fi
@@ -552,7 +555,7 @@ do_status() {
     TARGETS=$(detect_targets)
     STATUS_FAILURES=0
 
-    if claude_plugin_installed; then
+    if [ "$SOURCE_TYPE" = "public" ] && claude_plugin_installed; then
         for skill_dir in $(list_skills "$STATUS_SKILLS_DIR"); do
             skill_name=$(basename "$skill_dir")
             if [ -d "$USER_HOME/.claude/skills/$skill_name" ]; then
@@ -561,7 +564,7 @@ do_status() {
             fi
         done
     fi
-    if codex_plugin_installed; then
+    if [ "$SOURCE_TYPE" = "public" ] && codex_plugin_installed; then
         for target in "$USER_HOME/.agents/skills" "$USER_HOME/.codex/skills"; do
             for skill_dir in $(list_skills "$STATUS_SKILLS_DIR"); do
                 skill_name=$(basename "$skill_dir")

--- a/skills/synthesis-onboarding/scripts/direct_copy.sh
+++ b/skills/synthesis-onboarding/scripts/direct_copy.sh
@@ -29,6 +29,20 @@ BACKUP_KEEP_RUNS=10
 SOURCE_REPO="${SYNTHESIS_SKILLS_SOURCE_REPO:-github.com/synthesisengineering/synthesis-skills}"
 SOURCE_TYPE="${SYNTHESIS_SKILLS_SOURCE_TYPE:-public}"
 SKILLS_DIR="${CACHE_DIR}/skills"
+SOURCE_PATH_PREFIX="skills/"
+if [ "$SOURCE_TYPE" = "organization" ] && [ "$SOURCE_MODE" = "local" ]; then
+    if [ -d "$SKILLS_DIR" ]; then
+        for TOP_LEVEL_SKILL in "$CACHE_DIR"/*/SKILL.md; do
+            if [ -f "$TOP_LEVEL_SKILL" ]; then
+                echo "ERROR: organization skill source has ambiguous layouts." >&2
+                exit 1
+            fi
+        done
+    else
+        SKILLS_DIR="$CACHE_DIR"
+        SOURCE_PATH_PREFIX=""
+    fi
+fi
 
 # Skill directories to install to (auto-detected)
 detect_targets() {
@@ -182,7 +196,7 @@ retire_plugin_fallbacks() {
 
 # List skill directories (directories containing SKILL.md)
 list_skills() {
-    find "$1" -maxdepth 2 -name "SKILL.md" -exec dirname {} \; | sort
+    find "$1" -mindepth 2 -maxdepth 2 -name "SKILL.md" -exec dirname {} \; | sort
 }
 
 # Get list of our skill names from the repo
@@ -215,7 +229,7 @@ write_source_json() {
 {
   "source_repo": "${SOURCE_REPO}",
   "source_type": "${SOURCE_TYPE}",
-  "source_path": "skills/${skill_name}/SKILL.md",
+  "source_path": "${SOURCE_PATH_PREFIX}${skill_name}/SKILL.md",
   "source_commit": "${commit_hash}",
   "installed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "installed_by": "install.sh"

--- a/skills/synthesis-onboarding/scripts/enrollment.py
+++ b/skills/synthesis-onboarding/scripts/enrollment.py
@@ -1,0 +1,383 @@
+"""Durable, exact-target rollback for additive organization generation.
+
+Knowledge-base clones and source caches are retained as user data. Generated
+outputs, selected skill copies, receipts and invite state are journaled before
+mutation. A failed generation is moved into the journal, never deleted.
+"""
+
+from __future__ import annotations
+
+import json
+import errno
+import os
+import re
+import shutil
+import tempfile
+import contextlib
+import fcntl
+import hashlib
+import threading
+from pathlib import Path
+
+from system_contract import ContractError, atomic_write_json, json_digest, validate_desired_state
+
+_engine_mutex = threading.RLock()
+_engine_depth = {}
+
+
+def engine_state_root(home):
+    return Path(os.environ.get("SYNTHESIS_ONBOARD_STATE_DIR", str(Path(home) / ".synthesis/onboarding")))
+
+
+@contextlib.contextmanager
+def engine_lock(root, *, read_only=False):
+    root = Path(root)
+    with _engine_mutex:
+        if _engine_depth.get(str(root), 0):
+            yield
+            return
+        regular_tree(root)
+        lock_path = root / "engine.lock"
+        regular_tree(lock_path)
+        if read_only and not lock_path.exists():
+            yield
+            return
+        if not read_only:
+            root.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("rb" if read_only else "a+b") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            _engine_depth[str(root)] = 1
+            try:
+                yield
+            finally:
+                _engine_depth.pop(str(root), None)
+                fcntl.flock(lock, fcntl.LOCK_UN)
+
+
+def regular_tree(path: Path) -> None:
+    for parent in (path, *path.parents):
+        if parent.is_symlink():
+            # macOS canonical system aliases are not user-selected links.
+            aliases = {Path("/var"): Path("/private/var"), Path("/tmp"): Path("/private/tmp")}
+            if parent in aliases and parent.resolve() == aliases[parent]:
+                continue
+            raise ContractError("enrollment refuses a symbolic-link target: %s" % path)
+    if path.exists() and not (path.is_file() or path.is_dir()):
+        raise ContractError("enrollment target is not a regular file or directory")
+    if path.is_dir():
+        for child in path.rglob("*"):
+            if child.is_symlink() or not (child.is_file() or child.is_dir()):
+                raise ContractError("enrollment target contains a non-regular entry")
+
+
+def copy_verified(source, destination):
+    """Stage and verify on the destination device before atomic activation."""
+    regular_tree(source)
+    regular_tree(destination)
+    if destination.exists():
+        raise ContractError("verified copy destination already exists")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".enrollment-copy-", dir=destination.parent) as temporary:
+        staged = Path(temporary) / "payload"
+        if source.is_dir():
+            shutil.copytree(source, staged)
+        else:
+            shutil.copy2(source, staged)
+        if EnrollmentJournal._fingerprint(source) != EnrollmentJournal._fingerprint(staged):
+            raise ContractError("enrollment copy verification failed")
+        os.replace(staged, destination)
+
+
+def move_verified(source, destination):
+    """Call only after the caller proves the exact receipt/journal target."""
+    regular_tree(source)
+    regular_tree(destination)
+    if destination.exists():
+        raise ContractError("enrollment archive destination already exists")
+    try:
+        os.replace(source, destination)
+    except OSError as exc:
+        if exc.errno != errno.EXDEV:
+            raise
+        copy_verified(source, destination)
+        regular_tree(source)
+        if EnrollmentJournal._fingerprint(source) != EnrollmentJournal._fingerprint(destination):
+            raise ContractError("enrollment archive changed before retirement")
+        if source.is_dir():
+            shutil.rmtree(source)
+        else:
+            source.unlink()
+
+
+class EnrollmentJournal:
+    def __init__(self, root: Path):
+        self.root = Path(root)
+        regular_tree(self.root)
+        self.path = self.root / "journal.json"
+        self.data = json.loads(self.path.read_text())
+        if self.data.get("schema_version") != 1 or self.data.get("transaction_id") != self.root.name:
+            raise ContractError("invalid enrollment journal identity")
+        if self.data.get("state") not in {"pending", "committed", "rolled-back"}:
+            raise ContractError("invalid enrollment journal state")
+        for entry in self.data["entries"]:
+            if not re.fullmatch(r"[0-9]+", str(entry.get("slot", ""))):
+                raise ContractError("invalid enrollment backup slot")
+
+    def validate_scope(self, state, desired):
+        """Re-derive capabilities from runtime inputs, never from journal claims."""
+        proposed = validate_desired_state(self.data.get("proposed_desired"))
+        entries = proposed.get("organizations") or []
+        if len(entries) != 1 or entries[0].get("mode") != "additive":
+            raise ContractError("enrollment journal must declare one additive organization")
+        if json_digest(proposed) != self.data["proposed_desired_digest"]:
+            raise ContractError("enrollment journal proposed state digest changed")
+        workspaces = Path(os.environ.get("SYNTHESIS_WORKSPACES_ROOT", str(state.home / "workspaces")))
+        receipts = Path(os.environ.get("SYNTHESIS_ONBOARD_STATE_DIR", str(state.home / ".synthesis/onboarding"))) / "receipts.json"
+        files = {str(p) for p in (state.desired_path, state.invites_path, receipts)}
+        files.update(str(workspaces / entries[0]["workspace"] / name) for name in ("AGENTS.md", "CLAUDE.md"))
+        parents = {str(state.home / (".claude" if c == "claude" else ".agents") / "skills") for c in desired["clients"]}
+        if not set(self.data["skill_parents"]) <= parents:
+            raise ContractError("enrollment journal claims an unselected skill target")
+        for value in self.data["allowed_files"]:
+            path = Path(value)
+            if str(path) not in files:
+                raise ContractError("enrollment journal claims a forbidden output")
+        for entry in self.data["entries"]:
+            self._target(entry["target"])
+
+    @classmethod
+    def create(cls, root, transaction_id, desired, *, files, skill_parents, proposed=None, purpose="enroll"):
+        if not re.fullmatch(r"[a-f0-9]{32}", transaction_id):
+            raise ContractError("invalid enrollment transaction identity")
+        root = Path(root) / transaction_id
+        regular_tree(root)
+        if root.exists():
+            raise ContractError("enrollment journal identity already exists")
+        staging_root = root.parent / ".staging"
+        regular_tree(staging_root)
+        staging_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        data = {
+            "schema_version": 1, "transaction_id": transaction_id,
+            "purpose": purpose,
+            "previous_desired_digest": json_digest(desired), "state": "pending",
+            "proposed_desired_digest": json_digest(proposed),
+            "proposed_desired": proposed,
+            "allowed_files": [str(Path(p).absolute()) for p in files],
+            "skill_parents": [str(Path(p).absolute()) for p in skill_parents],
+            "entries": [], "retained_data": [],
+        }
+        # Only a complete identity is discoverable as a pending transaction.
+        # Interrupted staging has authorized no target mutation and is retained
+        # separately, never interpreted as an active journal.
+        with tempfile.TemporaryDirectory(prefix=transaction_id + "-", dir=staging_root) as stage:
+            atomic_write_json(Path(stage) / "journal.json", data)
+            os.replace(stage, root)
+        return cls(root)
+
+    def _save(self):
+        atomic_write_json(self.path, self.data)
+
+    def _target(self, value):
+        path = Path(value)
+        if not path.is_absolute() or ".." in path.parts:
+            raise ContractError("enrollment target must be absolute and contained")
+        allowed = str(path) in self.data["allowed_files"] or (
+            str(path.parent) in self.data["skill_parents"]
+            and re.fullmatch(r"[a-zA-Z0-9][a-zA-Z0-9_-]*", path.name)
+        )
+        if not allowed:
+            raise ContractError("enrollment target is outside its exact write set: %s" % path)
+        regular_tree(path)
+        return path
+
+    def capture(self, target):
+        target = self._target(target)
+        if any(e["target"] == str(target) for e in self.data["entries"]):
+            return
+        slot = str(len(self.data["entries"]))
+        backup = self.root / "before" / slot
+        entry = {"target": str(target), "slot": slot, "existed": target.exists()}
+        if target.exists():
+            backup.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            if target.is_dir():
+                shutil.copytree(target, backup)
+            else:
+                shutil.copy2(target, backup)
+            # Verification compares every byte, filename and mode before a
+            # durable journal entry can authorize the mutation.
+            entry["fingerprint"] = self._fingerprint(target)
+            if entry["fingerprint"] != self._fingerprint(backup):
+                raise ContractError("enrollment backup verification failed")
+        self.data["entries"].append(entry)
+        self._save()
+
+    @staticmethod
+    def _fingerprint(path):
+        import hashlib
+        entries = [path, *sorted(path.rglob("*"))] if path.is_dir() else [path]
+        return [
+            [str(p.relative_to(path)), p.stat().st_mode & 0o777,
+             hashlib.sha256(p.read_bytes()).hexdigest() if p.is_file() else "directory"]
+            for p in entries
+        ]
+
+    def retain(self, path):
+        if str(path) not in self.data["retained_data"]:
+            self.data["retained_data"].append(str(path))
+            self._save()
+
+    def rollback(self):
+        if self.data["state"] == "rolled-back":
+            return
+        if self.data["state"] != "pending":
+            raise ContractError("cannot roll back a committed enrollment journal")
+        for entry in reversed(self.data["entries"]):
+            if entry.get("restored"):
+                continue
+            target = self._target(entry["target"])
+            backup = self.root / "before" / entry["slot"]
+            failed = self.root / "failed" / entry["slot"]
+            if entry["existed"]:
+                regular_tree(backup)
+                if not backup.exists() or self._fingerprint(backup) != entry.get("fingerprint"):
+                    raise ContractError("enrollment rollback backup is missing or changed")
+            if target.exists() and not failed.exists():
+                failed.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+                move_verified(target, failed)
+            elif target.exists() and failed.exists() and self._fingerprint(target) == self._fingerprint(failed):
+                # Interrupted cross-device retirement: the complete failed
+                # generation is already archived. Finish its exact removal.
+                self._target(target)
+                if target.is_dir():
+                    shutil.rmtree(target)
+                else:
+                    target.unlink()
+            if entry["existed"]:
+                regular_tree(backup)
+                if not backup.exists():
+                    raise ContractError("enrollment rollback backup is missing")
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if not target.exists():
+                    copy_verified(backup, target)
+                if self._fingerprint(target) != self._fingerprint(backup):
+                    raise ContractError("enrollment rollback verification failed")
+            elif target.exists():
+                raise ContractError("enrollment rollback target changed during recovery")
+            entry["restored"] = True
+            self._save()
+        self.data["state"] = "rolled-back"
+        self._save()
+
+    def commit(self):
+        self.data["state"] = "committed"
+        self._save()
+
+
+def recover_enrollments(state):
+    root = state.state_dir / "enrollments"
+    if not root.exists():
+        return
+    regular_tree(root)
+    transactions = {t["transaction_id"]: t for t in state.read_observation()["transactions"]}
+    for path in sorted(root.iterdir()):
+        if path.name == ".staging":
+            continue
+        journal = EnrollmentJournal(path)
+        if journal.data["state"] != "pending":
+            continue
+        current = state.read_desired()
+        if current is None:
+            raise ContractError("enrollment journal has no existing desired installation")
+        journal.validate_scope(state, current)
+        transaction = transactions.get(path.name)
+        if not transaction or transaction["command"] != "enroll" or transaction["desired_digest"] != journal.data["proposed_desired_digest"]:
+            raise ContractError("enrollment journal is not bound to its transaction")
+        if transaction and transaction["state"] == "committed":
+            journal.commit()
+        else:
+            # The same desired-state lock is held by every caller. Never
+            # guess ownership after an unrelated desired generation change.
+            if json_digest(current) not in {journal.data["previous_desired_digest"], journal.data["proposed_desired_digest"]}:
+                raise ContractError("interrupted enrollment has a different desired state; recovery required")
+            journal.rollback()
+
+
+def require_settled_enrollments(state):
+    """Read-only diagnostic gate; mutation commands own crash recovery."""
+    root = state.state_dir / "enrollments"
+    if not root.exists():
+        return
+    regular_tree(root)
+    for path in root.iterdir():
+        if path.name == ".staging":
+            continue
+        if EnrollmentJournal(path).data["state"] == "pending":
+            raise ContractError("unfinished enrollment requires recovery; run synthesis repair before diagnostic acceptance")
+
+
+def validate_copy_scope(journal, root, home):
+    if journal.data.get("purpose") != "org-copy" or journal.root.parent != Path(root) / "copy-transactions":
+        raise ContractError("invalid organization-copy journal identity")
+    if journal.data["allowed_files"] != [str(Path(root) / "receipts.json")]:
+        raise ContractError("organization-copy journal claims an unrelated receipt")
+    allowed = {str(Path(home) / c / "skills") for c in (".claude", ".agents")}
+    if not set(journal.data["skill_parents"]) <= allowed:
+        raise ContractError("organization-copy journal claims an unrelated runtime")
+    for entry in journal.data["entries"]:
+        journal._target(entry["target"])
+
+
+def recover_copy_transactions(root, home, *, verify_only=False):
+    directory = Path(root) / "copy-transactions"
+    if not directory.exists():
+        return
+    regular_tree(directory)
+    for path in directory.iterdir():
+        if path.name == ".staging":
+            continue
+        journal = EnrollmentJournal(path)
+        if journal.data["state"] != "pending":
+            continue
+        if verify_only:
+            raise ContractError("unfinished organization copy requires synthesis repair")
+        validate_copy_scope(journal, root, home)
+        receipt = Path(root) / "receipts.json"
+        original = next((e for e in journal.data["entries"] if e["target"] == str(receipt)), None)
+        if original is None:
+            if journal.data["entries"]:
+                raise ContractError("organization-copy journal has no receipt binding")
+            # Receipt capture is first. Its absence means no write capability
+            # escaped create/capture, including a failed backup operation.
+            journal.rollback()
+            continue
+        before = original.get("fingerprint", [[None, None, None]])[0][2]
+        current = hashlib.sha256(receipt.read_bytes()).hexdigest() if receipt.exists() else None
+        if current not in {before, journal.data.get("receipt_after_sha256")}:
+            raise ContractError("organization-copy receipt changed outside its transaction")
+        journal.rollback()
+
+
+@contextlib.contextmanager
+def organization_copy_transaction(receipts, paths, home):
+    import uuid
+    root = receipts.path.parent
+    journal = EnrollmentJournal.create(root / "copy-transactions", uuid.uuid4().hex, None,
+        files=[receipts.path], skill_parents=sorted({p.parent for p in paths}), purpose="org-copy")
+    validate_copy_scope(journal, root, home)
+    journal.capture(receipts.path)
+    for path in paths:
+        journal.capture(path)
+    previous_data = json.loads(json.dumps(receipts.data))
+    try:
+        yield
+        # Receipts.save uses this canonical encoding. Journal the expected
+        # committed bytes before activation for crash-safe recovery.
+        encoded = (json.dumps(receipts.data, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        journal.data["receipt_after_sha256"] = hashlib.sha256(encoded).hexdigest()
+        journal._save()
+        receipts.save()
+        journal.commit()
+    except BaseException:
+        journal.rollback()
+        receipts.data = previous_data
+        raise

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -34,6 +34,9 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from enrollment import (EnrollmentJournal, regular_tree, move_verified, engine_lock,
+                        recover_copy_transactions, organization_copy_transaction)
+
 from plugin_currency import (
     compare_versions,
     normalize_policy,
@@ -45,11 +48,14 @@ from plugin_currency import (
 from system_contract import (
     ContractError,
     DriftError,
+    SystemState,
     describe_personal_instruction_source,
     file_digest,
+    json_digest,
     materialize_instruction_pair,
     personal_instruction_source_path,
     public_source_identity,
+    validate_additive_organization,
     validate_desired_state,
     validate_org_manifest,
     validate_repository_url,
@@ -82,7 +88,7 @@ from whole_system import (
     validate_personal_policy,
 )
 
-ENGINE_VERSION = "2.2.0"
+ENGINE_VERSION = "2.3.0"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"
@@ -1397,18 +1403,121 @@ def phase_ecosystem(
             report.add("ecosystem", ERROR, "fallback install.sh failed", hint=(err or out).strip()[-400:])
 
 
-def phase_org_skills(report, manifest, receipts, dry_run):
+def organization_skill_targets(clients_wanted=None):
+    return [HOME / (".claude" if client == "claude" else ".agents") / "skills"
+            for client in (clients_wanted if clients_wanted is not None else ["claude", "codex"])]
+
+
+def verify_org_copy(path, metadata, clients_wanted=None, source_repo=None):
+    path = Path(path)
+    if path.parent not in organization_skill_targets(clients_wanted) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", path.name):
+        raise ContractError("organization copy receipt names an unsafe target")
+    regular_tree(path)
+    if path.exists():
+        provenance = json.loads((path / ".source.json").read_text())
+        if provenance.get("source_type") != "organization" or provenance.get("source_repo") != metadata["repository"]:
+            raise ContractError("organization skill conflicts with an existing source: %s" % path.name)
+        if metadata.get("sha256") and paths_digest([path]) != metadata["sha256"]:
+            raise ContractError("organization skill was edited; preserved: %s" % path.name)
+        if not metadata.get("sha256"):
+            commit = provenance.get("source_commit", "")
+            prefix = "skills/%s/" % path.name
+            if source_repo is None or not re.fullmatch(r"[0-9a-f]{40}", commit) or provenance.get("source_path") != prefix + "SKILL.md":
+                raise ContractError("organization skill has no verifiable ownership receipt; preserved: %s" % path.name)
+            listing = subprocess.run(["git", "-C", str(source_repo), "ls-tree", "-rz", commit, "--", prefix], capture_output=True)
+            expected = {}
+            if listing.returncode:
+                raise ContractError("organization skill's recorded source revision is unavailable")
+            for record in listing.stdout.split(b"\0"):
+                if not record:
+                    continue
+                header, name = record.split(b"\t", 1)
+                mode, kind, oid = header.split()
+                name = name.decode("utf-8")
+                if mode not in {b"100644", b"100755"} or kind != b"blob" or not name.startswith(prefix):
+                    raise ContractError("organization skill recorded source contains a non-regular entry")
+                blob = subprocess.run(["git", "-C", str(source_repo), "cat-file", "blob", oid.decode("ascii")], capture_output=True)
+                if blob.returncode:
+                    raise ContractError("organization skill recorded source is unreadable")
+                expected[name[len(prefix):]] = blob.stdout
+            actual = {str(p.relative_to(path)): p.read_bytes() for p in path.rglob("*")
+                      if p.is_file() and p.name not in {".source.json", ".DS_Store"}}
+            expected = {n: v for n, v in expected.items() if Path(n).name not in {".source.json", ".DS_Store"}}
+            if "SKILL.md" not in expected or actual != expected:
+                raise ContractError("unreceipted organization skill differs from its recorded source; preserved: %s" % path.name)
+
+
+def retire_org_copy(report, receipts, path, metadata, dry_run, journal=None):
+    path = Path(path)
+    try:
+        verify_org_copy(path, metadata)
+        if path.exists():
+            if dry_run:
+                report.add("org-skills", CHANGED, "would archive receipt-owned %s" % path.name)
+                return
+            if journal is not None:
+                journal.capture(path)
+            archive = STATE_DIR / "backups" / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ") / "org-skills" / path.name
+            regular_tree(archive)
+            archive.parent.mkdir(parents=True, exist_ok=False)
+            with organization_copy_transaction(receipts, [path], HOME):
+                move_verified(path, archive)
+                receipts.data.setdefault("org_skill_copies", {}).pop(str(path), None)
+            report.add("org-skills", CHANGED, "archived receipt-owned %s" % path.name)
+        if not dry_run:
+            receipts.data.setdefault("org_skill_copies", {}).pop(str(path), None)
+    except (ContractError, OSError, ValueError) as exc:
+        report.add("org-skills", ACTION, str(exc))
+
+
+def phase_org_skills(report, manifest, receipts, dry_run, clients_wanted=None, journal=None):
+    repos = manifest.get("skills_repos") or []
+    prepared = {}
+    owners = {}
+    targets = organization_skill_targets(clients_wanted)
+    # Resolve the complete source set and detect collisions before any copy or
+    # retirement. A second organization source cannot take over a first one's name.
+    for repo in repos:
+        cache = CACHE_DIR / repo["name"]
+        prepared[repo["name"]] = clone_or_update(report, "org-skills", [repo["repository"]], cache, dry_run)
+        if prepared[repo["name"]] in {ERROR, WOULD}:
+            continue
+        for skill in (cache / "skills").glob("*/SKILL.md"):
+            for parent in targets:
+                target = str(parent / skill.parent.name)
+                if target in owners and owners[target] != repo["repository"]:
+                    report.add("org-skills", ERROR, "organization sources declare the same skill target")
+                    return
+                owners[target] = repo["repository"]
+                old = receipts.data.get("org_skill_copies", {}).get(target)
+                if old and old["repository"] != repo["repository"]:
+                    report.add("org-skills", ERROR, "organization skill target is owned by another source")
+                    return
+                if not dry_run:
+                    try:
+                        verify_org_copy(target, old or {"repository": repo["repository"]}, clients_wanted, cache)
+                    except (ContractError, OSError, ValueError) as exc:
+                        report.add("org-skills", ERROR, str(exc))
+                        return
+    if report.exit_code():
+        return
+    declared_repos = {repo["repository"] for repo in repos}
+    for path, metadata in list(receipts.data.get("org_skill_copies", {}).items()):
+        if Path(path).parent in targets and metadata["repository"] not in declared_repos:
+            retire_org_copy(report, receipts, path, metadata, dry_run, journal)
+    if report.exit_code():
+        return
     for repo in manifest.get("skills_repos") or []:
         cache = CACHE_DIR / repo["name"]
-        urls = [repo["repository"]]
-        status = clone_or_update(report, "org-skills", urls, cache, dry_run)
+        status = prepared[repo["name"]]
         if status in (ERROR,):
             continue
         if repo.get("capability") != "skills-install":
             report.add("org-skills", ERROR, "%s requested an unsupported capability" % repo["name"])
             continue
         installer = source_root() / "skills" / "synthesis-onboarding" / "scripts" / "direct_copy.sh"
-        targets = "%s %s" % (HOME / ".claude" / "skills", HOME / ".agents" / "skills")
+        target_paths = organization_skill_targets(clients_wanted)
+        targets = " ".join(map(str, target_paths))
         env = {
             "SYNTHESIS_SKILLS_SOURCE_DIR": str(cache),
             "SYNTHESIS_SKILLS_HOME": str(HOME),
@@ -1426,23 +1535,59 @@ def phase_org_skills(report, manifest, receipts, dry_run):
         source_names = [
             path.parent.name for path in (cache / "skills").glob("*/SKILL.md")
         ]
+        owned = receipts.data.setdefault("org_skill_copies", {})
+        current_targets = {str(target / name) for target in target_paths for name in source_names}
+        try:
+            regular_tree(cache / "skills")
+            for target in target_paths:
+                for name in source_names:
+                    installed = target / name
+                    verify_org_copy(installed, owned.get(str(installed)) or {"repository": repo["repository"]}, clients_wanted, cache)
+                    if journal is not None:
+                        journal.capture(installed)
+        except (ContractError, OSError, ValueError) as exc:
+            report.add("org-skills", ERROR, str(exc))
+            return
+        for path, metadata in list(owned.items()):
+            if metadata["repository"] == repo["repository"] and Path(path).parent in target_paths and path not in current_targets:
+                retire_org_copy(report, receipts, path, metadata, dry_run, journal)
+        if report.exit_code():
+            return
         copies_present = bool(source_names) and all(
             (target / name / "SKILL.md").is_file()
-            for target in (HOME / ".claude" / "skills", HOME / ".agents" / "skills")
+            for target in target_paths
             for name in source_names
         )
-        if rc == 0 and copies_present:
+        installed_now = not (rc == 0 and copies_present)
+        if not installed_now:
             report.add("org-skills", OK, "%s already installed and clean" % repo["name"])
-            continue
-        rc, out, err = run(["sh", str(installer), "install"], env=env, timeout=600)
+            out, err = "", ""
+        else:
+            try:
+                with organization_copy_transaction(receipts, [Path(p) for p in sorted(current_targets)], HOME):
+                    rc, out, err = run(["sh", str(installer), "install"], env=env, timeout=600)
+                    if rc:
+                        raise ContractError("%s skills-install failed: %s" % (repo["name"], (err or out).strip()[-400:]))
+                    _, installed_commit, _ = git(["rev-parse", "HEAD^{commit}"], cwd=cache)
+                    for target in current_targets:
+                        owned[target] = {"repository": repo["repository"], "commit": installed_commit.strip(),
+                                         "sha256": paths_digest([Path(target)])}
+            except (ContractError, OSError, ValueError) as exc:
+                report.add("org-skills", ERROR, str(exc))
+                return
         if rc == 0:
             _, commit, _ = git(["rev-parse", "HEAD^{commit}"], cwd=cache)
+            for target in current_targets:
+                owned[target] = {"repository": repo["repository"], "commit": commit.strip(),
+                                 "sha256": paths_digest([Path(target)])}
             receipts.data.setdefault("org_skill_sources", {})[repo["name"]] = {
                 "repository": repo["repository"],
                 "commit": commit.strip(),
                 "capability": "skills-install",
             }
-            report.add("org-skills", CHANGED, "%s installed through public skills-install" % repo["name"])
+            receipts.save()
+            if installed_now:
+                report.add("org-skills", CHANGED, "%s installed through public skills-install" % repo["name"])
         else:
             report.add("org-skills", ERROR, "%s skills-install failed" % repo["name"],
                        hint=(err or out).strip()[-400:])
@@ -1461,7 +1606,18 @@ def find_adoptable(name, primary, superseded):
     return None
 
 
-def phase_kbs(report, manifest, receipts, dry_run):
+def knowledge_hooks_present(repo):
+    rc, configured, _ = git(["config", "--get", "core.hooksPath"], cwd=repo)
+    if rc or not configured.strip():
+        return False
+    path = Path(configured.strip()).expanduser()
+    if not path.is_absolute():
+        path = Path(repo) / path
+    hook = path / "pre-commit"
+    return hook.is_file() and os.access(hook, os.X_OK)
+
+
+def phase_kbs(report, manifest, receipts, dry_run, enrolling=False, journal=None):
     workspace = manifest["org"]["workspace"]
     auth_help = (manifest.get("auth_help") or "").strip()
     for kb in manifest.get("knowledge_bases") or []:
@@ -1478,6 +1634,7 @@ def phase_kbs(report, manifest, receipts, dry_run):
                 repo = found
                 receipts.record_adoption(name, found)
                 report.add("knowledge-base", OK, "adopted existing clone of %s at %s" % (name, found))
+        existing_repo = repo is not None
         if repo is None:
             if dry_run:
                 report.add("knowledge-base", CHANGED, "would clone %s -> %s" % (primary, standard))
@@ -1493,6 +1650,8 @@ def phase_kbs(report, manifest, receipts, dry_run):
                 report.add("knowledge-base", ERROR, "clone of %s failed" % name, hint=err.strip()[-400:])
                 continue
             repo = standard
+            if journal is not None:
+                journal.retain(standard)
             report.add("knowledge-base", CHANGED, "cloned %s -> %s" % (name, standard))
         current_origin = origin_url(repo)
         if current_origin in superseded:
@@ -1504,7 +1663,7 @@ def phase_kbs(report, manifest, receipts, dry_run):
         elif current_origin != primary:
             report.add("knowledge-base", ERROR, "%s has the wrong remote; refusing reuse" % name)
             continue
-        if not dry_run:
+        if not dry_run and not (enrolling and existing_repo):
             if is_dirty(repo):
                 report.add("knowledge-base", WARN, "%s has local changes; skipped pull" % name)
             else:
@@ -1515,6 +1674,12 @@ def phase_kbs(report, manifest, receipts, dry_run):
                     report.add("knowledge-base", WARN, "%s could not fast-forward" % name,
                                hint=err.strip()[-300:] if err else None)
         if kb.get("local_hooks") and (Path(repo) / ".githooks").is_dir():
+            if enrolling and existing_repo:
+                if knowledge_hooks_present(repo):
+                    report.add("knowledge-base", OK, "%s existing repository protection verified; configuration preserved" % name)
+                else:
+                    report.add("knowledge-base", ACTION, "%s requires configured executable pre-commit protection; existing configuration preserved" % name)
+                continue
             rc, out, _ = git(["config", "--global", "--get", "core.hooksPath"])
             if rc == 0 and out.strip():
                 report.add("knowledge-base", OK, "global git hooks engine already active; not overriding")
@@ -1632,6 +1797,16 @@ def phase_workspace(
     )
     if previous is None and existing and not adopt_existing:
         report.add("workspace", ERROR, "workspace instructions exist without a source receipt; preserved")
+        return
+    try:
+        materialize_instruction_pair(
+            graph, source_roots, ws_dir,
+            generation=int(receipts.data.get("instruction_generation", 0)) + 1,
+            previous_receipt=previous,
+            source_identities={"public": public_identity}, validate_only=True,
+        )
+    except (ContractError, DriftError, OSError) as exc:
+        report.add("workspace", ERROR, str(exc))
         return
     if dry_run:
         if previous is None and existing and adopt_existing:
@@ -2794,9 +2969,7 @@ def doctor(report, manifest, clients_wanted, policy, desired_state=None):
             env = {
                 "SYNTHESIS_SKILLS_SOURCE_DIR": str(cache),
                 "SYNTHESIS_SKILLS_HOME": str(HOME),
-                "SYNTHESIS_SKILLS_TARGETS": "%s %s" % (
-                    HOME / ".claude" / "skills", HOME / ".agents" / "skills"
-                ),
+                "SYNTHESIS_SKILLS_TARGETS": " ".join(map(str, organization_skill_targets(clients_wanted))),
                 "SYNTHESIS_SKILLS_SOURCE_REPO": repo["repository"],
                 "SYNTHESIS_SKILLS_SOURCE_TYPE": "organization",
             }
@@ -2807,6 +2980,17 @@ def doctor(report, manifest, clients_wanted, policy, desired_state=None):
                 report.add("doctor", ERROR, "%s status reports problems" % repo["name"],
                            hint=(out + err).strip()[-300:])
         receipts = Receipts()
+        for path, metadata in receipts.data.get("org_skill_copies", {}).items():
+            if Path(path).parent not in organization_skill_targets(clients_wanted):
+                continue
+            try:
+                if metadata["repository"] not in {r["repository"] for r in manifest.get("skills_repos") or []}:
+                    raise ContractError("organization skill source was removed; reconciliation required")
+                verify_org_copy(path, metadata, clients_wanted)
+                if not Path(path).is_dir():
+                    raise ContractError("receipt-owned organization skill is missing")
+            except (ContractError, OSError, ValueError) as exc:
+                report.add("doctor", ERROR, str(exc))
         workspace = manifest["org"]["workspace"]
         for kb in manifest.get("knowledge_bases") or []:
             adopted = receipts.adopted(kb["name"])
@@ -2818,6 +3002,8 @@ def doctor(report, manifest, clients_wanted, policy, desired_state=None):
                 report.add("doctor", ERROR, "%s origin differs from manifest repository" % kb["name"])
             else:
                 report.add("doctor", OK, "knowledge base %s present at %s" % (kb["name"], repo_path))
+            if kb.get("local_hooks") and not knowledge_hooks_present(repo_path):
+                report.add("doctor", ERROR, "%s required pre-commit protection is unavailable" % kb["name"])
         receipt = receipts.data.get("instruction_receipt") or {}
         source_errors = []
         source_receipts = receipt.get("sources") or []
@@ -2826,6 +3012,21 @@ def doctor(report, manifest, clients_wanted, policy, desired_state=None):
                 verify_instruction_source_receipt(entry)
             except (ContractError, DriftError, OSError) as exc:
                 source_errors.append(str(exc))
+        declared_roots = {"public": source_root().resolve(),
+                          "organization": Path(manifest["_path"]).resolve().parents[1]}
+        declared_paths = {"public": "skills/synthesis-onboarding/references/kernel.example.md",
+                          "organization": manifest["instruction_sources"][0]["path"]}
+        for role in ("public", "organization"):
+            actual = [s for s in source_receipts if isinstance(s, dict) and s.get("role") == role]
+            if len(actual) != 1 or any(actual[0].get(k) != v for k, v in {
+                "repository": str(declared_roots[role]), "path": declared_paths[role]
+            }.items()):
+                source_errors.append("%s instruction receipt differs from declared source" % role)
+        if desired_state and desired_state.get("organizations"):
+            expected_commit = desired_state["organizations"][0]["commit"]
+            actual_org = next((s for s in source_receipts if s.get("role") == "organization"), {})
+            if actual_org.get("commit") != expected_commit:
+                source_errors.append("organization instruction commit differs from desired state")
         expected_personal = (
             (desired_state or {}).get("personal_instruction_source")
             if desired_state is not None
@@ -3085,6 +3286,10 @@ def verify_uninstalled(report, clients_wanted):
         clean = False
     receipts = Receipts()
     retained = []
+    for path_text in receipts.data.get("org_skill_copies", {}):
+        path = Path(path_text)
+        if path.parent in organization_skill_targets(clients_wanted) and (path.exists() or path.is_symlink()):
+            retained.append(path_text)
     for path_text in receipts.data.get("generated_files", {}):
         path = Path(path_text)
         if path.exists() or path.is_symlink():
@@ -3171,6 +3376,9 @@ def _remove_plugins_and_direct_copies(report, clients_wanted, dry_run):
 def uninstall(report, dry_run, clients_wanted=None):
     clients_wanted = list(clients_wanted or ["claude", "codex"])
     receipts = Receipts()
+    for path, metadata in list(receipts.data.get("org_skill_copies", {}).items()):
+        if Path(path).parent in organization_skill_targets(clients_wanted):
+            retire_org_copy(report, receipts, path, metadata, dry_run)
     hooks_clean = remove_managed_hooks(report, receipts, dry_run)
     files = list(receipts.data.get("generated_files", {}).items())
     if not files and not receipts.data.get("managed_json_entries"):
@@ -3268,7 +3476,7 @@ def build_parser():
     parser = argparse.ArgumentParser(prog="onboard.py", description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("command", nargs="?", default="install",
-                        choices=["install", "update", "repair", "init", "kernel", "doctor", "init-workspace", "uninstall", "uninstall-doctor"])
+                        choices=["install", "enroll", "update", "repair", "init", "kernel", "doctor", "init-workspace", "uninstall", "uninstall-doctor"])
     parser.add_argument("--manifest", type=Path, help="org onboarding manifest (.agents/onboarding.yaml)")
     parser.add_argument("--clients",
                         help="comma-separated clients to target (default: manifest or claude,codex)")
@@ -3316,11 +3524,27 @@ def build_parser():
                         help="skip client plugin CLIs; use file-copy fallback")
     parser.add_argument("--policy-transition", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument("--desired-state", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--enrollment-journal", type=Path, help=argparse.SUPPRESS)
     parser.add_argument("--json", action="store_true", help="machine-readable output")
     return parser
 
 
 def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if args.dry_run:
+        return _main_unlocked(argv)
+    with engine_lock(STATE_DIR, read_only=args.command in {"doctor", "uninstall-doctor"}):
+        try:
+            recover_copy_transactions(STATE_DIR, HOME,
+                verify_only=args.command in {"doctor", "uninstall-doctor"})
+        except (ContractError, OSError, ValueError) as exc:
+            report = Report(as_json=args.json)
+            report.add("recovery", ERROR, str(exc))
+            return finish(report, args, 2)
+        return _main_unlocked(argv)
+
+
+def _main_unlocked(argv=None):
     args = build_parser().parse_args(argv)
     no_services = args.no_services or os.environ.get(
         "SYNTHESIS_ONBOARD_NO_SERVICES"
@@ -3378,6 +3602,15 @@ def main(argv=None):
         return finish(report, args, 2)
     plugin_requested = ((manifest or {}).get("ecosystem") or {}).get("plugin", True)
 
+    if desired_state and desired_state.get("organizations") and desired_state["organizations"][0].get("mode") == "additive":
+        try:
+            if not manifest:
+                raise ContractError("additive organization requires its declared manifest")
+            validate_additive_organization(desired_state, manifest, desired_state["organizations"][0])
+        except (ContractError, ValueError) as exc:
+            report.add("enroll", ERROR, str(exc))
+            return finish(report, args, 2)
+
     if args.command == "doctor":
         code = doctor(
             report,
@@ -3417,7 +3650,31 @@ def main(argv=None):
         uninstall(report, args.dry_run, clients_wanted)
         return finish(report, args, report.exit_code())
 
-    # install / update / whole-system init
+    journal = None
+    if args.command == "enroll":
+        if not manifest or not desired_state or not args.enrollment_journal:
+            report.add("enroll", ERROR, "enrollment requires a manifest, saved selection, and transaction journal; use synthesis enroll")
+            return finish(report, args, 2)
+        org_entries = desired_state.get("organizations") or []
+        if len(org_entries) != 1 or org_entries[0].get("mode") != "additive":
+            report.add("enroll", ERROR, "enrollment requires exactly one additive organization selection")
+            return finish(report, args, 2)
+        if args.with_personal_workspace or args.profile or args.answers:
+            report.add("enroll", ERROR, "enrollment cannot initialize personal layers")
+            return finish(report, args, 2)
+        try:
+            journal = EnrollmentJournal(args.enrollment_journal)
+            journal.validate_scope(SystemState(), desired_state)
+            if journal.data["state"] != "pending" or journal.data["proposed_desired_digest"] != json_digest(desired_state):
+                raise ContractError("enrollment journal does not match proposed desired state")
+            journal.capture(RECEIPTS_PATH)
+            for name in ("AGENTS.md", "CLAUDE.md"):
+                journal.capture(WORKSPACES_ROOT / manifest["org"]["workspace"] / name)
+        except (ContractError, OSError, ValueError) as exc:
+            report.add("enroll", ERROR, str(exc))
+            return finish(report, args, 2)
+
+    # install / additive enrollment / update / whole-system init
     receipts = Receipts()
     profile = None
     answers = None
@@ -3442,6 +3699,14 @@ def main(argv=None):
     if args.command == "init" and not selected_clients:
         report.add("preflight", ERROR, "setup requires at least one installed AI client")
         return finish(report, args, 1)
+    if args.command == "enroll":
+        validation = Report(dry_run=True, as_json=True)
+        phase_workspace(validation, manifest, receipts, True,
+                        personal_instruction_source=personal_instruction_source,
+                        adopt_existing=args.adopt_workspace_instructions)
+        if validation.exit_code():
+            report.steps.extend(validation.steps)
+            return finish(report, args, validation.exit_code())
     if desired_state is not None and selected_clients != desired_state["clients"]:
         missing = sorted(set(desired_state["clients"]) - set(selected_clients))
         if selected_clients:
@@ -3459,7 +3724,7 @@ def main(argv=None):
             hint=hint,
         )
         return finish(report, args, 1)
-    if plugin_requested:
+    if plugin_requested and args.command != "enroll":
         phase_ecosystem(
             report,
             clients,
@@ -3470,11 +3735,19 @@ def main(argv=None):
             preserve_ahead=args.command in ("update", "repair") and not args.policy_transition,
             policy_transition=args.policy_transition,
         )
+    elif args.command == "enroll":
+        report.add("ecosystem", SKIP, "enrollment preserves the existing public plugin installation")
     else:
         report.add("ecosystem", SKIP, "public plugin disabled by manifest")
+    if report.exit_code():
+        return finish(report, args, report.exit_code())
     if manifest:
-        phase_org_skills(report, manifest, receipts, args.dry_run)
-        phase_kbs(report, manifest, receipts, args.dry_run)
+        phase_org_skills(report, manifest, receipts, args.dry_run, clients_wanted, journal)
+        if report.exit_code():
+            return finish(report, args, report.exit_code())
+        phase_kbs(report, manifest, receipts, args.dry_run, enrolling=args.command == "enroll", journal=journal)
+        if report.exit_code():
+            return finish(report, args, report.exit_code())
         phase_workspace(
             report,
             manifest,
@@ -3483,6 +3756,8 @@ def main(argv=None):
             personal_instruction_source=personal_instruction_source,
             adopt_existing=args.adopt_workspace_instructions,
         )
+        if report.exit_code():
+            return finish(report, args, report.exit_code())
     if args.with_personal_workspace:
         init_workspace(report, receipts, args.with_personal_workspace, args.dry_run)
     if args.command == "init":
@@ -3496,7 +3771,7 @@ def main(argv=None):
             args.dry_run,
             no_services,
         )
-    elif args.command == "repair" and desired_state is not None:
+    elif args.command == "repair" and desired_state is not None and desired_state["profile"] == "full":
         try:
             repair_answers = reconcile_answers(desired_state, receipts)
         except ValueError as exc:

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -1408,6 +1408,37 @@ def organization_skill_targets(clients_wanted=None):
             for client in (clients_wanted if clients_wanted is not None else ["claude", "codex"])]
 
 
+def organization_skill_directory(repository):
+    repository = Path(repository)
+    nested = repository / "skills"
+    if nested.is_dir():
+        if any(repository.glob("*/SKILL.md")):
+            raise ContractError("organization skill repository has ambiguous nested and top-level layouts")
+        return nested
+    return repository
+
+
+def organization_source_identity(value):
+    from urllib.parse import urlsplit
+    value = str(value)
+    if "://" in value:
+        parsed = urlsplit(value)
+        host, path = parsed.hostname or "", parsed.path
+        default_port = {"ssh": 22, "https": 443}.get(parsed.scheme)
+        if parsed.port is not None and parsed.port != default_port:
+            host += ":%s" % parsed.port
+    elif re.match(r"^[^@/]+@[^:/]+:", value):
+        host, path = value.split("@", 1)[1].split(":", 1)
+    else:
+        host, _, path = value.partition("/")
+    path = path.strip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    if not host or not path or ".." in path.split("/"):
+        raise ContractError("organization source identity is invalid")
+    return host.lower() + "/" + path
+
+
 def verify_org_copy(path, metadata, clients_wanted=None, source_repo=None):
     path = Path(path)
     if path.parent not in organization_skill_targets(clients_wanted) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", path.name):
@@ -1415,15 +1446,17 @@ def verify_org_copy(path, metadata, clients_wanted=None, source_repo=None):
     regular_tree(path)
     if path.exists():
         provenance = json.loads((path / ".source.json").read_text())
-        if provenance.get("source_type") != "organization" or provenance.get("source_repo") != metadata["repository"]:
+        if provenance.get("source_type") not in {"organization", "shared"} or organization_source_identity(provenance.get("source_repo")) != organization_source_identity(metadata["repository"]):
             raise ContractError("organization skill conflicts with an existing source: %s" % path.name)
         if metadata.get("sha256") and paths_digest([path]) != metadata["sha256"]:
             raise ContractError("organization skill was edited; preserved: %s" % path.name)
         if not metadata.get("sha256"):
             commit = provenance.get("source_commit", "")
-            prefix = "skills/%s/" % path.name
-            if source_repo is None or not re.fullmatch(r"[0-9a-f]{40}", commit) or provenance.get("source_path") != prefix + "SKILL.md":
+            source_path = provenance.get("source_path")
+            allowed = {"skills/%s/SKILL.md" % path.name, "%s/SKILL.md" % path.name}
+            if source_repo is None or not re.fullmatch(r"[0-9a-f]{40}", commit) or source_path not in allowed:
                 raise ContractError("organization skill has no verifiable ownership receipt; preserved: %s" % path.name)
+            prefix = source_path[:-len("SKILL.md")]
             listing = subprocess.run(["git", "-C", str(source_repo), "ls-tree", "-rz", commit, "--", prefix], capture_output=True)
             expected = {}
             if listing.returncode:
@@ -1482,7 +1515,12 @@ def phase_org_skills(report, manifest, receipts, dry_run, clients_wanted=None, j
         prepared[repo["name"]] = clone_or_update(report, "org-skills", [repo["repository"]], cache, dry_run)
         if prepared[repo["name"]] in {ERROR, WOULD}:
             continue
-        for skill in (cache / "skills").glob("*/SKILL.md"):
+        try:
+            skill_directory = organization_skill_directory(cache)
+        except ContractError as exc:
+            report.add("org-skills", ERROR, str(exc))
+            return
+        for skill in skill_directory.glob("*/SKILL.md"):
             for parent in targets:
                 target = str(parent / skill.parent.name)
                 if target in owners and owners[target] != repo["repository"]:
@@ -1533,12 +1571,12 @@ def phase_org_skills(report, manifest, receipts, dry_run, clients_wanted=None, j
             continue
         rc, _, _ = run(["sh", str(installer), "status"], env=env, timeout=300)
         source_names = [
-            path.parent.name for path in (cache / "skills").glob("*/SKILL.md")
+            path.parent.name for path in organization_skill_directory(cache).glob("*/SKILL.md")
         ]
         owned = receipts.data.setdefault("org_skill_copies", {})
         current_targets = {str(target / name) for target in target_paths for name in source_names}
         try:
-            regular_tree(cache / "skills")
+            regular_tree(organization_skill_directory(cache))
             for target in target_paths:
                 for name in source_names:
                     installed = target / name

--- a/skills/synthesis-onboarding/scripts/organization.py
+++ b/skills/synthesis-onboarding/scripts/organization.py
@@ -70,9 +70,14 @@ def acquire_repository(
     data_root: Path,
     expected_commit: str | None = None,
     refresh: bool = True,
+    restore_commit: bool = False,
 ) -> tuple[Path, str]:
     """Clone or fast-forward a data-only org repository and return its commit."""
     validate_repository_url(url)
+    if expected_commit is not None and not re.fullmatch(r"[0-9a-f]{40}", expected_commit):
+        raise ContractError("organization commit must be an exact commit identity")
+    if restore_commit and not expected_commit:
+        raise ContractError("organization repair requires its recorded commit")
     slug = repository_slug(url)
     data_root = Path(data_root)
     data_root.mkdir(parents=True, exist_ok=True)
@@ -104,6 +109,10 @@ def acquire_repository(
             else:
                 branch = _git("symbolic-ref", "--short", "refs/remotes/origin/HEAD", cwd=root)
                 _git("checkout", "--detach", branch, cwd=root)
+        elif restore_commit:
+            if not _git("branch", "-r", "--contains", expected_commit, cwd=root):
+                raise ContractError("recorded organization commit has no fetched source provenance")
+            _git("checkout", "--detach", expected_commit, cwd=root)
     else:
         if not refresh:
             raise ContractError("organization repository is not installed")

--- a/skills/synthesis-onboarding/scripts/synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/synthesis_cli.py
@@ -11,12 +11,15 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
 import onboard
 import organization
+from enrollment import (EnrollmentJournal, recover_enrollments, require_settled_enrollments,
+                        engine_lock, engine_state_root, recover_copy_transactions)
 from system_contract import (
     DESCRIPTOR_FIELDS,
     LAUNCHER_MARK,
@@ -24,12 +27,14 @@ from system_contract import (
     ContractError,
     SystemState,
     active_release_descriptor,
+    atomic_write_json,
     consume_invite,
     describe_personal_instruction_source,
     default_desired_state,
     json_digest,
     personal_instruction_source_path,
     validate_invite,
+    validate_additive_organization as _validate_additive_organization,
     validate_desired_state,
     validate_repository_url,
     verify_materialized_release,
@@ -37,10 +42,11 @@ from system_contract import (
 )
 
 
-ENGINE_VERSION = "2.2.0"
+ENGINE_VERSION = "2.3.0"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CLI_COMMANDS = (
     "setup",
+    "enroll",
     "update",
     "repair",
     "status",
@@ -103,6 +109,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="archive and replace an existing unreceipted workspace instruction pair",
     )
     _common_output(setup)
+
+    enroll = commands.add_parser("enroll", help="add an organization without reinitializing personal layers")
+    org_source = enroll.add_mutually_exclusive_group(required=True)
+    org_source.add_argument("--org-repo")
+    org_source.add_argument("--invite", type=Path)
+    overlay = enroll.add_mutually_exclusive_group()
+    overlay.add_argument("--personal-instruction-source", type=Path)
+    overlay.add_argument("--clear-personal-instruction-source", action="store_true")
+    enroll.add_argument("--adopt-workspace-instructions", action="store_true")
+    _common_output(enroll)
 
     for name in ("update", "repair"):
         sub = commands.add_parser(name, help="%s the declared installation" % name)
@@ -754,6 +770,7 @@ def _prepare_organization(
     desired: dict[str, Any],
     *,
     verify_only: bool = False,
+    restore_commit: bool = False,
 ) -> tuple[dict[str, Any], Path | None, dict[str, Any] | None]:
     organizations = desired.get("organizations") or []
     if not organizations:
@@ -767,13 +784,16 @@ def _prepare_organization(
         organization.default_data_root(state.home),
         expected_commit=expected,
         refresh=not verify_only,
+        **({"restore_commit": True} if restore_commit else {}),
     )
     manifest_path = root / organization.MANIFEST_RELATIVE
     manifest = onboard.load_manifest(manifest_path)
+    if entry.get("mode") == "additive":
+        _validate_additive_organization(desired, manifest, entry)
     entry["commit"] = commit
     updated = dict(desired)
     updated["organizations"] = [entry]
-    if not verify_only:
+    if not verify_only and entry.get("mode") != "additive":
         ecosystem = manifest.get("ecosystem") or {}
         updated["clients"] = sorted(
             set(ecosystem.get("clients", ["claude", "codex"]))
@@ -784,6 +804,102 @@ def _prepare_organization(
         }
     validate_desired_state(updated)
     return updated, manifest_path, manifest
+
+
+@contextlib.contextmanager
+def _proposed_state(state, desired):
+    state.state_dir.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="proposed-", dir=state.state_dir) as directory:
+        path = Path(directory) / "desired.json"
+        atomic_write_json(path, desired)
+        yield path
+
+
+def _enroll(args, argv, state, engine_runner):
+    with state.locked(), engine_lock(engine_state_root(state.home)):
+        base = state.read_desired()
+        if not base or not base["enabled"]:
+            raise ContractError("enrollment requires an existing enabled installation; run synthesis setup")
+        invite = validate_invite(json.loads(args.invite.read_text())) if args.invite else None
+        repository = invite["repository"] if invite else args.org_repo
+        validate_repository_url(repository)
+        previous = (base.get("organizations") or [None])[0]
+        if previous and organization.canonical_remote(previous["repository"]) != organization.canonical_remote(repository):
+            raise ContractError("an organization is already enrolled; replacement is not additive")
+        active = _active_release()
+        if active and not _active_matches_policy(active, base):
+            raise RebootstrapRequired(base["release"]["channel"], base["release"]["version_pin"])
+        expected = invite.get("repository_commit") if invite else None
+        if previous and previous.get("commit_policy") == "pinned":
+            if expected and expected != previous["commit"]:
+                raise ContractError("enrollment cannot replace a pinned organization commit")
+            expected = previous["commit"]
+        root, commit = organization.acquire_repository(
+            repository, organization.default_data_root(state.home), expected_commit=expected,
+        )
+        manifest_path = root / organization.MANIFEST_RELATIVE
+        manifest = onboard.load_manifest(manifest_path)
+        entry = {"repository": repository, "manifest_path": organization.MANIFEST_RELATIVE,
+                 "commit_policy": "pinned" if expected else "floating", "commit": commit,
+                 "mode": "additive", "workspace": manifest["org"]["workspace"]}
+        if previous and previous.get("workspace") and previous["workspace"] != entry["workspace"]:
+            raise ContractError("organization workspace changed; refusing replacement")
+        _validate_additive_organization(base, manifest, entry)
+        desired = {**base, "organizations": [entry],
+                   "layers": {**base["layers"], "organization": "selected"}}
+        if args.clear_personal_instruction_source:
+            if args.adopt_workspace_instructions:
+                raise ContractError("workspace instruction adoption cannot clear the personal instruction source")
+            desired["personal_instruction_source"] = None
+        elif args.personal_instruction_source:
+            desired["personal_instruction_source"] = describe_personal_instruction_source(args.personal_instruction_source)
+        validate_desired_state(desired)
+        workspaces = Path(os.environ.get("SYNTHESIS_WORKSPACES_ROOT", str(state.home / "workspaces")))
+        receipts = Path(os.environ.get("SYNTHESIS_ONBOARD_STATE_DIR", str(state.home / ".synthesis/onboarding"))) / "receipts.json"
+        pair = [workspaces / entry["workspace"] / name for name in ("AGENTS.md", "CLAUDE.md")]
+        parents = [state.home / (".claude" if c == "claude" else ".agents") / "skills" for c in base["clients"]]
+        journal = None
+
+        def operation(tx):
+            nonlocal journal
+            journal = EnrollmentJournal.create(
+                state.state_dir / "enrollments", tx["transaction_id"], base,
+                files=[*pair, receipts, state.invites_path, state.desired_path],
+                skill_parents=parents, proposed=desired,
+            )
+            journal.validate_scope(state, desired)
+            for path in (state.desired_path, state.invites_path, receipts, *pair):
+                journal.capture(path)
+            if invite:
+                consume_invite(invite, state, already_locked=True)
+            details = {}
+            with _proposed_state(state, desired) as proposed:
+                for command in ("enroll", "doctor"):
+                    engine_args = _engine_args(desired, command, args, desired_state_path=proposed)
+                    engine_args.extend(["--manifest", str(manifest_path)])
+                    if command == "enroll":
+                        engine_args.extend(["--enrollment-journal", str(journal.root)])
+                    code, result = _execute_engine(engine_runner, engine_args)
+                    if code:
+                        raise EngineFailure(code)
+                    if result is not None:
+                        details[command] = result
+            result = _planes(desired, "enroll")
+            result.update({"_desired": desired, "details": {"engine": details,
+                "enrollment_journal": str(journal.root)}})
+            return result
+
+        def rollback(_error):
+            if journal is not None:
+                # The engine writes additional exact targets to the journal.
+                recovered = EnrollmentJournal(journal.root)
+                recovered.validate_scope(state, base)
+                recovered.rollback()
+
+        transaction = state.run_transaction("enroll", desired, operation,
+                                            rollback=rollback, already_locked=True)
+        EnrollmentJournal(journal.root).commit()
+        return transaction
 
 
 def _active_matches_policy(active: dict[str, Any], desired: dict[str, Any]) -> bool:
@@ -1025,6 +1141,20 @@ def main(
         lambda engine_args: _quiet_engine_runner(engine_args, verbose=args.verbose)
     )
     try:
+        if args.command in {"setup", "enroll", "update", "repair", "workspace", "uninstall"}:
+            with state.locked(), engine_lock(engine_state_root(state.home)):
+                recover_copy_transactions(engine_state_root(state.home), state.home)
+                recover_enrollments(state)
+        if args.command == "enroll":
+            try:
+                transaction = _enroll(args, argv, state, engine_runner)
+            except RebootstrapRequired as exc:
+                active = _active_release()
+                if active is None:
+                    raise ContractError("enrollment cannot transfer to its selected release")
+                return _run_release_bootstrap(argv, active, exc.channel, exc.version_pin)
+            _render(transaction, args.json)
+            return 0
         if args.command == "update":
             transferred = _bootstrap_update(argv, state)
             if transferred is not None:
@@ -1048,6 +1178,8 @@ def main(
                 expected_commit = invite.get("repository_commit")
             if repository:
                 validate_repository_url(repository)
+                if args.profile == "skills-only":
+                    raise ContractError("set up skills-only first, then use synthesis enroll to add an organization")
             else:
                 # Without an organization the release policy is fully known
                 # here, so a needed transfer to the bootstrap happens before
@@ -1248,7 +1380,8 @@ def main(
 
                     def update_operation(_transaction: dict[str, Any]) -> dict[str, Any]:
                         resolved, manifest_path, _manifest = _prepare_organization(
-                            state, desired, verify_only=args.command == "repair"
+                            state, desired, verify_only=args.command == "repair",
+                            restore_commit=args.command == "repair",
                         )
                         active = _active_release()
                         if active and not _active_matches_policy(active, resolved):
@@ -1256,19 +1389,19 @@ def main(
                             raise RebootstrapRequired(
                                 release["channel"], release.get("version_pin")
                             )
-                        engine_args = _engine_args(
-                            resolved,
-                            args.command,
-                            args,
-                            desired_state_path=(
-                                None if migrated_legacy else state.desired_path
-                            ),
+                        # The engine must see the newly resolved commit,
+                        # clients and policy, not the preceding generation.
+                        proposed_context = (
+                            _proposed_state(state, resolved) if resolved != desired
+                            else contextlib.nullcontext(None if migrated_legacy else state.desired_path)
                         )
-                        if resolved["release"] != desired["release"]:
-                            engine_args.append("--policy-transition")
-                        if manifest_path:
-                            engine_args.extend(["--manifest", str(manifest_path)])
-                        code, engine_details = _execute_engine(engine_runner, engine_args)
+                        with proposed_context as desired_path:
+                            engine_args = _engine_args(resolved, args.command, args, desired_state_path=desired_path)
+                            if resolved["release"] != desired["release"]:
+                                engine_args.append("--policy-transition")
+                            if manifest_path:
+                                engine_args.extend(["--manifest", str(manifest_path)])
+                            code, engine_details = _execute_engine(engine_runner, engine_args)
                         if code:
                             raise EngineFailure(code)
                         result = _planes(resolved, args.command)
@@ -1365,6 +1498,7 @@ def main(
 
         if args.command == "doctor":
             with state.locked():
+                require_settled_enrollments(state)
                 desired = state.read_desired()
                 if desired is None:
                     raise ContractError("no desired state exists; run synthesis setup")

--- a/skills/synthesis-onboarding/scripts/system_contract.py
+++ b/skills/synthesis-onboarding/scripts/system_contract.py
@@ -37,7 +37,7 @@ TRUTH_PLANES = (
     "live-loaded",
     "outcome-verified",
 )
-TRANSACTION_COMMANDS = {"setup", "update", "repair", "workspace-ensure", "uninstall"}
+TRANSACTION_COMMANDS = {"setup", "enroll", "update", "repair", "workspace-ensure", "uninstall"}
 SAFE_IDENTIFIER_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 HEX40_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -768,15 +768,13 @@ def default_desired_state(
     personal_instruction_source = validate_personal_instruction_source(
         personal_instruction_source
     )
-    if personal_instruction_source is not None and (
-        profile != "full" or not organization_entries
-    ):
+    if personal_instruction_source is not None and not organization_entries:
         raise ContractError(
-            "a personal instruction source requires a full organization setup"
+            "a personal instruction source requires an organization"
         )
     if layers is None:
         selected = set(PROFILE_LAYERS[profile])
-        if profile == "full" and organization_entries:
+        if organization_entries:
             selected.add("organization")
         layers = {
             layer_id: "selected" if layer_id in selected else "declined"
@@ -867,16 +865,12 @@ def validate_desired_state(value: Any) -> dict[str, Any]:
         raise ContractError("desired state organizations must be a list")
     if len(organizations) > 1:
         raise ContractError("desired state supports at most one organization")
-    if profile == "skills-only" and organizations:
-        raise ContractError("skills-only desired state cannot enroll an organization")
-    if instruction_source is not None and (
-        profile != "full" or not organizations
-    ):
+    if instruction_source is not None and not organizations:
         raise ContractError(
-            "a personal instruction source requires a full organization setup"
+            "a personal instruction source requires an organization"
         )
     selected_layers = set(PROFILE_LAYERS[profile])
-    if profile == "full" and organizations:
+    if organizations:
         selected_layers.add("organization")
     expected_layers = {
         layer_id: "selected" if layer_id in selected_layers else "declined"
@@ -887,8 +881,8 @@ def validate_desired_state(value: Any) -> dict[str, Any]:
     for index, entry_value in enumerate(organizations):
         entry = _require_mapping(entry_value, "desired state organizations[%d]" % index)
         fields = {"repository", "manifest_path", "commit_policy", "commit"}
-        _reject_unknown(entry, fields, "desired state organizations[%d]" % index)
-        if set(entry) != fields:
+        _reject_unknown(entry, fields | {"mode", "workspace"}, "desired state organizations[%d]" % index)
+        if not fields <= set(entry):
             raise ContractError("desired state organizations[%d] is incomplete" % index)
         validate_repository_url(entry.get("repository"))
         if entry.get("manifest_path") != ".agents/onboarding.yaml":
@@ -897,7 +891,33 @@ def validate_desired_state(value: Any) -> dict[str, Any]:
             raise ContractError("desired state organization commit policy is invalid")
         if not HEX40_RE.fullmatch(str(entry.get("commit") or "")):
             raise ContractError("desired state organization commit is invalid")
+        if "mode" in entry or "workspace" in entry:
+            if entry.get("mode") != "additive":
+                raise ContractError("desired state organization mode is invalid")
+            safe_identifier(entry.get("workspace"), "desired state organization workspace")
+            if entry["workspace"] == workspace:
+                raise ContractError("organization workspace collides with personal workspace")
+        elif profile == "skills-only":
+            raise ContractError("skills-only organization enrollment must be additive")
     return value
+
+
+def validate_additive_organization(desired, manifest, entry):
+    """An organization overlay cannot take over the installation's policy."""
+    ecosystem = manifest.get("ecosystem") or {}
+    policy = {"channel": ecosystem.get("channel", "stable"),
+              "version_pin": ecosystem.get("version_pin")}
+    if policy != desired["release"]:
+        raise ContractError("organization release policy conflicts with the existing installation")
+    if sorted(ecosystem.get("clients", ["claude", "codex"])) != sorted(desired["clients"]):
+        raise ContractError("organization clients conflict with the existing installation")
+    if ecosystem.get("plugin", True) is not True:
+        raise ContractError("organization cannot disable the existing public plugin")
+    workspace = manifest["org"]["workspace"]
+    if workspace == desired.get("personal_workspace"):
+        raise ContractError("organization workspace collides with personal workspace")
+    if entry.get("workspace") != workspace:
+        raise ContractError("organization workspace changed; refusing replacement")
 
 
 def validate_personal_instruction_source(value: Any) -> dict[str, str] | None:
@@ -1389,6 +1409,7 @@ class SystemState:
                     else:
                         atomic_write_bytes(self.desired_path, old_desired)
                 transaction["state"] = "aborted"
+                observation["generation"] = transaction["previous_active_generation"] or 0
                 transaction["error"] = str(exc)
                 if rollback is not None:
                     details = dict(transaction.get("details") or {})
@@ -1885,6 +1906,7 @@ def materialize_instruction_pair(
     previous_receipt: dict[str, Any] | None = None,
     fail_after_first: bool = False,
     source_identities: dict[str, dict[str, Any]] | None = None,
+    validate_only: bool = False,
 ) -> dict[str, Any]:
     graph = _require_mapping(graph, "instruction graph")
     source_identities = source_identities or {}
@@ -1899,13 +1921,14 @@ def materialize_instruction_pair(
     workspace = Path(workspace)
     if workspace.is_symlink():
         raise ContractError("workspace must not be a symbolic link")
-    workspace.mkdir(parents=True, exist_ok=True)
     targets = [workspace / "AGENTS.md", workspace / "CLAUDE.md"]
     if any(target.is_symlink() for target in targets):
         raise DriftError("instruction output is a symbolic link")
     if previous_receipt:
         expected_outputs = previous_receipt.get("outputs") or {}
         for target in targets:
+            if (expected_outputs.get(target.name) or {}).get("path") != str(target):
+                raise DriftError("instruction receipt belongs to a different workspace")
             expected = (expected_outputs.get(target.name) or {}).get("sha256")
             if expected is None or not target.is_file() or file_digest(target) != expected:
                 raise DriftError("instruction output drift: %s" % target.name)
@@ -1958,6 +1981,8 @@ def materialize_instruction_pair(
         )
     rendered = ("\n".join(parts).rstrip() + "\n").encode("utf-8")
     rendered_digest = hashlib.sha256(rendered).hexdigest()
+    if validate_only:
+        return {"schema_version": 1, "sources": source_receipts, "validated": True}
     if previous_receipt:
         expected_outputs = previous_receipt.get("outputs") or {}
         if all(
@@ -1979,6 +2004,7 @@ def materialize_instruction_pair(
             )
         )
     temporary_paths = []
+    workspace.mkdir(parents=True, exist_ok=True)
     try:
         for target in targets:
             with tempfile.NamedTemporaryFile(

--- a/skills/synthesis-onboarding/scripts/test_additive_enrollment.py
+++ b/skills/synthesis-onboarding/scripts/test_additive_enrollment.py
@@ -533,6 +533,64 @@ def test_legacy_org_copy_adoption_verifies_recorded_source_bytes(box, edited):
         assert str(target.parent) in json.loads(receipts_path.read_text())["org_skill_copies"]
 
 
+@pytest.mark.parametrize("edited", [False, True])
+def test_flat_shared_repository_adoption_proves_source_bytes(box, edited):
+    import shutil
+    source = box.root / "skills-src"
+    subprocess.run(["git", "-C", str(source), "mv", "skills/example-skill", "example-skill"],
+        env=box.git_env, check=True)
+    box._commit_all(source, "fixture layout")
+    subprocess.run(["git", "-C", str(source), "push", str(box.skills_remote), "main"],
+        env=box.git_env, capture_output=True, check=True)
+    commit = subprocess.check_output(["git", "-C", str(source), "rev-parse", "HEAD"], text=True).strip()
+    for client in (".claude", ".agents"):
+        target = box.home / client / "skills/example-skill"
+        target.parent.mkdir(parents=True)
+        shutil.copytree(source / "example-skill", target)
+        (target / ".source.json").write_text(json.dumps({"source_type": "shared",
+            "source_repo": "fixture/example-shared-skills", "source_path": "example-skill/SKILL.md",
+            "source_commit": commit, "installed_by": "install.sh"}))
+        if edited:
+            (target / "SKILL.md").write_text("personal modification\n")
+    manifest = box.manifest()
+    result = box.run_engine("install", "--manifest", str(manifest), "--json")
+    assert result.returncode == (1 if edited else 0), result.stdout + result.stderr
+    for client in (".claude", ".agents"):
+        target = box.home / client / "skills/example-skill"
+        if edited:
+            assert (target / "SKILL.md").read_text() == "personal modification\n"
+        else:
+            receipt = json.loads((box.home / ".synthesis/onboarding/receipts.json").read_text())
+            assert receipt["org_skill_copies"][str(target)]["repository"] == box.skills_url
+    if not edited:
+        box.run_engine("repair", "--manifest", str(manifest), expect=0)
+        box.run_engine("uninstall", expect=0)
+        assert not (box.home / ".agents/skills/example-skill").exists()
+
+
+def test_organization_source_identity_keeps_host_path_and_nondefault_port():
+    identity = cli.onboard.organization_source_identity
+    assert identity("git@example.test:team/config.git") == identity("example.test/team/config")
+    assert identity("ssh://git@example.test:22/team/config.git") == identity("https://example.test/team/config.git")
+    assert identity("ssh://git@example.test:222/team/config.git") != identity("example.test/team/config")
+    assert identity("other.test/team/config") != identity("example.test/team/config")
+    assert identity("example.test/other/config") != identity("example.test/team/config")
+
+
+def test_mixed_organization_skill_layout_refuses_before_copies(box):
+    source = box.root / "skills-src"
+    (source / "other-skill").mkdir()
+    (source / "other-skill/SKILL.md").write_text("ambiguous second layout\n")
+    box._commit_all(source, "fixture ambiguity")
+    subprocess.run(["git", "-C", str(source), "push", str(box.skills_remote), "main"],
+        env=box.git_env, capture_output=True, check=True)
+    manifest = box.manifest()
+    result = box.run_engine("install", "--manifest", str(manifest), "--json")
+    assert result.returncode != 0
+    assert not (box.home / ".agents/skills/example-skill").exists()
+    assert not (box.home / ".agents/skills/other-skill").exists()
+
+
 def test_two_org_sources_cannot_own_the_same_skill_target(box):
     import yaml
     manifest = box.manifest()

--- a/skills/synthesis-onboarding/scripts/test_additive_enrollment.py
+++ b/skills/synthesis-onboarding/scripts/test_additive_enrollment.py
@@ -1,0 +1,769 @@
+"""Defect-pinned additive enrollment boundaries, independent of setup."""
+
+import copy
+import errno
+from datetime import datetime, timedelta, timezone
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import synthesis_cli as cli
+import system_contract as contract
+from test_synthesis_cli import full_configuration
+from test_onboard import Sandbox
+
+
+REPOSITORY = "https://example.test/team/config.git"
+
+
+def base_state(tmp_path, profile="skills-only"):
+    state = contract.SystemState(home=tmp_path)
+    desired = contract.default_desired_state(
+        profile, ["codex"], "stable",
+        personal_workspace="personal" if profile == "full" else None,
+        personal_configuration=full_configuration() if profile == "full" else None,
+    )
+    state.run_transaction("setup", desired, lambda _tx: {})
+    return state, desired
+
+
+def org_fixture(tmp_path, monkeypatch):
+    root = tmp_path / "org-source"
+    root.mkdir()
+    manifest = {
+        "org": {"workspace": "example-team"},
+        "ecosystem": {"clients": ["codex"], "channel": "stable", "version_pin": None},
+    }
+    monkeypatch.setattr(cli.organization, "acquire_repository", lambda *a, **k: (root, "1" * 40))
+    monkeypatch.setattr(cli.onboard, "load_manifest", lambda _path: manifest)
+    monkeypatch.setattr(cli, "_active_release", lambda: None)
+    return manifest
+
+
+@pytest.mark.parametrize("profile", ["skills-only", "full"])
+def test_enroll_preserves_base_and_replays_overlay(tmp_path, monkeypatch, profile):
+    state, base = base_state(tmp_path, profile)
+    org_fixture(tmp_path, monkeypatch)
+    calls = []
+
+    def engine(argv):
+        assert argv[0] != "init"
+        proposed = json.loads(Path(argv[argv.index("--desired-state") + 1]).read_text())
+        calls.append((argv, proposed))
+        return 0
+
+    assert cli.main(["enroll", "--org-repo", REPOSITORY], state=state, engine_runner=engine) == 0
+    enrolled = state.read_desired()
+    for key, value in base.items():
+        if key not in {"organizations", "layers"}:
+            assert enrolled[key] == value, key
+    assert enrolled["layers"] == {**base["layers"], "organization": "selected"}
+    assert enrolled["organizations"][0] == {
+        "repository": REPOSITORY, "manifest_path": ".agents/onboarding.yaml",
+        "commit_policy": "floating", "commit": "1" * 40,
+        "mode": "additive", "workspace": "example-team",
+    }
+    assert [argv[0] for argv, _ in calls] == ["enroll", "doctor"]
+    assert all(proposed == enrolled for _, proposed in calls)
+    for command in ("update", "repair", "doctor"):
+        # The fixture has no genuine client SessionStart receipt. Doctor
+        # reaches the correct engine but must still report restart-required.
+        assert cli.main([command], state=state, engine_runner=engine) == (1 if command == "doctor" else 0)
+        assert state.read_desired() == enrolled
+    assert cli.main(["enroll", "--org-repo", REPOSITORY], state=state, engine_runner=engine) == 0
+    assert state.read_desired() == enrolled
+
+
+@pytest.mark.parametrize("enabled", [None, False])
+def test_enroll_requires_existing_enabled_state(tmp_path, monkeypatch, capsys, enabled):
+    state = contract.SystemState(home=tmp_path)
+    if enabled is False:
+        desired = contract.default_desired_state("skills-only", ["codex"], "stable", enabled=False)
+        state.run_transaction("setup", desired, lambda _tx: {})
+    calls = []
+    assert cli.main(["enroll", "--org-repo", REPOSITORY], state=state, engine_runner=lambda a: calls.append(a)) == 2
+    assert "existing enabled" in capsys.readouterr().err
+    assert calls == []
+
+
+@pytest.mark.parametrize("conflict", ["clients", "channel", "pin", "workspace"])
+def test_enroll_conflict_is_pre_mutation(tmp_path, monkeypatch, capsys, conflict):
+    state, base = base_state(tmp_path, "full")
+    manifest = org_fixture(tmp_path, monkeypatch)
+    if conflict == "clients":
+        manifest["ecosystem"]["clients"] = ["claude", "codex"]
+    elif conflict == "channel":
+        manifest["ecosystem"]["channel"] = "edge"
+    elif conflict == "pin":
+        manifest["ecosystem"]["version_pin"] = "1.2.3"
+    else:
+        manifest["org"]["workspace"] = "personal"
+    calls = []
+    assert cli.main(["enroll", "--org-repo", REPOSITORY], state=state, engine_runner=lambda a: calls.append(a)) == 2
+    assert calls == []
+    assert state.read_desired() == base
+    assert capsys.readouterr().err
+
+
+def test_additive_replay_refuses_policy_and_workspace_changes(tmp_path, monkeypatch):
+    state, _ = base_state(tmp_path)
+    manifest = org_fixture(tmp_path, monkeypatch)
+    assert cli.main(["enroll", "--org-repo", REPOSITORY], state=state, engine_runner=lambda a: 0) == 0
+    baseline = state.desired_path.read_bytes()
+    for field, value in (("channel", "edge"), ("clients", ["claude"]), ("version_pin", "1.0.0")):
+        original = manifest["ecosystem"][field]
+        manifest["ecosystem"][field] = value
+        for command in ("update", "repair", "doctor"):
+            calls = []
+            assert cli.main([command], state=state, engine_runner=lambda a: calls.append(a)) == 2
+            assert not calls
+            assert state.desired_path.read_bytes() == baseline
+        manifest["ecosystem"][field] = original
+    manifest["org"]["workspace"] = "another-team"
+    assert cli.main(["update"], state=state, engine_runner=lambda a: pytest.fail("engine ran")) == 2
+    assert state.desired_path.read_bytes() == baseline
+    assert cli.main(["enroll", "--org-repo", "https://example.test/other/config.git"], state=state, engine_runner=lambda a: pytest.fail("engine ran")) == 2
+
+
+@pytest.mark.parametrize("failure", ["engine", "doctor", "commit"])
+def test_enroll_failure_restores_generated_files_and_desired(tmp_path, monkeypatch, failure):
+    state, _ = base_state(tmp_path)
+    org_fixture(tmp_path, monkeypatch)
+    baseline = state.desired_path.read_bytes()
+    target = tmp_path / "workspaces/example-team/AGENTS.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("custom original\n")
+    original_save = state._save_observation
+
+    def save(observation):
+        if failure == "commit" and observation["transactions"][-1]["command"] == "enroll" and observation["transactions"][-1]["state"] == "committed":
+            raise OSError("commit fixture")
+        return original_save(observation)
+
+    monkeypatch.setattr(state, "_save_observation", save)
+
+    def engine(argv):
+        if argv[0] == "enroll":
+            from enrollment import EnrollmentJournal
+            journal = EnrollmentJournal(Path(argv[argv.index("--enrollment-journal") + 1]))
+            journal.capture(target)
+            target.write_text("generated\n")
+            return 1 if failure == "engine" else 0
+        return 1 if failure == "doctor" else 0
+
+    assert cli.main(["enroll", "--org-repo", REPOSITORY], state=state, engine_runner=engine) != 0
+    assert target.read_text() == "custom original\n"
+    assert state.desired_path.read_bytes() == baseline
+    latest = state.read_observation()["transactions"][-1]
+    assert latest["state"] == "aborted"
+    assert latest["details"]["rollback"]["status"] == "restored"
+    assert state.read_observation()["generation"] == 1
+
+
+def test_skills_only_overlay_matches_runtime_and_schema(tmp_path):
+    desired = contract.default_desired_state(
+        "skills-only", ["codex"], "stable",
+        organizations=[{
+            "repository": REPOSITORY, "manifest_path": ".agents/onboarding.yaml",
+            "commit_policy": "floating", "commit": "1" * 40,
+            "mode": "additive", "workspace": "example-team",
+        }],
+        personal_instruction_source={"repository": str(tmp_path / "private"), "path": ".agents/instructions.md"},
+    )
+    assert contract.validate_desired_state(desired) == desired
+    import jsonschema
+    schema = json.loads((Path(__file__).parents[1] / "references/system-state.schema.json").read_text())
+    jsonschema.validate(desired, schema)
+    invalid = copy.deepcopy(desired)
+    invalid["layers"]["agent-kernel"] = "selected"
+    with pytest.raises(contract.ContractError):
+        contract.validate_desired_state(invalid)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(invalid, schema)
+
+
+@pytest.fixture
+def box():
+    value = Sandbox()
+    # Use macOS's canonical temporary root; user-controlled symlinks remain
+    # forbidden by the enrollment journal.
+    for name in ("root", "home", "remotes", "cache"):
+        setattr(value, name, getattr(value, name).resolve())
+    yield value
+    value.cleanup()
+
+
+def engine_desired(box):
+    manifest = box.manifest()
+    manifest.write_text(manifest.read_text() + "\necosystem:\n  plugin: true\n  clients: [codex]\n  channel: stable\n")
+    box._commit_all(manifest.parents[1], "fixture policy")
+    commit = subprocess.check_output(["git", "-C", str(manifest.parents[1]), "rev-parse", "HEAD"], text=True).strip()
+    desired = contract.default_desired_state("skills-only", ["codex"], "stable",
+        organizations=[{"repository": REPOSITORY, "manifest_path": ".agents/onboarding.yaml",
+            "commit_policy": "floating", "commit": commit, "mode": "additive", "workspace": "exampleco"}])
+    path = box.root / "desired.json"
+    contract.atomic_write_json(path, desired)
+    return manifest, desired, path
+
+
+def test_real_engine_enroll_and_repair_preserve_personal_files_and_receipts(box):
+    from enrollment import EnrollmentJournal
+    manifest, desired, path = engine_desired(box)
+    state = contract.SystemState(home=box.home)
+    receipt_path = box.home / ".synthesis/onboarding/receipts.json"
+    original = {"version": 1, "profile": "custom", "personal_workspace": "independent",
+        "component_choices": {"day-end": {"choice": "selected", "custom": "preserve"}},
+        "layer_choices": {"agent-kernel": {"choice": "selected", "custom": "preserve"}},
+        "generated_files": {}, "adoptions": {}}
+    contract.atomic_write_json(receipt_path, original)
+    sentinels = [box.home / p for p in (
+        ".agents/AGENTS.md", ".claude/CLAUDE.md", ".synthesis/personal-policy/profile.json",
+        ".synthesis/day-end/config.json", ".synthesis/agent-control/AGENTS.source.md")]
+    for sentinel in sentinels:
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.write_bytes(b"custom personal bytes\n")
+    # Unselected client copies are independent user data, including .codex.
+    untouched = [box.home / p / "skills/example-skill/SKILL.md" for p in (".claude", ".codex")]
+    for item in untouched:
+        item.parent.mkdir(parents=True, exist_ok=True)
+        item.write_text("independent client skill\n")
+    pair = [box.home / "workspaces/exampleco" / n for n in ("AGENTS.md", "CLAUDE.md")]
+    journal = EnrollmentJournal.create(state.state_dir / "enrollments", "a" * 32,
+        contract.default_desired_state("skills-only", ["codex"], "stable"),
+        files=[receipt_path, *pair], skill_parents=[box.home / ".agents/skills"], proposed=desired)
+    binary = box.fake_client()
+    box.seed_currency()
+    extra = {"SYNTHESIS_CODEX_BIN": str(binary)}
+    result = box.run_with_env(extra, "enroll", "--manifest", str(manifest), "--clients", "codex",
+        "--desired-state", str(path), "--enrollment-journal", str(journal.root), "--json")
+    assert result.returncode == 0, result.stdout + result.stderr
+    for command in ("repair",):
+        result = box.run_with_env(extra, command, "--manifest", str(manifest), "--clients", "codex",
+            "--desired-state", str(path), "--json")
+        assert result.returncode == 0, result.stdout + result.stderr
+    receipt = json.loads(receipt_path.read_text())
+    for key in ("profile", "personal_workspace", "component_choices", "layer_choices"):
+        assert receipt[key] == original[key]
+    assert all(s.read_bytes() == b"custom personal bytes\n" for s in sentinels)
+    assert all(s.read_text() == "independent client skill\n" for s in untouched)
+    assert (box.home / ".agents/skills/example-skill/SKILL.md").is_file()
+    assert pair[0].read_bytes() == pair[1].read_bytes()
+    result = box.run_with_env(extra, "uninstall", "--clients", "codex", "--json")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not (box.home / ".agents/skills/example-skill").exists()
+    assert all(s.read_bytes() == b"custom personal bytes\n" for s in sentinels)
+    assert all(s.read_text() == "independent client skill\n" for s in untouched)
+
+
+def test_organization_copy_never_retires_unselected_clients(box):
+    source = box.root / "skills-source"
+    (source / "skills/example-skill").mkdir(parents=True)
+    (source / "skills/example-skill/SKILL.md").write_text("organization skill\n")
+    for client in (".claude", ".codex"):
+        target = box.home / client / "skills/example-skill"
+        target.mkdir(parents=True)
+        (target / "SKILL.md").write_text("personal sentinel\n")
+    binary = box.root / "enabled-client"
+    binary.write_text("#!/bin/sh\nprintf '%s\\n' '[{\"id\":\"synthesis-skills@synthesis-engineering\",\"name\":\"synthesis-skills\",\"enabled\":true}]'\n")
+    binary.chmod(0o755)
+    env = {**os.environ, **box.env_overrides(), "SYNTHESIS_SKILLS_SOURCE_DIR": str(source),
+        "SYNTHESIS_SKILLS_HOME": str(box.home), "SYNTHESIS_SKILLS_SOURCE_TYPE": "organization",
+        "SYNTHESIS_SKILLS_SOURCE_REPO": REPOSITORY, "SYNTHESIS_SKILLS_TARGETS": str(box.home / ".agents/skills"),
+        "SYNTHESIS_CLAUDE_BIN": str(binary), "SYNTHESIS_CODEX_BIN": str(binary)}
+    result = subprocess.run(["sh", str(Path(__file__).with_name("direct_copy.sh")), "install"], env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    for client in (".claude", ".codex"):
+        assert (box.home / client / "skills/example-skill/SKILL.md").read_text() == "personal sentinel\n"
+
+
+@pytest.mark.parametrize("stage", ["pending", "desired-written", "committed"])
+def test_interrupted_enrollment_recovers_only_uncommitted_generation(tmp_path, stage):
+    from enrollment import EnrollmentJournal, recover_enrollments
+    state, base = base_state(tmp_path)
+    target = tmp_path / "workspaces/example-team/AGENTS.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("original\n")
+    proposed = {**base, "organizations": [{"repository": REPOSITORY,
+        "manifest_path": ".agents/onboarding.yaml", "commit_policy": "floating",
+        "commit": "1" * 40, "mode": "additive", "workspace": "example-team"}],
+        "layers": {**base["layers"], "organization": "selected"}}
+    observation = state.read_observation()
+    tx = {**observation["transactions"][-1], "transaction_id": "b" * 32, "generation": 2,
+        "command": "enroll", "desired_digest": contract.json_digest(proposed),
+        "state": "committed" if stage == "committed" else "pending"}
+    observation["transactions"].append(tx)
+    if stage == "committed":
+        observation["generation"] = 2
+    state._save_observation(observation)
+    journal = EnrollmentJournal.create(state.state_dir / "enrollments", tx["transaction_id"], base,
+        files=[target, state.desired_path], skill_parents=[], proposed=proposed)
+    journal.capture(state.desired_path)
+    journal.capture(target)
+    target.write_text("generated\n")
+    if stage in {"desired-written", "committed"}:
+        contract.atomic_write_json(state.desired_path, proposed)
+    with state.locked():
+        recover_enrollments(state)
+    assert target.read_text() == ("generated\n" if stage == "committed" else "original\n")
+    assert state.read_desired() == (proposed if stage == "committed" else base)
+    with state.locked():
+        recover_enrollments(state)
+
+
+def test_recovery_refuses_corrupt_backup_and_broad_target(tmp_path):
+    from enrollment import EnrollmentJournal, recover_enrollments
+    state, base = base_state(tmp_path)
+    target = tmp_path / "workspaces/example-team/AGENTS.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("original\n")
+    proposed = {**base, "organizations": [{"repository": REPOSITORY,
+        "manifest_path": ".agents/onboarding.yaml", "commit_policy": "floating",
+        "commit": "1" * 40, "mode": "additive", "workspace": "example-team"}],
+        "layers": {**base["layers"], "organization": "selected"}}
+    observation = state.read_observation()
+    observation["transactions"].append({**observation["transactions"][-1],
+        "transaction_id": "c" * 32, "generation": 2, "command": "enroll",
+        "desired_digest": contract.json_digest(proposed), "state": "pending"})
+    state._save_observation(observation)
+    journal = EnrollmentJournal.create(state.state_dir / "enrollments", "c" * 32, base,
+        files=[target], skill_parents=[], proposed=proposed)
+    journal.capture(target)
+    target.write_text("generated\n")
+    backup = journal.root / "before/0"
+    backup.write_text("corrupted backup\n")
+    with state.locked(), pytest.raises(contract.ContractError, match="backup"):
+        recover_enrollments(state)
+    assert target.read_text() == "generated\n"
+    journal.data["allowed_files"].append(str(tmp_path))
+    journal._save()
+    with state.locked(), pytest.raises(contract.ContractError, match="forbidden output"):
+        recover_enrollments(state)
+    assert target.exists()
+
+
+def test_enroll_does_not_pull_or_reconfigure_adopted_kb(box, monkeypatch):
+    manifest_path = box.manifest()
+    manifest = cli.onboard.load_manifest(manifest_path)
+    elsewhere = box.home / "workspaces/example-elsewhere" / manifest["knowledge_bases"][0]["name"]
+    elsewhere.parent.mkdir(parents=True)
+    env = {**os.environ, **box.env_overrides()}
+    subprocess.run(["git", "clone", manifest["knowledge_bases"][0]["repository"], str(elsewhere)], env=env, capture_output=True, check=True)
+    subprocess.run(["git", "-C", str(elsewhere), "config", "core.hooksPath", ".githooks"], env=env, check=True)
+    for key, value in box.env_overrides().items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(cli.onboard, "WORKSPACES_ROOT", box.home / "workspaces")
+    monkeypatch.setattr(cli.onboard, "find_adoptable", lambda *a: elsewhere)
+    receipts = cli.onboard.Receipts(box.root / "receipts.json")
+    report = cli.onboard.Report(as_json=True)
+    calls = []
+    original_git = cli.onboard.git
+    def git(args, **kwargs):
+        calls.append(args)
+        if args[0] == "pull" or (args[0] == "config" and "--get" not in args):
+            pytest.fail("existing knowledge repository was mutated")
+        return original_git(args, **kwargs)
+    monkeypatch.setattr(cli.onboard, "git", git)
+    cli.onboard.phase_kbs(report, manifest, receipts, False, enrolling=True)
+    assert report.exit_code() == 0
+    assert receipts.adopted(manifest["knowledge_bases"][0]["name"]) == str(elsewhere)
+
+
+def test_workspace_dry_run_validates_dirty_source_without_creating_outputs(box):
+    manifest = box.manifest()
+    source = manifest.parent / "workspace-instructions.md"
+    source.write_text(source.read_text() + "\nUncommitted source.\n")
+    proc = box.run_engine("install", "--manifest", str(manifest), "--dry-run", "--json")
+    assert proc.returncode != 0, proc.stdout
+    assert not (box.home / "workspaces/exampleco/AGENTS.md").exists()
+
+
+def test_completed_journal_does_not_constrain_later_client_selection(tmp_path):
+    from enrollment import EnrollmentJournal, recover_enrollments
+    state, base = base_state(tmp_path)
+    journal = EnrollmentJournal.create(state.state_dir / "enrollments", "d" * 32, base,
+        files=[], skill_parents=[tmp_path / ".agents/skills"])
+    journal.commit()
+    state.run_transaction("setup", {**base, "clients": ["claude"]}, lambda tx: {})
+    with state.locked():
+        recover_enrollments(state)
+
+
+@pytest.mark.parametrize("command", ["update", "repair"])
+def test_organization_replay_preserves_colliding_private_skill(box, command):
+    manifest = box.manifest()
+    box.run_engine("install", "--manifest", str(manifest), expect=0)
+    target = box.home / ".agents/skills/example-skill"
+    (target / "SKILL.md").write_text("private replacement\n")
+    (target / ".source.json").write_text(json.dumps({"source_type": "private", "source_repo": "private"}))
+    result = box.run_engine(command, "--manifest", str(manifest), "--json")
+    assert result.returncode != 0
+    assert (target / "SKILL.md").read_text() == "private replacement\n"
+
+
+def test_organization_removed_skill_is_receipted_through_retirement(box):
+    manifest = box.manifest()
+    box.run_engine("install", "--manifest", str(manifest), expect=0)
+    source = box.root / "skills-src"
+    subprocess.run(["git", "-C", str(source), "mv", "skills/example-skill", "skills/renamed-skill"], env=box.git_env, check=True)
+    box._commit_all(source, "fixture rename")
+    subprocess.run(["git", "-C", str(source), "push", str(box.skills_remote), "main"], env=box.git_env, capture_output=True, check=True)
+    box.run_engine("update", "--manifest", str(manifest), expect=0)
+    for client in (".claude", ".agents"):
+        assert not (box.home / client / "skills/example-skill").exists()
+        assert (box.home / client / "skills/renamed-skill/SKILL.md").exists()
+
+
+def test_enroll_invite_is_reusable_after_abort_but_not_after_commit(tmp_path, monkeypatch):
+    state, _ = base_state(tmp_path)
+    org_fixture(tmp_path, monkeypatch)
+    now = datetime.now(timezone.utc)
+    invite = {"schema_version": 1, "repository": REPOSITORY, "provider": "generic",
+        "manifest_path": ".agents/onboarding.yaml", "nonce": "enrollment_nonce_0123456789",
+        "issued_at": (now - timedelta(minutes=1)).isoformat(),
+        "expires_at": (now + timedelta(hours=1)).isoformat()}
+    path = tmp_path / "invite.json"
+    path.write_text(json.dumps(invite))
+    args = ["enroll", "--invite", str(path)]
+    assert cli.main(args, state=state, engine_runner=lambda a: 1) == 1
+    assert not state.invites_path.exists()
+    assert cli.main(args, state=state, engine_runner=lambda a: 0) == 0
+    consumed = state.invites_path.read_bytes()
+    assert cli.main(args, state=state, engine_runner=lambda a: pytest.fail("consumed invite reached engine")) == 2
+    assert state.invites_path.read_bytes() == consumed
+
+
+def test_pending_enrollment_keeps_doctor_non_green_without_writes(tmp_path, monkeypatch):
+    from enrollment import EnrollmentJournal
+    state, base = base_state(tmp_path)
+    journal = EnrollmentJournal.create(state.state_dir / "enrollments", "f" * 32, base, files=[], skill_parents=[])
+    before = journal.path.read_bytes()
+    desired = state.desired_path.read_bytes()
+    assert cli.main(["doctor"], state=state, engine_runner=lambda a: pytest.fail("unsettled engine ran")) == 2
+    assert journal.path.read_bytes() == before
+    assert state.desired_path.read_bytes() == desired
+
+
+@pytest.mark.parametrize("directory", [False, True])
+def test_cross_device_enrollment_rollback_preserves_bytes(tmp_path, monkeypatch, directory):
+    import enrollment
+    state, base = base_state(tmp_path)
+    target = tmp_path / ".agents/skills/example-skill" if directory else tmp_path / "workspaces/example-team/AGENTS.md"
+    target.parent.mkdir(parents=True)
+    if directory:
+        target.mkdir()
+        payload = target / "SKILL.md"
+    else:
+        payload = target
+    payload.write_text("original bytes\n")
+    journal = enrollment.EnrollmentJournal.create(state.state_dir / "enrollments", "e" * 32, base,
+        files=[] if directory else [target], skill_parents=[target.parent] if directory else [])
+    journal.capture(target)
+    payload.write_text("failed generation\n")
+    real_replace = os.replace
+    def replace(source, destination):
+        if Path(source) == target:
+            raise OSError(errno.EXDEV, "cross-device fixture")
+        return real_replace(source, destination)
+    monkeypatch.setattr(enrollment.os, "replace", replace)
+    journal.rollback()
+    assert payload.read_text() == "original bytes\n"
+    archived = journal.root / "failed/0"
+    assert (archived / "SKILL.md" if directory else archived).read_text() == "failed generation\n"
+
+
+def test_uninstall_preserves_edited_organization_skill_and_reports_non_green(box):
+    manifest = box.manifest()
+    box.run_engine("install", "--manifest", str(manifest), expect=0)
+    path = box.home / ".agents/skills/example-skill/SKILL.md"
+    path.write_text("edited organization skill\n")
+    result = box.run_engine("uninstall", "--clients", "codex", "--json")
+    assert result.returncode != 0
+    assert path.read_text() == "edited organization skill\n"
+    assert not any(s.get("uninstall_verified") for s in json.loads(result.stdout)["steps"])
+
+
+def test_enrollment_journal_refuses_another_workspace_even_when_claimed(tmp_path):
+    from enrollment import EnrollmentJournal
+    state, base = base_state(tmp_path)
+    proposed = {**base, "organizations": [{"repository": REPOSITORY,
+        "manifest_path": ".agents/onboarding.yaml", "commit_policy": "floating",
+        "commit": "1" * 40, "mode": "additive", "workspace": "example-team"}],
+        "layers": {**base["layers"], "organization": "selected"}}
+    journal = EnrollmentJournal.create(state.state_dir / "enrollments", "0" * 32, base,
+        files=[tmp_path / "workspaces/example-unrelated/AGENTS.md"], skill_parents=[], proposed=proposed)
+    with pytest.raises(contract.ContractError, match="forbidden output"):
+        journal.validate_scope(state, base)
+
+
+def test_removing_entire_org_source_retires_exact_owned_inventory(box):
+    import yaml
+    manifest = box.manifest()
+    box.run_engine("install", "--manifest", str(manifest), expect=0)
+    data = yaml.safe_load(manifest.read_text())
+    data["skills_repos"] = []
+    manifest.write_text(yaml.safe_dump(data))
+    box._commit_all(manifest.parents[1], "fixture removal")
+    before = box.run_engine("doctor", "--manifest", str(manifest), "--json")
+    assert before.returncode != 0
+    box.run_engine("update", "--manifest", str(manifest), expect=0)
+    for client in (".claude", ".agents"):
+        assert not (box.home / client / "skills/example-skill").exists()
+
+
+@pytest.mark.parametrize("edited", [False, True])
+def test_legacy_org_copy_adoption_verifies_recorded_source_bytes(box, edited):
+    manifest = box.manifest()
+    box.run_engine("install", "--manifest", str(manifest), expect=0)
+    receipts_path = box.home / ".synthesis/onboarding/receipts.json"
+    receipts = json.loads(receipts_path.read_text())
+    receipts.pop("org_skill_copies")
+    receipts_path.write_text(json.dumps(receipts))
+    target = box.home / ".agents/skills/example-skill/SKILL.md"
+    if edited:
+        target.write_text("unreceipted personal addition\n")
+    result = box.run_engine("update", "--manifest", str(manifest), "--json")
+    assert result.returncode == (1 if edited else 0), result.stdout
+    if edited:
+        assert target.read_text() == "unreceipted personal addition\n"
+    else:
+        assert str(target.parent) in json.loads(receipts_path.read_text())["org_skill_copies"]
+
+
+def test_two_org_sources_cannot_own_the_same_skill_target(box):
+    import yaml
+    manifest = box.manifest()
+    box.run_engine("install", "--manifest", str(manifest), expect=0)
+    second = box.remotes / "second-skills.git"
+    subprocess.run(["git", "clone", "--bare", str(box.skills_remote), str(second)], env=box.git_env, capture_output=True, check=True)
+    data = yaml.safe_load(manifest.read_text())
+    data["skills_repos"].append({"name": "second-skills", "repository": "ssh://fixture/second-skills.git", "capability": "skills-install"})
+    manifest.write_text(yaml.safe_dump(data))
+    box._commit_all(manifest.parents[1], "fixture collision")
+    target = box.home / ".agents/skills/example-skill/.source.json"
+    before = target.read_bytes()
+    result = box.run_engine("update", "--manifest", str(manifest), "--json")
+    assert result.returncode != 0
+    assert target.read_bytes() == before
+
+
+def test_real_cli_enroll_reaches_engine_and_preserves_personal_state(box):
+    manifest, desired, _ = engine_desired(box)
+    remote = box.remotes / "config.git"
+    subprocess.run(["git", "clone", "--bare", str(manifest.parents[1]), str(remote)],
+        env=box.git_env, capture_output=True, check=True)
+    state, base = base_state(box.home)
+    sentinel = box.home / ".synthesis/agent-control/AGENTS.source.md"
+    sentinel.parent.mkdir(parents=True)
+    sentinel.write_text("independent personal kernel\n")
+    binary = box.fake_client()
+    box.seed_currency()
+    env = {**os.environ, **box.env_overrides(), "SYNTHESIS_HOME": str(box.home),
+        "SYNTHESIS_CODEX_BIN": str(binary)}
+    # Keep the production SSH-only transport policy. A fixture SSH process
+    # serves the real local bare repository through git-upload-pack.
+    ssh = box.root / "fixture_ssh.py"
+    ssh.write_text("import os, shlex, sys\nfrom pathlib import Path\n"
+        "command = shlex.split(sys.argv[-1])\n"
+        "assert command[0] == 'git-upload-pack'\n"
+        "repository = Path(%r) / Path(command[1]).name\n"
+        "assert repository.is_dir()\n"
+        "os.execvp('git-upload-pack', ['git-upload-pack', str(repository)])\n" % str(box.remotes))
+    env.update({"GIT_SSH_COMMAND": "%s %s" % (sys.executable, ssh), "GIT_SSH_VARIANT": "ssh"})
+    for name in ("SYNTHESIS_ACTIVE_DESCRIPTOR", "SYNTHESIS_RELEASE_ROOT"):
+        env.pop(name, None)
+    result = subprocess.run([sys.executable, str(Path(cli.__file__)), "enroll", "--org-repo",
+        "ssh://fixture/config.git", "--json"], env=env, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stdout + result.stderr
+    enrolled = state.read_desired()
+    assert enrolled["organizations"][0]["mode"] == "additive"
+    for key in ("profile", "personal_workspace", "personal_configuration", "clients", "release"):
+        assert enrolled[key] == base[key]
+    assert sentinel.read_text() == "independent personal kernel\n"
+    assert (box.home / ".agents/skills/example-skill/SKILL.md").exists()
+    assert not (box.home / ".claude/skills/example-skill").exists()
+
+
+def test_read_only_engine_lock_never_creates_state(tmp_path):
+    from enrollment import engine_lock
+    root = tmp_path / "missing-state"
+    with engine_lock(root, read_only=True):
+        assert not root.exists()
+    assert not root.exists()
+
+
+def advance_skill_source(box):
+    source = box.root / "skills-src"
+    payload = source / "skills/example-skill/SKILL.md"
+    payload.write_text(payload.read_text() + "\nNew organization guidance.\n")
+    box._commit_all(source, "fixture update")
+    subprocess.run(["git", "-C", str(source), "push", str(box.skills_remote), "main"],
+        env=box.git_env, capture_output=True, check=True)
+
+
+def test_failed_later_phase_keeps_copied_skills_repairable(box):
+    manifest = box.manifest()
+    box.run_engine("install", "--manifest", str(manifest), expect=0)
+    advance_skill_source(box)
+    source = manifest.parent / "workspace-instructions.md"
+    original = source.read_bytes()
+    source.write_bytes(original + b"\nUncommitted instruction source.\n")
+    result = box.run_engine("update", "--manifest", str(manifest), "--json")
+    assert result.returncode == 1, result.stdout
+    target = box.home / ".agents/skills/example-skill"
+    assert "New organization guidance" in (target / "SKILL.md").read_text()
+    receipts = json.loads((box.home / ".synthesis/onboarding/receipts.json").read_text())
+    assert receipts["org_skill_copies"][str(target)]["sha256"] == cli.onboard.paths_digest([target])
+    source.write_bytes(original)
+    box.run_engine("repair", "--manifest", str(manifest), expect=0)
+
+
+def test_partial_organization_copy_restores_exact_receipts_and_skill_bytes(box, monkeypatch):
+    from enrollment import EnrollmentJournal
+    manifest = box.manifest()
+    box.run_engine("install", "--manifest", str(manifest), expect=0)
+    advance_skill_source(box)
+    engine = cli.onboard
+    for key, value in box.env_overrides().items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(engine, "HOME", box.home)
+    monkeypatch.setattr(engine, "STATE_DIR", box.home / ".synthesis/onboarding")
+    monkeypatch.setattr(engine, "CACHE_DIR", box.cache / "synthesis-onboarding")
+    receipt_path = box.home / ".synthesis/onboarding/receipts.json"
+    before = receipt_path.read_bytes()
+    target = box.home / ".agents/skills/example-skill"
+    fingerprint = EnrollmentJournal._fingerprint(target)
+    run = engine.run
+    injected = []
+    def fail_copy(args, **kwargs):
+        if args[0] == "sh" and args[-1] == "install":
+            injected.append(True)
+            (target / "SKILL.md").write_text("interrupted copy\n")
+            return 1, "", "injected partial copy"
+        return run(args, **kwargs)
+    monkeypatch.setattr(engine, "run", fail_copy)
+    report = engine.Report(as_json=True)
+    engine.phase_org_skills(report, engine.load_manifest(manifest), engine.Receipts(receipt_path), False)
+    assert injected and report.exit_code() != 0
+    assert receipt_path.read_bytes() == before
+    assert EnrollmentJournal._fingerprint(target) == fingerprint
+
+
+def test_nested_copy_recovery_precedes_outer_enrollment_rollback(tmp_path, monkeypatch):
+    from enrollment import EnrollmentJournal, recover_copy_transactions
+    state, base = base_state(tmp_path)
+    receipt = tmp_path / ".synthesis/onboarding/receipts.json"
+    target = tmp_path / ".agents/skills/example-skill"
+    target.mkdir(parents=True)
+    (target / "SKILL.md").write_text("original skill\n")
+    contract.atomic_write_json(receipt, {"generation": 0})
+    original_receipt = receipt.read_bytes()
+    proposed = {**base, "organizations": [{"repository": REPOSITORY,
+        "manifest_path": ".agents/onboarding.yaml", "commit_policy": "floating",
+        "commit": "1" * 40, "mode": "additive", "workspace": "example-team"}],
+        "layers": {**base["layers"], "organization": "selected"}}
+    observation = state.read_observation()
+    tx = {**observation["transactions"][-1], "transaction_id": "1" * 32, "generation": 2,
+        "command": "enroll", "desired_digest": contract.json_digest(proposed), "state": "pending"}
+    observation["transactions"].append(tx)
+    state._save_observation(observation)
+    outer = EnrollmentJournal.create(state.state_dir / "enrollments", tx["transaction_id"], base,
+        files=[receipt], skill_parents=[target.parent], proposed=proposed)
+    outer.capture(receipt)
+    outer.capture(target)
+    contract.atomic_write_json(receipt, {"generation": 1})
+    (target / "SKILL.md").write_text("intermediate skill\n")
+    inner = EnrollmentJournal.create(receipt.parent / "copy-transactions", "2" * 32, None,
+        files=[receipt], skill_parents=[target.parent], purpose="org-copy")
+    inner.capture(receipt)
+    inner.capture(target)
+    (target / "SKILL.md").write_text("partial second copy\n")
+    monkeypatch.setattr(cli, "_active_release", lambda: None)
+    assert cli.main(["repair"], state=state, engine_runner=lambda a: 0) == 0
+    assert receipt.read_bytes() == original_receipt
+    assert (target / "SKILL.md").read_text() == "original skill\n"
+    assert EnrollmentJournal(inner.root).data["state"] == "rolled-back"
+    assert EnrollmentJournal(outer.root).data["state"] == "rolled-back"
+    recover_copy_transactions(receipt.parent, tmp_path)
+    assert receipt.read_bytes() == original_receipt
+
+
+@pytest.mark.parametrize("backup_failure", [False, True])
+def test_empty_copy_journal_recovers_before_any_target_mutation(tmp_path, monkeypatch, backup_failure):
+    import enrollment
+    receipt = tmp_path / ".synthesis/onboarding/receipts.json"
+    contract.atomic_write_json(receipt, {"generation": 0})
+    before = receipt.read_bytes()
+    if backup_failure:
+        monkeypatch.setattr(enrollment.shutil, "copy2", lambda *a, **k: (_ for _ in ()).throw(OSError("backup fixture")))
+        with pytest.raises(OSError):
+            with enrollment.organization_copy_transaction(cli.onboard.Receipts(receipt), [], tmp_path):
+                pytest.fail("copy body ran without receipt backup")
+    else:
+        enrollment.EnrollmentJournal.create(receipt.parent / "copy-transactions", "4" * 32, None,
+            files=[receipt], skill_parents=[], purpose="org-copy")
+    enrollment.recover_copy_transactions(receipt.parent, tmp_path)
+    assert receipt.read_bytes() == before
+    journals = [p for p in (receipt.parent / "copy-transactions").iterdir() if p.name != ".staging"]
+    assert len(journals) == 1
+    assert enrollment.EnrollmentJournal(journals[0]).data["state"] == "rolled-back"
+
+
+def test_journal_creation_publishes_only_complete_identity(tmp_path, monkeypatch):
+    import enrollment
+    parent = tmp_path / ".synthesis/onboarding/copy-transactions"
+    root = parent / ("5" * 32)
+    def interrupted_write(path, data):
+        assert not root.exists()
+        assert path.parent.parent == parent / ".staging"
+        raise OSError("publication fixture")
+    monkeypatch.setattr(enrollment, "atomic_write_json", interrupted_write)
+    with pytest.raises(OSError):
+        enrollment.EnrollmentJournal.create(parent, root.name, None,
+            files=[parent.parent / "receipts.json"], skill_parents=[], purpose="org-copy")
+    assert not root.exists()
+    # An interrupted pre-publication directory never issued target authority.
+    (parent / ".staging/interrupted-fixture").mkdir()
+    enrollment.recover_copy_transactions(parent.parent, tmp_path)
+
+
+def test_copy_journal_diagnostic_is_read_only_and_recovery_is_bound(tmp_path):
+    from enrollment import EnrollmentJournal, recover_copy_transactions
+    receipt = tmp_path / ".synthesis/onboarding/receipts.json"
+    contract.atomic_write_json(receipt, {"generation": 0})
+    journal = EnrollmentJournal.create(receipt.parent / "copy-transactions", "3" * 32, None,
+        files=[receipt], skill_parents=[], purpose="org-copy")
+    journal.capture(receipt)
+    before = journal.path.read_bytes()
+    with pytest.raises(contract.ContractError, match="unfinished"):
+        recover_copy_transactions(receipt.parent, tmp_path, verify_only=True)
+    assert journal.path.read_bytes() == before
+    contract.atomic_write_json(receipt, {"unrelated": True})
+    with pytest.raises(contract.ContractError, match="outside its transaction"):
+        recover_copy_transactions(receipt.parent, tmp_path)
+    assert json.loads(receipt.read_text()) == {"unrelated": True}
+
+
+def test_repair_restores_recorded_org_commit_without_fetch_or_personal_setup(tmp_path):
+    from test_synthesis_cli import commit_fixture_repo
+    root = tmp_path / "organizations/config"
+    manifest = root / ".agents/onboarding.yaml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text("version: 2\n")
+    commit_fixture_repo(root)
+    original = subprocess.check_output(["git", "-C", str(root), "rev-parse", "HEAD"], text=True).strip()
+    manifest.write_text("version: 2\n# incompatible newer policy\n")
+    commit_fixture_repo(root)
+    newer = subprocess.check_output(["git", "-C", str(root), "rev-parse", "HEAD"], text=True).strip()
+    subprocess.run(["git", "-C", str(root), "remote", "add", "origin", REPOSITORY], check=True)
+    subprocess.run(["git", "-C", str(root), "update-ref", "refs/remotes/origin/main", newer], check=True)
+    with pytest.raises(contract.ContractError):
+        cli.organization.acquire_repository(REPOSITORY, tmp_path, expected_commit=original, refresh=False)
+    assert subprocess.check_output(["git", "-C", str(root), "rev-parse", "HEAD"], text=True).strip() == newer
+    resolved, commit = cli.organization.acquire_repository(REPOSITORY, tmp_path,
+        expected_commit=original, refresh=False, restore_commit=True)
+    assert resolved == root and commit == original
+    assert cli.organization.acquire_repository(REPOSITORY, tmp_path, expected_commit=original, refresh=False)[1] == original

--- a/skills/synthesis-onboarding/scripts/test_synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/test_synthesis_cli.py
@@ -970,7 +970,7 @@ def test_repair_reconciles_recorded_org_policy_without_advancing_it(
         engine_runner=lambda argv: engine_calls.append(argv) or 0,
     ) == 0
     assert acquisition_calls == [
-        {"expected_commit": recorded_commit, "refresh": False}
+        {"expected_commit": recorded_commit, "refresh": False, "restore_commit": True}
     ]
     assert engine_calls == [
         [

--- a/skills/synthesis-repo-guard/SKILL.md
+++ b/skills/synthesis-repo-guard/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.4.0"
+  version: "2.4.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -86,8 +86,12 @@ Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`)
 - Manifest writers, Stop receipts, remote flushes, and worktree retirement use
   one lifecycle lock. Retirement pins a freshly fetched remote-tracking
   commit, fsyncs a resumable intent before removal, invalidates old receipts,
-  and completes idempotently after interruption. A missing path without this
-  proof remains a fail-closed Stop error.
+  and completes idempotently after interruption. A missing worktree without
+  this proof remains a fail-closed Stop error. Deleted files and child
+  directories within a verified live repository are recorded as missing,
+  without restoring them or discarding their pending attribution. Resolution
+  refuses symlink ancestry, unavailable worktree inventory and a missing
+  registered nested worktree rather than borrowing the enclosing repository.
 - A distinct commit author identifies batched remote-context commits.
 - Divergence leaves the exact commit and manifest local and reports the
   block. Never rebase or force-push.

--- a/skills/synthesis-repo-guard/checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/checkpoint_sync.py
@@ -479,9 +479,33 @@ def summarize_paths(paths: list[str], limit: int = 3) -> str:
 
 
 def repo_root_for_path(path: Path) -> Path | None:
+    path = lexical_absolute(path)
+    # Keep lexical ancestry until symlinks have been rejected. Resolving first
+    # would silently attribute a pending path to the link target's repository.
+    if any(part.is_symlink() for part in (path, *path.parents)):
+        return None
     probe = path if path.is_dir() else path.parent
+    crossed_missing_parent = False
+    while not probe.is_dir():
+        if probe.exists() or probe == probe.parent:
+            return None
+        crossed_missing_parent = True
+        probe = probe.parent
     rc, output, _ = git(probe, "rev-parse", "--show-toplevel")
-    return Path(output).resolve() if rc == 0 and output else None
+    if rc != 0 or not output:
+        return None
+    root = Path(output).resolve()
+    if not root.is_dir() or not path_is_within(path, root):
+        return None
+    if crossed_missing_parent:
+        roots, error = listed_worktree_roots(root)
+        if error or root not in roots:
+            return None
+        # A missing registered nested worktree needs retirement reconciliation,
+        # not evidence incorrectly attributed to its enclosing repository.
+        if any(other != root and path_is_within(path, other) for other in roots):
+            return None
+    return root
 
 
 def path_is_within(path: Path, root: Path) -> bool:

--- a/skills/synthesis-repo-guard/test_checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/test_checkpoint_sync.py
@@ -28,7 +28,9 @@ def command(*args: str, cwd: Path | None = None) -> str:
 def repository(tmp_path: Path) -> tuple[Path, Path, dict]:
     remote = tmp_path / "remote.git"
     repo = tmp_path / "repo"
-    command("git", "init", "--bare", "-q", str(remote))
+    # Retirement fixtures name origin/main; do not inherit a runner-specific
+    # default branch when constructing their synthetic remote.
+    command("git", "init", "--bare", "-q", "-b", "main", str(remote))
     command("git", "clone", "-q", str(remote), str(repo))
     command("git", "config", "user.name", "Test", cwd=repo)
     command("git", "config", "user.email", "test@example.com", cwd=repo)

--- a/skills/synthesis-repo-guard/test_deleted_paths.py
+++ b/skills/synthesis-repo-guard/test_deleted_paths.py
@@ -1,0 +1,124 @@
+"""Deleted child directories must not erase a valid repository boundary."""
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SPEC = importlib.util.spec_from_file_location(
+    "deleted_path_checkpoint", Path(__file__).with_name("checkpoint_sync.py")
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def git(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args], check=True,
+                          capture_output=True, text=True).stdout.strip()
+
+
+def repo(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    git(root, "init", "-b", "main")
+    return root.resolve()
+
+
+def test_checkpoint_ci_runs_both_regression_modules():
+    source = Path(__file__).resolve().parents[2]
+    workflow = yaml.safe_load((source / ".github/workflows/repo-guard.yml").read_text())
+    runs = [step.get("run", "") for step in workflow["jobs"]["checkpoint"]["steps"]]
+    assert "python -m pytest skills/synthesis-repo-guard/test_checkpoint_sync.py skills/synthesis-repo-guard/test_deleted_paths.py -q" in runs
+    assert workflow["permissions"] == {"contents": "read"}
+
+
+def test_removed_cache_parent_still_resolves_its_repository(tmp_path):
+    root = repo(tmp_path)
+    target = root / "scripts" / "__pycache__" / "fixture.pyc"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"generated fixture")
+    assert MODULE.repo_root_for_path(target) == root  # positive control
+    target.unlink()
+    target.parent.rmdir()
+    assert MODULE.repo_root_for_path(target) == root
+    assert MODULE.file_evidence(target)["state"] == "deleted-or-missing"
+    assert not target.parent.exists()
+
+
+def test_missing_multiple_child_directories_resolve_inside_live_repository(tmp_path):
+    root = repo(tmp_path)
+    assert MODULE.repo_root_for_path(root / "removed" / "children" / "file") == root
+
+
+def test_missing_repository_does_not_resolve_from_unrelated_workspace(tmp_path):
+    root = repo(tmp_path)
+    assert MODULE.repo_root_for_path(root / "present") == root
+    assert MODULE.repo_root_for_path(tmp_path / "missing-repository" / "file") is None
+
+
+@pytest.mark.parametrize("dangling", [False, True])
+def test_symlink_ancestor_is_not_a_repository_boundary(tmp_path, dangling):
+    root = repo(tmp_path)
+    alias = tmp_path / "alias"
+    alias.symlink_to(root / "missing" if dangling else root, target_is_directory=True)
+    assert MODULE.repo_root_for_path(alias / "file") is None
+
+
+def test_missing_registered_nested_worktree_cannot_fall_into_parent_repo(tmp_path):
+    root = repo(tmp_path)
+    nested = root / "nested"
+    git(root, "worktree", "add", "--orphan", "-b", "nested", str(nested))
+    assert MODULE.repo_root_for_path(nested / "file") == nested
+    # Model interruption, not the sanctioned retirement workflow. This exact
+    # synthetic directory is inside this test's freshly created repository.
+    assert nested.parent == root and (nested / ".git").is_file()
+    shutil.rmtree(nested)
+    assert MODULE.repo_root_for_path(nested / "removed" / "file") is None
+
+
+def test_deleted_path_resolution_fails_when_worktree_inventory_is_unavailable(tmp_path, monkeypatch):
+    root = repo(tmp_path)
+    monkeypatch.setattr(MODULE, "listed_worktree_roots", lambda _repo: ([], "unavailable"))
+    assert MODULE.repo_root_for_path(root / "missing-parent" / "file") is None
+
+
+def test_local_receipt_preserves_missing_file_evidence_without_restoring_it(tmp_path, monkeypatch):
+    root = repo(tmp_path)
+    target = root / "scripts" / "removed" / "cache.pyc"
+    (root / "scripts").mkdir()
+    state = tmp_path / "state"
+    pending = state / "pending"
+    pending.mkdir(parents=True)
+    monkeypatch.setattr(MODULE, "STATE_DIR", state)
+    monkeypatch.setattr(MODULE, "PENDING_DIR", pending)
+    monkeypatch.setattr(MODULE, "LOCAL_HANDOFF_DIR", state / "receipts")
+    manifest = MODULE.pending_manifest_path("deleted-path-fixture")
+    content = {"schema_version": 2, "session_id": "deleted-path-fixture",
+               "paths": [str(target)], "remote_paths": []}
+    manifest.write_text(json.dumps(content))
+    original_git = MODULE.git
+
+    def fixture_git(path, *args, **kwargs):
+        # This fixture tests file resolution/receipt semantics, not commits.
+        # Real Git resolves the repository; fixed read-only HEAD metadata
+        # avoids creating commits in the synthetic repository.
+        if args == ("branch", "--show-current"):
+            return 0, "main", ""
+        if args == ("rev-parse", "HEAD"):
+            return 0, "a" * 40, ""
+        return original_git(path, *args, **kwargs)
+
+    monkeypatch.setattr(MODULE, "git", fixture_git)
+    results, observed = MODULE.local_handoff_checkpoint(
+        {"session_id": "deleted-path-fixture", "cwd": str(root)}, MODULE.DEFAULTS
+    )
+    assert observed == manifest
+    assert results[0]["action"] == "local-ready"
+    assert results[0]["file_evidence"] == [{"path": str(target), "state": "deleted-or-missing"}]
+    assert json.loads(manifest.read_text()) == content
+    assert not target.parent.exists()


### PR DESCRIPTION
Adds an explicit enrollment command for existing installations. It preserves the personal profile, configuration, selected clients and release policy while registering organization sources for update, repair and doctor.

Includes exact-target recovery, organization-copy ownership and retirement, saved-revision repair, selected-client protection, verified top-level shared-source adoption, and actual CLI-to-engine regression tests. Integrates the reviewed repository handoff correction from #123 without replacing its safety boundaries.

Verification: independent mutation/recovery and source-layout reviews; onboarding regression suite; source conformance; capability and scaffold contracts; installer acceptance; the required repository matrix. The combined closed acceptance manifest binds 24 defect-pinned cases to all changed surfaces. Publication and client refresh remain gated by release.py. No website deployment is included.