### PR TITLE
Update enrollment boundaries

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.95.0",
+  "version": "4.95.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.95.0",
+  "version": "4.95.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.95.1] - 2026-09-04
+
+**Verified enrollment can reach SSH organization repositories.** The bootstrap
+keeps public acquisition HTTPS-only, then gives the verified CLI a separate
+HTTPS/SSH transport policy. File and external-helper transports remain blocked.
+Onboarding 2.3.1 tests the policy handoff and actual CLI/engine organization
+acquisition through SSH without local transport rewrites.
+
 ## [4.95.0] - 2026-09-04
 
 **Additive organization enrollment preserves an existing personal installation.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ HTTPS/SSH transport policy. File and external-helper transports remain blocked.
 Onboarding 2.3.1 tests the policy handoff and actual CLI/engine organization
 acquisition through SSH without local transport rewrites.
 
+Enrollment, engine locking, and rollback now resolve the same receipt directory
+for default, XDG, and explicit state roots. Real CLI tests cover all three
+layouts, and injected failures verify restoration of the actual engine receipt.
+
 ## [4.95.0] - 2026-09-04
 
 **Additive organization enrollment preserves an existing personal installation.**

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 **SSH organization enrollment follows verified bootstrap acquisition (September
 2026).** Release **4.95.1** separates the public HTTPS-only download policy from
 the verified CLI's HTTPS/SSH organization operations. Local-file and external
-helper transports remain blocked.
+helper transports remain blocked. Enrollment and rollback share the engine's
+receipt directory under default, XDG, and explicitly selected state roots.
 
 **Add an organization without resetting an existing installation (September
 2026).** Release **4.95.0** adds `synthesis enroll` for saved full or skills-only

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**SSH organization enrollment follows verified bootstrap acquisition (September
+2026).** Release **4.95.1** separates the public HTTPS-only download policy from
+the verified CLI's HTTPS/SSH organization operations. Local-file and external
+helper transports remain blocked.
+
 **Add an organization without resetting an existing installation (September
 2026).** Release **4.95.0** adds `synthesis enroll` for saved full or skills-only
 installations. It preserves personal configuration, selected clients, and release

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,45 +1,28 @@
-# AGENT HEURISTIC: authored for the 4.95.0 additive enrollment transaction.
-# Closed membership is checked against the complete committed release diff.
+# AGENT HEURISTIC: authored for the 4.95.1 verified transport handoff.
 schema: 2
-suite: additive-organization-enrollment
+suite: verified-organization-transport
 membership: closed
-production_entry_point: skills/synthesis-onboarding/scripts/synthesis_cli.py
-enforcing_boundary: additive enrollment preserves personal selection and journals exact generated resources through commit recovery replay doctor and uninstall
+production_entry_point: skills/synthesis-onboarding/scripts/bootstrap.py
+enforcing_boundary: public acquisition stays HTTPS-only while verified CLI organization operations permit SSH and refuse file and external-helper transports
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: live organization adoption build-only site refresh terminal updater and genuine client lifecycle receipts remain runtime gates
+unverified_remainder: live enrollment personal preservation build-only sites terminal updater and genuine client lifecycle receipts remain separate gates
 changed_surfaces:
-  - path: skills/synthesis-onboarding/scripts/system_contract.py
-    cases: [additive-schema, enrollment-regressions]
-  - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
-    cases: [additive-selection, enrollment-regressions]
-  - path: skills/synthesis-onboarding/scripts/enrollment.py
-    cases: [enrollment-regressions, partial-copy-rollback, copy-recovery-binding, premutation-copy-recovery, journal-publication]
-  - path: skills/synthesis-onboarding/scripts/organization.py
-    cases: [enrollment-regressions]
-  - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [engine-personal-preservation, enrollment-regressions, replay-after-failure, removed-org-source, legacy-copy-ownership, shared-layout-adoption, mixed-layout-refusal]
-  - path: skills/synthesis-onboarding/scripts/direct_copy.sh
-    cases: [selected-client-preservation, cli-engine-boundary, shared-layout-adoption, mixed-layout-refusal]
+  - path: skills/synthesis-onboarding/scripts/bootstrap.py
+    cases: [verified-cli-transport, bootstrap-handoff, real-cli-ssh]
+  - path: skills/synthesis-onboarding/scripts/test_bootstrap.py
+    cases: [verified-cli-transport, bootstrap-handoff]
   - path: skills/synthesis-onboarding/scripts/test_additive_enrollment.py
