### PR TITLE
Deduplicate historical recovery storage

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.95.1",
+  "version": "4.95.2",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.95.1",
+  "version": "4.95.2",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.95.2] - 2026-09-04
+
+**Historical recovery deduplicates payloads without retiring versions.** Skills
+manager 2.7.0 stores shared file contents once in a verified SQLite archive.
+Each version retains its paths, types, permissions and installation metadata.
+The unchanged 512 MiB hard limit covers the complete database, including indexes
+and page overhead. Admission refuses before native cache refresh if validation
+or the size check fails; no historical version is evicted.
+
+The standalone archive-aware guardian is installed and its supervisor verified
+before migration retires duplicate trees. Candidate commit, atomic promotion,
+move-before-delete retirement and resumed partial retirement are tested with
+real process interruptions. Blob and manifest hashes detect corruption beyond
+SQLite structure checks. Restored files are independent copies, never links to
+shared stored payloads. Historical integrity now checks executable permissions
+as well as source bytes, while the newest client-owned cache remains excluded.
+
 ## [4.95.1] - 2026-09-04
 
 **Verified enrollment can reach SSH organization repositories.** The bootstrap

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Historical recovery shares storage, not mutable files (September 2026).**
+Release **4.95.2** deduplicates recovery payloads while keeping every historical
+version and the existing 512 MiB limit. Version records preserve file types,
+permissions and content hashes. The publisher verifies the archive-aware
+guardian before migrating storage or refreshing the client; interrupted
+migration remains recoverable.
+
 **SSH organization enrollment follows verified bootstrap acquisition (September
 2026).** Release **4.95.1** separates the public HTTPS-only download policy from
 the verified CLI's HTTPS/SSH organization operations. Local-file and external

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -12,30 +12,30 @@ issues_authority_receipt: false
 unverified_remainder: production filesystem durability under hardware failure, malicious same-user mutation, live enrollment, deployment and genuine lifecycle acceptance remain separate
 changed_surfaces:
   - path: skills/synthesis-skills-manager/scripts/cache_guardian.py
-    cases: [archive-preservation, archive-budget, archive-interruptions, archive-corruption, archive-unsafe-manifest, archive-unsafe-database, archive-immutable, guardian-standalone, guardian-mode, guardian-suite]
+    cases: [archive-preservation, archive-budget, archive-interruptions, archive-corruption, archive-unsafe-manifest, archive-unsafe-database, archive-immutable, guardian-standalone, guardian-mode, guardian-root-mode, archive-inventory]
   - path: skills/synthesis-skills-manager/scripts/release.py
-    cases: [publisher-cutover, tag-history, manager-suite]
+    cases: [publisher-cutover, tag-history, publisher-lock, archive-umask, release-contract]
   - path: skills/synthesis-skills-manager/scripts/test_cache_guardian.py
     cases: [archive-preservation, archive-budget, archive-interruptions, archive-corruption, archive-unsafe-manifest, archive-unsafe-database, archive-immutable, guardian-standalone, guardian-mode]
   - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [publisher-cutover, tag-history, manager-suite]
+    cases: [publisher-cutover, tag-history, release-contract]
   - path: skills/synthesis-skills-manager/SKILL.md
-    cases: [manager-suite]
+    cases: [release-contract]
   - path: .claude-plugin/plugin.json
-    cases: [manager-suite]
+    cases: [release-contract]
   - path: .codex-plugin/plugin.json
-    cases: [manager-suite]
+    cases: [release-contract]
   - path: CHANGELOG.md
-    cases: [manager-suite]
+    cases: [release-contract]
   - path: README.md
-    cases: [manager-suite]
+    cases: [release-contract]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [manifest-consumer]
 cases:
-  - id: guardian-suite
+  - id: guardian-root-mode
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py
-    motivating_defect: complete-standalone-reader-migration-and-mode-contract-needs-execution
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_historical_root_mode_is_part_of_verified_identity
+    motivating_defect: root-directory-mode-is-part-of-immutable-history
   - id: archive-preservation
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_recovery_archive_deduplicates_and_preserves_all_history
@@ -80,11 +80,23 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots
     motivating_defect: all-tagged-intervening-releases-and-known-metadata-must-survive
-  - id: manager-suite
+  - id: release-contract
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_deduplicated_archive_release_contract_is_public_and_coherent
     motivating_defect: release-source-metadata-and-enforcing-consumer-must-stay-coherent
   - id: manifest-consumer
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
     motivating_defect: closed-manifest-must-validate-at-publication-boundary
+  - id: publisher-lock
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_contending_publisher_cannot_prepare_or_restart_guardian
+    motivating_defect: publisher-must-hold-shared-lock-before-consumer-cutover
+  - id: archive-umask
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_repeated_archive_admission_preserves_root_identity_across_umask
+    motivating_defect: git-export-root-mode-must-not-redefine-historical-identity
+  - id: archive-inventory
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_unowned_archive_files_refuse_before_migration
+    motivating_defect: unowned-data-must-not-be-silently-excluded-from-archive-budget

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,70 +1,90 @@
-# AGENT HEURISTIC: authored for the 4.95.1 verified transport handoff.
+# AGENT HEURISTIC: closed recovery storage and consumer acceptance.
 schema: 2
-suite: verified-organization-enrollment-boundaries
+suite: deduplicated-historical-recovery
 membership: closed
-production_entry_point: skills/synthesis-onboarding/scripts/bootstrap.py
-enforcing_boundary: verified organization operations permit HTTPS and SSH only while enrollment and rollback share the actual engine receipt directory
+production_entry_point: skills/synthesis-skills-manager/scripts/release.py
+enforcing_boundary: verified standalone guardian and budgeted complete archive precede destructive native cache refresh
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: live enrollment personal preservation build-only sites terminal updater and genuine client lifecycle receipts remain separate gates
+unverified_remainder: production filesystem durability under hardware failure, malicious same-user mutation, live enrollment, deployment and genuine lifecycle acceptance remain separate
 changed_surfaces:
-  - path: skills/synthesis-onboarding/scripts/bootstrap.py
-    cases: [verified-cli-transport, bootstrap-handoff, real-cli-ssh]
-  - path: skills/synthesis-onboarding/scripts/test_bootstrap.py
-    cases: [verified-cli-transport, bootstrap-handoff]
-  - path: skills/synthesis-onboarding/scripts/test_additive_enrollment.py
-    cases: [real-cli-ssh, engine-receipt-rollback]
-  - path: skills/synthesis-onboarding/scripts/enrollment.py
-    cases: [real-cli-ssh, engine-receipt-rollback]
-  - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [engine-version-contract, real-cli-ssh, engine-receipt-rollback]
-  - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
-    cases: [engine-version-contract, real-cli-ssh, engine-receipt-rollback]
-  - path: skills/synthesis-onboarding/SKILL.md
-    cases: [engine-version-contract, verified-cli-transport]
+  - path: skills/synthesis-skills-manager/scripts/cache_guardian.py
+    cases: [archive-preservation, archive-budget, archive-interruptions, archive-corruption, archive-unsafe-manifest, archive-unsafe-database, archive-immutable, guardian-standalone, guardian-mode, guardian-suite]
+  - path: skills/synthesis-skills-manager/scripts/release.py
+    cases: [publisher-cutover, tag-history, manager-suite]
+  - path: skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+    cases: [archive-preservation, archive-budget, archive-interruptions, archive-corruption, archive-unsafe-manifest, archive-unsafe-database, archive-immutable, guardian-standalone, guardian-mode]
+  - path: skills/synthesis-skills-manager/scripts/test_release.py
+    cases: [publisher-cutover, tag-history, manager-suite]
+  - path: skills/synthesis-skills-manager/SKILL.md
+    cases: [manager-suite]
   - path: .claude-plugin/plugin.json