-    cases: [enrollment-regressions]
-  - path: skills/synthesis-onboarding/references/system-state.schema.json
-    cases: [additive-schema]
-  - path: skills/synthesis-onboarding/references/machine-observation.schema.json
-    cases: [additive-schema, enrollment-regressions]
-  - path: skills/synthesis-onboarding/references/release-capabilities.json
-    cases: [capability-contract]
-  - path: skills/synthesis-onboarding/scripts/check_capabilities.py
-    cases: [capability-contract]
-  - path: skills/synthesis-onboarding/references/org-manifest.md
-    cases: [capability-contract, engine-personal-preservation]
+    cases: [real-cli-ssh]
+  - path: skills/synthesis-onboarding/scripts/onboard.py
+    cases: [engine-version-contract, real-cli-ssh]
+  - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
+    cases: [engine-version-contract, real-cli-ssh]
   - path: skills/synthesis-onboarding/SKILL.md
-    cases: [engine-version-contract, additive-selection]
-  - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
-    cases: [shipped-manifest-self-consumption]
+    cases: [engine-version-contract, verified-cli-transport]
   - path: .claude-plugin/plugin.json
     cases: [release-manifest-parity]
   - path: .codex-plugin/plugin.json
@@ -47,113 +30,35 @@ changed_surfaces:
   - path: CHANGELOG.md
     cases: [release-changelog-parity]
   - path: README.md
-    cases: [release-changelog-parity, capability-contract]
-  - path: skills/synthesis-onboarding/scripts/test_synthesis_cli.py
-    cases: [recorded-org-repair, engine-version-contract]
-  - path: skills/synthesis-repo-guard/checkpoint_sync.py
-    cases: [deleted-path-handoff, missing-worktree-boundary]
-  - path: skills/synthesis-repo-guard/test_checkpoint_sync.py
-    cases: [checkpoint-ci-binding]
-  - path: skills/synthesis-repo-guard/test_deleted_paths.py
-    cases: [deleted-path-handoff, missing-worktree-boundary, checkpoint-ci-binding]
-  - path: skills/synthesis-repo-guard/SKILL.md
-    cases: [deleted-path-handoff, missing-worktree-boundary]
-  - path: .github/workflows/repo-guard.yml
-    cases: [checkpoint-ci-binding]
+    cases: [release-changelog-parity, verified-cli-transport]
+  - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
+    cases: [shipped-manifest-self-consumption]
 cases:
-  - id: additive-schema
+  - id: verified-cli-transport
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_skills_only_overlay_matches_runtime_and_schema
-    motivating_defect: an-organization-tied-to-full-profile-forces-unrelated-personal-initialization
-  - id: additive-selection
+    fixture: ../synthesis-onboarding/scripts/test_bootstrap.py::test_verified_cli_can_use_org_ssh_without_enabling_local_transports
+    motivating_defect: public-download-policy-leaks-into-verified-organization-git-operations
+  - id: real-cli-ssh
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_enroll_preserves_base_and_replays_overlay
-    motivating_defect: setup-reinitializes-personal-state-and-engine-only-install-omits-future-updates
-  - id: engine-personal-preservation
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_real_cli_enroll_reaches_engine_and_preserves_personal_state
+    motivating_defect: transport-rewrites-in-fixtures-can-hide-real-ssh-enrollment-failure
+  - id: bootstrap-handoff
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_real_engine_enroll_and_repair_preserve_personal_files_and_receipts
-    motivating_defect: routing-tests-alone-do-not-prove-personal-preservation-through-real-repair-and-uninstall
-  - id: selected-client-preservation
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_organization_copy_never_retires_unselected_clients
-    motivating_defect: organization-copy-retired-unselected-client-copies-as-public-plugin-fallbacks
-  - id: enrollment-regressions
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_nested_copy_recovery_precedes_outer_enrollment_rollback
-    motivating_defect: recovering-outer-enrollment-before-interrupted-inner-copy-restores-the-wrong-generation
-  - id: capability-contract
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_check_capabilities.py::test_repository_capabilities_are_consistent
-    motivating_defect: public-install-surfaces-can-advertise-unimplemented-commands-or-profile-layers
+    fixture: ../synthesis-onboarding/scripts/test_bootstrap.py::test_onboard_handoff_consumes_resolution_policy_before_update_cli
+    motivating_defect: bootstrap-must-forward-the-original-command-after-verified-resolution
   - id: engine-version-contract
     control_class: acceptance-test
     fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_engine_versions_and_skill_contract_agree
-    motivating_defect: installed-guidance-and-engine-versions-can-disagree-across-clients
-  - id: shipped-manifest-self-consumption
-    control_class: acceptance-test
-    fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: an-acceptance-manifest-must-be-consumed-by-its-own-runner
+    motivating_defect: installed-guidance-and-engine-versions-must-match
   - id: release-manifest-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
-    motivating_defect: a-version-reaching-only-one-client-cannot-be-installed-or-audited-reliably
+    motivating_defect: both-native-clients-must-install-the-same-version
   - id: release-changelog-parity
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed
-    motivating_defect: release-changelog-and-manifest-disagreement-prevents-reliable-audit
-  - id: cli-engine-boundary
+    motivating_defect: release-changelog-and-manifest-identity-must-agree
+  - id: shipped-manifest-self-consumption
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_real_cli_enroll_reaches_engine_and_preserves_personal_state
-    motivating_defect: organization-copies-mistaken-for-public-plugin-duplicates-abort-real-cli-enrollment
-  - id: replay-after-failure
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_failed_later_phase_keeps_copied_skills_repairable
-    motivating_defect: a-later-phase-failure-strands-copied-skills-with-old-ownership-receipts
-  - id: partial-copy-rollback
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_partial_organization_copy_restores_exact_receipts_and_skill_bytes
-    motivating_defect: partial-copy-failure-corrupts-owned-skills-before-repair
-  - id: recorded-org-repair
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_repair_restores_recorded_org_commit_without_fetch_or_personal_setup
-    motivating_defect: failed-update-leaves-managed-org-cache-at-an-uncommitted-desired-revision
-  - id: removed-org-source
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_removing_entire_org_source_retires_exact_owned_inventory
-    motivating_defect: removed-organization-sources-leave-unowned-runtime-copies
-  - id: legacy-copy-ownership
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_legacy_org_copy_adoption_verifies_recorded_source_bytes
-    motivating_defect: legacy-provenance-alone-can-overwrite-edited-private-bytes
-  - id: copy-recovery-binding
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_copy_journal_diagnostic_is_read_only_and_recovery_is_bound
-    motivating_defect: diagnostic-or-unbound-recovery-can-overwrite-unrelated-receipts
-  - id: deleted-path-handoff
-    control_class: acceptance-test
-    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_local_receipt_preserves_missing_file_evidence_without_restoring_it
-    motivating_defect: deleted-parent-prevents-durable-handoff-of-an-existing-repository
-  - id: missing-worktree-boundary
-    control_class: acceptance-test
-    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_missing_registered_nested_worktree_cannot_fall_into_parent_repo
-    motivating_defect: ancestor-resolution-can-misattribute-a-missing-nested-worktree
-  - id: checkpoint-ci-binding
-    control_class: acceptance-test
-    fixture: ../synthesis-repo-guard/test_deleted_paths.py::test_checkpoint_ci_runs_both_regression_modules
-    motivating_defect: retirement-and-deleted-path-regressions-need-hosted-execution
-  - id: premutation-copy-recovery
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_empty_copy_journal_recovers_before_any_target_mutation
-    motivating_defect: interruption-or-backup-failure-before-receipt-capture-strands-all-future-mutations
-  - id: journal-publication
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_journal_creation_publishes_only_complete_identity
-    motivating_defect: partially-written-journal-identity-prevents-recovery-before-any-target-was-mutated
-  - id: shared-layout-adoption
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_flat_shared_repository_adoption_proves_source_bytes
-    motivating_defect: top-level-shared-skill-copies-are-not-inventoried-or-safely-adopted
-  - id: mixed-layout-refusal
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_mixed_organization_skill_layout_refuses_before_copies
-    motivating_defect: mixed-source-layouts-make-engine-inventory-and-copy-capability-disagree
+    fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
+    motivating_defect: release-authority-must-consume-its-exact-closed-manifest

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,9 +1,9 @@
 # AGENT HEURISTIC: authored for the 4.95.1 verified transport handoff.
 schema: 2