-    cases: [release-manifest-parity]
+    cases: [manager-suite]
   - path: .codex-plugin/plugin.json
-    cases: [release-manifest-parity]
+    cases: [manager-suite]
   - path: CHANGELOG.md
-    cases: [release-changelog-parity]
+    cases: [manager-suite]
   - path: README.md
-    cases: [release-changelog-parity, verified-cli-transport]
+    cases: [manager-suite]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
-    cases: [shipped-manifest-self-consumption]
+    cases: [manifest-consumer]
 cases:
-  - id: engine-receipt-rollback
+  - id: guardian-suite
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_enrollment_rollback_protects_actual_engine_receipt
-    motivating_defect: enrollment-journal-protects-legacy-receipt-instead-of-default-or-xdg-engine-receipt
-  - id: verified-cli-transport
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py
+    motivating_defect: complete-standalone-reader-migration-and-mode-contract-needs-execution
+  - id: archive-preservation
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_bootstrap.py::test_verified_cli_can_use_org_ssh_without_enabling_local_transports
-    motivating_defect: public-download-policy-leaks-into-verified-organization-git-operations
-  - id: real-cli-ssh
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_recovery_archive_deduplicates_and_preserves_all_history
+    motivating_defect: duplicate-payloads-exhaust-archive-budget-despite-sufficient-unique-content
+  - id: archive-budget
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_real_cli_enroll_reaches_engine_and_preserves_personal_state
-    motivating_defect: transport-rewrites-in-fixtures-can-hide-real-ssh-enrollment-failure
-  - id: bootstrap-handoff
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_recovery_archive_budget_refuses_before_promoting
+    motivating_defect: budget-must-count-stored-database-pages-and-indexes-before-admission
+  - id: archive-interruptions
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_bootstrap.py::test_onboard_handoff_consumes_resolution_policy_before_update_cli
-    motivating_defect: bootstrap-must-forward-the-original-command-after-verified-resolution
-  - id: engine-version-contract
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_recovery_archive_real_process_interruptions_resume
+    motivating_defect: partial-migration-must-not-strand-historical-hooks
+  - id: archive-corruption
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_engine_versions_and_skill_contract_agree
-    motivating_defect: installed-guidance-and-engine-versions-must-match
-  - id: release-manifest-parity
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_recovery_archive_rejects_structurally_valid_database_corruption
+    motivating_defect: database-structure-integrity-does-not-prove-payload-or-manifest-integrity
+  - id: archive-unsafe-manifest
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
-    motivating_defect: both-native-clients-must-install-the-same-version
-  - id: release-changelog-parity
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_recovery_archive_refuses_rehashed_unsafe_manifest
+    motivating_defect: untrusted-restoration-paths-and-modes-must-fail-before-cache-writes
+  - id: archive-unsafe-database
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed
-    motivating_defect: release-changelog-and-manifest-identity-must-agree
-  - id: shipped-manifest-self-consumption
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_recovery_archive_refuses_unsafe_database_targets
+    motivating_defect: links-or-special-database-targets-cannot-be-followed-during-migration
+  - id: archive-immutable
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_existing_version_cannot_replace_historical_source
+    motivating_defect: repeated-admission-must-not-replace-historical-source
+  - id: guardian-standalone
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_standalone_guardian_restores_database_history_after_repeated_reconciliation
+    motivating_defect: guardian-must-recover-after-client-cache-reconciliation-without-source-checkout
+  - id: guardian-mode
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_cache_guardian.py::test_mode_corruption_is_not_accepted_as_historical_integrity
+    motivating_defect: byte-equal-nonexecutable-hook-was-accepted
+  - id: publisher-cutover
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_database_guardian_cutover_gates_destructive_native_refresh
+    motivating_defect: new-storage-consumer-must-be-verified-before-migration-or-native-refresh
+  - id: tag-history
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots
+    motivating_defect: all-tagged-intervening-releases-and-known-metadata-must-survive
+  - id: manager-suite
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py
+    motivating_defect: release-source-metadata-and-enforcing-consumer-must-stay-coherent
+  - id: manifest-consumer
     control_class: acceptance-test
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: release-authority-must-consume-its-exact-closed-manifest
+    motivating_defect: closed-manifest-must-validate-at-publication-boundary

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -81,11 +81,11 @@ cases:
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots
     motivating_defect: all-tagged-intervening-releases-and-known-metadata-must-survive
   - id: release-contract
-    control_class: acceptance-test
+    control_class: diagnostic
     fixture: ../synthesis-skills-manager/scripts/test_release.py::test_deduplicated_archive_release_contract_is_public_and_coherent
     motivating_defect: release-source-metadata-and-enforcing-consumer-must-stay-coherent
   - id: manifest-consumer
-    control_class: acceptance-test
+    control_class: diagnostic
     fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
     motivating_defect: closed-manifest-must-validate-at-publication-boundary
   - id: publisher-lock

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -359,8 +359,8 @@ The sequence, each stage gating the next:
   The deduplicated archive has a 512 MiB hard budget and never evicts a historical version
   automatically when that budget is reached; unverifiable cleanup fails the
   release closed. Transient verified migration copies are retired after the
-  committed store contains their bytes and modes. Symlink recovery artifacts and client liveness markers are not
-  preserved.
+  committed store contains their bytes and modes. Symlinked recovery roots and
+  unsafe links are refused; client liveness markers are excluded.
 - **Verify** is the point of the whole script, and it checks each client
   **twice**: what the CLI reports, and the plugin manifest at the path the CLI
   says it loads. Agreement of both with the source version is the only pass.

--- a/skills/synthesis-skills-manager/SKILL.md
+++ b/skills/synthesis-skills-manager/SKILL.md
@@ -5,12 +5,22 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.6.3"
+  version: "2.7.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
 
 # Synthesis Skills Manager
+**Version 2.7.0** (2026-09-04) deduplicates historical payloads in a SQLite
+content-addressed archive. Immutable per-version manifests preserve paths,
+types, modes and metadata; restoration creates independent files. SHA-256
+validation covers every payload and manifest, beyond database structure checks.
+The complete database, including page overhead, stays within the unchanged
+512 MiB budget. A verified candidate replaces the store atomically; legacy
+trees move before deletion only after their complete recovery is verified.
+Interrupted retirement resumes against the committed version manifest. The
+archive-aware standalone guardian and supervisor are verified before migration
+or native refresh. Source integrity includes permissions, not just bytes.
 
 **Version 2.6.3** (2026-09-03) makes synchronous historical-cache verification
 wait up to 120 seconds for the shared transition lock. This covers a complete
@@ -30,19 +40,13 @@ as one directory instead of copying through untrusted entries, so a nested
 symlink or hard link cannot redirect repair writes outside the cache. All other
 source and filesystem-type checks remain fail-closed.
 
-**Version 2.6.1** (2026-09-03) keeps historical-cache integrity scoped to
-release source even while an older running task executes Python hooks from its
-versioned root. The guardian excludes only regular `.pyc` or `.pyo` files
-directly inside a real `__pycache__` directory; unknown files, loose bytecode,
-links, special objects, and source changes remain integrity failures. Shipped
-Python hooks also use `-B` so current runtimes do not create bytecode there.
+**Version 2.6.1** (2026-09-03) bounds runtime-bytecode exclusions to real
+Python cache directories; unknown files, links and source changes still fail.
+Shipped Python hooks use `-B` to avoid creating bytecode there.
 
-**Version 2.6.0** (2026-09-02) makes public CLI activation part of the same
-gated release transaction as source publication and dual-client verification.
-The release manager resolves the immutable version tag, materializes its exact
-commit, Git tree, and canonical content digest under the synthesis-owned release
-store, and atomically activates the managed launcher and descriptor only after
-both supported clients verify the release.
+**Version 2.6.0** (2026-09-02) includes immutable public CLI activation in the
+gated publication and dual-client verification transaction. The launcher binds
+the verified version tag, commit, Git tree and content digest.
 
 **Version 2.5.1** (2026-09-02) prioritizes the newest historical Codex roots
 during recovery, so the version most likely to be pinned by a just-updated task