-suite: verified-organization-transport
+suite: verified-organization-enrollment-boundaries
 membership: closed
 production_entry_point: skills/synthesis-onboarding/scripts/bootstrap.py
-enforcing_boundary: public acquisition stays HTTPS-only while verified CLI organization operations permit SSH and refuse file and external-helper transports
+enforcing_boundary: verified organization operations permit HTTPS and SSH only while enrollment and rollback share the actual engine receipt directory
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
@@ -16,11 +16,13 @@ changed_surfaces:
   - path: skills/synthesis-onboarding/scripts/test_bootstrap.py
     cases: [verified-cli-transport, bootstrap-handoff]
   - path: skills/synthesis-onboarding/scripts/test_additive_enrollment.py
-    cases: [real-cli-ssh]
+    cases: [real-cli-ssh, engine-receipt-rollback]
+  - path: skills/synthesis-onboarding/scripts/enrollment.py
+    cases: [real-cli-ssh, engine-receipt-rollback]
   - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [engine-version-contract, real-cli-ssh]
+    cases: [engine-version-contract, real-cli-ssh, engine-receipt-rollback]
   - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
-    cases: [engine-version-contract, real-cli-ssh]
+    cases: [engine-version-contract, real-cli-ssh, engine-receipt-rollback]
   - path: skills/synthesis-onboarding/SKILL.md
     cases: [engine-version-contract, verified-cli-transport]
   - path: .claude-plugin/plugin.json
@@ -34,6 +36,10 @@ changed_surfaces:
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [shipped-manifest-self-consumption]
 cases:
+  - id: engine-receipt-rollback
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_enrollment_rollback_protects_actual_engine_receipt
+    motivating_defect: enrollment-journal-protects-legacy-receipt-instead-of-default-or-xdg-engine-receipt
   - id: verified-cli-transport
     control_class: acceptance-test
     fixture: ../synthesis-onboarding/scripts/test_bootstrap.py::test_verified_cli_can_use_org_ssh_without_enabling_local_transports

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -195,6 +195,11 @@ The copy capability accepts either `skills/<name>/SKILL.md` or top-level
 Existing shared copies require matching repository identity and exact source
 bytes at their recorded commit before enrollment can adopt their ownership.
 
+Enrollment, engine locking, and rollback use the same receipt directory:
+`SYNTHESIS_ONBOARD_STATE_DIR` when set, otherwise
+`${XDG_STATE_HOME:-$HOME/.local/state}/synthesis`. Legacy receipts are not the
+default destination for new enrollment transactions.
+
 Public bootstrap acquisition remains HTTPS-only. After verifying the immutable
 release, the CLI permits HTTPS and SSH repository transports; local-file and
 external-helper transports remain forbidden.

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.3.0"
+  version: "2.3.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -194,6 +194,10 @@ The copy capability accepts either `skills/<name>/SKILL.md` or top-level
 `<name>/SKILL.md` organization repositories, never both layouts at once.
 Existing shared copies require matching repository identity and exact source
 bytes at their recorded commit before enrollment can adopt their ownership.
+
+Public bootstrap acquisition remains HTTPS-only. After verifying the immutable
+release, the CLI permits HTTPS and SSH repository transports; local-file and
+external-helper transports remain forbidden.
 
 For a new installation, use `synthesis setup --org-repo URL`. For an existing
 enabled full or skills-only installation, use `synthesis enroll --org-repo URL`.

--- a/skills/synthesis-onboarding/scripts/bootstrap.py
+++ b/skills/synthesis-onboarding/scripts/bootstrap.py
@@ -244,6 +244,11 @@ def main(argv: list[str] | None = None) -> int:
     environment = dict(os.environ)
     environment["SYNTHESIS_ACTIVE_DESCRIPTOR"] = str(args.active_descriptor)
     environment["SYNTHESIS_BOOTSTRAP_RESOLVED"] = "1"
+    # The public acquisition stage is HTTPS-only. The now-verified CLI also
+    # acquires validated organization repositories over SSH; keep file/ext
+    # transports forbidden without leaking the narrower download policy.
+    environment["GIT_ALLOW_PROTOCOL"] = "https:ssh"
+    environment["GIT_PROTOCOL_FROM_USER"] = "0"
     return subprocess.call(command, env=environment)
 
 