@@ -338,7 +342,8 @@ The sequence, each stage gating the next:
   receipt covers the release transaction; it cannot prove that the client will
   not create another cache generation minutes later. The publisher therefore
   installs `cache_guardian.py` under the durable recovery root and verifies its
-  user-level launchd or systemd supervisor before returning. The guardian shares
+  user-level launchd or systemd supervisor before archive migration, then verifies
+  recovery again before returning. The guardian shares
   the release lock, protects every archived version except the newest
   client-owned version, and rehydrates missing historical roots after any later
   cache replacement. It never deletes a cache path or overwrites differing
@@ -351,9 +356,10 @@ The sequence, each stage gating the next:
   watcher and explicit one-shot mode stay nonblocking. The watcher continues
   protecting those roots against later reconciliation after either command
   exits.
-  The archive has a 512 MiB hard budget and never deletes a historical root
+  The deduplicated archive has a 512 MiB hard budget and never evicts a historical version
   automatically when that budget is reached; unverifiable cleanup fails the
-  release closed. Symlink recovery artifacts and client liveness markers are not
+  release closed. Transient verified migration copies are retired after the
+  committed store contains their bytes and modes. Symlink recovery artifacts and client liveness markers are not
   preserved.
 - **Verify** is the point of the whole script, and it checks each client
   **twice**: what the CLI reports, and the plugin manifest at the path the CLI

--- a/skills/synthesis-skills-manager/scripts/cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/cache_guardian.py
@@ -23,12 +23,13 @@ import os
 import plistlib
 import re
 import shutil
+import sqlite3
 import stat
 import subprocess
 import sys
 import tempfile
 import time
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Iterator
@@ -48,6 +49,9 @@ ERROR_RETRY_SECONDS = 10.0
 LOCK_WAIT_TIMEOUT_SECONDS = 120.0
 LOCK_WAIT_INTERVAL_SECONDS = 0.1
 EX_TEMPFAIL = 75
+STORE_NAME = "recovery.sqlite3"
+ARCHIVE_BUDGET_BYTES = 512 * 1024 * 1024
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
 
 
 class GuardianError(RuntimeError):
@@ -128,7 +132,10 @@ def _is_ignorable_bytecode(path: Path, relative_path: Path) -> bool:
 
 
 def _tree_digest(root: Path) -> str:
+    if root.is_symlink() or not root.is_dir():
+        raise GuardianError(f"unsafe or missing cache root: {root}")
     digest = hashlib.sha256()
+    digest.update(b"ROOT\0" + str(stat.S_IMODE(root.stat().st_mode)).encode("ascii"))
     for path in sorted(root.rglob("*"), key=lambda item: str(item.relative_to(root))):
         relative_path = path.relative_to(root)
         if relative_path.parts and relative_path.parts[0] in IGNORED_ROOTS:
@@ -136,15 +143,291 @@ def _tree_digest(root: Path) -> str:
         if _is_ignorable_bytecode(path, relative_path):
             continue
         relative = str(relative_path).encode("utf-8")
+        mode = str(stat.S_IMODE(path.lstat().st_mode)).encode("ascii")
         if path.is_symlink():
             digest.update(b"L\0" + relative + b"\0" + os.readlink(path).encode("utf-8"))
         elif path.is_dir():
-            digest.update(b"D\0" + relative)
+            digest.update(b"D\0" + relative + b"\0" + mode)
         elif path.is_file():
-            digest.update(b"F\0" + relative + b"\0" + path.read_bytes())
+            digest.update(b"F\0" + relative + b"\0" + mode + b"\0" + path.read_bytes())
         else:
             raise GuardianError(f"unsupported cache entry type: {relative_path}")
     return digest.hexdigest()