--- a/skills/synthesis-onboarding/scripts/enrollment.py
+++ b/skills/synthesis-onboarding/scripts/enrollment.py
@@ -26,7 +26,8 @@ _engine_depth = {}
 
 
 def engine_state_root(home):
-    return Path(os.environ.get("SYNTHESIS_ONBOARD_STATE_DIR", str(Path(home) / ".synthesis/onboarding")))
+    default = Path(os.environ.get("XDG_STATE_HOME", str(Path(home) / ".local/state"))) / "synthesis"
+    return Path(os.environ.get("SYNTHESIS_ONBOARD_STATE_DIR", str(default)))
 
 
 @contextlib.contextmanager
@@ -132,7 +133,7 @@ class EnrollmentJournal:
         if json_digest(proposed) != self.data["proposed_desired_digest"]:
             raise ContractError("enrollment journal proposed state digest changed")
         workspaces = Path(os.environ.get("SYNTHESIS_WORKSPACES_ROOT", str(state.home / "workspaces")))
-        receipts = Path(os.environ.get("SYNTHESIS_ONBOARD_STATE_DIR", str(state.home / ".synthesis/onboarding"))) / "receipts.json"
+        receipts = engine_state_root(state.home) / "receipts.json"
         files = {str(p) for p in (state.desired_path, state.invites_path, receipts)}
         files.update(str(workspaces / entries[0]["workspace"] / name) for name in ("AGENTS.md", "CLAUDE.md"))
         parents = {str(state.home / (".claude" if c == "claude" else ".agents") / "skills") for c in desired["clients"]}

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -34,7 +34,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from enrollment import (EnrollmentJournal, regular_tree, move_verified, engine_lock,
+from enrollment import (EnrollmentJournal, regular_tree, move_verified, engine_lock, engine_state_root,
                         recover_copy_transactions, organization_copy_transaction)
 
 from plugin_currency import (
@@ -103,12 +103,7 @@ def semver_tuple(value):
     return tuple(int(part) for part in value.split("."))
 
 HOME = Path(os.environ.get("SYNTHESIS_ONBOARD_HOME", str(Path.home())))
-STATE_DIR = Path(
-    os.environ.get(
-        "SYNTHESIS_ONBOARD_STATE_DIR",
-        str(Path(os.environ.get("XDG_STATE_HOME", str(HOME / ".local" / "state"))) / "synthesis"),
-    )
-)
+STATE_DIR = engine_state_root(HOME)
 WORKSPACES_ROOT = Path(os.environ.get("SYNTHESIS_WORKSPACES_ROOT", str(HOME / "workspaces")))
 CACHE_DIR = Path(os.environ.get("SYNTHESIS_ONBOARD_CACHE_DIR", os.environ.get("XDG_CACHE_HOME", str(HOME / ".cache")))) / "synthesis-onboarding"
 RECEIPTS_PATH = STATE_DIR / "receipts.json"

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -88,7 +88,7 @@ from whole_system import (
     validate_personal_policy,
 )
 
-ENGINE_VERSION = "2.3.0"
+ENGINE_VERSION = "2.3.1"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"

--- a/skills/synthesis-onboarding/scripts/synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/synthesis_cli.py
@@ -855,7 +855,7 @@ def _enroll(args, argv, state, engine_runner):
             desired["personal_instruction_source"] = describe_personal_instruction_source(args.personal_instruction_source)
         validate_desired_state(desired)
         workspaces = Path(os.environ.get("SYNTHESIS_WORKSPACES_ROOT", str(state.home / "workspaces")))
-        receipts = Path(os.environ.get("SYNTHESIS_ONBOARD_STATE_DIR", str(state.home / ".synthesis/onboarding"))) / "receipts.json"
+        receipts = engine_state_root(state.home) / "receipts.json"
         pair = [workspaces / entry["workspace"] / name for name in ("AGENTS.md", "CLAUDE.md")]
         parents = [state.home / (".claude" if c == "claude" else ".agents") / "skills" for c in base["clients"]]
         journal = None

--- a/skills/synthesis-onboarding/scripts/synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/synthesis_cli.py
@@ -42,7 +42,7 @@ from system_contract import (
 )
 
 
-ENGINE_VERSION = "2.3.0"
+ENGINE_VERSION = "2.3.1"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CLI_COMMANDS = (
     "setup",

--- a/skills/synthesis-onboarding/scripts/test_additive_enrollment.py
+++ b/skills/synthesis-onboarding/scripts/test_additive_enrollment.py
@@ -608,7 +608,8 @@ def test_two_org_sources_cannot_own_the_same_skill_target(box):
     assert target.read_bytes() == before
 
 
-def test_real_cli_enroll_reaches_engine_and_preserves_personal_state(box):
+@pytest.mark.parametrize("state_layout", ["override", "default", "xdg"])
+def test_real_cli_enroll_reaches_engine_and_preserves_personal_state(box, state_layout):
     manifest, desired, _ = engine_desired(box)
     remote = box.remotes / "config.git"
     subprocess.run(["git", "clone", "--bare", str(manifest.parents[1]), str(remote)],
@@ -621,6 +622,11 @@ def test_real_cli_enroll_reaches_engine_and_preserves_personal_state(box):
     box.seed_currency()
     env = {**os.environ, **box.env_overrides(), "SYNTHESIS_HOME": str(box.home),
         "SYNTHESIS_CODEX_BIN": str(binary)}
+    env.pop("XDG_STATE_HOME", None)
+    if state_layout != "override":
+        env.pop("SYNTHESIS_ONBOARD_STATE_DIR", None)
+    if state_layout == "xdg":
+        env["XDG_STATE_HOME"] = str(box.home / "xdg-state")
     # Keep the production SSH-only transport policy. A fixture SSH process
     # serves the real local bare repository through git-upload-pack.
     ssh = box.root / "fixture_ssh.py"
@@ -650,6 +656,13 @@ def test_real_cli_enroll_reaches_engine_and_preserves_personal_state(box):
     assert sentinel.read_text() == "independent personal kernel\n"
     assert (box.home / ".agents/skills/example-skill/SKILL.md").exists()
     assert not (box.home / ".claude/skills/example-skill").exists()
+    engine_root = Path(env.get("SYNTHESIS_ONBOARD_STATE_DIR",
+        str(Path(env.get("XDG_STATE_HOME", str(box.home / ".local/state"))) / "synthesis")))
+    assert (engine_root / "receipts.json").is_file()
+    journals_root = Path(env.get("XDG_STATE_HOME", str(box.home / ".local/state"))) / "synthesis/enrollments"
+    journal = json.loads(next(journals_root.glob("*/journal.json")).read_text())
+    assert str(engine_root / "receipts.json") in journal["allowed_files"]
+    assert journal["state"] == "committed"
 
 
 def test_read_only_engine_lock_never_creates_state(tmp_path):
@@ -658,6 +671,38 @@ def test_read_only_engine_lock_never_creates_state(tmp_path):
     with engine_lock(root, read_only=True):
         assert not root.exists()
     assert not root.exists()
+
+
+@pytest.mark.parametrize("state_layout", ["override", "default", "xdg"])
+def test_enrollment_rollback_protects_actual_engine_receipt(tmp_path, monkeypatch, state_layout):
+    monkeypatch.delenv("SYNTHESIS_ONBOARD_STATE_DIR", raising=False)
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    expected_root = tmp_path / ".local/state/synthesis"
+    if state_layout == "override":
+        expected_root = tmp_path / "explicit-engine-state"
+        monkeypatch.setenv("SYNTHESIS_ONBOARD_STATE_DIR", str(expected_root))
+    elif state_layout == "xdg":
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg-state"))
+        expected_root = tmp_path / "xdg-state/synthesis"
+    state, base = base_state(tmp_path)
+    org_fixture(tmp_path, monkeypatch)
+    receipt = expected_root / "receipts.json"
+    legacy = tmp_path / ".synthesis/onboarding/receipts.json"
+    for path in (receipt, legacy):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"personal": "unchanged"}\n')
+    before = receipt.read_bytes()
+
+    def engine(argv):
+        if argv[0] == "enroll":
+            receipt.write_text('{"changed": true}\n')
+            return 0
+        return 1
+
+    assert cli.main(["enroll", "--org-repo", REPOSITORY], state=state, engine_runner=engine) == 1
+    assert receipt.read_bytes() == before
+    assert legacy.read_bytes() == before
+    assert state.read_desired() == base
 
 
 def advance_skill_source(box):
@@ -719,6 +764,7 @@ def test_partial_organization_copy_restores_exact_receipts_and_skill_bytes(box, 
 
 def test_nested_copy_recovery_precedes_outer_enrollment_rollback(tmp_path, monkeypatch):
     from enrollment import EnrollmentJournal, recover_copy_transactions
+    monkeypatch.setenv("SYNTHESIS_ONBOARD_STATE_DIR", str(tmp_path / ".synthesis/onboarding"))
     state, base = base_state(tmp_path)
     receipt = tmp_path / ".synthesis/onboarding/receipts.json"
     target = tmp_path / ".agents/skills/example-skill"

--- a/skills/synthesis-onboarding/scripts/test_additive_enrollment.py
+++ b/skills/synthesis-onboarding/scripts/test_additive_enrollment.py
@@ -631,6 +631,13 @@ def test_real_cli_enroll_reaches_engine_and_preserves_personal_state(box):
         "assert repository.is_dir()\n"
         "os.execvp('git-upload-pack', ['git-upload-pack', str(repository)])\n" % str(box.remotes))
     env.update({"GIT_SSH_COMMAND": "%s %s" % (sys.executable, ssh), "GIT_SSH_VARIANT": "ssh"})
+    env["GIT_ALLOW_PROTOCOL"] = "https:ssh"
+    env["GIT_PROTOCOL_FROM_USER"] = "0"
+    # All three real organization repositories use the SSH fixture process;
+    # no local-transport rewrite bypasses the verified CLI's allowlist.
+    for name in list(env):
+        if name == "GIT_CONFIG_COUNT" or name.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
+            env.pop(name)
     for name in ("SYNTHESIS_ACTIVE_DESCRIPTOR", "SYNTHESIS_RELEASE_ROOT"):
         env.pop(name, None)
     result = subprocess.run([sys.executable, str(Path(cli.__file__)), "enroll", "--org-repo",

--- a/skills/synthesis-onboarding/scripts/test_bootstrap.py
+++ b/skills/synthesis-onboarding/scripts/test_bootstrap.py
@@ -22,6 +22,29 @@ import system_contract  # noqa: E402
 from test_system_contract import git, release_repo  # noqa: E402
 
 
+def test_verified_cli_can_use_org_ssh_without_enabling_local_transports(tmp_path, monkeypatch):
+    checkout = release_repo(tmp_path)
+    calls = []
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "https")
+    monkeypatch.setenv("GIT_PROTOCOL_FROM_USER", "0")
+    monkeypatch.setattr(bootstrap.subprocess, "call", lambda command, env=None: calls.append((command, env)) or 0)
+    assert bootstrap.main([
+        "--checkout", str(checkout), "--releases-dir", str(tmp_path / "releases"),
+        "--launcher", str(tmp_path / "bin/synthesis"),
+        "--active-descriptor", str(tmp_path / "state/active.json"),
+        "--channel", "stable", "--ref", "stable",
+        "--source-url", "https://example.test/synthesis-skills.git", "--", "update",
+    ]) == 0
+    environment = calls[0][1]
+    assert environment["GIT_ALLOW_PROTOCOL"] == "https:ssh"
+    assert environment["GIT_PROTOCOL_FROM_USER"] == "0"
+    assert os.environ["GIT_ALLOW_PROTOCOL"] == "https"
+    for forbidden in (checkout.as_uri(), "ext::git --version"):
+        blocked = subprocess.run(["git", "ls-remote", forbidden], env=environment,
+            capture_output=True, text=True)
+        assert blocked.returncode != 0 and "not allowed" in blocked.stderr
+
+
 def test_materialization_is_content_addressed_and_idempotent(tmp_path: Path) -> None:
     checkout = release_repo(tmp_path)
     releases = tmp_path / "cache" / "releases"


### PR DESCRIPTION
## Changes

Keep public acquisition HTTPS-only and give the verified CLI an HTTPS/SSH organization policy. File and external-helper transports remain refused.

Unify engine, enrollment journal, and rollback receipt paths for default, XDG, and explicit state directories. Preserve the existing personal installation.

## Verification

Real CLI and engine SSH fixtures cover all three state layouts. Injected doctor failures prove receipt restoration. A closed eight-case acceptance manifest covers the complete twelve-path change. Repository release checks and independent review gate publication.