+
+
+def _safe_archive_boundary(path: Path) -> None:
+    if not path.is_absolute() or path in (Path("/"), Path.home(), Path.cwd()):
+        raise GuardianError(f"unsafe archive boundary: {path}")
+    for part in (path, *path.parents):
+        if part.is_symlink():
+            raise GuardianError(f"symlinked archive boundary: {part}")
+    if (path / ".git").exists():
+        raise GuardianError(f"repository cannot be an archive: {path}")
+
+
+def _json_bytes(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _capture_tree(root: Path, version: str, objects: dict[str, bytes], *, validate: bool = True) -> dict:
+    if not root.is_dir() or root.is_symlink():
+        raise GuardianError(f"unsafe recovery input: {root}")
+    entries = {}
+    for path in sorted(root.rglob("*")):
+        relative = path.relative_to(root)
+        if relative.parts[0] in {".git", ".in_use"}:
+            continue
+        if _is_ignorable_bytecode(path, relative):
+            continue
+        info = path.lstat()
+        mode = stat.S_IMODE(info.st_mode)
+        if stat.S_ISLNK(info.st_mode):
+            target = os.readlink(path)
+            link = PurePosixPath(target)
+            if not target or link.is_absolute() or ".." in link.parts:
+                raise GuardianError(f"unsafe archive symlink: {relative}")
+            entry = ["link", mode, target]
+        elif stat.S_ISDIR(info.st_mode):
+            entry = ["dir", mode]
+        elif stat.S_ISREG(info.st_mode):
+            descriptor = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+            with os.fdopen(descriptor, "rb") as handle:
+                before = os.fstat(handle.fileno())
+                data = handle.read()
+                after = os.fstat(handle.fileno())
+            if (before.st_ino, before.st_size, before.st_mtime_ns, before.st_mode) != (
+                after.st_ino, after.st_size, after.st_mtime_ns, after.st_mode
+            ) or before.st_ino != info.st_ino:
+                raise GuardianError(f"recovery input changed while reading: {relative}")
+            digest = hashlib.sha256(data).hexdigest()
+            objects[digest] = data
+            entry = ["file", mode, digest]
+        else:
+            raise GuardianError(f"unsupported archive entry type: {relative}")
+        entries[relative.as_posix()] = entry
+    manifest = {"version": version, "root_mode": stat.S_IMODE(root.stat().st_mode), "entries": entries}
+    if validate:
+        _validate_manifest(manifest, version, objects)
+    return manifest
+
+
+def _validate_manifest(manifest: dict, version: str, objects: dict[str, bytes]) -> None:
+    if not isinstance(manifest, dict) or set(manifest) != {"version", "root_mode", "entries"}:
+        raise GuardianError("invalid recovery manifest fields")
+    if VERSION_RE.fullmatch(version) is None or manifest["version"] != version:
+        raise GuardianError("invalid recovery version identity")
+    if type(manifest["root_mode"]) is not int or not 0 <= manifest["root_mode"] <= 0o777:
+        raise GuardianError("invalid recovery root mode")
+    entries = manifest["entries"]
+    if not isinstance(entries, dict) or not entries:
+        raise GuardianError("empty or invalid recovery manifest")
+    for name, entry in entries.items():
+        if not isinstance(name, str):
+            raise GuardianError("invalid recovery manifest path type")
+        relative = PurePosixPath(name)
+        if not name or relative.is_absolute() or relative.as_posix() != name or ".." in relative.parts or "\\" in name or "\0" in name:
+            raise GuardianError(f"unsafe recovery manifest path: {name!r}")
+        for parent in relative.parents:
+            if parent == PurePosixPath("."):
+                break
+            parent_entry = entries.get(parent.as_posix())
+            if not isinstance(parent_entry, list) or len(parent_entry) != 2 or parent_entry[0] != "dir":
+                raise GuardianError(f"non-directory recovery manifest parent: {name}")
+        if not isinstance(entry, list) or len(entry) not in (2, 3):
+            raise GuardianError(f"invalid recovery manifest entry: {name}")
+        kind, mode = entry[:2]
+        if type(mode) is not int or not 0 <= mode <= 0o777:
+            raise GuardianError(f"invalid recovery entry mode: {name}")
+        if kind == "file" and len(entry) == 3:
+            if not isinstance(entry[2], str) or not SHA256_RE.fullmatch(entry[2]) or entry[2] not in objects:
+                raise GuardianError(f"missing or invalid recovery object: {name}")
+        elif kind == "link" and len(entry) == 3:
+            target = entry[2]
+            if not isinstance(target, str) or not target or "\0" in target or "\\" in target or PurePosixPath(target).is_absolute() or ".." in PurePosixPath(target).parts:
+                raise GuardianError(f"unsafe recovery link: {name}")
+        elif kind != "dir" or len(entry) != 2:
+            raise GuardianError(f"unsupported recovery manifest entry: {name}")
+
+
+def _source_entries(manifest: dict) -> dict:
+    return {"root_mode": manifest["root_mode"], "entries": {name: entry for name, entry in manifest["entries"].items() if name.split("/")[0] not in IGNORED_ROOTS}}
+
+
+class RecoveryStore:
+    """Immutable, independently verified SQLite content-addressed archive.
+
+    Publishers build a separate candidate and replace the closed database only
+    after validation and budget checks. Readers never open a writable database.
+    The store travels inside this standalone guardian, including after restart.
+    """
+
+    def __init__(self) -> None:
+        self.versions: dict[str, dict] = {}
+        self.objects: dict[str, bytes] = {}
+        self.stored_bytes = 0
+
+    @classmethod
+    def read(cls, archive: Path, *, budget: int = ARCHIVE_BUDGET_BYTES) -> RecoveryStore:
+        _safe_archive_boundary(archive)
+        if archive.exists():
+            for child in archive.iterdir():
+                if child.name == STORE_NAME:
+                    continue
+                version = child.name.removeprefix(".retired-")
+                if not VERSION_RE.fullmatch(version) or child.is_symlink() or not child.is_dir():
+                    raise GuardianError(f"unexpected or unsafe archive entry: {child}")
+        return cls.read_file(archive / STORE_NAME, budget=budget)
+
+    @classmethod
+    def read_file(cls, path: Path, *, budget: int = ARCHIVE_BUDGET_BYTES) -> RecoveryStore:
+        result = cls()
+        if not path.exists() and not path.is_symlink():
+            return result
+        info = path.lstat()
+        if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+            raise GuardianError(f"unsafe recovery database: {path}")
+        if info.st_size > budget:
+            raise GuardianError("recovery archive exceeds the 512 MiB hard budget")
+        try:
+            with closing(sqlite3.connect(path.as_uri() + "?mode=ro&immutable=1", uri=True)) as db:
+                db.execute("PRAGMA trusted_schema=OFF")
+                if db.execute("PRAGMA user_version").fetchone()[0] != 1 or db.execute("PRAGMA integrity_check").fetchall() != [("ok",)]:
+                    raise GuardianError("recovery database integrity or schema failure")
+                for digest, payload in db.execute("SELECT digest, payload FROM objects"):
+                    if not isinstance(payload, bytes) or hashlib.sha256(payload).hexdigest() != digest:
+                        raise GuardianError("recovery object digest mismatch")
+                    result.objects[digest] = payload
+                for version, raw, digest in db.execute("SELECT version, manifest, digest FROM versions"):
+                    if not isinstance(raw, str) or hashlib.sha256(raw.encode()).hexdigest() != digest:
+                        raise GuardianError("recovery manifest digest mismatch")
+                    manifest = json.loads(raw)
+                    _validate_manifest(manifest, version, result.objects)
+                    result.versions[version] = manifest
+                referenced = {entry[2] for manifest in result.versions.values() for entry in manifest["entries"].values() if entry[0] == "file"}
+                if referenced != set(result.objects):
+                    raise GuardianError("recovery object membership differs from version manifests")
+                pages = db.execute("PRAGMA page_count").fetchone()[0] * db.execute("PRAGMA page_size").fetchone()[0]
+                if pages != info.st_size or pages > budget:
+                    raise GuardianError("recovery database pages violate hard budget or file size")
+        except (sqlite3.Error, ValueError, TypeError) as exc:
+            raise GuardianError(f"unreadable recovery database: {exc}") from exc
+        if not result.versions:
+            raise GuardianError("recovery database has no versions")
+        result.stored_bytes = info.st_size
+        return result
+
+    def materialize(self, version: str, target: Path) -> None:
+        manifest = self.versions[version]
+        _validate_manifest(manifest, version, self.objects)
+        target.mkdir(parents=True, exist_ok=False)
+        # Create with writable staging modes; final directory modes come last.
+        for name, entry in sorted(manifest["entries"].items()):
+            path = target / name
+            if entry[0] == "dir":
+                path.mkdir()
+            elif entry[0] == "file":
+                data = self.objects[entry[2]]
+                if hashlib.sha256(data).hexdigest() != entry[2]:
+                    raise GuardianError("recovery object changed before materialization")
+                with path.open("xb") as handle:
+                    handle.write(data)
+                path.chmod(entry[1])
+            else:
+                path.symlink_to(entry[2])
+        for name, entry in sorted(manifest["entries"].items(), reverse=True):
+            if entry[0] == "dir":
+                (target / name).chmod(entry[1])
+        target.chmod(manifest["root_mode"])
+        observed = _capture_tree(target, version, {})
+        if observed != manifest:
+            raise GuardianError(f"materialized recovery differs from manifest: {version}")
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _retire_legacy(archive: Path, store: RecoveryStore) -> None:
+    """Resume a verified move-before-delete, even after partial tree removal."""
+    for child in sorted(archive.iterdir()):
+        version = child.name.removeprefix(".retired-")
+        if not VERSION_RE.fullmatch(version):
+            continue
+        if child.is_symlink() or not child.is_dir() or version not in store.versions:
+            raise GuardianError(f"unsafe legacy retirement: {child}")
+        observed = _capture_tree(child, version, {}, validate=False)
+        expected = store.versions[version]
+        retiring = child.name.startswith(".retired-")
+        if observed["root_mode"] != expected["root_mode"] or (not retiring and observed != expected) or any(expected["entries"].get(key) != entry for key, entry in observed["entries"].items()):
+            raise GuardianError(f"legacy retirement differs from committed recovery: {child}")
+        target = archive / f".retired-{version}"
+        if not retiring:
+            if target.exists() or target.is_symlink():
+                raise GuardianError(f"legacy retirement destination already exists: {target}")
+            os.rename(child, target)
+            _fsync_directory(archive)
+        if target.parent != archive or target.is_symlink() or archive in (Path.home(), Path.cwd(), Path("/")):
+            raise GuardianError(f"unsafe retirement cleanup: {target}")
+        shutil.rmtree(target)
+        _fsync_directory(archive)
+
+
+def persist_archive(archive: Path, roots: dict[str, Path], *, budget: int = ARCHIVE_BUDGET_BYTES) -> RecoveryStore:
+    """Admit complete versions under the publisher's shared transition lock.
+
+    Transient candidate and migration copies coexist until verification; only
+    committed recovery storage is admitted against the unchanged hard limit.
+    No version or unique payload is evicted to satisfy the limit.
+    """
+    _safe_archive_boundary(archive)
+    archive.mkdir(parents=True, exist_ok=True)
+    store = RecoveryStore.read(archive)
+    legacy = _version_roots(archive)
+    for version, root in [*legacy.items(), *roots.items()]:
+        manifest = _capture_tree(root, version, store.objects)
+        previous = store.versions.get(version)
+        if previous is not None:
+            if _source_entries(previous) != _source_entries(manifest):
+                raise GuardianError(f"immutable historical version differs: {version}")
+            # Retain original installation metadata, never replace history.
+        else:
+            store.versions[version] = manifest
+    if not store.versions:
+        raise GuardianError("no recovery versions to persist")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=".recovery-candidate-", dir=archive.parent)
+    os.close(descriptor)
+    candidate = Path(temporary_name)
+    try:
+        with closing(sqlite3.connect(candidate)) as db:
+            db.execute("PRAGMA journal_mode=DELETE")
+            db.execute("PRAGMA synchronous=FULL")
+            db.execute("PRAGMA user_version=1")
+            db.execute("CREATE TABLE objects (digest TEXT PRIMARY KEY, payload BLOB NOT NULL)")
+            db.execute("CREATE TABLE versions (version TEXT PRIMARY KEY, manifest TEXT NOT NULL, digest TEXT NOT NULL)")
+            referenced = {entry[2] for manifest in store.versions.values() for entry in manifest["entries"].values() if entry[0] == "file"}
+            db.executemany("INSERT INTO objects VALUES (?, ?)", ((digest, store.objects[digest]) for digest in sorted(referenced)))
+            for version, manifest in sorted(store.versions.items()):
+                raw = _json_bytes(manifest)
+                db.execute("INSERT INTO versions VALUES (?, ?, ?)", (version, raw.decode(), hashlib.sha256(raw).hexdigest()))
+            db.commit()
+        verified = RecoveryStore.read_file(candidate, budget=budget)
+        if verified.versions != store.versions or set(verified.objects) != referenced:
+            raise GuardianError("candidate recovery store differs after commit")
+        _safe_archive_boundary(archive)
+        destination = archive / STORE_NAME
+        if destination.is_symlink() or (destination.exists() and (not destination.is_file() or destination.stat().st_nlink != 1)):
+            raise GuardianError("unsafe recovery database promotion target")
+        os.replace(candidate, destination)
+        _fsync_directory(archive)
+        committed = RecoveryStore.read(archive, budget=budget)
+        _retire_legacy(archive, committed)
+        return committed
+    finally:
+        candidate.unlink(missing_ok=True)
 
 
 def _validate_root(root: Path, version: str) -> None:
@@ -288,6 +571,22 @@ def _restore_missing(source: Path, destination: Path, parent: Path) -> bool:
         _remove_staging(staging, parent)
 
 
+def _restore_stored(store: RecoveryStore, version: str, destination: Path, parent: Path) -> bool:
+    staging = parent / f".guardian-{version}-{os.getpid()}-{time.time_ns()}"
+    try:
+        store.materialize(version, staging)
+        _validate_root(staging, version)
+        if destination.exists() or destination.is_symlink():
+            if destination.is_symlink() or not destination.is_dir() or _tree_digest(staging) != _tree_digest(destination):
+                raise GuardianError(f"cache root appeared with differing content: {destination}")
+            return False
+        os.rename(staging, destination)
+        _fsync_directory(parent)
+        return True
+    finally:
+        _remove_staging(staging, parent)
+
+
 def restore_once(home: Path | None = None, *, blocking: bool = False) -> dict[str, object]:
     home = (home or Path.home()).absolute()
     archive = archive_root(home)
@@ -296,15 +595,16 @@ def restore_once(home: Path | None = None, *, blocking: bool = False) -> dict[st
     _refuse_symlinked_boundary(home, cache)
     if not archive.is_dir():
         raise GuardianError(f"recovery archive is unavailable: {archive}")
-    archived = _version_roots(archive)
-    if not archived:
-        raise GuardianError(f"recovery archive has no version roots: {archive}")
-    ordered = sorted(archived, key=_version_key)
-    current = ordered[-1]
-    protected = ordered[:-1]
     restored: list[str] = []
     verified: list[str] = []
     with _cache_lock(home, blocking=blocking):
+        store = RecoveryStore.read(archive)
+        archived = _version_roots(archive)
+        ordered = sorted(set(archived) | set(store.versions), key=_version_key)
+        if not ordered:
+            raise GuardianError(f"recovery archive has no version roots: {archive}")
+        current = ordered[-1]
+        protected = ordered[:-1]
         cache.mkdir(parents=True, exist_ok=True)
         if cache.is_symlink():
             raise GuardianError(f"cache parent is a symlink: {cache}")
@@ -312,11 +612,22 @@ def restore_once(home: Path | None = None, *, blocking: bool = False) -> dict[st
         # the current release. Restore from newest to oldest so that root is
         # available first even when a large archive takes time to rehydrate.
         for version in reversed(protected):
-            source = archived[version]
-            _validate_root(source, version)
             destination = cache / version
             if destination.is_symlink() or (destination.exists() and not destination.is_dir()):
                 raise GuardianError(f"historical cache root has an unsafe type: {destination}")
+            if version in store.versions:
+                if not destination.exists():
+                    if _restore_stored(store, version, destination, cache):
+                        restored.append(version)
+                else:
+                    observed = _capture_tree(destination, version, {})
+                    if _source_entries(observed) != _source_entries(store.versions[version]):
+                        raise GuardianError(f"historical cache root differs from archive: {destination}")
+                    _validate_root(destination, version)
+                verified.append(version)
+                continue
+            source = archived[version]
+            _validate_root(source, version)
             if not destination.exists():
                 if _restore_missing(source, destination, cache):
                     restored.append(version)
@@ -448,7 +759,7 @@ def install_supervisor(
     raise GuardianError(f"no supported user supervisor on platform {platform}")
 
 
-def install(home: Path | None = None) -> dict[str, object]:
+def prepare_runtime(home: Path | None = None) -> dict[str, object]:
     home = (home or Path.home()).absolute()
     runtime = runtime_path(home)
     _refuse_symlinked_boundary(home, runtime)
@@ -456,10 +767,15 @@ def install(home: Path | None = None) -> dict[str, object]:
     _atomic_write(runtime, source.read_bytes(), 0o755)
     if runtime.read_bytes() != source.read_bytes():
         raise GuardianError(f"installed guardian differs from source: {runtime}")
-    record = restore_once(home, blocking=True)
     supervisor = install_supervisor(home, runtime)
-    record["runtime"] = str(runtime)
-    record["supervisor"] = supervisor
+    return {"runtime": str(runtime), "supervisor": supervisor}
+
+
+def install(home: Path | None = None) -> dict[str, object]:
+    home = (home or Path.home()).absolute()
+    deployed = prepare_runtime(home)
+    record = restore_once(home, blocking=True)
+    record.update(deployed)
     return record
 
 
@@ -469,6 +785,7 @@ def main(argv: list[str] | None = None) -> int:
     modes.add_argument("--once", action="store_true", help="restore and verify historical roots once")
     modes.add_argument("--watch", action="store_true", help="continuously guard later cache generations")
     modes.add_argument("--install", action="store_true", help="install and start the durable user supervisor")
+    modes.add_argument("--prepare", action="store_true", help="verify the archive-aware supervisor before archive migration")
     modes.add_argument(
         "--doctor",
         action="store_true",
@@ -480,7 +797,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.watch:
             watch(interval=max(args.interval, 0.1))
             return 0
-        if args.install:
+        if args.prepare:
+            record = prepare_runtime()
+        elif args.install:
             record = install()
         else:
             # A synchronous doctor is a completion gate for onboarding. It

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -47,6 +47,7 @@ import os
 import re
 import secrets
 import shutil
+import stat
 import subprocess
 import sys
 import tarfile
@@ -77,6 +78,7 @@ except ImportError:  # pragma: no cover - resolved at runtime in the repo
 from bootstrap import materialize_release
 from cache_guardian import GuardianError as CacheGuardianError
 from cache_guardian import _tree_digest as _guardian_tree_digest
+from cache_guardian import RecoveryStore, persist_archive
 from system_contract import ContractError, activate_cli, atomic_write_json
 
 
@@ -775,15 +777,7 @@ def _tree_bytes(root: Path) -> int:
 def _persist_codex_archive(
     backup: Path, versions: list[str], archive: Path
 ) -> None:
-    archive.mkdir(parents=True, exist_ok=True)
-    for version in versions:
-        source = backup / version
-        destination = archive / version
-        if destination.is_symlink():
-            raise OSError(f"recovery archive root is a symlink: {destination}")
-        shutil.copytree(source, destination, dirs_exist_ok=True, symlinks=True)
-        if _tree_digest(source) != _tree_digest(destination):
-            raise OSError(f"recovery archive differs after write: {destination}")
+    persist_archive(archive, {version: backup / version for version in versions}, budget=CODEX_CACHE_ARCHIVE_BUDGET_BYTES)
 
 
 def snapshot_codex_caches(
@@ -813,6 +807,12 @@ def snapshot_codex_caches(
         cache_roots = _real_version_roots(parent)
         peer_roots = _real_version_roots(peers["Claude cache"])
         archive_roots = _real_version_roots(archive) if archive is not None else {}
+        if archive is not None:
+            stored = RecoveryStore.read(archive)
+            for version in stored.versions:
+                restored_archive = backup / ".archive-input" / version
+                stored.materialize(version, restored_archive)
+                archive_roots[version] = restored_archive
         boundary_versions = set(cache_roots) | set(peer_roots) | set(archive_roots)
         preserved_versions = set(boundary_versions)
         seed_versions = set(boundary_versions)
@@ -875,6 +875,10 @@ def snapshot_codex_caches(
                 destination,
                 current_version=current_version or "",
             )
+            # Git records child modes but no mode for the release root itself.
+            # Keep its prior archive identity; new tagged roots use one declared
+            # mode rather than inheriting the publisher's changing umask.
+            destination.chmod(stat.S_IMODE(archive_roots[version].stat().st_mode) if version in archive_roots else 0o755)
             if version in archive_roots:
                 _copy_cache_extras(archive_roots[version], destination, tracked)
             if version in peer_roots:
@@ -883,12 +887,6 @@ def snapshot_codex_caches(
                 _copy_cache_extras(cache_roots[version], destination, tracked)
 
         if archive is not None:
-            projected_bytes = _tree_bytes(backup)
-            if projected_bytes > CODEX_CACHE_ARCHIVE_BUDGET_BYTES:
-                raise OSError(
-                    "recovery archive would exceed the 512 MiB hard budget; "
-                    "no historical root was deleted automatically"
-                )
             _persist_codex_archive(
                 backup, sorted(seed_versions, key=_version_key), archive
             )
@@ -899,7 +897,7 @@ def snapshot_codex_caches(
                 True,
                 f"verified {len(seed_versions)} complete recovery root(s)",
             )
-    except (OSError, subprocess.SubprocessError, tarfile.TarError) as exc:
+    except (CacheGuardianError, OSError, subprocess.SubprocessError, tarfile.TarError) as exc:
         result.add(
             "install.codex.cache-snapshot",
             False,
@@ -920,9 +918,14 @@ def _remove_transition_backup(backup: Path) -> None:
     resolved = backup.resolve()
     temporary_root = Path(tempfile.gettempdir()).resolve()
     if (
+        backup.is_symlink()
+        or not backup.is_dir()
+        or resolved in (Path.home().resolve(), Path.cwd().resolve())
+        or (resolved / ".git").exists()
+        or Path.cwd().resolve().is_relative_to(resolved)
+        or
         resolved.parent != temporary_root
         or not resolved.name.startswith("synthesis-codex-cache-")
-        or resolved.is_symlink()
     ):
         raise OSError(f"refusing unsafe transition-backup cleanup target: {backup}")
     shutil.rmtree(resolved)
@@ -1169,6 +1172,10 @@ def refresh_client(
     try:
         cache_snapshot = None
         if client == "codex" and not dry_run:
+            # Keep the watcher serialized behind this transition while its new
+            # standalone consumer is installed, before retiring legacy roots.
+            if repo is not None and not install_codex_cache_guardian(repo, result, False, prepare_only=True):
+                return False
             cache_snapshot = snapshot_codex_caches(result, repo=repo)
             if cache_snapshot is None:
                 return False
@@ -1196,7 +1203,7 @@ def refresh_client(
 
 
 def install_codex_cache_guardian(
-    repo: Path, result: Result, dry_run: bool
+    repo: Path, result: Result, dry_run: bool, *, prepare_only: bool = False
 ) -> bool:
     """Install the durable supervisor that repairs later Codex cache generations."""
     source = repo / CACHE_GUARDIAN
@@ -1206,7 +1213,7 @@ def install_codex_cache_guardian(
             False,
             f"guardian source is unavailable or unsafe: {source}",
         )
-    command = [sys.executable, str(source), "--install"]
+    command = [sys.executable, str(source), "--prepare" if prepare_only else "--install"]
     if dry_run:
         return result.add(
             "install.codex.cache-guardian",

--- a/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
@@ -6,6 +6,7 @@ import json
 import os
 import plistlib
 import shutil
+import sqlite3
 import subprocess
 import sys
 import time
@@ -72,6 +73,76 @@ def test_restore_protects_history_but_never_installs_current(tmp_path: Path) -> 
     assert record["current_excluded"] == "4.77.1"
     assert record["restored"] == ["4.73.0"]
     assert json.loads(guardian.receipt_path(home).read_text(encoding="utf-8"))["verified"] == 1
+
+
+def test_recovery_archive_deduplicates_and_preserves_all_history(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    archive = guardian.archive_root(home)
+    for version in ("4.73.0", "4.77.1"):
+        root = archive / version
+        (root / "shared").write_bytes(b"shared payload" * 10000)
+        (root / "shared").chmod(0o755 if version == "4.73.0" else 0o644)
+        (root / "empty").mkdir(mode=0o750)
+        (root / "alias").symlink_to("shared")
+    expected = {v: guardian._tree_digest(archive / v) for v in ("4.73.0", "4.77.1")}
+    guardian.persist_archive(archive, {}, budget=200000)
+    store = guardian.RecoveryStore.read(archive)
+    assert set(store.versions) == set(expected)
+    assert sum(data == b"shared payload" * 10000 for data in store.objects.values()) == 1
+    assert store.stored_bytes <= 200000
+    assert not (archive / "4.73.0").exists()
+    for version, digest in expected.items():
+        target = tmp_path / version
+        store.materialize(version, target)
+        assert guardian._tree_digest(target) == digest
+        assert (target / "shared").stat().st_mode & 0o777 == (0o755 if version == "4.73.0" else 0o644)
+    guardian.restore_once(home)
+    cache = guardian.cache_parent(home)
+    (cache / "4.73.0" / "shared").write_bytes(b"changed cache")
+    assert b"shared payload" * 10000 in guardian.RecoveryStore.read(archive).objects.values()
+    assert (tmp_path / "4.77.1" / "shared").read_bytes() == b"shared payload" * 10000
+
+
+def test_recovery_archive_budget_refuses_before_promoting(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    archive = guardian.archive_root(home)
+    guardian.persist_archive(archive, {})
+    database = archive / guardian.STORE_NAME
+    before = database.read_bytes()
+    new = tmp_path / "new"
+    seed_root(new, "4.78.0", "new")
+    with pytest.raises(guardian.GuardianError, match="hard budget"):
+        guardian.persist_archive(archive, {"4.78.0": new}, budget=1)
+    assert database.read_bytes() == before
+    assert set(guardian.RecoveryStore.read(archive).versions) == {"4.73.0", "4.77.1"}
+
+
+@pytest.mark.parametrize("damage", ["payload", "missing", "manifest"])
+def test_recovery_archive_rejects_structurally_valid_database_corruption(tmp_path: Path, damage: str) -> None:
+    home = seeded_home(tmp_path)
+    archive = guardian.archive_root(home)
+    guardian.persist_archive(archive, {})
+    with sqlite3.connect(archive / guardian.STORE_NAME) as db:
+        if damage == "payload":
+            db.execute("UPDATE objects SET payload = ? WHERE digest = (SELECT digest FROM objects LIMIT 1)", (b"bad",))
+        elif damage == "missing":
+            db.execute("DELETE FROM objects WHERE digest = (SELECT digest FROM objects LIMIT 1)")
+        else:
+            db.execute("UPDATE versions SET manifest = '{}' WHERE version = '4.73.0'")
+        assert db.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    with pytest.raises(guardian.GuardianError):
+        guardian.restore_once(home)
+    assert not guardian.cache_parent(home).exists()
+
+
+def test_mode_corruption_is_not_accepted_as_historical_integrity(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    hook = Path("skills/synthesis-autopilot/scripts/autopilot_gate.py")
+    (guardian.archive_root(home) / "4.73.0" / hook).chmod(0o755)
+    guardian.restore_once(home)
+    (guardian.cache_parent(home) / "4.73.0" / hook).chmod(0o644)
+    with pytest.raises(guardian.GuardianError, match="differs from archive"):
+        guardian.restore_once(home)
 
 
 def test_restore_prioritizes_newest_historical_roots(tmp_path: Path) -> None:

--- a/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
+++ b/skills/synthesis-skills-manager/scripts/test_cache_guardian.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import fcntl
+import hashlib
 import importlib.util
 import json
 import os
@@ -143,6 +144,163 @@ def test_mode_corruption_is_not_accepted_as_historical_integrity(tmp_path: Path)
     (guardian.cache_parent(home) / "4.73.0" / hook).chmod(0o644)
     with pytest.raises(guardian.GuardianError, match="differs from archive"):
         guardian.restore_once(home)
+
+
+@pytest.mark.parametrize("database", [False, True])
+def test_historical_root_mode_is_part_of_verified_identity(tmp_path: Path, database: bool) -> None:
+    home = seeded_home(tmp_path)
+    if database:
+        guardian.persist_archive(guardian.archive_root(home), {})
+    guardian.restore_once(home)
+    (guardian.cache_parent(home) / "4.73.0").chmod(0o777)
+    with pytest.raises(guardian.GuardianError, match="differs from archive"):
+        guardian.restore_once(home)
+
+
+@pytest.mark.parametrize("phase", ["candidate", "promoted", "renamed", "partial-retirement"])
+def test_recovery_archive_real_process_interruptions_resume(tmp_path: Path, phase: str) -> None:
+    home = seeded_home(tmp_path)
+    archive = guardian.archive_root(home)
+    code = r'''
+import importlib.util, os, shutil, sys
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("guardian", sys.argv[1])
+g = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(g)
+archive, phase = Path(sys.argv[2]), sys.argv[3]
+if phase == "candidate":
+    real = g.RecoveryStore.read_file.__func__
+    def interrupted(cls, path, **kwargs):
+        result = real(cls, path, **kwargs)
+        if path.name.startswith(".recovery-candidate-"):
+            os._exit(23)
+        return result
+    g.RecoveryStore.read_file = classmethod(interrupted)
+elif phase == "promoted":
+    real = g.os.replace
+    def interrupted(source, target):
+        real(source, target)
+        if Path(target).name == g.STORE_NAME:
+            os._exit(23)
+    g.os.replace = interrupted
+elif phase == "renamed":
+    real = g.os.rename
+    def interrupted(source, target):
+        real(source, target)
+        if Path(target).name.startswith(".retired-"):
+            os._exit(23)
+    g.os.rename = interrupted
+else:
+    def interrupted(path):
+        next(p for p in Path(path).rglob("*") if p.is_file()).unlink()
+        os._exit(23)
+    g.shutil.rmtree = interrupted
+g.persist_archive(archive, {})
+'''
+    result = subprocess.run([sys.executable, "-B", "-c", code, str(SCRIPT), str(archive), phase])
+    assert result.returncode == 23
+    # Independently restarted reader can recover during every cutover state.
+    assert guardian.restore_once(home)["verified"] == 1
+    guardian.persist_archive(archive, {})
+    assert set(guardian.RecoveryStore.read(archive).versions) == {"4.73.0", "4.77.1"}
+    assert not any(p.is_dir() for p in archive.iterdir())
+    assert guardian.restore_once(home)["verified"] == 1
+
+
+@pytest.mark.parametrize("damage", ["traversal", "mode", "parent-link", "empty-parent", "link-traversal"])
+def test_recovery_archive_refuses_rehashed_unsafe_manifest(tmp_path: Path, damage: str) -> None:
+    home = seeded_home(tmp_path)
+    archive = guardian.archive_root(home)
+    guardian.persist_archive(archive, {})
+    with sqlite3.connect(archive / guardian.STORE_NAME) as db:
+        payload = json.loads(db.execute("SELECT manifest FROM versions WHERE version = '4.73.0'").fetchone()[0])
+        if damage == "traversal":
+            payload["entries"]["../sentinel"] = ["dir", 0o755]
+        elif damage == "mode":
+            payload["entries"]["skills"][1] = 0o4777
+        elif damage == "parent-link":
+            payload["entries"]["skills"] = ["link", 0o755, "hooks"]
+        elif damage == "empty-parent":
+            payload["entries"]["skills"] = []
+        else:
+            payload["entries"]["alias"] = ["link", 0o755, "../sentinel"]
+        raw = json.dumps(payload)
+        db.execute("UPDATE versions SET manifest=?, digest=? WHERE version='4.73.0'", (raw, hashlib.sha256(raw.encode()).hexdigest()))
+    with pytest.raises(guardian.GuardianError):
+        guardian.restore_once(home)
+    assert not guardian.cache_parent(home).exists()
+
+
+@pytest.mark.parametrize("damage", ["symlink", "hardlink", "parent-link", "fifo"])
+def test_recovery_archive_refuses_unsafe_database_targets(tmp_path: Path, damage: str) -> None:
+    home = seeded_home(tmp_path)
+    archive = guardian.archive_root(home)
+    guardian.persist_archive(archive, {})
+    database = archive / guardian.STORE_NAME
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "sentinel"
+    sentinel.write_bytes(database.read_bytes())
+    before = sentinel.read_bytes()
+    if damage == "parent-link":
+        moved = archive.with_name("saved")
+        archive.rename(moved)
+        archive.symlink_to(moved)
+    else:
+        database.unlink()
+        if damage == "symlink":
+            database.symlink_to(sentinel)
+        elif damage == "hardlink":
+            os.link(sentinel, database)
+        else:
+            os.mkfifo(database)
+    with pytest.raises(guardian.GuardianError):
+        guardian.persist_archive(archive, {})
+    assert sentinel.read_bytes() == before
+
+
+def test_existing_version_cannot_replace_historical_source(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    archive = guardian.archive_root(home)
+    guardian.persist_archive(archive, {})
+    previous = (archive / guardian.STORE_NAME).read_bytes()
+    differing = tmp_path / "differing"
+    seed_root(differing, "4.73.0", "altered history")
+    with pytest.raises(guardian.GuardianError, match="immutable historical version"):
+        guardian.persist_archive(archive, {"4.73.0": differing})
+    assert (archive / guardian.STORE_NAME).read_bytes() == previous
+
+
+def test_unowned_archive_files_refuse_before_migration(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    archive = guardian.archive_root(home)
+    sentinel = archive / "unowned"
+    sentinel.write_bytes(b"preserve")
+    with pytest.raises(guardian.GuardianError, match="unexpected or unsafe archive entry"):
+        guardian.persist_archive(archive, {})
+    assert sentinel.read_bytes() == b"preserve"
+    assert (archive / "4.73.0").is_dir()
+    assert not (archive / guardian.STORE_NAME).exists()
+
+
+def test_standalone_guardian_restores_database_history_after_repeated_reconciliation(tmp_path: Path) -> None:
+    home = seeded_home(tmp_path)
+    guardian.persist_archive(guardian.archive_root(home), {})
+    runtime = guardian.runtime_path(home)
+    runtime.write_bytes(SCRIPT.read_bytes())
+    env = dict(os.environ, HOME=str(home), PYTHONDONTWRITEBYTECODE="1")
+    env.pop("PYTHONPATH", None)
+    cache = guardian.cache_parent(home)
+    for _ in range(2):
+        cache.mkdir(parents=True, exist_ok=True)
+        current = cache / "4.77.1"
+        current.mkdir()
+        (current / "client-owned").write_text("untouched")
+        result = subprocess.run([sys.executable, "-B", str(runtime), "--once"], cwd=tmp_path, env=env, capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout)["restored"] == ["4.73.0"]
+        assert (current / "client-owned").read_text() == "untouched"
+        shutil.rmtree(cache)
 
 
 def test_restore_prioritizes_newest_historical_roots(tmp_path: Path) -> None:

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -740,6 +740,23 @@ def test_lifecycle_hotfix_is_documented_on_every_public_maintenance_surface() ->
     assert "full TLS and" in readme
 
 
+def test_deduplicated_archive_release_contract_is_public_and_coherent() -> None:
+    repository = Path(__file__).resolve().parents[3]
+    version, detail = release.source_version(repository)
+    assert version is not None, detail
+    assert release.changelog_top_version(repository) == version
+    manager = (repository / "skills/synthesis-skills-manager/SKILL.md").read_text()
+    readme = (repository / "README.md").read_text()
+    changelog = (repository / "CHANGELOG.md").read_text()
+    for document in (manager, changelog):
+        assert "SQLite" in document
+    for document in (manager, readme, changelog):
+        assert "512 MiB" in document
+    assert "independent files" in manager
+    assert "no historical version is evicted" in changelog
+    assert release.CODEX_CACHE_ARCHIVE_BUDGET_BYTES == 512 * 1024 * 1024
+
+
 def test_cache_survival_release_contract_is_public_and_coherent() -> None:
     repository = Path(__file__).resolve().parents[3]
     manager = (repository / "skills/synthesis-skills-manager/SKILL.md").read_text(

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -1210,12 +1210,39 @@ def test_tag_backed_snapshot_repairs_partial_and_missing_historical_roots(
     assert (
         snapshot.backup / "4.74.1" / "skills/example/SKILL.md"
     ).read_text(encoding="utf-8") == "version: 4.74.1\nmiddle\n"
-    assert release._tree_digest(snapshot.backup / "4.74.1") == release._tree_digest(
-        recovery / "4.74.1"
-    )
+    materialized = tmp_path / "materialized"
+    release.RecoveryStore.read(recovery).materialize("4.74.1", materialized)
+    assert release._tree_digest(snapshot.backup / "4.74.1") == release._tree_digest(materialized)
     assert next(
         step for step in result.steps if step.name == "install.codex.cache-archive"
     ).ok
+
+
+def test_repeated_archive_admission_preserves_root_identity_across_umask(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    commit_release(source, "4.74.0", "old")
+    commit_release(source, "4.75.0", "current")
+    archive, cache = tmp_path / "archive", tmp_path / "cache"
+    (cache / "4.74.0").mkdir(parents=True)
+    monkeypatch.setattr(release, "codex_cache_archive", lambda: archive)
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache)
+    previous_umask = os.umask(0o022)
+    snapshots = []
+    try:
+        first = release.snapshot_codex_caches(release.Result(), repo=source)
+        assert first is not None
+        snapshots.append(first)
+        expected = release.RecoveryStore.read(archive).versions
+        os.umask(0o077)
+        second = release.snapshot_codex_caches(release.Result(), repo=source)
+        assert second is not None
+        snapshots.append(second)
+        assert release.RecoveryStore.read(archive).versions == expected
+    finally:
+        os.umask(previous_umask)
+        for snapshot in snapshots:
+            release._remove_transition_backup(snapshot.backup)
 
 
 def test_snapshot_imports_complete_untagged_peer_root_missing_from_codex(
@@ -1404,6 +1431,58 @@ def test_codex_cache_transition_lock_refuses_a_second_writer(
     try:
         with pytest.raises(OSError, match="another release process"):
             release._acquire_codex_cache_lock()
+    finally:
+        release._release_codex_cache_lock(first)
+
+
+@pytest.mark.parametrize("failure", [None, "prepare", "budget"])
+def test_database_guardian_cutover_gates_destructive_native_refresh(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: str | None) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    commit_release(source, "4.74.0", "old")
+    commit_release(source, "4.75.0", "current")
+    guardian_source = source / release.CACHE_GUARDIAN
+    guardian_source.parent.mkdir(parents=True)
+    guardian_source.write_text("fixture supervisor")
+    archive = tmp_path / "recovery"
+    cache = tmp_path / "cache"
+    (cache / "4.74.0").mkdir(parents=True)
+    monkeypatch.setattr(release, "resolve_client_binary", lambda name: "/fixture/codex")
+    monkeypatch.setattr(release, "codex_cache_archive", lambda: archive)
+    monkeypatch.setattr(release, "plugin_cache_parent", lambda client: cache)
+    monkeypatch.setattr(release, "CODEX_CACHE_QUIET_SECONDS", 0)
+    if failure == "budget":
+        monkeypatch.setattr(release, "CODEX_CACHE_ARCHIVE_BUDGET_BYTES", 1)
+    calls = []
+    original_run = release.run
+    def runner(command, cwd=None, timeout=900):
+        if command[0] == "/fixture/codex" or "--prepare" in command:
+            calls.append(command)
+            if "--prepare" not in command:
+                assert calls[0][-1] == "--prepare"
+                assert set(release.RecoveryStore.read(archive).versions) == {"4.74.0", "4.75.0"}
+            return subprocess.CompletedProcess(command, 1 if failure == "prepare" else 0, "ready", "")
+        return original_run(command, cwd=cwd, timeout=timeout)
+    monkeypatch.setattr(release, "run", runner)
+    result = release.Result()
+    assert release.refresh_client("codex", result, False, repo=source) == (failure is None)
+    assert calls[0][-1] == "--prepare"
+    assert len(calls) == (3 if failure is None else 1)
+    if failure is not None:
+        assert not (archive / "recovery.sqlite3").exists()
+
+
+def test_contending_publisher_cannot_prepare_or_restart_guardian(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(release, "codex_cache_archive", lambda: tmp_path / "archive")
+    monkeypatch.setattr(release, "resolve_client_binary", lambda name: "/fixture/codex")
+    calls = []
+    monkeypatch.setattr(release, "install_codex_cache_guardian", lambda *args, **kwargs: calls.append("prepare"))
+    first = release._acquire_codex_cache_lock()
+    try:
+        result = release.Result()
+        assert not release.refresh_client("codex", result, False, repo=tmp_path)
+        assert calls == []
+        assert result.steps[-1].name == "install.codex.cache-lock"
     finally:
         release._release_codex_cache_lock(first)
 


### PR DESCRIPTION
## Summary

Store shared historical payloads once while preserving every version, path, type, mode and installation metadata. Keep the existing 512 MiB limit, materialize independent cache files, and verify the standalone guardian before migration or native refresh under the shared publisher lock.

## Verification

The full gated check matrix passes. Independent source review and 17 executable cases cover all 10 changed paths. Regression coverage includes corruption, unsafe paths, executable and root modes, real process interruption, immutable history, lock contention and repeated native-cache reconciliation. A disposable 94-version archive migration round-tripped every version.

Public release and dual-client installation remain gated by release.py; source acceptance does not claim installed or live lifecycle acceptance.