### PR TITLE
Improve update and repair verification

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.95.2",
+  "version": "4.95.3",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.95.2",
+  "version": "4.95.3",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.95.3] - 2026-09-05
+
+**Updates respect repository ownership and one instruction format.** Onboarding
+2.3.2 records whether each knowledge checkout was created or adopted. Adopted
+checkouts stay user-managed across enrollment, update and repair. Created clones
+fast-forward only on their recorded origin, branch and upstream after protection,
+cleanliness and concurrent-change checks.
+
+Generated organization instructions now use canonical `AGENTS.md` content and a
+literal Claude import adapter with separate receipt hashes. Earlier duplicate
+outputs converge only after historical source verification. Concurrent target
+edits remain protected, failed activation restores only engine-owned writes,
+and later generations retain original adoption-archive references. Doctor checks
+ownership and output provenance without repairing them or reporting legacy
+representations as accepted.
+
+The release also includes the merged weekly-review PR queue source. Its bounded
+report distinguishes owned work from requested reviews and names unavailable
+repository coverage instead of treating unreadable queues as empty.
+
 ## [4.95.2] - 2026-09-04
 
 **Historical recovery deduplicates payloads without retiring versions.** Skills

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Updates respect existing work (September 2026).** Release **4.95.3** leaves
+adopted knowledge checkouts under their owner's control and binds managed
+updates to the original branch and upstream. Generated organization instructions
+converge on canonical content plus a Claude import adapter, with verified
+provenance, retained archives and concurrent-edit protection. Doctor exposes
+migration or ownership problems without changing those files. The merged
+weekly-review PR queue source is included too.
+
 **Historical recovery shares storage, not mutable files (September 2026).**
 Release **4.95.2** deduplicates recovery payloads while keeping every historical
 version and the existing 512 MiB limit. Version records preserve file types,

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -38,7 +38,7 @@ changed_surfaces:
   - path: skills/synthesis-onboarding/scripts/test_instruction_adversarial.py
     cases: [instruction-proof, instruction-attacks, instruction-source-race, instruction-activation-race, instruction-staging, instruction-rollback, instruction-atime, doctor-public-commit]
   - path: skills/synthesis-onboarding/scripts/test_kb_update_ownership.py
-    cases: [kb-adopted, kb-created, kb-binding]
+    cases: [kb-adopted, kb-created, kb-binding, fixture-maintenance]
   - path: skills/synthesis-onboarding/scripts/test_kb_adversarial.py
     cases: [kb-symlink, kb-branch-race, kb-refmap, kb-native-locks, kb-partial-write, kb-recovery-index]
   - path: skills/synthesis-onboarding/scripts/test_updater_doctor.py
@@ -170,3 +170,7 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_git_paths_find_pending_state_after_administrative_directory_move
     motivating_defect: separate-git-directories-could-hide-retained-update-state
+  - id: fixture-maintenance
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_kb_update_ownership.py::test_fixture_suppresses_automatic_maintenance_without_hiding_locks
+    motivating_defect: fixture-peer-commit-started-detached-maintenance-during-preservation-snapshots

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,48 +1,172 @@
-# AGENT HEURISTIC: closed acceptance universe for the weekly-review PR-queue
-# transaction. Fresh per transaction: changed_surfaces must equal the
-# authoritative base-to-head Git diff before release.py can consume the receipt.
+# Transaction-bound acceptance for updater ownership and instruction convergence.
 schema: 2
-suite: weekly-review-pr-queue-source-2026-09
+suite: updater-ownership-2026-09-05
 membership: closed
-production_entry_point: Weekly Loose-Ends Review -> declared sources -> pr_queue_scan.py over the workspace's own .agents/repos.yaml
-enforcing_boundary: release.py consumes this transaction-bound closed manifest before publishing the immutable release, installing both clients, and activating the public CLI
+production_entry_point: synthesis update and repair through the installed onboarding engine
+enforcing_boundary: release.py consumes the exact base-to-head acceptance before publication and dual-client installation
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: the live GitHub queue itself, `gh` authentication on the running machine, per-workspace repos.yaml accuracy, and whether an agent executing the review actually runs the declared source — all verified only against a real workspace after this release installs
+unverified_remainder: source tests cover declared interleavings, not universal exclusion of uncooperating writers; installed personal-state preservation, historical archive restoration and genuine client lifecycle acceptance require separate live verification; no production deployment is authorized
 changed_surfaces:
-  - path: skills/synthesis-daily-rituals/SKILL.md
-    cases: [rituals-skill-budget]
-  - path: skills/synthesis-daily-rituals/scripts/pr_queue_scan.py
-    cases: [pr-queue-scope, pr-queue-coverage-honesty, pr-queue-classification, pr-queue-surface-not-gate]
-  - path: skills/synthesis-daily-rituals/scripts/test_pr_queue_scan.py
-    cases: [pr-queue-scope, pr-queue-coverage-honesty, pr-queue-classification, pr-queue-surface-not-gate]
+  - path: .claude-plugin/plugin.json
+    cases: [release-contract]
+  - path: .codex-plugin/plugin.json
+    cases: [release-contract]
+  - path: CHANGELOG.md
+    cases: [release-contract]
+  - path: README.md
+    cases: [release-contract]
+  - path: skills/synthesis-onboarding/SKILL.md
+    cases: [engine-contract, instruction-fresh, kb-adopted]
+  - path: skills/synthesis-onboarding/references/org-manifest.md
+    cases: [instruction-fresh, kb-adopted, doctor-legacy]
+  - path: skills/synthesis-onboarding/scripts/onboard.py
+    cases: [kb-adopted, kb-created, kb-binding, doctor-current, doctor-legacy, doctor-corrupt, doctor-ownership, doctor-public-commit, kb-symlink, kb-branch-race, kb-refmap, kb-native-locks, kb-partial-write, kb-recovery-index, kb-pending-state, kb-adopted-locks, kb-admin-paths]
+  - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
+    cases: [engine-contract]
+  - path: skills/synthesis-onboarding/scripts/system_contract.py
+    cases: [instruction-fresh, instruction-legacy, instruction-proof, instruction-attacks, instruction-source-race, instruction-activation-race, instruction-staging, instruction-rollback, instruction-atime, doctor-public-commit]
+  - path: skills/synthesis-onboarding/scripts/test_additive_enrollment.py
+    cases: [enrollment-preservation]
+  - path: skills/synthesis-onboarding/scripts/test_onboard.py
+    cases: [engine-idempotence]
+  - path: skills/synthesis-onboarding/scripts/test_instruction_convergence.py
+    cases: [instruction-fresh, instruction-legacy]
+  - path: skills/synthesis-onboarding/scripts/test_instruction_adversarial.py
+    cases: [instruction-proof, instruction-attacks, instruction-source-race, instruction-activation-race, instruction-staging, instruction-rollback, instruction-atime, doctor-public-commit]
+  - path: skills/synthesis-onboarding/scripts/test_kb_update_ownership.py
+    cases: [kb-adopted, kb-created, kb-binding]
+  - path: skills/synthesis-onboarding/scripts/test_kb_adversarial.py
+    cases: [kb-symlink, kb-branch-race, kb-refmap, kb-native-locks, kb-partial-write, kb-recovery-index]
+  - path: skills/synthesis-onboarding/scripts/test_updater_doctor.py
+    cases: [doctor-current, doctor-legacy, doctor-corrupt, doctor-ownership, kb-pending-state, kb-adopted-locks, kb-admin-paths]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [acceptance-self]
 cases:
   - id: acceptance-self
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: a-release-manifest-could-claim-closed-membership-with-unmapped-or-invalid-cases
-  - id: rituals-skill-budget
+    motivating_defect: closed-manifest-must-cover-the-current-transaction
+  - id: release-contract
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_skill_documents.py::test_rituals_skill_document_stays_within_repo_budget
-    motivating_defect: a-new-declared-source-could-push-the-skill-document-past-its-published-size-ceiling
-  - id: pr-queue-scope
+    fixture: ../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent
+    motivating_defect: public-version-surfaces-could-disagree
+  - id: engine-contract
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_declared_repos_does_not_filter_by_ritual_sync
-    motivating_defect: filtering-a-review-queue-by-a-source-sync-policy-hid-open-pull-requests-authored-under-the-principals-own-account
-  - id: pr-queue-coverage-honesty
+    fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_engine_versions_and_skill_contract_agree
+    motivating_defect: engine-and-skill-versions-could-disagree
+  - id: instruction-fresh
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_unscannable_repos_are_named_not_silently_dropped
-    motivating_defect: an-unreadable-queue-could-report-as-an-empty-queue-which-is-the-exact-coverage-lie-this-scan-exists-to-correct
-  - id: pr-queue-classification
+    fixture: ../synthesis-onboarding/scripts/test_instruction_convergence.py::test_fresh_pair_is_canonical_content_and_literal_import
+    motivating_defect: duplicate-outputs-conflicted-with-the-client-import-contract
+  - id: instruction-legacy
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_query_repo_splits_review_requested_from_own
-    motivating_defect: a-139-day-old-review-request-naming-the-principal-was-invisible-to-a-review-that-reported-one-waiting-on-item
-  - id: pr-queue-surface-not-gate
+    fixture: ../synthesis-onboarding/scripts/test_instruction_convergence.py::test_receipted_predecessor_converges_without_losing_archive
+    motivating_defect: exact-prior-adapter-transition-blocked-update
+  - id: instruction-proof
     control_class: acceptance-test
-    fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_missing_gh_exits_zero_and_says_not_scanned
-    motivating_defect: a-missing-or-unauthenticated-cli-could-make-a-reporting-surface-into-the-reason-a-daily-ritual-fails
+    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_retained_immutable_release_proof_accepts_committed_org_update
+    motivating_defect: immutable-installed-source-needs-retained-release-proof
+  - id: instruction-attacks
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_retained_immutable_release_proof_attacks
+    motivating_defect: corrupt-release-proof-could-escape-the-handled-error-boundary
+  - id: instruction-source-race
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_source_resolution_cannot_hide_a_new_concurrent_instruction_edit
+    motivating_defect: source-resolution-window-could-overwrite-a-newer-target-edit
+  - id: instruction-activation-race
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_activation_or_rollback_never_clobbers_a_newer_output_edit
+    motivating_defect: rollback-could-restore-over-a-concurrent-edit
+  - id: instruction-staging
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_staged_candidate_must_still_match_the_verified_render
+    motivating_defect: modified-staged-payload-could-disagree-with-returned-receipt
+  - id: instruction-rollback
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_failure_restoring_one_owned_output_does_not_skip_the_other
+    motivating_defect: one-restore-error-could-prevent-independent-output-recovery
+  - id: instruction-atime
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_instruction_read_access_time_is_not_a_concurrent_content_edit
+    motivating_defect: normal-read-access-time-was-misclassified-as-drift
+  - id: kb-adopted
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_kb_update_ownership.py::test_adopted_checkout_survives_enrollment_and_two_replays
+    motivating_defect: replayed-update-pulled-user-owned-checkouts
+  - id: kb-created
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_kb_update_ownership.py::test_created_checkout_records_tracking_and_fast_forwards
+    motivating_defect: managed-updates-lacked-durable-acquisition-binding
+  - id: kb-binding
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_kb_update_ownership.py::test_managed_state_change_during_fetch_is_preserved
+    motivating_defect: fetch-window-could-invalidate-update-authority
+  - id: kb-symlink
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_symlinked_parent_replacement_must_not_update_different_checkout
+    motivating_defect: symlinked-parent-could-redirect-an-update-to-a-user-checkout
+  - id: kb-branch-race
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_peer_branch_change_after_final_verification_must_not_be_merged
+    motivating_defect: blind-merge-followed-a-concurrently-changed-head
+  - id: kb-refmap
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_fetch_must_not_apply_unrelated_configured_ref_mappings
+    motivating_defect: fetch-applied-extra-ref-mappings-outside-ownership
+  - id: doctor-current
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_current_instruction_and_owned_checkout_doctor_passes_read_only
+    motivating_defect: read-only-acceptance-needs-a-positive-control
+  - id: doctor-legacy
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_doctor_requires_migration_for_both_legacy_output_forms
+    motivating_defect: duplicate-output-receipt-was-incorrectly-green
+  - id: doctor-corrupt
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_doctor_handles_malformed_instruction_receipts_without_traceback
+    motivating_defect: malformed-receipts-caused-unhandled-diagnostic-failure
+  - id: doctor-ownership
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_doctor_and_both_probes_fail_closed_on_knowledge_ownership
+    motivating_defect: ownership-drift-was-not-consumed-by-doctor-or-layer-probes
+  - id: enrollment-preservation
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_real_engine_enroll_and_repair_preserve_personal_files_and_receipts
+    motivating_defect: reconciliation-must-preserve-independent-personal-layers
+  - id: engine-idempotence
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_install_then_idempotent_rerun
+    motivating_defect: current-output-contract-must-survive-full-engine-replay
+  - id: doctor-public-commit
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_actual_doctor_rejects_forged_public_commit_in_current_receipt
+    motivating_defect: matching-public-source-bytes-did-not-prove-the-recorded-commit
+  - id: kb-native-locks
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_prepared_update_excludes_real_concurrent_git_writers
+    motivating_defect: a-separate-check-then-blind-merge-could-advance-a-peer-branch
+  - id: kb-partial-write
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_real_filesystem_checkout_failure_preserves_original_state
+    motivating_defect: failed-read-tree-could-partially-write-without-replacing-its-index
+  - id: kb-recovery-index
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_failed_index_activation_retains_new_index_and_recovery_identity
+    motivating_defect: index-activation-failure-could-delete-the-only-updated-index
+  - id: kb-pending-state
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_created_pending_git_state_remains_non_green_without_mutation
+    motivating_defect: retained-recovery-state-could-be-ignored-by-later-updates-or-doctor
+  - id: kb-adopted-locks
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_adopted_git_state_is_not_owned_or_changed
+    motivating_defect: adopted-checkout-locks-are-not-updater-owned-recovery-state
+  - id: kb-admin-paths
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_git_paths_find_pending_state_after_administrative_directory_move
+    motivating_defect: separate-git-directories-could-hide-retained-update-state

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.3.1"
+  version: "2.3.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -159,8 +159,13 @@ Organization instructions use the same provenance rule. The rendered graph is
 public baseline, exactly one organization source, then an optional user-owned
 personal source. Every repository source must be a committed, clean, regular
 Git-tracked file; untracked, dirty, traversing, and symbolic-link sources are
-refused. Both outputs activate or neither does. Doctor verifies each source
-commit and digest plus both output digests against the receipt.
+refused. `AGENTS.md` contains the canonical graph; `CLAUDE.md` is the literal
+`@AGENTS.md` import adapter, with its own receipt hash. Activation rechecks
+both targets for concurrent changes and rolls back only its own writes, never
+over a newer user edit. Doctor verifies each source commit and digest plus both
+exact output paths and digests against the receipt. Historical duplicate outputs
+or an already-converted exact adapter require provenance-checked migration;
+doctor reports migration required until update or repair commits the new receipt.
 
 The optional personal layer is local desired state, never organization data:
 
@@ -187,8 +192,13 @@ the verified archives.
 An organization repository contains data only: `.agents/onboarding.yaml`, one
 tracked instruction source, and optional documentation. It cannot select or
 execute an installer. Shared skill repositories are copied through the public
-engine's fixed direct-copy capability. Knowledge repositories are cloned or
-updated only when their exact remote and cleanliness checks pass.
+engine's fixed direct-copy capability. Knowledge repository receipts distinguish
+engine-created clones from adopted user checkouts. Only created clones on their
+recorded path, origin, branch and upstream may fast-forward; uncertain, changed,
+dirty, ahead or diverged state remains non-green and preserves the checkout.
+Pending native Git locks or retained updater recovery artifacts also remain
+non-green until resolved; doctor never deletes them. Adopted checkout locks
+remain the user's responsibility and are not inspected as updater-owned state.
 
 The copy capability accepts either `skills/<name>/SKILL.md` or top-level
 `<name>/SKILL.md` organization repositories, never both layouts at once.
@@ -223,8 +233,11 @@ or state-commit failure restores instructions, selected skill copies, ownership
 receipts, and invite use. Mutating commands recover interrupted enrollment;
 doctor remains non-green until recovery finishes. Verified archives, organization
 source caches, and new knowledge clones are retained. Existing knowledge clones
-are adopted without pulling or changing their configuration during enrollment;
-required executable pre-commit protection must already be configured.
+are adopted without pulling or changing their configuration during enrollment,
+update or repair; required executable pre-commit protection must already be
+configured. This includes clones reused at the conventional workspace path.
+Missing older ownership records never confer permission to update a checkout.
+Organization configuration updates independently in its managed source cache.
 
 Organization skill ownership is checked before every replay. Changed private
 copies are preserved; unchanged legacy copies can be adopted only after their

--- a/skills/synthesis-onboarding/references/org-manifest.md
+++ b/skills/synthesis-onboarding/references/org-manifest.md
@@ -125,7 +125,8 @@ repair, and doctor. Its manifest must agree with that installation's client,
 channel, and exact-pin selection. A conflicting policy, different organization,
 or changed workspace identity is refused rather than taking over personal
 configuration. Existing knowledge repositories are adopted without a pull or
-configuration change; required pre-commit protection must already be configured.
+configuration change throughout enrollment, update and repair; required
+pre-commit protection must already be configured.
 
 A user may add a private personal instruction layer without putting its path or
 repository in this shareable manifest:
@@ -155,8 +156,20 @@ doctor inspects the recorded commit without fetching or changing state.
 
 Knowledge bases use the workspace convention. Existing clones are accepted
 only at their declared remote; the engine never silently repoints them.
-Repository-local hooks are enabled only through the public engine's audited
-capability.
+Acquisition receipts record exact path, repository and `created` or `adopted`
+ownership. Adopted repositories remain user-managed, including those found at
+the conventional path or recovered from older receipts without ownership.
+Updates never fetch, pull, change branches or configure those checkouts.
+
+Only engine-created clones may update on their recorded branch and upstream.
+The engine verifies identity, protection, clean state and an ancestor-only
+fast-forward, and rechecks the binding after fetching. Detached, switched,
+dirty, ahead or diverged checkouts require action without discarding work.
+Pending native locks and retained updater indexes or recovery records also
+block further managed updates and doctor acceptance without being removed.
+Repository-local hooks are enabled only for newly created clones through the
+public engine's audited capability; adopted clones must already be protected.
+The separately managed organization-configuration cache still receives updates.
 
 Shared skills repositories are data sources, not execution authorities. The
 engine validates the repository and installs `skills/*` using its fixed
@@ -169,10 +182,18 @@ The declared source must be a regular, committed, clean Git-tracked file in the
 organization configuration repository. The engine records its repository,
 commit, relative path, and digest. It renders the public baseline first, then
 the organization source, then the optional user-local personal source, and
-activates identical `AGENTS.md` and `CLAUDE.md` outputs as one transaction. If
-either target collides or activation fails, neither new output remains active.
-Doctor verifies source commits and digests plus both output digests against the
-receipt.
+activates canonical `AGENTS.md` content and the literal `@AGENTS.md` adapter in
+`CLAUDE.md`. Each output has its own path and digest in the receipt. Targets are
+rechecked before activation; a failure restores only the engine's own writes,
+never overwriting a concurrent edit. Doctor verifies source commits and digests
+plus both exact output paths and digests against the receipt.
+
+Older duplicate-output receipts migrate only when their canonical content can
+be reconstructed from the recorded Git objects or verified immutable public
+release. An already-converted exact adapter follows the same proof requirement.
+Additional text, edited canonical content, malformed receipts and symlinks are
+refused. Doctor reports migration required without changing files or receipts.
+Original adoption archives remain referenced across later instruction generations.
 
 Existing workspace-root instruction files remain untouched unless the user
 passes `--adopt-workspace-instructions`. Adoption accepts regular files only,

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -51,6 +51,7 @@ from system_contract import (
     SystemState,
     describe_personal_instruction_source,
     file_digest,
+    instruction_output_state,
     json_digest,
     materialize_instruction_pair,
     personal_instruction_source_path,
@@ -88,7 +89,7 @@ from whole_system import (
     validate_personal_policy,
 )
 
-ENGINE_VERSION = "2.3.1"
+ENGINE_VERSION = "2.3.2"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"
@@ -433,10 +434,60 @@ class Receipts:
         self.data["generated_files"].pop(str(path), None)
 
     def adopted(self, name):
-        return self.data["adopted_repos"].get(name)
+        inventory = self.data["adopted_repos"]
+        if not isinstance(inventory, dict):
+            raise ContractError("knowledge repository adoption inventory is invalid")
+        if name not in inventory:
+            return None
+        path = inventory[name]
+        if not isinstance(path, str) or not Path(path).is_absolute() or ".." in Path(path).parts:
+            raise ContractError("knowledge repository adoption path is invalid")
+        return path
 
     def record_adoption(self, name, path):
         self.data["adopted_repos"][name] = str(path)
+
+    def knowledge_repository(self, name):
+        """Read explicit acquisition authority; missing history grants none."""
+        inventory = self.data.get("knowledge_repositories", {})
+        if not isinstance(inventory, dict):
+            raise ContractError("knowledge repository acquisition inventory is invalid")
+        if name not in inventory:
+            return None
+        entry = inventory[name]
+        if not isinstance(entry, dict):
+            raise ContractError("knowledge repository acquisition receipt is invalid")
+        acquisition = entry.get("acquisition")
+        expected = {"path", "repository", "acquisition"}
+        if acquisition == "created":
+            expected |= {"branch", "upstream"}
+        elif acquisition != "adopted":
+            raise ContractError("knowledge repository acquisition must be created or adopted")
+        if set(entry) != expected or any(not isinstance(value, str) or not value for value in entry.values()):
+            raise ContractError("knowledge repository acquisition fields are invalid")
+        path = Path(entry["path"])
+        if not path.is_absolute() or ".." in path.parts:
+            raise ContractError("knowledge repository acquisition path is invalid")
+        validate_repository_url(entry["repository"])
+        if acquisition == "created":
+            rc, _, _ = git(["check-ref-format", "refs/heads/" + entry["branch"]])
+            if rc or entry["upstream"] != "refs/remotes/origin/" + entry["branch"]:
+                raise ContractError("knowledge repository update binding is invalid")
+        return dict(entry)
+
+    def record_knowledge_repository(self, name, path, repository, acquisition,
+                                    branch=None, upstream=None):
+        entry = {"path": str(path), "repository": repository, "acquisition": acquisition}
+        if acquisition == "created":
+            entry.update(branch=branch, upstream=upstream)
+        inventory = self.data.setdefault("knowledge_repositories", {})
+        if not isinstance(inventory, dict):
+            raise ContractError("knowledge repository acquisition inventory is invalid")
+        inventory[name] = entry
+        self.knowledge_repository(name)
+        if acquisition == "adopted":
+            self.record_adoption(name, path)
+        self.save()
 
     def record_layer_choices(self, choices):
         now = utcnow()
@@ -1650,23 +1701,281 @@ def knowledge_hooks_present(repo):
     return hook.is_file() and os.access(hook, os.X_OK)
 
 
+def verify_knowledge_git_update_state(repo, entry):
+    """Refuse unresolved updater state without inspecting adopted Git locks.
+
+    Git administrative files may live outside the checkout (separate Git
+    directories and linked worktrees). Ask Git for each path, then check its
+    lexical components before resolving it so symbolic redirection cannot hide
+    a pending transaction. Nothing here refreshes the index or removes state.
+    """
+    if entry["acquisition"] == "adopted":
+        return
+    if entry["acquisition"] != "created":
+        raise ContractError("knowledge repository acquisition ownership is unknown")
+    repo = Path(repo)
+
+    def administrative_path(arguments):
+        rc, output, _ = git(["rev-parse", *arguments], cwd=repo)
+        if rc or not output.strip():
+            raise ContractError("cannot resolve knowledge repository Git administrative paths")
+        path = Path(output.rstrip("\n"))
+        if not path.is_absolute():
+            path = repo / path
+        if ".." in path.parts or any(part.is_symlink() for part in (path, *path.parents)):
+            raise ContractError("knowledge repository Git administrative path has symbolic or unsafe redirection")
+        return path.resolve()
+
+    git_dir = administrative_path(["--absolute-git-dir"])
+    common_dir = administrative_path(["--git-common-dir"])
+    if not git_dir.is_dir() or not common_dir.is_dir():
+        raise ContractError("knowledge repository Git administrative directory is unavailable")
+    paths = {
+        "HEAD": administrative_path(["--git-path", "HEAD"]),
+        "index": administrative_path(["--git-path", "index"]),
+        "branch": administrative_path(["--git-path", "refs/heads/" + entry["branch"]]),
+    }
+    for name, path in paths.items():
+        if not any(path.is_relative_to(root) for root in (git_dir, common_dir)):
+            raise ContractError("knowledge repository Git administrative path escaped its directory")
+        if (name != "branch" or path.exists()) and not path.is_file():
+            raise ContractError("knowledge repository Git administrative file is unavailable")
+        lock = path.with_name(path.name + ".lock")
+        if lock.exists() or lock.is_symlink():
+            raise ContractError("knowledge repository has a pending Git %s lock; checkout preserved" % name)
+    if any(path.name.startswith(".synthesis-index-") for path in paths["index"].parent.iterdir()):
+        raise ContractError("knowledge repository has retained Git update recovery state; checkout preserved")
+
+
 def phase_kbs(report, manifest, receipts, dry_run, enrolling=False, journal=None):
+    def verify_path(path):
+        path = Path(path)
+        if not path.is_absolute() or ".." in path.parts or any(
+                part.is_symlink() for part in (path, *path.parents)):
+            raise ContractError("knowledge repository path contains an unsafe symbolic component")
+
+    def checked_git(repo, arguments):
+        rc, out, err = git(arguments, cwd=repo)
+        if rc:
+            raise ContractError("cannot verify knowledge repository: %s" % (err.strip()[-300:] or "Git check failed"))
+        return out.strip()
+
+    def update_binding(repo):
+        branch_ref = checked_git(repo, ["symbolic-ref", "HEAD"])
+        if not branch_ref.startswith("refs/heads/"):
+            raise ContractError("knowledge repository is not on a local branch")
+        branch = branch_ref[len("refs/heads/"):]
+        remote = checked_git(repo, ["config", "--get", "branch.%s.remote" % branch])
+        merge = checked_git(repo, ["config", "--get", "branch.%s.merge" % branch])
+        upstream = checked_git(repo, ["rev-parse", "--symbolic-full-name", "@{upstream}"])
+        if remote != "origin" or merge != branch_ref or upstream != "refs/remotes/origin/" + branch:
+            raise ContractError("knowledge repository branch has no exact origin update binding")
+        return branch, upstream
+
+    def verify_managed(repo, entry):
+        verify_path(repo)
+        if origin_url(repo) != entry["repository"]:
+            raise ContractError("knowledge repository origin differs from its acquisition receipt")
+        branch, upstream = update_binding(repo)
+        if branch != entry["branch"] or upstream != entry["upstream"]:
+            raise ContractError("knowledge repository branch or upstream changed; checkout preserved")
+        # Status is a read here: optional index refreshes would alter staged
+        # metadata even when this operation ultimately refuses the update.
+        dirty = checked_git(repo, ["--no-optional-locks", "status", "--porcelain"])
+        if dirty:
+            raise ContractError("knowledge repository has local changes; checkout preserved")
+        return checked_git(repo, ["rev-parse", "HEAD^{commit}"])
+
+    def fast_forward(repo, entry, before, target):
+        """Hold Git's checkout locks and update only the receipt-bound branch.
+
+        A blind merge races HEAD: another checkout can change its destination
+        after the last read. Prepare a compare-and-swap transaction first, then
+        verify its destination while Git holds HEAD and the resolved branch
+        locks. An index lock also excludes concurrent checkout and commit while
+        read-tree performs its non-destructive two-tree update.
+        """
+        import select
+        import tempfile
+
+        verify_path(repo)
+        verify_knowledge_git_update_state(repo, entry)
+        git_paths = {}
+        for name in ("HEAD", "index"):
+            path = Path(checked_git(repo, ["rev-parse", "--git-path", name]))
+            path = path if path.is_absolute() else Path(repo) / path
+            verify_path(path)
+            if not path.is_file():
+                raise ContractError("knowledge repository Git state is not a regular file")
+            git_paths[name] = path
+        locks, temporary_index, transaction = [], None, None
+        tree_attempted = ref_committed = False
+
+        def exchange(command, expected):
+            transaction.stdin.write(command + "\n")
+            transaction.stdin.flush()
+            ready, _, _ = select.select([transaction.stdout], [], [], 30)
+            response = transaction.stdout.readline().strip() if ready else ""
+            if response != expected:
+                detail = transaction.stderr.read().strip()[-300:] if ready and not response else response
+                raise ContractError("knowledge repository reference transaction was refused: %s" % detail)
+
+        def read_tree(old, new):
+            rc, out, err = run(
+                ["git", "read-tree", "--no-recurse-submodules", "-m", "-u", old, new],
+                cwd=repo, env={"GIT_INDEX_FILE": str(temporary_index)})
+            if rc:
+                raise ContractError("knowledge repository checkout update refused: %s" %
+                                    ((err or out).strip()[-300:] or "Git read-tree failed"))
+
+        try:
+            for name in ("index",):
+                path = Path(str(git_paths[name]) + ".lock")
+                # Exclusive creation never steals a lock from a concurrent Git
+                # process. Keep these guards until both index and ref converge.
+                descriptor = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                locks.append((path, descriptor))
+            if verify_managed(repo, entry) != before:
+                raise ContractError("knowledge repository changed before its locked update")
+            descriptor, path = tempfile.mkstemp(prefix=".synthesis-index-", dir=git_paths["index"].parent)
+            os.close(descriptor)
+            temporary_index = Path(path)
+            shutil.copy2(git_paths["index"], temporary_index)
+            transaction = subprocess.Popen(
+                ["git", "update-ref", "--stdin"], cwd=repo,
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, text=True)
+            exchange("start", "start: ok")
+            exchange("update HEAD %s %s\nprepare" % (target, before), "prepare: ok")
+            # Git now owns HEAD.lock and the resolved branch lock. Bind the
+            # prepared destination while those locks are held, not before.
+            if verify_managed(repo, entry) != before:
+                raise ContractError("knowledge repository changed before its prepared update")
+            tree_attempted = True
+            read_tree(before, target)
+            exchange("commit", "commit: ok")
+            ref_committed = True
+            os.replace(temporary_index, git_paths["index"])
+            temporary_index = None
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise ContractError("knowledge repository locked update failed: %s" % exc) from exc
+        finally:
+            if transaction is not None:
+                # EOF aborts a still-prepared transaction, releasing its exact
+                # branch lock. No process-name matching or unrelated cleanup.
+                try:
+                    transaction.communicate(timeout=5)
+                except subprocess.TimeoutExpired:
+                    transaction.kill()
+                    try:
+                        transaction.communicate(timeout=5)
+                    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+                        report.add("knowledge-base", ERROR, "cannot finish Git reference process: %s" % exc)
+                except (OSError, ValueError) as exc:
+                    report.add("knowledge-base", ERROR, "cannot finish Git reference process: %s" % exc)
+            if tree_attempted and not ref_committed:
+                # A lost commit acknowledgement is not proof of an abort.
+                # Reconcile the exact destination after the child terminates
+                # before considering a reverse checkout.
+                rc, observed_ref, _ = git(["rev-parse", "refs/heads/" + entry["branch"] + "^{commit}"], cwd=repo)
+                if not rc and observed_ref.strip() == target:
+                    ref_committed = True
+                elif rc or observed_ref.strip() != before:
+                    ref_committed = None
+                    report.add("knowledge-base", ERROR, "Git reference outcome is uncertain; staged state retained")
+            retain_index = ref_committed is not False and temporary_index is not None
+            if tree_attempted and ref_committed is False:
+                # read-tree refuses to discard intervening file edits. Retain
+                # the staged index if recovery cannot be proved safe.
+                try:
+                    # A failed checkout can write some files without replacing
+                    # its index. Describe the intended target in our private
+                    # index first; the reverse merge can then recognize and
+                    # undo only those target bytes, refusing unrelated edits.
+                    rc, _, err = run(["git", "read-tree", target], cwd=repo,
+                                     env={"GIT_INDEX_FILE": str(temporary_index)})
+                    if rc:
+                        raise ContractError("cannot prepare Git checkout recovery: %s" % err.strip()[-300:])
+                    # Refill stat data only for bytes that really match target;
+                    # nonzero means a missing/edited path, which the following
+                    # non-destructive merge must classify rather than discard.
+                    run(["git", "update-index", "--refresh"], cwd=repo,
+                        env={"GIT_INDEX_FILE": str(temporary_index)})
+                    read_tree(target, before)
+                except ContractError:
+                    retain_index = True
+                    report.add("knowledge-base", ERROR,
+                               "knowledge repository update requires recovery; staged index retained")
+            if temporary_index is not None and retain_index:
+                try:
+                    recovery = {
+                        "schema": 1, "repository": str(repo), "branch": entry["branch"],
+                        "before": before, "target": target, "ref_committed": ref_committed,
+                        "index": str(temporary_index),
+                        "index_sha256": file_digest(temporary_index),
+                        "original_index_sha256": file_digest(git_paths["index"]),
+                    }
+                    with Path(str(temporary_index) + ".recovery.json").open("x", encoding="utf-8") as stream:
+                        json.dump(recovery, stream, sort_keys=True)
+                        stream.write("\n")
+                except (OSError, ContractError) as exc:
+                    report.add("knowledge-base", ERROR, "cannot record retained Git recovery state: %s" % exc)
+                report.add("knowledge-base", ERROR, "staged Git index retained for recovery", hint=str(temporary_index))
+            elif temporary_index is not None:
+                try:
+                    temporary_index.unlink(missing_ok=True)
+                except OSError as exc:
+                    report.add("knowledge-base", ERROR, "cannot remove staged Git index: %s" % exc)
+            for path, descriptor in reversed(locks):
+                try:
+                    if path.exists() and path.stat().st_ino == os.fstat(descriptor).st_ino:
+                        path.unlink()
+                except OSError as exc:
+                    report.add("knowledge-base", ERROR, "cannot remove owned Git lock: %s" % exc)
+                finally:
+                    try:
+                        os.close(descriptor)
+                    except OSError as exc:
+                        report.add("knowledge-base", ERROR, "cannot close owned Git lock: %s" % exc)
+
     workspace = manifest["org"]["workspace"]
     auth_help = (manifest.get("auth_help") or "").strip()
     for kb in manifest.get("knowledge_bases") or []:
         name, primary = kb["name"], kb["repository"]
-        superseded = []
         standard = WORKSPACES_ROOT / workspace / name
-        adopted = receipts.adopted(name)
-        repo = Path(adopted) if adopted and Path(adopted, ".git").exists() else None
-        if repo is None and (standard / ".git").exists():
-            repo = standard
-        if repo is None:
-            found = find_adoptable(name, primary, superseded)
-            if found is not None:
-                repo = found
-                receipts.record_adoption(name, found)
-                report.add("knowledge-base", OK, "adopted existing clone of %s at %s" % (name, found))
+        try:
+            verify_path(standard)
+            entry = receipts.knowledge_repository(name)
+            adopted = receipts.adopted(name)
+            if entry:
+                if entry["repository"] != primary:
+                    raise ContractError("knowledge repository manifest differs from its acquisition receipt")
+                if entry["acquisition"] == "created" and Path(entry["path"]) != standard:
+                    raise ContractError("created knowledge repository path differs from its declared workspace")
+                if adopted and (entry["acquisition"] != "adopted" or entry["path"] != adopted):
+                    raise ContractError("knowledge repository acquisition and adoption paths disagree")
+            recorded = entry["path"] if entry else adopted
+            repo = Path(recorded) if recorded else None
+            if repo is not None and not (repo / ".git").exists():
+                raise ContractError("recorded knowledge repository is missing; refusing another checkout")
+            if repo is None and (standard.exists() or standard.is_symlink()):
+                repo = standard
+            if repo is None:
+                repo = find_adoptable(name, primary, [])
+            if repo is not None:
+                verify_path(repo)
+                if repo.is_symlink() or not repo.is_dir() or not (repo / ".git").exists() or (repo / ".git").is_symlink():
+                    raise ContractError("knowledge repository path is not a real Git checkout")
+                root = checked_git(repo, ["rev-parse", "--show-toplevel"])
+                if Path(root).resolve() != repo.resolve():
+                    raise ContractError("knowledge repository path is not its Git root")
+                if origin_url(repo) != primary:
+                    raise ContractError("%s has the wrong remote; refusing reuse" % name)
+                if kb.get("local_hooks") and not knowledge_hooks_present(repo):
+                    raise ContractError("%s requires configured executable pre-commit protection; checkout and configuration preserved" % name)
+        except (ContractError, OSError, ValueError) as exc:
+            report.add("knowledge-base", ERROR, str(exc))
+            continue
         existing_repo = repo is not None
         if repo is None:
             if dry_run:
@@ -1678,6 +1987,7 @@ def phase_kbs(report, manifest, receipts, dry_run, enrolling=False, journal=None
                            hint=(auth_help or "Set up your git access for %s, then re-run this installer." % primary))
                 continue
             standard.parent.mkdir(parents=True, exist_ok=True)
+            verify_path(standard)
             rc, _, err = git(["clone", primary, str(standard)], timeout=900)
             if rc != 0:
                 report.add("knowledge-base", ERROR, "clone of %s failed" % name, hint=err.strip()[-400:])
@@ -1686,28 +1996,51 @@ def phase_kbs(report, manifest, receipts, dry_run, enrolling=False, journal=None
             if journal is not None:
                 journal.retain(standard)
             report.add("knowledge-base", CHANGED, "cloned %s -> %s" % (name, standard))
-        current_origin = origin_url(repo)
-        if current_origin in superseded:
-            if dry_run:
-                report.add("knowledge-base", CHANGED, "would repoint %s origin -> %s" % (name, primary))
-            else:
-                git(["remote", "set-url", "origin", primary], cwd=repo)
-                report.add("knowledge-base", CHANGED, "repointed %s origin to the current primary remote" % name)
-        elif current_origin != primary:
-            report.add("knowledge-base", ERROR, "%s has the wrong remote; refusing reuse" % name)
-            continue
-        if not dry_run and not (enrolling and existing_repo):
-            if is_dirty(repo):
-                report.add("knowledge-base", WARN, "%s has local changes; skipped pull" % name)
-            else:
-                rc, _, err = git(["pull", "--ff-only"], cwd=repo, timeout=300)
-                if rc == 0:
-                    report.add("knowledge-base", OK, "%s is up to date" % name)
+        try:
+            if origin_url(repo) != primary:
+                raise ContractError("%s has the wrong remote; refusing reuse" % name)
+            if entry is None:
+                acquisition = "adopted" if existing_repo else "created"
+                branch, upstream = (None, None) if existing_repo else update_binding(repo)
+                if not dry_run:
+                    receipts.record_knowledge_repository(name, repo, primary, acquisition, branch, upstream)
+                    entry = receipts.knowledge_repository(name)
                 else:
-                    report.add("knowledge-base", WARN, "%s could not fast-forward" % name,
-                               hint=err.strip()[-300:] if err else None)
-        if kb.get("local_hooks") and (Path(repo) / ".githooks").is_dir():
-            if enrolling and existing_repo:
+                    entry = {"acquisition": acquisition}
+            if entry["acquisition"] == "adopted":
+                report.add("knowledge-base", OK,
+                           "%s user-managed checkout preserved; content updates remain with its owner" % name)
+            elif existing_repo and not enrolling:
+                verify_knowledge_git_update_state(repo, entry)
+                before_head = verify_managed(repo, entry)
+                if dry_run:
+                    report.add("knowledge-base", CHANGED, "would check the recorded update branch for %s" % name)
+                else:
+                    remote_ref = "refs/heads/" + entry["branch"]
+                    checked_git(repo, ["fetch", "--no-tags", "--refmap=", "origin",
+                                       remote_ref + ":" + entry["upstream"]])
+                    # FETCH_HEAD is shared by every fetch in this checkout;
+                    # resolve only the receipt-bound remote-tracking ref.
+                    target = checked_git(repo, ["rev-parse", entry["upstream"] + "^{commit}"])
+                    if verify_managed(repo, entry) != before_head:
+                        raise ContractError("knowledge repository HEAD changed during update; checkout preserved")
+                    rc, _, _ = git(["merge-base", "--is-ancestor", before_head, target], cwd=repo)
+                    if rc:
+                        raise ContractError("knowledge repository is ahead or diverged; checkout preserved")
+                    if before_head != target:
+                        fast_forward(repo, entry, before_head, target)
+                        if checked_git(repo, ["rev-parse", "HEAD^{commit}"]) != target:
+                            raise ContractError("knowledge repository fast-forward did not reach its verified target")
+                        report.add("knowledge-base", CHANGED, "%s fast-forwarded on its recorded update branch" % name)
+                    else:
+                        report.add("knowledge-base", OK, "%s is up to date on its recorded update branch" % name)
+            elif existing_repo:
+                report.add("knowledge-base", OK, "%s existing checkout preserved during enrollment" % name)
+        except (ContractError, OSError, ValueError) as exc:
+            report.add("knowledge-base", ACTION, str(exc))
+            continue
+        if kb.get("local_hooks"):
+            if existing_repo:
                 if knowledge_hooks_present(repo):
                     report.add("knowledge-base", OK, "%s existing repository protection verified; configuration preserved" % name)
                 else:
@@ -1725,6 +2058,8 @@ def phase_kbs(report, manifest, receipts, dry_run, enrolling=False, journal=None
                 else:
                     git(["config", "--local", "core.hooksPath", ".githooks"], cwd=repo)
                     report.add("knowledge-base", CHANGED, "wired %s repo-local pre-commit protection" % name)
+            if not dry_run and not knowledge_hooks_present(repo):
+                report.add("knowledge-base", ACTION, "%s requires configured executable pre-commit protection" % name)
 
 
 def archive_existing_workspace_instructions(workspace):
@@ -2796,21 +3131,59 @@ def _personal_policy_probe():
 def _organization_probe(manifest, receipts):
     if not manifest:
         return False, "no organization manifest was selected"
-    for repo in manifest.get("skills_repos") or []:
-        if not (CACHE_DIR / repo["name"] / ".git").exists():
-            return False, "organization skills source %s is missing" % repo["name"]
-    workspace = manifest["org"]["workspace"]
-    for kb in manifest.get("knowledge_bases") or []:
-        adopted = receipts.adopted(kb["name"])
-        path = Path(adopted) if adopted else WORKSPACES_ROOT / workspace / kb["name"]
-        if not (path / ".git").exists():
-            return False, "organization knowledge base %s is missing" % kb["name"]
-    return True, "manifest-selected organization sources are present"
+    try:
+        for repo in manifest.get("skills_repos") or []:
+            if not (CACHE_DIR / repo["name"] / ".git").exists():
+                return False, "organization skills source %s is missing" % repo["name"]
+        workspace = manifest["org"]["workspace"]
+        for kb in manifest.get("knowledge_bases") or []:
+            name = kb["name"]
+            entry = receipts.knowledge_repository(name)
+            adopted = receipts.adopted(name)
+            if entry is None:
+                return False, "knowledge base %s acquisition provenance missing; update or repair required" % name
+            if entry["repository"] != kb["repository"]:
+                return False, "knowledge base %s manifest and acquisition identities disagree" % name
+            path = Path(entry["path"])
+            if entry["acquisition"] == "created" and path != WORKSPACES_ROOT / workspace / name:
+                return False, "knowledge base %s acquisition workspace path differs" % name
+            if adopted and (entry["acquisition"] != "adopted" or adopted != str(path)):
+                return False, "knowledge base %s acquisition and adoption paths disagree" % name
+            if any(parent.is_symlink() for parent in (path, *path.parents)) or (path / ".git").is_symlink():
+                return False, "knowledge base %s path contains a symbolic link" % name
+            if not (path / ".git").exists():
+                return False, "knowledge base %s not installed at its recorded path" % name
+            rc, actual_root, _ = git(["rev-parse", "--show-toplevel"], cwd=path)
+            if rc or Path(actual_root.strip()).resolve() != path.resolve():
+                return False, "knowledge base %s acquisition path is not its Git root" % name
+            if origin_url(path) != kb["repository"]:
+                return False, "knowledge base %s origin differs from its acquisition receipt" % name
+            if kb.get("local_hooks") and not knowledge_hooks_present(path):
+                return False, "knowledge base %s required pre-commit protection is unavailable" % name
+            if entry["acquisition"] == "created":
+                verify_knowledge_git_update_state(path, entry)
+                branch = entry["branch"]
+                checks = (
+                    (["symbolic-ref", "HEAD"], "refs/heads/" + branch),
+                    (["config", "--get", "branch.%s.remote" % branch], "origin"),
+                    (["config", "--get", "branch.%s.merge" % branch], "refs/heads/" + branch),
+                    (["rev-parse", "--symbolic-full-name", "@{upstream}"], entry["upstream"]),
+                    (["--no-optional-locks", "status", "--porcelain"], ""),
+                )
+                for arguments, expected in checks:
+                    rc, actual, _ = git(arguments, cwd=path)
+                    if rc or actual.strip() != expected:
+                        return False, "knowledge base %s update binding or working state changed; checkout preserved" % name
+        return True, "organization source identities and knowledge acquisition provenance verified"
+    except (ContractError, OSError, ValueError, TypeError, KeyError, AttributeError) as exc:
+        return False, "organization provenance could not be verified: %s" % exc
 
 
 def _knowledge_probe(manifest, receipts, workspace=None):
     workspace = workspace or receipts.data.get("personal_workspace")
     if workspace:
+        if not isinstance(workspace, str) or re.fullmatch(r"[a-z0-9][a-z0-9_-]*", workspace) is None:
+            return False, "personal knowledge workspace identity is invalid"
         personal = WORKSPACES_ROOT / workspace / ("ai-knowledge-%s" % workspace)
         if not (personal / ".git").exists():
             return False, "personal knowledge workspace is missing"
@@ -3012,39 +3385,64 @@ def doctor(report, manifest, clients_wanted, policy, desired_state=None):
             else:
                 report.add("doctor", ERROR, "%s status reports problems" % repo["name"],
                            hint=(out + err).strip()[-300:])
-        receipts = Receipts()
-        for path, metadata in receipts.data.get("org_skill_copies", {}).items():
-            if Path(path).parent not in organization_skill_targets(clients_wanted):
-                continue
+        try:
+            receipts = Receipts()
+        except (OSError, ValueError, TypeError, AttributeError) as exc:
+            report.add("doctor", ERROR, "onboarding receipt is malformed: %s" % exc)
+            return 1
+        org_copies = receipts.data.get("org_skill_copies", {})
+        if not isinstance(org_copies, dict):
+            report.add("doctor", ERROR, "organization skill copy inventory is malformed")
+            org_copies = {}
+        for path, metadata in org_copies.items():
             try:
+                if (not isinstance(path, str) or not Path(path).is_absolute()
+                        or Path(path).parent not in organization_skill_targets()
+                        or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", Path(path).name) is None):
+                    raise ContractError("organization copy receipt names an unsafe target")
+                if (not isinstance(metadata, dict)
+                        or set(metadata) != {"repository", "commit", "sha256"}
+                        or any(not isinstance(value, str) for value in metadata.values())
+                        or re.fullmatch(r"[0-9a-f]{40}", metadata["commit"]) is None
+                        or re.fullmatch(r"[0-9a-f]{64}", metadata["sha256"]) is None):
+                    raise ContractError("organization skill copy ownership receipt is malformed")
+                validate_repository_url(metadata["repository"])
+                if Path(path).parent not in organization_skill_targets(clients_wanted):
+                    continue
                 if metadata["repository"] not in {r["repository"] for r in manifest.get("skills_repos") or []}:
                     raise ContractError("organization skill source was removed; reconciliation required")
                 verify_org_copy(path, metadata, clients_wanted)
                 if not Path(path).is_dir():
                     raise ContractError("receipt-owned organization skill is missing")
-            except (ContractError, OSError, ValueError) as exc:
+            except (ContractError, OSError, ValueError, TypeError, KeyError, AttributeError) as exc:
                 report.add("doctor", ERROR, str(exc))
         workspace = manifest["org"]["workspace"]
         for kb in manifest.get("knowledge_bases") or []:
-            adopted = receipts.adopted(kb["name"])
-            repo_path = Path(adopted) if adopted else WORKSPACES_ROOT / workspace / kb["name"]
-            if not (repo_path / ".git").exists():
-                report.add("doctor", ERROR, "knowledge base %s not installed" % kb["name"])
-                continue
-            if origin_url(repo_path) != kb["repository"]:
-                report.add("doctor", ERROR, "%s origin differs from manifest repository" % kb["name"])
+            verified, detail = _organization_probe(
+                {**manifest, "skills_repos": [], "knowledge_bases": [kb]}, receipts
+            )
+            if not verified:
+                report.add("doctor", ERROR, detail)
             else:
-                report.add("doctor", OK, "knowledge base %s present at %s" % (kb["name"], repo_path))
-            if kb.get("local_hooks") and not knowledge_hooks_present(repo_path):
-                report.add("doctor", ERROR, "%s required pre-commit protection is unavailable" % kb["name"])
-        receipt = receipts.data.get("instruction_receipt") or {}
+                report.add("doctor", OK, "knowledge base %s identity, protection, and acquisition provenance verified" % kb["name"])
+        receipt = receipts.data.get("instruction_receipt")
         source_errors = []
-        source_receipts = receipt.get("sources") or []
-        for entry in source_receipts:
+        if not isinstance(receipt, dict):
+            source_errors.append("instruction receipt is missing or malformed")
+            receipt = {}
+        raw_sources = receipt.get("sources")
+        if not isinstance(raw_sources, list) or not raw_sources:
+            source_errors.append("instruction source receipts are missing or malformed")
+            raw_sources = []
+        source_receipts = []
+        for entry in raw_sources:
             try:
-                verify_instruction_source_receipt(entry)
-            except (ContractError, DriftError, OSError) as exc:
+                source_receipts.append(verify_instruction_source_receipt(entry))
+            except (ContractError, DriftError, OSError, ValueError, TypeError, AttributeError) as exc:
                 source_errors.append(str(exc))
+        roles = [entry["role"] for entry in source_receipts]
+        if roles not in (["public", "organization"], ["public", "organization", "personal"]):
+            source_errors.append("instruction source roles must be public, organization, and at most one personal source in order")
         declared_roots = {"public": source_root().resolve(),
                           "organization": Path(manifest["_path"]).resolve().parents[1]}
         declared_paths = {"public": "skills/synthesis-onboarding/references/kernel.example.md",
@@ -3098,17 +3496,15 @@ def doctor(report, manifest, clients_wanted, policy, desired_state=None):
                 OK,
                 "tracked workspace instruction sources match their receipts",
             )
-        outputs = receipt.get("outputs") or {}
-        output_errors = []
-        for name in ("AGENTS.md", "CLAUDE.md"):
-            target = WORKSPACES_ROOT / workspace / name
-            expected = (outputs.get(name) or {}).get("sha256")
-            if not expected or not target.is_file() or target.is_symlink() or file_digest(target) != expected:
-                output_errors.append(name)
-        if output_errors:
-            report.add("doctor", ERROR, "workspace instruction provenance or output drift: %s" % ", ".join(output_errors))
-        else:
-            report.add("doctor", OK, "tracked workspace instruction pair matches its receipt")
+        try:
+            output_state = instruction_output_state(WORKSPACES_ROOT / workspace, receipt)
+            if output_state != "current":
+                report.add("doctor", ERROR,
+                           "workspace instruction migration required: %s; update or repair must converge the canonical/import pair" % output_state)
+            else:
+                report.add("doctor", OK, "tracked workspace canonical/import pair matches its receipt")
+        except (ContractError, DriftError, OSError, ValueError, TypeError, AttributeError) as exc:
+            report.add("doctor", ERROR, "workspace instruction provenance or output drift: %s" % exc)
     layer_unverifiable = render_layer_doctor(
         report,
         manifest,

--- a/skills/synthesis-onboarding/scripts/synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/synthesis_cli.py
@@ -42,7 +42,7 @@ from system_contract import (
 )
 
 
-ENGINE_VERSION = "2.3.1"
+ENGINE_VERSION = "2.3.2"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CLI_COMMANDS = (
     "setup",

--- a/skills/synthesis-onboarding/scripts/system_contract.py
+++ b/skills/synthesis-onboarding/scripts/system_contract.py
@@ -459,6 +459,7 @@ def _manifest_version(root: Path) -> str:
             payload = json.loads((Path(root) / relative).read_text(encoding="utf-8"))
         except (OSError, ValueError) as exc:
             raise ContractError("release manifest %s is unreadable: %s" % (relative, exc))
+        payload = _require_mapping(payload, "release manifest %s" % relative)
         version = payload.get("version")
         if not isinstance(version, str) or not VERSION_RE.fullmatch(version):
             raise ContractError("release manifest %s has no exact version" % relative)
@@ -1835,7 +1836,7 @@ def _tracked_source(
     )
     if proc.returncode:
         raise ContractError("instruction source is not Git-tracked: %s" % relative)
-    if _git(root, "status", "--porcelain=v1", "--", relative):
+    if _git(root, "--no-optional-locks", "status", "--porcelain=v1", "--", relative):
         raise ContractError(
             "instruction source has uncommitted changes: %s" % relative
         )
@@ -1843,14 +1844,14 @@ def _tracked_source(
     return path, commit, file_digest(path)
 
 
-def verify_instruction_source_receipt(value: Any) -> dict[str, str]:
+def _instruction_source_record(value: Any) -> dict[str, str]:
     value = _require_mapping(value, "instruction source receipt")
     fields = {"role", "repository", "commit", "path", "sha256"}
     _reject_unknown(value, fields, "instruction source receipt")
     if set(value) != fields:
         raise ContractError("instruction source receipt is incomplete")
     role = value.get("role")
-    if role not in {"public", "organization", "personal"}:
+    if not isinstance(role, str) or role not in {"public", "organization", "personal"}:
         raise ContractError("instruction source receipt role is invalid")
     repository = value.get("repository")
     if not isinstance(repository, str) or not Path(repository).is_absolute():
@@ -1860,6 +1861,15 @@ def verify_instruction_source_receipt(value: Any) -> dict[str, str]:
     if not HEX40_RE.fullmatch(commit) or not HEX64_RE.fullmatch(digest):
         raise ContractError("instruction source receipt identity is invalid")
     relative = safe_relative_path(value.get("path"), "instruction source receipt path")
+    return {"role": role, "repository": repository, "commit": commit,
+            "path": relative, "sha256": digest}
+
+
+def verify_instruction_source_receipt(value: Any) -> dict[str, str]:
+    value = _instruction_source_record(value)
+    role, repository, commit, relative, digest = (
+        value[key] for key in ("role", "repository", "commit", "path", "sha256")
+    )
     root = Path(repository)
     path = contained_path(root, relative, "instruction source receipt path")
     if not path.is_file() or path.is_symlink() or file_digest(path) != digest:
@@ -1868,16 +1878,11 @@ def verify_instruction_source_receipt(value: Any) -> dict[str, str]:
         git_root = Path(_git(root, "rev-parse", "--show-toplevel")).resolve()
         if git_root != root.resolve():
             raise ContractError("instruction source repository root drifted: %s" % role)
-        if _git(root, "status", "--porcelain=v1", "--", relative):
+        if _git(root, "--no-optional-locks", "status", "--porcelain=v1", "--", relative):
             raise DriftError("instruction source has uncommitted changes: %s" % role)
-        proc = subprocess.run(
-            ["git", "-C", str(root), "show", "%s:%s" % (commit, relative)],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=False,
-        )
-        if proc.returncode or hashlib.sha256(proc.stdout).hexdigest() != digest:
-            raise DriftError("instruction source commit no longer binds bytes: %s" % role)
+    # A matching current file does not prove the recorded commit exists. The
+    # same Git-blob/immutable-release reader authenticates every source role.
+    _historical_instruction_content(value)
     return {
         "role": role,
         "repository": str(root.resolve()),
@@ -1885,6 +1890,111 @@ def verify_instruction_source_receipt(value: Any) -> dict[str, str]:
         "path": relative,
         "sha256": digest,
     }
+
+
+CLAUDE_INSTRUCTION_ADAPTER = b"@AGENTS.md\n"
+
+
+def _historical_instruction_content(value: Any) -> bytes:
+    """Read prior source bytes from their original Git/release identity."""
+    record = _instruction_source_record(value)
+    root = Path(record["repository"])
+    path = contained_path(root, record["path"], "historical instruction source")
+    git_root = _git_optional(root, "rev-parse", "--show-toplevel")
+    if git_root and Path(git_root).resolve() == root.resolve():
+        if _git(root, "cat-file", "-t", record["commit"]) != "commit":
+            raise DriftError("historical instruction source identity is not a Git commit")
+        entry = _git(root, "ls-tree", record["commit"], "--", record["path"])
+        if not entry.startswith(("100644 blob ", "100755 blob ")):
+            raise DriftError("historical instruction source is not a regular Git blob")
+        result = subprocess.run(
+            ["git", "-C", str(root), "show", record["commit"] + ":" + record["path"]],
+            capture_output=True, check=False,
+        )
+        if result.returncode:
+            raise DriftError("historical instruction source commit is unavailable")
+        content = result.stdout
+    elif record["role"] == "public":
+        state = SystemState()
+        version = _manifest_version(root)
+        descriptor_path = state.state_dir / "releases" / (version + ".json")
+        if descriptor_path.is_symlink() or not descriptor_path.is_file():
+            raise DriftError("historical public instruction release proof is unavailable")
+        try:
+            descriptor = validate_release_descriptor(json.loads(descriptor_path.read_text()))
+        except (ValueError, UnicodeError) as exc:
+            raise ContractError("historical public release proof is malformed") from exc
+        if (descriptor["commit"] != record["commit"] or
+                root != state.cache_dir / "releases" / descriptor["content_digest"]):
+            raise DriftError("historical public instruction release identity differs")
+        verify_materialized_release(root, descriptor)
+        content = path.read_bytes()
+    else:
+        raise DriftError("historical instruction source repository is unavailable")
+    if hashlib.sha256(content).hexdigest() != record["sha256"]:
+        raise DriftError("historical instruction source digest differs")
+    return content
+
+
+def instruction_output_state(workspace: Path, receipt: Any) -> str:
+    """Verify exact output ownership; legacy states require explicit convergence.
+
+    A strict import created by another installer is recoverable only when the
+    entire prior canonical document can be reconstructed from recorded sources.
+    This does not allow an edited canonical document or extra adapter content.
+    """
+    workspace = Path(workspace)
+    if not workspace.is_absolute() or any(p.is_symlink() for p in (workspace, *workspace.parents)):
+        raise DriftError("instruction workspace must be an absolute non-symlink path")
+    receipt = _require_mapping(receipt, "instruction receipt")
+    if type(receipt.get("schema_version")) is not int or receipt["schema_version"] != 1:
+        raise ContractError("instruction receipt schema_version is unsupported")
+    outputs = _require_mapping(receipt.get("outputs"), "instruction receipt outputs")
+    if set(outputs) != {"AGENTS.md", "CLAUDE.md"}:
+        raise ContractError("instruction receipt needs both exact outputs")
+    contents = {}
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        target = workspace / name
+        output = _require_mapping(outputs[name], "instruction output receipt")
+        if output.get("path") != str(target):
+            raise DriftError("instruction receipt belongs to a different workspace")
+        if not isinstance(output.get("sha256"), str) or not HEX64_RE.fullmatch(output["sha256"]):
+            raise ContractError("instruction output receipt digest is invalid")
+        if target.is_symlink() or not target.is_file():
+            raise DriftError("instruction output is missing or a symbolic link: %s" % name)
+        contents[name] = target.read_bytes()
+    agents_hash = hashlib.sha256(contents["AGENTS.md"]).hexdigest()
+    if agents_hash != outputs["AGENTS.md"]["sha256"]:
+        raise DriftError("instruction output drift: AGENTS.md")
+    adapter_hash = hashlib.sha256(CLAUDE_INSTRUCTION_ADAPTER).hexdigest()
+    if outputs["CLAUDE.md"]["sha256"] == adapter_hash:
+        if contents["CLAUDE.md"] != CLAUDE_INSTRUCTION_ADAPTER:
+            raise DriftError("instruction output drift: CLAUDE.md")
+        return "current"
+    if outputs["CLAUDE.md"]["sha256"] != agents_hash:
+        raise DriftError("instruction receipt has an unsupported output representation")
+    if contents["CLAUDE.md"] not in (contents["AGENTS.md"], CLAUDE_INSTRUCTION_ADAPTER):
+        raise DriftError("instruction output drift: CLAUDE.md")
+    sources = receipt.get("sources")
+    if not isinstance(sources, list) or not sources:
+        raise ContractError("historical instruction sources are unavailable")
+    parts = ["<!-- synthesis-instructions:generated -->", "# Workspace Instructions"]
+    roles = []
+    for source in sources:
+        record = _instruction_source_record(source)
+        role = record["role"]
+        if role in roles:
+            raise ContractError("historical instruction sources repeat a role")
+        roles.append(role)
+        try:
+            text = _historical_instruction_content(record).decode("utf-8").strip()
+        except UnicodeError as exc:
+            raise ContractError("historical instruction source is not UTF-8") from exc
+        parts.extend(["", "## %s" % role.title(), "", text])
+    reconstructed = ("\n".join(parts).rstrip() + "\n").encode("utf-8")
+    if reconstructed != contents["AGENTS.md"]:
+        raise DriftError("historical instruction sources do not reproduce canonical output")
+    return "legacy-adapter" if contents["CLAUDE.md"] == CLAUDE_INSTRUCTION_ADAPTER else "legacy-duplicate"
 
 
 def _restore_file(path: Path, previous: tuple[bool, bytes, int]) -> None:
@@ -1896,6 +2006,29 @@ def _restore_file(path: Path, previous: tuple[bool, bytes, int]) -> None:
             path.unlink()
         except FileNotFoundError:
             pass
+
+
+def _instruction_snapshot(path: Path) -> tuple[bool, bytes, int, int, int]:
+    if any(parent.is_symlink() for parent in path.parents):
+        raise DriftError("instruction workspace became a symbolic link")
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return False, b"", 0o644, 0, 0
+    if not stat.S_ISREG(metadata.st_mode):
+        raise DriftError("instruction output is not a regular file: %s" % path.name)
+    content = path.read_bytes()
+    after = path.lstat()
+    mutation_fields = ("st_dev", "st_ino", "st_mode", "st_size", "st_mtime_ns", "st_ctime_ns")
+    if any(getattr(metadata, field) != getattr(after, field) for field in mutation_fields):
+        raise DriftError("instruction output changed while being read: %s" % path.name)
+    return True, content, stat.S_IMODE(metadata.st_mode), metadata.st_dev, metadata.st_ino
+
+
+def _verify_instruction_snapshots(targets, expected) -> None:
+    for target, snapshot in zip(targets, expected):
+        if _instruction_snapshot(target) != snapshot:
+            raise DriftError("instruction output changed concurrently: %s" % target.name)
 
 
 def materialize_instruction_pair(
@@ -1911,7 +2044,7 @@ def materialize_instruction_pair(
     graph = _require_mapping(graph, "instruction graph")
     source_identities = source_identities or {}
     _reject_unknown(graph, {"schema_version", "sources", "output", "claude_adapter"}, "instruction graph")
-    if graph.get("schema_version") != 1:
+    if type(graph.get("schema_version")) is not int or graph["schema_version"] != 1:
         raise ContractError("instruction graph schema_version must be 1")
     if graph.get("output") != "AGENTS.md" or graph.get("claude_adapter") != "CLAUDE.md":
         raise ContractError("instruction graph outputs must be AGENTS.md and CLAUDE.md")
@@ -1919,19 +2052,14 @@ def materialize_instruction_pair(
     if not isinstance(sources, list) or not sources:
         raise ContractError("instruction graph needs at least one source")
     workspace = Path(workspace)
-    if workspace.is_symlink():
-        raise ContractError("workspace must not be a symbolic link")
+    if not workspace.is_absolute() or any(p.is_symlink() for p in (workspace, *workspace.parents)):
+        raise ContractError("workspace must be an absolute non-symlink path")
     targets = [workspace / "AGENTS.md", workspace / "CLAUDE.md"]
     if any(target.is_symlink() for target in targets):
         raise DriftError("instruction output is a symbolic link")
-    if previous_receipt:
-        expected_outputs = previous_receipt.get("outputs") or {}
-        for target in targets:
-            if (expected_outputs.get(target.name) or {}).get("path") != str(target):
-                raise DriftError("instruction receipt belongs to a different workspace")
-            expected = (expected_outputs.get(target.name) or {}).get("sha256")
-            if expected is None or not target.is_file() or file_digest(target) != expected:
-                raise DriftError("instruction output drift: %s" % target.name)
+    previous = [_instruction_snapshot(target) for target in targets]
+    prior_state = instruction_output_state(workspace, previous_receipt) if previous_receipt is not None else None
+    _verify_instruction_snapshots(targets, previous)
 
     parts = [
         "<!-- synthesis-instructions:generated -->",
@@ -1964,7 +2092,10 @@ def materialize_instruction_pair(
                 raise
             continue
         try:
-            text = path.read_text(encoding="utf-8").strip()
+            source_bytes = path.read_bytes()
+            if hashlib.sha256(source_bytes).hexdigest() != digest:
+                raise DriftError("instruction source changed during resolution: %s" % role)
+            text = source_bytes.decode("utf-8").strip()
         except UnicodeError as exc:
             raise ContractError(
                 "instruction source is not valid UTF-8: %s" % relative
@@ -1980,13 +2111,18 @@ def materialize_instruction_pair(
             }
         )
     rendered = ("\n".join(parts).rstrip() + "\n").encode("utf-8")
-    rendered_digest = hashlib.sha256(rendered).hexdigest()
+    rendered_outputs = {"AGENTS.md": rendered, "CLAUDE.md": CLAUDE_INSTRUCTION_ADAPTER}
+    output_receipts = {
+        target.name: {"path": str(target), "sha256": hashlib.sha256(rendered_outputs[target.name]).hexdigest()}
+        for target in targets
+    }
+    _verify_instruction_snapshots(targets, previous)
     if validate_only:
         return {"schema_version": 1, "sources": source_receipts, "validated": True}
     if previous_receipt:
         expected_outputs = previous_receipt.get("outputs") or {}
         if all(
-            (expected_outputs.get(target.name) or {}).get("sha256") == rendered_digest
+            (expected_outputs.get(target.name) or {}).get("sha256") == output_receipts[target.name]["sha256"]
             for target in targets
         ):
             unchanged = dict(previous_receipt)
@@ -1994,34 +2130,46 @@ def materialize_instruction_pair(
             unchanged["verified_at"] = utcnow()
             unchanged["unchanged"] = True
             return unchanged
-    previous = []
-    for target in targets:
-        previous.append(
-            (
-                target.exists(),
-                target.read_bytes() if target.exists() else b"",
-                stat.S_IMODE(target.stat().st_mode) if target.exists() else 0o644,
-            )
-        )
     temporary_paths = []
+    activated = {}
     workspace.mkdir(parents=True, exist_ok=True)
     try:
         for target in targets:
             with tempfile.NamedTemporaryFile(
                 mode="wb", dir=workspace, prefix=target.name + ".", suffix=".stage", delete=False
             ) as temporary:
-                temporary.write(rendered)
+                temporary.write(rendered_outputs[target.name])
                 temporary.flush()
                 os.fsync(temporary.fileno())
                 temporary_paths.append(Path(temporary.name))
-        os.replace(temporary_paths[0], targets[0])
-        if fail_after_first:
-            raise ContractError("injected failure after first instruction activation")
-        os.replace(temporary_paths[1], targets[1])
+        expected = list(previous)
+        for index, target in enumerate(targets):
+            _verify_instruction_snapshots(targets, expected)
+            staged = _instruction_snapshot(temporary_paths[index])
+            if staged[1] != rendered_outputs[target.name] or staged[2] != 0o600:
+                raise DriftError("staged instruction output differs from verified render")
+            os.replace(temporary_paths[index], target)
+            activated[index] = staged
+            expected[index] = staged
+            if index == 0 and fail_after_first:
+                raise ContractError("injected failure after first instruction activation")
+        _verify_instruction_snapshots(targets, expected)
         _fsync_directory(workspace)
-    except BaseException:
-        _restore_file(targets[0], previous[0])
-        _restore_file(targets[1], previous[1])
+    except BaseException as activation_error:
+        rollback_errors = []
+        for index, staged in activated.items():
+            # Never restore over a peer edit, nor touch a target we did not activate.
+            try:
+                owned = _instruction_snapshot(targets[index]) == staged
+            except (DriftError, OSError):
+                owned = False
+            if owned:
+                try:
+                    _restore_file(targets[index], previous[index][:3])
+                except OSError:
+                    rollback_errors.append(targets[index].name)
+        if rollback_errors:
+            raise ContractError("instruction rollback incomplete: %s" % ", ".join(rollback_errors)) from activation_error
         raise
     finally:
         for temporary in temporary_paths:
@@ -2029,15 +2177,18 @@ def materialize_instruction_pair(
                 temporary.unlink()
             except FileNotFoundError:
                 pass
-    return {
+    result = {
         "schema_version": 1,
         "generation": generation,
         "sources": source_receipts,
-        "outputs": {
-            target.name: {"path": str(target), "sha256": rendered_digest} for target in targets
-        },
+        "outputs": output_receipts,
         "materialized_at": utcnow(),
     }
+    if previous_receipt and "adopted_outputs" in previous_receipt:
+        result["adopted_outputs"] = previous_receipt["adopted_outputs"]
+    if prior_state and prior_state != "current":
+        result["migrated_from"] = prior_state
+    return result
 
 
 def verify_outcome(task_id: str, evidence: Any, repo_root: Path) -> dict[str, Any]:

--- a/skills/synthesis-onboarding/scripts/test_additive_enrollment.py
+++ b/skills/synthesis-onboarding/scripts/test_additive_enrollment.py
@@ -251,7 +251,9 @@ def test_real_engine_enroll_and_repair_preserve_personal_files_and_receipts(box)
     assert all(s.read_bytes() == b"custom personal bytes\n" for s in sentinels)
     assert all(s.read_text() == "independent client skill\n" for s in untouched)
     assert (box.home / ".agents/skills/example-skill/SKILL.md").is_file()
-    assert pair[0].read_bytes() == pair[1].read_bytes()
+    assert pair[1].read_bytes() == b"@AGENTS.md\n"
+    assert b"## Organization" in pair[0].read_bytes()
+    assert receipt["instruction_receipt"]["outputs"]["AGENTS.md"]["sha256"] != receipt["instruction_receipt"]["outputs"]["CLAUDE.md"]["sha256"]
     result = box.run_with_env(extra, "uninstall", "--clients", "codex", "--json")
     assert result.returncode == 0, result.stdout + result.stderr
     assert not (box.home / ".agents/skills/example-skill").exists()

--- a/skills/synthesis-onboarding/scripts/test_instruction_adversarial.py
+++ b/skills/synthesis-onboarding/scripts/test_instruction_adversarial.py
@@ -183,9 +183,9 @@ def test_historical_pair_attacks_preserve_outputs(tmp_path, converted, attack):
         assert (workspace / "CLAUDE.md").is_symlink()
 
 
-def immutable_legacy_pair(tmp_path, monkeypatch):
+def immutable_legacy_pair(tmp_path, monkeypatch, public_relative="instructions.md"):
     root = tmp_path.resolve()
-    public = source(root / "public-source", "Public committed rules.\n")
+    public = source(root / "public-source", "Public committed rules.\n", relative=public_relative)
     for client in (".claude-plugin", ".codex-plugin"):
         (public / client).mkdir()
         (public / client / "plugin.json").write_text(json.dumps({"name": "synthesis-skills", "version": "9.8.7"}) + "\n")
@@ -207,6 +207,7 @@ def immutable_legacy_pair(tmp_path, monkeypatch):
     identity = contract.public_source_identity(installed)
     org = source(root / "organization", "Organization committed rules.\n")
     graph = graph_for(("public", "organization"))
+    graph["sources"][0]["path"] = public_relative
     roots = {"public": installed, "organization": org}
     workspace = root / "workspace"
     # The materialized canonical content is independently checked below.
@@ -556,6 +557,66 @@ def test_instruction_read_access_time_is_not_a_concurrent_content_edit(tmp_path,
     observed = contract._instruction_snapshot(target)
     assert observed[0] is True
     assert observed[1] == b"Stable instruction bytes.\n"
+
+
+@pytest.mark.parametrize("source_kind", ["git", "immutable-release"])
+def test_actual_doctor_rejects_forged_public_commit_in_current_receipt(tmp_path, monkeypatch, source_kind):
+    import onboard
+
+    public_relative = "skills/synthesis-onboarding/references/kernel.example.md"
+    if source_kind == "immutable-release":
+        graph, roots, workspace, old, _descriptor, _retained, identity = immutable_legacy_pair(
+            tmp_path, monkeypatch, public_relative=public_relative)
+        receipt = migrate(graph, roots, workspace, old, source_identities={"public": identity})
+    else:
+        roots = {"public": source(tmp_path.resolve() / "public", "Public committed rules.\n", relative=public_relative),
+                 "organization": source(tmp_path.resolve() / "organization", "Organization committed rules.\n")}
+        graph = graph_for(roots)
+        graph["sources"][0]["path"] = public_relative
+        workspace = tmp_path.resolve() / "workspace"
+        receipt = contract.materialize_instruction_pair(graph, roots, workspace, generation=1)
+    assert contract.instruction_output_state(workspace, receipt) == "current"
+    manifest = {"org": {"workspace": workspace.name},
+                "_path": str(roots["organization"] / ".agents/onboarding.yaml"),
+                "skills_repos": [], "knowledge_bases": [],
+                "instruction_sources": [{"path": "instructions.md", "required": True}]}
+    actual_receipts = onboard.Receipts
+    path = tmp_path / "doctor-receipts.json"
+    receipts = actual_receipts(path)
+    receipts.data["instruction_receipt"] = receipt
+    receipts.save()
+    monkeypatch.setattr(onboard, "Receipts", lambda *args, **kwargs: actual_receipts(path))
+    monkeypatch.setattr(onboard, "WORKSPACES_ROOT", workspace.parent)
+    monkeypatch.setattr(onboard, "source_root", lambda: roots["public"])
+    # Execute the actual source and output doctor blocks. Unselected plugin and
+    # personal layers are outside this source-provenance control.
+    monkeypatch.setattr(onboard, "render_layer_doctor", lambda *args, **kwargs: False)
+
+    def doctor():
+        report = onboard.Report(as_json=True)
+        code = onboard.doctor(report, manifest, [], onboard.normalize_policy("stable", None))
+        return code, report
+
+    code, report = doctor()
+    assert code == 0, report.steps  # Positive control through the same consumer.
+    receipts.data["instruction_receipt"]["sources"][0]["commit"] = "e" * 40
+    receipts.save()
+    before = {str(p): p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    code, report = doctor()
+    after = {str(p): p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
+    assert after == before
+    assert code == 1, report.steps
+    assert any(step["status"] == onboard.ERROR and "source" in step["detail"] for step in report.steps)
+
+
+@pytest.mark.parametrize("manifest_bytes", [b"{incomplete", b"null", b"[]", b'"string"'])
+def test_historical_manifest_corruption_is_a_handled_contract_failure(tmp_path, monkeypatch, manifest_bytes):
+    graph, roots, workspace, receipt, _descriptor, _retained, identity = immutable_legacy_pair(tmp_path, monkeypatch)
+    (roots["public"] / ".claude-plugin/plugin.json").write_bytes(manifest_bytes)
+    before = pair_snapshot(workspace)
+    with pytest.raises(contract.ContractError):
+        migrate(graph, roots, workspace, receipt, source_identities={"public": identity})
+    assert pair_snapshot(workspace) == before
 
 
 def test_actual_private_adapter_and_public_engine_converge_without_mutating_sources(tmp_path, monkeypatch):

--- a/skills/synthesis-onboarding/scripts/test_instruction_adversarial.py
+++ b/skills/synthesis-onboarding/scripts/test_instruction_adversarial.py
@@ -1,0 +1,583 @@
+"""Independent historical-instruction migration and ownership attacks.
+
+Fixtures create actual committed sources and retained, content-addressed public
+releases. They never alter the user's installation or select a Git hooks path.
+"""
+
+from __future__ import annotations
+
+import copy
+import contextlib
+import hashlib
+import json
+import shutil
+import stat
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+import system_contract as contract  # noqa: E402
+
+
+ADAPTER = b"@AGENTS.md\n"
+
+
+@pytest.fixture(autouse=True)
+def isolated_configuration(tmp_path, monkeypatch):
+    root = tmp_path.resolve()
+    config = root / "gitconfig"
+    config.write_text("[user]\n\tname = Example\n\temail = fixture@example.test\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(config))
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Example")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "fixture@example.test")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Example")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "fixture@example.test")
+    monkeypatch.setenv("SYNTHESIS_HOME", str(root / "home"))
+    for name, directory in (("XDG_CONFIG_HOME", "config"),
+                            ("XDG_STATE_HOME", "state"),
+                            ("XDG_CACHE_HOME", "cache")):
+        monkeypatch.setenv(name, str(root / directory))
+    monkeypatch.delenv("SYNTHESIS_ACTIVE_DESCRIPTOR", raising=False)
+
+
+def git(root: Path, *args: str) -> str:
+    result = subprocess.run(["git", "-C", str(root), *args], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def digest(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def source(root: Path, text: str, relative="instructions.md") -> Path:
+    root.mkdir(parents=True)
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    git(root, "init", "-q", "-b", "main")
+    git(root, "add", "--", relative)
+    git(root, "commit", "-q", "-m", "Add fixture")
+    return root
+
+
+def graph_for(roles):
+    return {"schema_version": 1,
+            "sources": [{"role": role, "path": "instructions.md", "required": True}
+                        for role in roles],
+            "output": "AGENTS.md", "claude_adapter": "CLAUDE.md"}
+
+
+def legacy_pair(root: Path, *, converted=False):
+    """Build the old wire format independently of the changed renderer."""
+    root = root.resolve()
+    roots = {role: source(root / role, role.title() + " committed rules.\n")
+             for role in ("organization", "personal")}
+    graph = graph_for(roots)
+    workspace = root / "workspace"
+    workspace.mkdir()
+    records, parts = [], ["<!-- synthesis-instructions:generated -->", "# Workspace Instructions"]
+    for role, repository in roots.items():
+        content = (repository / "instructions.md").read_bytes()
+        records.append({"role": role, "repository": str(repository),
+                        "commit": git(repository, "rev-parse", "HEAD"),
+                        "path": "instructions.md", "sha256": digest(content)})
+        parts.extend(["", "## " + role.title(), "", content.decode().strip()])
+    canonical = ("\n".join(parts).rstrip() + "\n").encode()
+    (workspace / "AGENTS.md").write_bytes(canonical)
+    (workspace / "CLAUDE.md").write_bytes(ADAPTER if converted else canonical)
+    receipt = {"schema_version": 1, "generation": 1, "sources": records,
+               "outputs": {name: {"path": str(workspace / name), "sha256": digest(canonical)}
+                           for name in ("AGENTS.md", "CLAUDE.md")},
+               "materialized_at": "2026-09-01T00:00:00Z"}
+    return graph, roots, workspace, receipt
+
+
+def pair_snapshot(workspace):
+    return {name: ((workspace / name).read_bytes(), stat.S_IMODE((workspace / name).stat().st_mode))
+            for name in ("AGENTS.md", "CLAUDE.md")}
+
+
+def migrate(graph, roots, workspace, receipt, **kwargs):
+    return contract.materialize_instruction_pair(
+        graph, roots, workspace, generation=receipt["generation"] + 1,
+        previous_receipt=receipt, **kwargs,
+    )
+
+
+@pytest.mark.parametrize("converted", [False, True], ids=["duplicate", "preconverted"])
+def test_historical_pair_and_committed_source_advancement(tmp_path, converted):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path, converted=converted)
+    expected = "legacy-adapter" if converted else "legacy-duplicate"
+    assert contract.instruction_output_state(workspace, receipt) == expected
+    original = pair_snapshot(workspace)
+    original_receipt = copy.deepcopy(receipt)
+    (roots["personal"] / "instructions.md").write_text("New committed personal rules.\n")
+    git(roots["personal"], "add", "instructions.md")
+    git(roots["personal"], "commit", "-q", "-m", "Update fixture")
+    assert contract.instruction_output_state(workspace, receipt) == expected
+    validated = migrate(graph, roots, workspace, receipt, validate_only=True)
+    assert validated["validated"] is True
+    assert pair_snapshot(workspace) == original
+    assert receipt == original_receipt
+    result = migrate(graph, roots, workspace, receipt)
+    assert result["migrated_from"] == expected
+    assert (workspace / "CLAUDE.md").read_bytes() == ADAPTER
+    assert b"New committed personal rules." in (workspace / "AGENTS.md").read_bytes()
+    assert result["sources"][-1]["commit"] == git(roots["personal"], "rev-parse", "HEAD")
+    assert contract.instruction_output_state(workspace, result) == "current"
+    stable = pair_snapshot(workspace)
+    repeated = migrate(graph, roots, workspace, result)
+    assert repeated["unchanged"] is True
+    assert repeated["generation"] == result["generation"]
+    assert pair_snapshot(workspace) == stable
+
+
+@pytest.mark.parametrize("converted", [False, True])
+@pytest.mark.parametrize("attack", ["agents-edit", "adapter-extra", "adapter-crlf", "adapter-link",
+                                    "wrong-path", "wrong-digest", "extra-output", "wrong-schema", "boolean-schema",
+                                    "duplicate-role", "reordered-roles", "missing-source", "fake-commit"])
+def test_historical_pair_attacks_preserve_outputs(tmp_path, converted, attack):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path, converted=converted)
+    if attack == "agents-edit":
+        (workspace / "AGENTS.md").write_bytes(b"User-owned edit.\n")
+    elif attack == "adapter-extra":
+        (workspace / "CLAUDE.md").write_bytes(ADAPTER + b"Additional user rules.\n")
+    elif attack == "adapter-crlf":
+        (workspace / "CLAUDE.md").write_bytes(b"@AGENTS.md\r\n")
+    elif attack == "adapter-link":
+        (workspace / "CLAUDE.md").unlink()
+        (workspace / "CLAUDE.md").symlink_to("AGENTS.md")
+    elif attack == "wrong-path":
+        receipt["outputs"]["CLAUDE.md"]["path"] = str(tmp_path / "other/CLAUDE.md")
+    elif attack == "wrong-digest":
+        receipt["outputs"]["CLAUDE.md"]["sha256"] = "e" * 64
+    elif attack == "extra-output":
+        receipt["outputs"]["other.md"] = receipt["outputs"]["AGENTS.md"]
+    elif attack == "wrong-schema":
+        receipt["schema_version"] = 2
+    elif attack == "boolean-schema":
+        receipt["schema_version"] = True
+    elif attack == "duplicate-role":
+        receipt["sources"].append(copy.deepcopy(receipt["sources"][0]))
+    elif attack == "reordered-roles":
+        receipt["sources"].reverse()
+    elif attack == "missing-source":
+        receipt["sources"] = []
+    elif attack == "fake-commit":
+        receipt["sources"][0]["commit"] = "f" * 40
+    before = pair_snapshot(workspace)
+    receipt_before = copy.deepcopy(receipt)
+    with pytest.raises(contract.ContractError):
+        migrate(graph, roots, workspace, receipt)
+    assert pair_snapshot(workspace) == before
+    assert receipt == receipt_before
+    if attack == "adapter-link":
+        assert (workspace / "CLAUDE.md").is_symlink()
+
+
+def immutable_legacy_pair(tmp_path, monkeypatch):
+    root = tmp_path.resolve()
+    public = source(root / "public-source", "Public committed rules.\n")
+    for client in (".claude-plugin", ".codex-plugin"):
+        (public / client).mkdir()
+        (public / client / "plugin.json").write_text(json.dumps({"name": "synthesis-skills", "version": "9.8.7"}) + "\n")
+    git(public, "add", "--", ".claude-plugin", ".codex-plugin")
+    git(public, "commit", "-q", "-m", "Add fixture metadata")
+    git(public, "branch", "stable")
+    git(public, "tag", "v9.8.7")
+    descriptor = contract.release_descriptor_from_checkout(
+        public, "stable", "stable", "https://example.test/public-skills.git")
+    state = contract.SystemState()
+    installed = state.cache_dir / "releases" / descriptor["content_digest"]
+    shutil.copytree(public, installed, ignore=shutil.ignore_patterns(".git"))
+    retained = state.state_dir / "releases" / "9.8.7.json"
+    retained.parent.mkdir(parents=True)
+    retained.write_text(json.dumps(descriptor))
+    active = root / "active-release.json"
+    active.write_text(json.dumps({**descriptor, "release_root": str(installed)}))
+    monkeypatch.setenv("SYNTHESIS_ACTIVE_DESCRIPTOR", str(active))
+    identity = contract.public_source_identity(installed)
+    org = source(root / "organization", "Organization committed rules.\n")
+    graph = graph_for(("public", "organization"))
+    roots = {"public": installed, "organization": org}
+    workspace = root / "workspace"
+    # The materialized canonical content is independently checked below.
+    receipt = contract.materialize_instruction_pair(
+        graph, roots, workspace, generation=1, source_identities={"public": identity})
+    expected = ("<!-- synthesis-instructions:generated -->\n# Workspace Instructions\n\n"
+                "## Public\n\nPublic committed rules.\n\n"
+                "## Organization\n\nOrganization committed rules.\n").encode()
+    assert (workspace / "AGENTS.md").read_bytes() == expected
+    receipt["outputs"]["CLAUDE.md"]["sha256"] = digest(expected)
+    # This is the real failure shape: the private installer already converted it.
+    (workspace / "CLAUDE.md").write_bytes(ADAPTER)
+    return graph, roots, workspace, receipt, descriptor, retained, identity
+
+
+def test_retained_immutable_release_proof_accepts_committed_org_update(tmp_path, monkeypatch):
+    graph, roots, workspace, receipt, descriptor, _retained, identity = immutable_legacy_pair(tmp_path, monkeypatch)
+    assert contract.instruction_output_state(workspace, receipt) == "legacy-adapter"
+    assert not (roots["public"] / ".git").exists()
+    assert roots["public"].name == descriptor["content_digest"]
+    (roots["organization"] / "instructions.md").write_text("Advanced organization rules.\n")
+    git(roots["organization"], "add", "instructions.md")
+    git(roots["organization"], "commit", "-q", "-m", "Update fixture")
+    result = migrate(graph, roots, workspace, receipt, source_identities={"public": identity})
+    assert contract.instruction_output_state(workspace, result) == "current"
+    assert b"Advanced organization rules." in (workspace / "AGENTS.md").read_bytes()
+
+
+@pytest.mark.parametrize("attack", ["missing-descriptor", "descriptor-link", "invalid-descriptor", "broken-json",
+                                    "different-commit", "different-content", "content-tamper",
+                                    "non-addressed-root", "receipt-commit", "source-link"])
+def test_retained_immutable_release_proof_attacks(tmp_path, monkeypatch, attack):
+    graph, roots, workspace, receipt, descriptor, retained, identity = immutable_legacy_pair(tmp_path, monkeypatch)
+    if attack == "missing-descriptor":
+        retained.unlink()
+    elif attack == "descriptor-link":
+        other = tmp_path / "descriptor.json"
+        retained.rename(other)
+        retained.symlink_to(other)
+    elif attack == "invalid-descriptor":
+        retained.write_text(json.dumps({"schema_version": 1}))
+    elif attack == "broken-json":
+        retained.write_text("{incomplete")
+    elif attack == "different-commit":
+        retained.write_text(json.dumps({**descriptor, "commit": "e" * 40}))
+    elif attack == "different-content":
+        retained.write_text(json.dumps({**descriptor, "content_digest": "e" * 64}))
+    elif attack == "content-tamper":
+        (roots["public"] / "instructions.md").write_text("Unexpected changed rules.\n")
+    elif attack == "non-addressed-root":
+        copied = tmp_path.resolve() / "copied-public"
+        shutil.copytree(roots["public"], copied)
+        receipt["sources"][0]["repository"] = str(copied)
+    elif attack == "receipt-commit":
+        receipt["sources"][0]["commit"] = "e" * 40
+    elif attack == "source-link":
+        target = roots["public"] / "instructions.md"
+        moved = tmp_path / "public-instructions.md"
+        target.rename(moved)
+        target.symlink_to(moved)
+    before = pair_snapshot(workspace)
+    with pytest.raises(contract.ContractError):
+        migrate(graph, roots, workspace, receipt, source_identities={"public": identity})
+    assert pair_snapshot(workspace) == before
+
+
+@pytest.mark.parametrize("receipted", [False, True])
+def test_workspace_symlink_ancestor_cannot_redirect_activation(tmp_path, receipted):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path)
+    real_parent = workspace.parent
+    alias = tmp_path.resolve() / "alias"
+    alias.symlink_to(real_parent, target_is_directory=True)
+    redirected = alias / "workspace"
+    redirected_receipt = copy.deepcopy(receipt)
+    for name, output in redirected_receipt["outputs"].items():
+        output["path"] = str(redirected / name)
+    before = pair_snapshot(workspace)
+    with pytest.raises(contract.ContractError, match="non-symlink"):
+        contract.materialize_instruction_pair(
+            graph, roots, redirected, generation=2,
+            previous_receipt=redirected_receipt if receipted else None)
+    assert pair_snapshot(workspace) == before
+
+
+def test_adoption_metadata_survives_migration_and_later_changed_generation(tmp_path):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path, converted=True)
+    archive = tmp_path / "archive"
+    archive.mkdir()
+    old = {"AGENTS.md": b"Original canonical rules.\n", "CLAUDE.md": b"Original separate rules.\n"}
+    metadata = {}
+    for name, content in old.items():
+        (archive / name).write_bytes(content)
+        metadata[name] = {"archive_path": str(archive / name), "sha256": digest(content),
+                          "mode": "0o640", "archived_at": "2026-09-01T00:00:00Z"}
+    receipt["adopted_outputs"] = copy.deepcopy(metadata)
+    result = migrate(graph, roots, workspace, receipt)
+    (roots["personal"] / "instructions.md").write_text("Subsequent committed rules.\n")
+    git(roots["personal"], "add", "instructions.md")
+    git(roots["personal"], "commit", "-q", "-m", "Update fixture")
+    later = migrate(graph, roots, workspace, result)
+    assert later["generation"] == 3
+    assert result["adopted_outputs"] == later["adopted_outputs"] == metadata
+    assert all((archive / name).read_bytes() == content for name, content in old.items())
+    assert contract.instruction_output_state(workspace, later) == "current"
+
+
+@pytest.mark.parametrize("converted", [False, True])
+def test_migration_second_activation_failure_restores_prior_bytes_modes_and_receipt(tmp_path, converted):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path, converted=converted)
+    (workspace / "AGENTS.md").chmod(0o640)
+    (workspace / "CLAUDE.md").chmod(0o600)
+    before = pair_snapshot(workspace)
+    original_receipt = copy.deepcopy(receipt)
+    with pytest.raises(contract.ContractError, match="injected"):
+        migrate(graph, roots, workspace, receipt, fail_after_first=True)
+    assert pair_snapshot(workspace) == before
+    assert receipt == original_receipt
+    assert sorted(p.name for p in workspace.iterdir()) == ["AGENTS.md", "CLAUDE.md"]
+
+
+@pytest.mark.parametrize("initial", ["legacy-duplicate", "legacy-adapter", "current"])
+@pytest.mark.parametrize("validate_only", [False, True], ids=["activate", "validate-only"])
+def test_source_resolution_cannot_hide_a_new_concurrent_instruction_edit(tmp_path, monkeypatch, initial, validate_only):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path, converted=initial != "legacy-duplicate")
+    if initial == "current":
+        receipt = migrate(graph, roots, workspace, receipt)
+    original_claude = (workspace / "CLAUDE.md").read_bytes()
+    original = contract._tracked_source
+    concurrent_content = b"Concurrent user-owned instructions.\n"
+    changed = False
+
+    def source_probe(*args, **kwargs):
+        nonlocal changed
+        result = original(*args, **kwargs)
+        if not changed:
+            changed = True
+            (workspace / "AGENTS.md").write_bytes(concurrent_content)
+        return result
+
+    monkeypatch.setattr(contract, "_tracked_source", source_probe)
+    with pytest.raises(contract.ContractError):
+        migrate(graph, roots, workspace, receipt, validate_only=validate_only)
+    assert (workspace / "AGENTS.md").read_bytes() == concurrent_content
+    assert (workspace / "CLAUDE.md").read_bytes() == original_claude
+
+
+@pytest.mark.parametrize("target_name", ["AGENTS.md", "CLAUDE.md"])
+@pytest.mark.parametrize("edit", ["bytes", "mode"])
+def test_completed_staging_does_not_replace_newer_output_edits(tmp_path, monkeypatch, target_name, edit):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path, converted=True)
+    before = pair_snapshot(workspace)
+    original = contract.tempfile.NamedTemporaryFile
+    staged = 0
+    changed = False
+    concurrent_content = b"User-owned edit after staging.\n"
+
+    @contextlib.contextmanager
+    def stage(*args, **kwargs):
+        nonlocal staged, changed
+        with original(*args, **kwargs) as temporary:
+            yield temporary
+        if kwargs.get("suffix") == ".stage":
+            staged += 1
+            if staged == 2:
+                changed = True
+                target = workspace / target_name
+                if edit == "bytes":
+                    target.write_bytes(concurrent_content)
+                else:
+                    target.chmod(0o400)
+
+    monkeypatch.setattr(contract.tempfile, "NamedTemporaryFile", stage)
+    with pytest.raises(contract.ContractError):
+        migrate(graph, roots, workspace, receipt)
+    assert changed
+    after = pair_snapshot(workspace)
+    for name in before:
+        expected = before[name]
+        if name == target_name:
+            expected = ((concurrent_content, expected[1]) if edit == "bytes"
+                        else (expected[0], 0o400))
+        assert after[name] == expected
+
+
+@pytest.mark.parametrize("target_name", ["AGENTS.md", "CLAUDE.md"])
+def test_staging_error_cannot_restore_over_a_concurrent_edit(tmp_path, monkeypatch, target_name):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path, converted=True)
+    original_receipt = copy.deepcopy(receipt)
+    before = pair_snapshot(workspace)
+    original = contract.tempfile.NamedTemporaryFile
+    staged = 0
+    concurrent_content = b"User-owned edit before staging failure.\n"
+
+    @contextlib.contextmanager
+    def stage(*args, **kwargs):
+        nonlocal staged
+        with original(*args, **kwargs) as temporary:
+            yield temporary
+        if kwargs.get("suffix") == ".stage":
+            staged += 1
+            if staged == 2:
+                (workspace / target_name).write_bytes(concurrent_content)
+                raise contract.ContractError("injected staging failure")
+
+    monkeypatch.setattr(contract.tempfile, "NamedTemporaryFile", stage)
+    with pytest.raises(contract.ContractError):
+        migrate(graph, roots, workspace, receipt)
+    assert staged == 2
+    assert receipt == original_receipt
+    for name, (content, mode) in before.items():
+        expected = concurrent_content if name == target_name else content
+        assert (workspace / name).read_bytes() == expected
+        assert stat.S_IMODE((workspace / name).stat().st_mode) == mode
+
+
+@pytest.mark.parametrize("target_name", ["AGENTS.md", "CLAUDE.md"])
+@pytest.mark.parametrize("after_activation", ["AGENTS.md", "CLAUDE.md"], ids=["first-activation", "second-activation"])
+def test_activation_or_rollback_never_clobbers_a_newer_output_edit(tmp_path, monkeypatch, target_name, after_activation):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path, converted=True)
+    before = pair_snapshot(workspace)
+    original_receipt = copy.deepcopy(receipt)
+    (roots["personal"] / "instructions.md").write_text("New candidate source rules.\n")
+    git(roots["personal"], "add", "instructions.md")
+    git(roots["personal"], "commit", "-q", "-m", "Update fixture")
+    original = contract.os.replace
+    changed = False
+    concurrent_content = b"User-owned edit during pair activation.\n"
+
+    def replace(source_path, target_path):
+        nonlocal changed
+        result = original(source_path, target_path)
+        if (not changed and str(source_path).endswith(".stage")
+                and Path(target_path) == workspace / after_activation):
+            changed = True
+            (workspace / target_name).write_bytes(concurrent_content)
+        return result
+
+    monkeypatch.setattr(contract.os, "replace", replace)
+    with pytest.raises(contract.ContractError):
+        migrate(graph, roots, workspace, receipt)
+    assert changed
+    assert receipt == original_receipt
+    for name, (content, _mode) in before.items():
+        expected = concurrent_content if name == target_name else content
+        assert (workspace / name).read_bytes() == expected
+    assert sorted(p.name for p in workspace.iterdir()) == ["AGENTS.md", "CLAUDE.md"]
+
+
+@pytest.mark.parametrize("target_name", ["AGENTS.md", "CLAUDE.md"])
+def test_staged_candidate_must_still_match_the_verified_render(tmp_path, monkeypatch, target_name):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path, converted=True)
+    before = pair_snapshot(workspace)
+    original = contract.tempfile.NamedTemporaryFile
+    staged = {}
+
+    @contextlib.contextmanager
+    def stage(*args, **kwargs):
+        with original(*args, **kwargs) as temporary:
+            yield temporary
+            if kwargs.get("suffix") == ".stage":
+                staged[str(kwargs["prefix"]).removesuffix(".")] = Path(temporary.name)
+        if len(staged) == 2:
+            staged[target_name].write_bytes(b"Unverified staged content.\n")
+
+    monkeypatch.setattr(contract.tempfile, "NamedTemporaryFile", stage)
+    with pytest.raises(contract.ContractError):
+        migrate(graph, roots, workspace, receipt)
+    assert len(staged) == 2
+    assert pair_snapshot(workspace) == before
+
+
+def test_failure_restoring_one_owned_output_does_not_skip_the_other(tmp_path, monkeypatch):
+    graph, roots, workspace, receipt = legacy_pair(tmp_path, converted=True)
+    (workspace / "CLAUDE.md").chmod(0o640)
+    before = pair_snapshot(workspace)
+    original_receipt = copy.deepcopy(receipt)
+    (roots["personal"] / "instructions.md").write_text("New candidate source rules.\n")
+    git(roots["personal"], "add", "instructions.md")
+    git(roots["personal"], "commit", "-q", "-m", "Update fixture")
+    original_fsync = contract._fsync_directory
+    original_restore = contract._restore_file
+    failed = False
+    restoration_attempts = []
+
+    def fail_final_sync(path):
+        nonlocal failed
+        if Path(path) == workspace and not failed:
+            failed = True
+            raise contract.ContractError("injected final activation failure")
+        return original_fsync(path)
+
+    def restore(path, prior):
+        restoration_attempts.append(Path(path).name)
+        if Path(path).name == "AGENTS.md":
+            raise OSError("injected first-output restoration failure")
+        return original_restore(path, prior)
+
+    monkeypatch.setattr(contract, "_fsync_directory", fail_final_sync)
+    monkeypatch.setattr(contract, "_restore_file", restore)
+    with pytest.raises((contract.ContractError, OSError)):
+        migrate(graph, roots, workspace, receipt)
+    assert failed
+    assert restoration_attempts == ["AGENTS.md", "CLAUDE.md"]
+    assert pair_snapshot(workspace)["CLAUDE.md"] == before["CLAUDE.md"]
+    assert b"New candidate source rules." in (workspace / "AGENTS.md").read_bytes()
+    assert receipt == original_receipt
+
+
+def test_instruction_read_access_time_is_not_a_concurrent_content_edit(tmp_path, monkeypatch):
+    target = tmp_path.resolve() / "instructions.md"
+    target.write_bytes(b"Stable instruction bytes.\n")
+    original = Path.lstat
+    calls = 0
+
+    class AccessTimeAdvanced:
+        """Model the kernel updating only atime after the real content read."""
+
+        def __init__(self, metadata):
+            self.metadata = metadata
+
+        def __getattr__(self, name):
+            value = getattr(self.metadata, name)
+            if name == "st_atime":
+                return value + 60
+            if name == "st_atime_ns":
+                return value + 60_000_000_000
+            return value
+
+        def __iter__(self):
+            values = list(self.metadata)
+            values[7] += 60
+            return iter(values)
+
+        def __eq__(self, other):
+            return tuple(self) == tuple(other)
+
+    def lstat(path, *args, **kwargs):
+        nonlocal calls
+        metadata = original(path, *args, **kwargs)
+        if path == target:
+            calls += 1
+            if calls >= 2:
+                return AccessTimeAdvanced(metadata)
+        return metadata
+
+    monkeypatch.setattr(Path, "lstat", lstat)
+    observed = contract._instruction_snapshot(target)
+    assert observed[0] is True
+    assert observed[1] == b"Stable instruction bytes.\n"
+
+
+def test_actual_private_adapter_and_public_engine_converge_without_mutating_sources(tmp_path, monkeypatch):
+    installed = Path.home() / ".synthesis/agent-control/scripts/instruction_adapters.py"
+    if not installed.is_file() or installed.is_symlink():
+        pytest.skip("optional private adapter is not installed")
+    original_source = installed.read_bytes()
+    module = types.ModuleType("isolated_instruction_adapters")
+    module.__file__ = str(installed)
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    # Compile the actual installed code without generating a cache beside it.
+    exec(compile(original_source, str(installed), "exec"), module.__dict__)
+    graph, roots, workspace, receipt = legacy_pair(tmp_path)
+    classified = module.classify(workspace)
+    assert classified.action == "deduplicate"
+    result = module.apply(workspace, classified, tmp_path / "adapter-backups")
+    assert result.action == "ok"
+    assert (workspace / "CLAUDE.md").read_bytes() == ADAPTER
+    migrated = migrate(graph, roots, workspace, receipt)
+    stable = pair_snapshot(workspace)
+    assert contract.instruction_output_state(workspace, migrated) == "current"
+    classified = module.classify(workspace)
+    assert classified.action == "ok" and not classified.changed
+    assert pair_snapshot(workspace) == stable
+    assert installed.read_bytes() == original_source

--- a/skills/synthesis-onboarding/scripts/test_instruction_adversarial.py
+++ b/skills/synthesis-onboarding/scripts/test_instruction_adversarial.py
@@ -560,7 +560,8 @@ def test_instruction_read_access_time_is_not_a_concurrent_content_edit(tmp_path,
 
 
 @pytest.mark.parametrize("source_kind", ["git", "immutable-release"])
-def test_actual_doctor_rejects_forged_public_commit_in_current_receipt(tmp_path, monkeypatch, source_kind):
+@pytest.mark.parametrize("forgery", ["missing-commit", "tree-object"])
+def test_actual_doctor_rejects_forged_public_commit_in_current_receipt(tmp_path, monkeypatch, source_kind, forgery):
     import onboard
 
     public_relative = "skills/synthesis-onboarding/references/kernel.example.md"
@@ -575,6 +576,11 @@ def test_actual_doctor_rejects_forged_public_commit_in_current_receipt(tmp_path,
         graph["sources"][0]["path"] = public_relative
         workspace = tmp_path.resolve() / "workspace"
         receipt = contract.materialize_instruction_pair(graph, roots, workspace, generation=1)
+        # The original commit still binds the same instruction bytes after an
+        # unrelated source-repository commit. Fresh HEAD equality is not proof.
+        (roots["public"] / "unrelated.md").write_text("Unrelated committed content.\n")
+        git(roots["public"], "add", "unrelated.md")
+        git(roots["public"], "commit", "-q", "-m", "Update fixture")
     assert contract.instruction_output_state(workspace, receipt) == "current"
     manifest = {"org": {"workspace": workspace.name},
                 "_path": str(roots["organization"] / ".agents/onboarding.yaml"),
@@ -599,7 +605,11 @@ def test_actual_doctor_rejects_forged_public_commit_in_current_receipt(tmp_path,
 
     code, report = doctor()
     assert code == 0, report.steps  # Positive control through the same consumer.
-    receipts.data["instruction_receipt"]["sources"][0]["commit"] = "e" * 40
+    forged_commit = "e" * 40
+    if forgery == "tree-object":
+        forged_commit = (_descriptor["tree"] if source_kind == "immutable-release"
+                         else git(roots["public"], "rev-parse", "HEAD^{tree}"))
+    receipts.data["instruction_receipt"]["sources"][0]["commit"] = forged_commit
     receipts.save()
     before = {str(p): p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()}
     code, report = doctor()

--- a/skills/synthesis-onboarding/scripts/test_instruction_convergence.py
+++ b/skills/synthesis-onboarding/scripts/test_instruction_convergence.py
@@ -1,0 +1,151 @@
+"""Instruction ownership regressions, including a real recorded predecessor."""
+
+import copy
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import system_contract as contract
+
+
+ADAPTER = b"@AGENTS.md\n"
+
+
+@pytest.fixture
+def instructions(tmp_path, monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("GIT_CONFIG_") or key in {
+            "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR",
+            "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        }:
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "gitconfig"))
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    source = tmp_path / "source"
+    source.mkdir()
+
+    def git(*args):
+        result = subprocess.run(
+            ["git", "-C", str(source), *args], capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        return result.stdout.strip()
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.name", "Fixture")
+    git("config", "user.email", "fixture@example.test")
+    (source / "instructions.md").write_text("Keep every user instruction.\n")
+    git("add", "instructions.md")
+    git("commit", "-q", "-m", "Seed fixture")
+    graph = {
+        "schema_version": 1,
+        "sources": [{"role": "personal", "path": "instructions.md", "required": True}],
+        "output": "AGENTS.md", "claude_adapter": "CLAUDE.md",
+    }
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    body = (b"<!-- synthesis-instructions:generated -->\n# Workspace Instructions\n"
+            b"\n## Personal\n\nKeep every user instruction.\n")
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        (workspace / name).write_bytes(body)
+        (workspace / name).chmod(0o600)
+    receipt = {
+        "schema_version": 1, "generation": 1,
+        "outputs": {name: {"path": str(workspace / name),
+                    "sha256": hashlib.sha256(body).hexdigest()}
+                    for name in ("AGENTS.md", "CLAUDE.md")},
+        "sources": [{"role": "personal", "repository": str(source),
+                     "path": "instructions.md", "commit": git("rev-parse", "HEAD"),
+                     "sha256": contract.file_digest(source / "instructions.md")}],
+        "adopted_outputs": {"AGENTS.md": {"archive_path": "retained-original", "sha256": "a" * 64}},
+    }
+    return source, workspace, graph, receipt, git
+
+
+def materialize(fixture, receipt=None, **kwargs):
+    source, workspace, graph, _, _ = fixture
+    return contract.materialize_instruction_pair(
+        graph, {"personal": source}, workspace, 2, previous_receipt=receipt, **kwargs,
+    )
+
+
+def test_fresh_pair_is_canonical_content_and_literal_import(instructions):
+    receipt = materialize(instructions)
+    workspace = instructions[1]
+    assert (workspace / "CLAUDE.md").read_bytes() == ADAPTER
+    assert receipt["outputs"]["AGENTS.md"]["sha256"] != receipt["outputs"]["CLAUDE.md"]["sha256"]
+    assert materialize(instructions, receipt)["unchanged"] is True
+
+
+@pytest.mark.parametrize("preconverted", [False, True])
+@pytest.mark.parametrize("advance_source", [False, True])
+def test_receipted_predecessor_converges_without_losing_archive(instructions, preconverted, advance_source):
+    source, workspace, _, previous, git = instructions
+    if preconverted:
+        (workspace / "CLAUDE.md").write_bytes(ADAPTER)
+    if advance_source:
+        (source / "instructions.md").write_text("Keep every user instruction.\nAdd a verified instruction.\n")
+        git("add", "instructions.md")
+        git("commit", "-q", "-m", "Update fixture")
+    before = {p.name: p.read_bytes() for p in workspace.iterdir()}
+    materialize(instructions, previous, validate_only=True)
+    assert before == {p.name: p.read_bytes() for p in workspace.iterdir()}
+    current = materialize(instructions, previous)
+    assert (workspace / "CLAUDE.md").read_bytes() == ADAPTER
+    assert current["adopted_outputs"] == previous["adopted_outputs"]
+    assert current["generation"] == 2
+    assert contract.instruction_output_state(workspace, current) == "current"
+    assert materialize(instructions, current)["unchanged"] is True
+
+
+@pytest.mark.parametrize("bad", ["agents", "comment", "crlf", "missing", "path", "source-hash", "commit", "roles", "schema", "symlink"])
+def test_preconverted_transition_rejects_unproved_changes(instructions, bad):
+    source, workspace, _, original, _ = instructions
+    previous = copy.deepcopy(original)
+    (workspace / "CLAUDE.md").write_bytes(ADAPTER)
+    if bad == "agents":
+        (workspace / "AGENTS.md").write_text("User edit\n")
+    elif bad == "comment":
+        (workspace / "CLAUDE.md").write_bytes(ADAPTER + b"# User note\n")
+    elif bad == "crlf":
+        (workspace / "CLAUDE.md").write_bytes(b"@AGENTS.md\r\n")
+    elif bad == "missing":
+        (workspace / "AGENTS.md").unlink()
+    elif bad == "path":
+        previous["outputs"]["CLAUDE.md"]["path"] = str(workspace / "elsewhere.md")
+    elif bad == "source-hash":
+        previous["sources"][0]["sha256"] = "0" * 64
+    elif bad == "commit":
+        previous["sources"][0]["commit"] = "0" * 40
+    elif bad == "roles":
+        previous["sources"] *= 2
+    elif bad == "schema":
+        previous["schema_version"] = 999
+    elif bad == "symlink":
+        (workspace / "CLAUDE.md").unlink()
+        (workspace / "CLAUDE.md").symlink_to(source / "instructions.md")
+    before = {p.name: (p.is_symlink(), p.read_bytes()) for p in workspace.iterdir()}
+    with pytest.raises(contract.ContractError):
+        materialize(instructions, previous)
+    assert before == {p.name: (p.is_symlink(), p.read_bytes()) for p in workspace.iterdir()}
+
+
+@pytest.mark.parametrize("preconverted", [False, True])
+def test_transition_failure_restores_both_outputs_and_modes(instructions, preconverted):
+    _, workspace, _, previous, _ = instructions
+    if preconverted:
+        (workspace / "CLAUDE.md").write_bytes(ADAPTER)
+    before = {p.name: (p.read_bytes(), p.stat().st_mode) for p in workspace.iterdir()}
+    with pytest.raises(contract.ContractError, match="injected"):
+        materialize(instructions, previous, fail_after_first=True)
+    assert before == {p.name: (p.read_bytes(), p.stat().st_mode) for p in workspace.iterdir()}
+
+
+def test_legacy_output_is_explicitly_migration_required(instructions):
+    _, workspace, _, previous, _ = instructions
+    assert contract.instruction_output_state(workspace, previous) == "legacy-duplicate"
+    (workspace / "CLAUDE.md").write_bytes(ADAPTER)
+    assert contract.instruction_output_state(workspace, previous) == "legacy-adapter"

--- a/skills/synthesis-onboarding/scripts/test_kb_adversarial.py
+++ b/skills/synthesis-onboarding/scripts/test_kb_adversarial.py
@@ -1,0 +1,66 @@
+"""Independent real-Git controls for checkout identity and concurrent ownership."""
+
+import onboard
+from test_kb_update_ownership import kb, snapshot
+
+
+def test_symlinked_workspace_parent_must_not_receive_created_clone(kb):
+    elsewhere = kb.root / "outside-workspace"
+    elsewhere.mkdir()
+    kb.workspaces.mkdir(parents=True)
+    (kb.workspaces / "example").symlink_to(elsewhere, target_is_directory=True)
+    report, receipts = kb.run(enrolling=True)
+    assert report.exit_code() != 0, report.steps
+    assert not (elsewhere / "knowledge").exists()
+    assert "knowledge" not in receipts.data.get("knowledge_repositories", {})
+
+
+def test_peer_branch_change_after_final_verification_must_not_be_merged(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    before_head = kb.git("rev-parse", "HEAD", cwd=kb.standard)
+    kb.advance()
+    original = onboard.git
+    peer_snapshot = []
+
+    def git(args, **kwargs):
+        result = original(args, **kwargs)
+        if args[:2] == ["merge-base", "--is-ancestor"]:
+            kb.git("checkout", "-q", "-b", "peer/topic", cwd=kb.standard)
+            peer_snapshot.append(snapshot(kb.standard))
+        return result
+
+    monkeypatch.setattr(onboard, "git", git)
+    report, _ = kb.run()
+    assert peer_snapshot
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == before_head, report.steps
+    assert snapshot(kb.standard) == peer_snapshot[0]
+    assert report.exit_code() != 0, report.steps
+
+
+def test_symlinked_parent_replacement_must_not_update_different_checkout(kb):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    parent = kb.workspaces / "example"
+    saved_parent = kb.root / "saved-created-workspace"
+    parent.rename(saved_parent)
+    elsewhere = kb.root / "outside-workspace"
+    target = kb.clone(elsewhere / "knowledge")
+    parent.symlink_to(elsewhere, target_is_directory=True)
+    kb.advance()
+    before = snapshot(target)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert snapshot(target) == before
+
+
+def test_fetch_must_not_apply_unrelated_configured_ref_mappings(kb):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    kb.git("branch", "peer/topic", cwd=kb.standard)
+    before = kb.git("rev-parse", "refs/heads/peer/topic", cwd=kb.standard)
+    kb.git("config", "--add", "remote.origin.fetch",
+           "+refs/heads/main:refs/heads/peer/topic", cwd=kb.standard)
+    kb.advance()
+    report, _ = kb.run()
+    assert kb.git("rev-parse", "refs/heads/peer/topic", cwd=kb.standard) == before, report.steps

--- a/skills/synthesis-onboarding/scripts/test_kb_adversarial.py
+++ b/skills/synthesis-onboarding/scripts/test_kb_adversarial.py
@@ -1,5 +1,12 @@
 """Independent real-Git controls for checkout identity and concurrent ownership."""
 
+import json
+import select
+import subprocess
+from pathlib import Path
+
+import pytest
+
 import onboard
 from test_kb_update_ownership import kb, snapshot
 
@@ -64,3 +71,315 @@ def test_fetch_must_not_apply_unrelated_configured_ref_mappings(kb):
     kb.advance()
     report, _ = kb.run()
     assert kb.git("rev-parse", "refs/heads/peer/topic", cwd=kb.standard) == before, report.steps
+
+
+def test_concurrent_unrelated_fetch_cannot_choose_update_target(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    target = kb.advance()
+    source = kb.root / "source"
+    kb.git("checkout", "-q", "-b", "peer/topic", cwd=source)
+    (source / "peer.md").write_text("Unrelated branch content.\n")
+    kb.git("add", "peer.md", cwd=source)
+    kb.git("commit", "-q", "-m", "Add branch fixture", cwd=source)
+    kb.git("push", str(kb.root / "remote.git"), "peer/topic", cwd=source)
+    other = kb.git("rev-parse", "HEAD", cwd=source)
+    original = onboard.git
+
+    def git(arguments, **kwargs):
+        result = original(arguments, **kwargs)
+        if arguments[0] == "fetch":
+            kb.git("fetch", "--no-tags", "--refmap=", "origin", "refs/heads/peer/topic",
+                   cwd=kb.standard)
+            assert kb.git("rev-parse", "FETCH_HEAD", cwd=kb.standard) == other
+        return result
+
+    monkeypatch.setattr(onboard, "git", git)
+    report, _ = kb.run()
+    assert report.exit_code() == 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == target
+    assert kb.git("rev-parse", "refs/remotes/origin/main", cwd=kb.standard) == target
+    assert not (kb.standard / "peer.md").exists()
+
+
+def test_prepared_update_excludes_real_concurrent_git_writers(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    target = kb.advance()
+    kb.git("branch", "peer/topic", cwd=kb.standard)
+    original = onboard.run
+    attempts = []
+
+    def run(cmd, **kwargs):
+        if cmd[:2] == ["git", "read-tree"]:
+            for arguments in (["checkout", "peer/topic"],
+                              ["symbolic-ref", "HEAD", "refs/heads/peer/topic"],
+                              ["update-ref", "refs/heads/main", target]):
+                result = subprocess.run(["git", *arguments], cwd=kb.standard,
+                                        capture_output=True, text=True)
+                attempts.append((arguments, result.returncode, result.stderr))
+        return original(cmd, **kwargs)
+
+    monkeypatch.setattr(onboard, "run", run)
+    report, _ = kb.run()
+    assert len(attempts) == 3, attempts
+    assert all(code != 0 and ".lock" in error for _, code, error in attempts), attempts
+    assert report.exit_code() == 0, report.steps
+    assert kb.git("symbolic-ref", "HEAD", cwd=kb.standard) == "refs/heads/main"
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == target
+
+
+@pytest.mark.parametrize("lock", ["HEAD.lock", "index.lock", "refs/heads/main.lock"])
+def test_preexisting_git_locks_are_preserved(kb, lock):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    kb.advance()
+    path = kb.standard / ".git" / lock
+    path.write_text("Peer lock.\n")
+    before = (kb.standard / "content.md").read_bytes()
+    index = (kb.standard / ".git/index").read_bytes()
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert path.read_text() == "Peer lock.\n"
+    assert (kb.standard / "content.md").read_bytes() == before
+    assert (kb.standard / ".git/index").read_bytes() == index
+
+
+def test_failed_index_activation_retains_new_index_and_recovery_identity(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    before = kb.git("rev-parse", "HEAD", cwd=kb.standard)
+    target = kb.advance()
+    original_index = (kb.standard / ".git/index").read_bytes()
+    original = onboard.os.replace
+
+    def replace(source, destination):
+        if str(destination) == str(kb.standard / ".git/index"):
+            raise OSError("Fixture index activation failure")
+        return original(source, destination)
+
+    monkeypatch.setattr(onboard.os, "replace", replace)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == target
+    assert (kb.standard / ".git/index").read_bytes() == original_index
+    records = list((kb.standard / ".git").glob(".synthesis-index-*.recovery.json"))
+    assert len(records) == 1
+    recovery = json.loads(records[0].read_text())
+    assert recovery["before"] == before
+    assert recovery["target"] == target
+    assert recovery["ref_committed"] is True
+    assert onboard.file_digest(recovery["index"]) == recovery["index_sha256"]
+    assert not (kb.standard / ".git/index.lock").exists()
+
+
+def test_real_read_tree_refusal_preserves_new_peer_file(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    before_head = kb.git("rev-parse", "HEAD", cwd=kb.standard)
+    original_index = (kb.standard / ".git/index").read_bytes()
+    kb.advance()
+    original = onboard.run
+    injected = []
+
+    def run(cmd, **kwargs):
+        if cmd[:2] == ["git", "read-tree"] and not injected:
+            (kb.standard / "content.md").write_text("Peer edit at checkout boundary.\n")
+            injected.append(True)
+        return original(cmd, **kwargs)
+
+    monkeypatch.setattr(onboard, "run", run)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == before_head
+    assert (kb.standard / "content.md").read_text() == "Peer edit at checkout boundary.\n"
+    assert (kb.standard / ".git/index").read_bytes() == original_index
+
+
+def test_prepared_destination_changed_before_lock_is_refused(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    kb.advance()
+    kb.git("branch", "peer/topic", cwd=kb.standard)
+    before = kb.git("rev-parse", "HEAD", cwd=kb.standard)
+    index = (kb.standard / ".git/index").read_bytes()
+    original = subprocess.Popen
+
+    def popen(cmd, *args, **kwargs):
+        if cmd[:3] == ["git", "update-ref", "--stdin"]:
+            kb.git("symbolic-ref", "HEAD", "refs/heads/peer/topic", cwd=kb.standard)
+        return original(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", popen)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert kb.git("symbolic-ref", "HEAD", cwd=kb.standard) == "refs/heads/peer/topic"
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == before
+    assert (kb.standard / ".git/index").read_bytes() == index
+
+
+def test_native_reference_process_abort_restores_worktree_and_index(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    kb.advance()
+    before_head = kb.git("rev-parse", "HEAD", cwd=kb.standard)
+    content = (kb.standard / "content.md").read_bytes()
+    index = (kb.standard / ".git/index").read_bytes()
+    original_popen, original_run = subprocess.Popen, onboard.run
+    processes, aborted = [], []
+
+    def popen(cmd, *args, **kwargs):
+        process = original_popen(cmd, *args, **kwargs)
+        if cmd[:3] == ["git", "update-ref", "--stdin"]:
+            processes.append(process)
+        return process
+
+    def run(cmd, **kwargs):
+        result = original_run(cmd, **kwargs)
+        if cmd[:2] == ["git", "read-tree"] and not aborted:
+            assert result[0] == 0, result
+            processes[0].terminate()
+            processes[0].wait(timeout=5)
+            aborted.append(True)
+        return result
+
+    monkeypatch.setattr(subprocess, "Popen", popen)
+    monkeypatch.setattr(onboard, "run", run)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == before_head
+    assert (kb.standard / "content.md").read_bytes() == content
+    assert (kb.standard / ".git/index").read_bytes() == index
+    assert not list((kb.standard / ".git").glob("*.lock"))
+    assert not list((kb.standard / ".git").glob(".synthesis-index-*"))
+
+
+def test_read_tree_failure_after_write_recovers_original_state(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    kb.advance()
+    before_head = kb.git("rev-parse", "HEAD", cwd=kb.standard)
+    content = (kb.standard / "content.md").read_bytes()
+    index = (kb.standard / ".git/index").read_bytes()
+    original = onboard.run
+    failed = []
+
+    def run(cmd, **kwargs):
+        result = original(cmd, **kwargs)
+        if cmd[:2] == ["git", "read-tree"] and not failed:
+            assert result[0] == 0, result
+            failed.append(True)
+            return 1, "", "Fixture failure after checkout write"
+        return result
+
+    monkeypatch.setattr(onboard, "run", run)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == before_head
+    assert (kb.standard / "content.md").read_bytes() == content
+    assert (kb.standard / ".git/index").read_bytes() == index
+
+
+def test_reference_protocol_timeout_is_non_green_and_releases_owned_locks(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    kb.advance()
+    before_head = kb.git("rev-parse", "HEAD", cwd=kb.standard)
+    index = (kb.standard / ".git/index").read_bytes()
+    original = select.select
+    calls = []
+
+    def timeout(read, write, exceptional, duration):
+        calls.append(True)
+        return ([], [], []) if len(calls) == 2 else original(read, write, exceptional, duration)
+
+    monkeypatch.setattr(select, "select", timeout)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == before_head
+    assert (kb.standard / ".git/index").read_bytes() == index
+    assert not list((kb.standard / ".git").glob("*.lock"))
+
+
+def test_lost_commit_acknowledgement_preserves_committed_tree_and_staged_index(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    before = kb.git("rev-parse", "HEAD", cwd=kb.standard)
+    original_index = (kb.standard / ".git/index").read_bytes()
+    target = kb.advance()
+    original = select.select
+    calls = []
+
+    def timeout(read, write, exceptional, duration):
+        calls.append(True)
+        ready = original(read, write, exceptional, duration)
+        if len(calls) == 3:
+            assert ready[0]
+            assert kb.git("rev-parse", "refs/heads/main", cwd=kb.standard) == target
+            return [], [], []
+        return ready
+
+    monkeypatch.setattr(select, "select", timeout)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == target
+    assert (kb.standard / "content.md").read_text() == "Initial content.\nPublished content.\n"
+    assert (kb.standard / ".git/index").read_bytes() == original_index
+    records = list((kb.standard / ".git").glob(".synthesis-index-*.recovery.json"))
+    assert len(records) == 1
+    recovery = json.loads(records[0].read_text())
+    assert recovery["ref_committed"] is True
+    assert recovery["before"] == before
+    assert recovery["target"] == target
+    assert onboard.file_digest(recovery["index"]) == recovery["index_sha256"]
+    assert not list((kb.standard / ".git").glob("*.lock"))
+
+
+def test_lock_cleanup_failure_is_non_green_without_losing_committed_index(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    target = kb.advance()
+    original = Path.unlink
+    lock = kb.standard / ".git/index.lock"
+
+    def unlink(path, *args, **kwargs):
+        if path == lock:
+            raise OSError("Fixture cleanup failure")
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", unlink)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == target
+    assert kb.git("--no-optional-locks", "status", "--porcelain", cwd=kb.standard) == ""
+    assert lock.exists()
+
+
+def test_real_filesystem_checkout_failure_preserves_original_state(kb):
+    source = kb.root / "source"
+    locked_source = source / "locked"
+    locked_source.mkdir()
+    (locked_source / "keep.txt").write_text("Original content.\n")
+    kb.git("add", "locked", cwd=source)
+    kb.git("commit", "-q", "-m", "Seed checkout fixture", cwd=source)
+    kb.git("push", str(kb.root / "remote.git"), "main", cwd=source)
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    before_head = kb.git("rev-parse", "HEAD", cwd=kb.standard)
+    content = (kb.standard / "content.md").read_bytes()
+    index = (kb.standard / ".git/index").read_bytes()
+    kb.advance()
+    (locked_source / "new.txt").write_text("New content.\n")
+    kb.git("add", "locked", cwd=source)
+    kb.git("commit", "-q", "-m", "Extend checkout fixture", cwd=source)
+    kb.git("push", str(kb.root / "remote.git"), "main", cwd=source)
+    locked = kb.standard / "locked"
+    locked.chmod(0o555)
+    try:
+        report, _ = kb.run()
+    finally:
+        locked.chmod(0o755)
+    assert report.exit_code() != 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == before_head
+    assert (kb.standard / "content.md").read_bytes() == content
+    assert (kb.standard / ".git/index").read_bytes() == index

--- a/skills/synthesis-onboarding/scripts/test_kb_update_ownership.py
+++ b/skills/synthesis-onboarding/scripts/test_kb_update_ownership.py
@@ -1,5 +1,6 @@
 """Real-Git controls for knowledge-checkout ownership across engine replays."""
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -33,6 +34,13 @@ def kb(tmp_path, monkeypatch):
         result = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
         assert result.returncode == 0, result.stderr
         return result.stdout.strip()
+
+    # Snapshot comparisons isolate engine/peer mutations, not a detached Git
+    # housekeeper retiring its own transient locks after commit returns. These
+    # settings live only in this fixture's temporary global configuration and
+    # reach real Git calls from both the fixture and the engine under test.
+    git("config", "--global", "maintenance.auto", "false")
+    git("config", "--global", "gc.auto", "0")
 
     source = root / "source"
     source.mkdir()
@@ -86,6 +94,24 @@ def snapshot(repo):
     """Include index/config bytes, not only worktree content and HEAD."""
     return {str(path.relative_to(repo)): path.read_bytes()
             for path in repo.rglob("*") if path.is_file()}
+
+
+def test_fixture_suppresses_automatic_maintenance_without_hiding_locks(kb, monkeypatch):
+    repo = kb.clone()
+    assert kb.git("config", "--get", "maintenance.auto", cwd=repo) == "false"
+    assert kb.git("config", "--get", "gc.auto", cwd=repo) == "0"
+    for positive_control in (True, False):
+        trace = kb.root / ("maintenance-positive.json" if positive_control else "maintenance-disabled.json")
+        monkeypatch.setenv("GIT_TRACE2_EVENT", str(trace))
+        overrides = ["-c", "maintenance.auto=true", "-c", "maintenance.autoDetach=false"] if positive_control else []
+        kb.git(*overrides, "commit", "--allow-empty", "-q", "-m", "Check fixture isolation", cwd=repo)
+        events = [json.loads(line) for line in trace.read_text().splitlines()]
+        maintenance = [event for event in events if event.get("event") == "child_start"
+                       and any(value in {"maintenance", "gc"} for value in event.get("argv", []))]
+        assert bool(maintenance) is positive_control, maintenance
+    lock = repo / ".git/objects/maintenance.lock"
+    lock.write_bytes(b"")
+    assert snapshot(repo)[".git/objects/maintenance.lock"] == b""
 
 
 @pytest.mark.parametrize("location", ["standard", "elsewhere"])

--- a/skills/synthesis-onboarding/scripts/test_kb_update_ownership.py
+++ b/skills/synthesis-onboarding/scripts/test_kb_update_ownership.py
@@ -1,0 +1,249 @@
+"""Real-Git controls for knowledge-checkout ownership across engine replays."""
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import onboard
+
+
+@pytest.fixture
+def kb(tmp_path, monkeypatch):
+    root = tmp_path.resolve()
+    home = root / "home"
+    home.mkdir()
+    for key in list(os.environ):
+        if key.startswith("GIT_CONFIG_") or key in {
+            "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR",
+            "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        }:
+            monkeypatch.delenv(key)
+    for key, value in {
+        "HOME": str(home), "GIT_CONFIG_GLOBAL": str(root / "gitconfig"),
+        "GIT_CONFIG_NOSYSTEM": "1", "GIT_AUTHOR_NAME": "Fixture User",
+        "GIT_AUTHOR_EMAIL": "fixture@example.test", "GIT_COMMITTER_NAME": "Fixture User",
+        "GIT_COMMITTER_EMAIL": "fixture@example.test",
+    }.items():
+        monkeypatch.setenv(key, value)
+
+    def git(*args, cwd=None):
+        result = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+        return result.stdout.strip()
+
+    source = root / "source"
+    source.mkdir()
+    git("init", "-q", "-b", "main", cwd=source)
+    (source / "content.md").write_text("Initial content.\n")
+    hooks = source / ".githooks"
+    hooks.mkdir()
+    (hooks / "pre-commit").write_text("#!/bin/sh\nexit 0\n")
+    (hooks / "pre-commit").chmod(0o755)
+    git("add", ".", cwd=source)
+    git("commit", "-q", "-m", "Seed fixture", cwd=source)
+    remote = root / "remote.git"
+    git("clone", "-q", "--bare", str(source), str(remote))
+    url = "https://example.test/knowledge.git"
+    git("config", "--global", "url.%s.insteadOf" % remote.as_uri(), url)
+    workspaces = home / "workspaces"
+    monkeypatch.setattr(onboard, "WORKSPACES_ROOT", workspaces)
+    monkeypatch.setattr(onboard, "HOME", home)
+    manifest = {"org": {"workspace": "example"}, "knowledge_bases": [
+        {"name": "knowledge", "repository": url, "local_hooks": True},
+    ]}
+    receipts_path = root / "receipts.json"
+    standard = workspaces / "example/knowledge"
+
+    def clone(path=standard):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        git("clone", "-q", url, str(path))
+        git("config", "core.hooksPath", ".githooks", cwd=path)
+        return path
+
+    def advance():
+        content = source / "content.md"
+        content.write_text(content.read_text() + "Published content.\n")
+        git("add", "content.md", cwd=source)
+        git("commit", "-q", "-m", "Update fixture", cwd=source)
+        git("push", str(remote), "main", cwd=source)
+        return git("rev-parse", "HEAD", cwd=source)
+
+    def run(enrolling=False, dry_run=False):
+        receipts = onboard.Receipts(receipts_path)
+        report = onboard.Report(dry_run=dry_run, as_json=True)
+        onboard.phase_kbs(report, manifest, receipts, dry_run, enrolling=enrolling)
+        return report, receipts
+
+    return SimpleNamespace(root=root, git=git, clone=clone, advance=advance,
+        run=run, standard=standard, url=url, manifest=manifest,
+        receipts_path=receipts_path, workspaces=workspaces)
+
+
+def snapshot(repo):
+    """Include index/config bytes, not only worktree content and HEAD."""
+    return {str(path.relative_to(repo)): path.read_bytes()
+            for path in repo.rglob("*") if path.is_file()}
+
+
+@pytest.mark.parametrize("location", ["standard", "elsewhere"])
+@pytest.mark.parametrize("state", ["untracked-branch", "tracking-branch", "dirty", "detached"])
+def test_adopted_checkout_survives_enrollment_and_two_replays(kb, location, state):
+    path = kb.standard if location == "standard" else kb.workspaces / "another/knowledge"
+    kb.clone(path)
+    if state == "untracked-branch":
+        kb.git("checkout", "-q", "-b", "work/topic", cwd=path)
+    elif state == "tracking-branch":
+        kb.git("checkout", "-q", "-b", "work/topic", "--track", "origin/main", cwd=path)
+    elif state == "dirty":
+        (path / "content.md").write_text("Uncommitted work.\n")
+        kb.git("add", "content.md", cwd=path)
+        (path / "content.md").write_text("Additional unstaged work.\n")
+        (path / "untracked.md").write_text("Untracked work.\n")
+    else:
+        kb.git("checkout", "-q", "--detach", cwd=path)
+    before = snapshot(path)
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    assert snapshot(path) == before
+    kb.advance()
+    for _ in ("update", "repair"):
+        report, receipts = kb.run()
+        assert report.exit_code() == 0, report.steps
+        assert snapshot(path) == before
+        assert any("preserved" in step["detail"] for step in report.steps)
+        entry = receipts.data["knowledge_repositories"]["knowledge"]
+        assert entry["acquisition"] == "adopted"
+        assert entry["path"] == str(path)
+        assert entry["repository"] == kb.url
+
+
+def test_legacy_standard_checkout_is_adopted_not_inferred_created(kb):
+    path = kb.clone()
+    kb.advance()
+    before = snapshot(path)
+    report, receipts = kb.run()
+    assert report.exit_code() == 0, report.steps
+    assert snapshot(path) == before
+    assert receipts.data["knowledge_repositories"]["knowledge"]["acquisition"] == "adopted"
+    assert onboard.Receipts(kb.receipts_path).data["knowledge_repositories"] == receipts.data["knowledge_repositories"]
+
+
+def test_created_checkout_records_tracking_and_fast_forwards(kb):
+    report, receipts = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    entry = receipts.data["knowledge_repositories"]["knowledge"]
+    assert entry == {"path": str(kb.standard), "repository": kb.url,
+        "acquisition": "created", "branch": "main", "upstream": "refs/remotes/origin/main"}
+    config = (kb.standard / ".git/config").read_bytes()
+    target = kb.advance()
+    report, _ = kb.run()
+    assert report.exit_code() == 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=kb.standard) == target
+    assert (kb.standard / ".git/config").read_bytes() == config
+
+
+@pytest.mark.parametrize("change", ["branch", "upstream", "detached", "dirty", "ahead", "diverged"])
+def test_created_checkout_preserves_work_when_update_binding_is_not_safe(kb, change):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    path = kb.standard
+    if change == "branch":
+        kb.git("checkout", "-q", "-b", "work/topic", "--track", "origin/main", cwd=path)
+    elif change == "upstream":
+        kb.git("config", "branch.main.remote", ".", cwd=path)
+        kb.git("config", "branch.main.merge", "refs/heads/main", cwd=path)
+    elif change == "detached":
+        kb.git("checkout", "-q", "--detach", cwd=path)
+    else:
+        (path / "content.md").write_text("Personal work.\n")
+        kb.git("add", "content.md", cwd=path)
+        if change in {"ahead", "diverged"}:
+            kb.git("commit", "-q", "-m", "Local fixture", cwd=path)
+    if change in {"branch", "upstream", "detached", "dirty", "diverged"}:
+        kb.advance()
+    before_head = kb.git("rev-parse", "HEAD", cwd=path)
+    before = {name: (path / name).read_bytes() for name in ("content.md", ".git/config", ".git/index")}
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert kb.git("rev-parse", "HEAD", cwd=path) == before_head
+    assert {name: (path / name).read_bytes() for name in before} == before
+
+
+@pytest.mark.parametrize("field,value", [("path", "/unexpected/knowledge"),
+    ("repository", "https://example.test/other.git"), ("acquisition", "unknown"),
+    ("branch", "other"), ("upstream", "refs/remotes/other/main")])
+def test_corrupt_or_mismatched_provenance_fails_before_checkout_mutation(kb, field, value):
+    report, receipts = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    receipts.data["knowledge_repositories"]["knowledge"][field] = value
+    receipts.save()
+    before = snapshot(kb.standard)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert snapshot(kb.standard) == before
+
+
+def test_wrong_remote_is_not_adopted_or_changed(kb):
+    path = kb.clone()
+    kb.git("remote", "set-url", "origin", "https://example.test/wrong.git", cwd=path)
+    before = snapshot(path)
+    report, receipts = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert snapshot(path) == before
+    assert "knowledge" not in receipts.data.get("knowledge_repositories", {})
+
+
+def test_adopted_missing_protection_is_reported_without_reconfiguration(kb):
+    path = kb.clone()
+    kb.git("config", "--unset", "core.hooksPath", cwd=path)
+    before = snapshot(path)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert snapshot(path) == before
+
+
+def test_dry_run_does_not_persist_acquisition_or_touch_checkout(kb):
+    path = kb.clone()
+    before = snapshot(path)
+    report, _ = kb.run(dry_run=True)
+    assert report.exit_code() == 0, report.steps
+    assert snapshot(path) == before
+    assert not kb.receipts_path.exists()
+
+
+def test_legacy_elsewhere_receipt_does_not_fall_back_to_another_clone(kb):
+    elsewhere = kb.workspaces / "elsewhere/knowledge"
+    receipts = onboard.Receipts(kb.receipts_path)
+    receipts.record_adoption("knowledge", elsewhere)
+    receipts.save()
+    standard = kb.clone()
+    before = snapshot(standard)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert snapshot(standard) == before
+
+
+@pytest.mark.parametrize("value", [None, [], "unexpected", {"knowledge": None},
+    {"knowledge": {"acquisition": "created"}}])
+def test_invalid_provenance_inventory_is_not_silently_ignored(kb, value):
+    path = kb.clone()
+    receipts = onboard.Receipts(kb.receipts_path)
+    receipts.data["knowledge_repositories"] = value
+    receipts.save()
+    before = snapshot(path)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert snapshot(path) == before
+
+
+def test_symbolic_checkout_is_not_adopted(kb):
+    elsewhere = kb.clone(kb.workspaces / "elsewhere/knowledge")
+    kb.standard.parent.mkdir(parents=True)
+    kb.standard.symlink_to(elsewhere, target_is_directory=True)
+    before = snapshot(elsewhere)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert snapshot(elsewhere) == before

--- a/skills/synthesis-onboarding/scripts/test_kb_update_ownership.py
+++ b/skills/synthesis-onboarding/scripts/test_kb_update_ownership.py
@@ -247,3 +247,70 @@ def test_symbolic_checkout_is_not_adopted(kb):
     report, _ = kb.run()
     assert report.exit_code() != 0, report.steps
     assert snapshot(elsewhere) == before
+
+
+def test_managed_missing_protection_is_refused_before_fetch(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    kb.git("config", "--unset", "core.hooksPath", cwd=kb.standard)
+    kb.advance()
+    before = snapshot(kb.standard)
+    original = onboard.git
+    calls = []
+
+    def git(args, **kwargs):
+        calls.append(args)
+        return original(args, **kwargs)
+
+    monkeypatch.setattr(onboard, "git", git)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert not any(args[0] in {"fetch", "pull", "merge"} for args in calls)
+    assert snapshot(kb.standard) == before
+
+
+def test_managed_fetch_failure_is_non_green_and_preserves_checkout(kb, monkeypatch):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    before = snapshot(kb.standard)
+    original = onboard.git
+
+    def git(args, **kwargs):
+        if args[0] == "fetch":
+            return 1, "", "Fixture transport unavailable"
+        return original(args, **kwargs)
+
+    monkeypatch.setattr(onboard, "git", git)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert snapshot(kb.standard) == before
+
+
+@pytest.mark.parametrize("change", ["branch", "dirty", "head", "remote"])
+def test_managed_state_change_during_fetch_is_preserved(kb, monkeypatch, change):
+    report, _ = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    kb.advance()
+    original = onboard.git
+    after_peer = []
+
+    def git(args, **kwargs):
+        result = original(args, **kwargs)
+        if args[0] == "fetch":
+            if change == "branch":
+                kb.git("checkout", "-q", "-b", "work/topic", cwd=kb.standard)
+            elif change == "remote":
+                kb.git("remote", "set-url", "origin", "https://example.test/other.git", cwd=kb.standard)
+            else:
+                (kb.standard / "content.md").write_text("Concurrent work.\n")
+                if change == "head":
+                    kb.git("add", "content.md", cwd=kb.standard)
+                    kb.git("commit", "-q", "-m", "Concurrent fixture", cwd=kb.standard)
+            after_peer.append(snapshot(kb.standard))
+        return result
+
+    monkeypatch.setattr(onboard, "git", git)
+    report, _ = kb.run()
+    assert report.exit_code() != 0, report.steps
+    assert len(after_peer) == 1
+    assert snapshot(kb.standard) == after_peer[0]

--- a/skills/synthesis-onboarding/scripts/test_onboard.py
+++ b/skills/synthesis-onboarding/scripts/test_onboard.py
@@ -60,7 +60,7 @@ esac
 
 class Sandbox:
     def __init__(self):
-        self.root = Path(tempfile.mkdtemp(prefix="onboard-test-"))
+        self.root = Path(tempfile.mkdtemp(prefix="onboard-test-")).resolve()
         self.home = self.root / "home"
         self.remotes = self.root / "remotes"
         self.cache = self.root / "cache"
@@ -1062,7 +1062,7 @@ class EngineTests(unittest.TestCase):
         self.assertTrue(self.box.ws_agents.exists())
         self.assertEqual(
             (self.box.home / "workspaces" / "exampleco" / "CLAUDE.md").read_text(),
-            self.box.ws_agents.read_text(),
+            "@AGENTS.md\n",
         )
         for target in (".claude", ".agents"):
             self.assertTrue((self.box.home / target / "skills" / "example-skill" / "SKILL.md").exists())

--- a/skills/synthesis-onboarding/scripts/test_updater_doctor.py
+++ b/skills/synthesis-onboarding/scripts/test_updater_doctor.py
@@ -1,6 +1,7 @@
 """Read-only doctor consumers for checkout ownership and instruction migration."""
 
 import hashlib
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -194,3 +195,80 @@ def test_malformed_skill_copy_inventory_cannot_escape_doctor(installed, corrupti
     receipts.data["org_skill_copies"] = value
     receipts.save()
     assert_read_only_failure(installed)
+
+
+def git_artifact(installed, name):
+    kb = installed.kb
+    value = Path(kb.git("rev-parse", "--git-path", name, cwd=kb.standard))
+    path = value if value.is_absolute() else kb.standard / value
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("Retained fixture state.\n")
+    return path
+
+
+@pytest.mark.parametrize("consumer", ["doctor", "update"])
+@pytest.mark.parametrize("artifact", [".synthesis-index-fixture", ".synthesis-index-fixture.recovery.json",
+    ".synthesis-index-fixture.lock", "HEAD.lock", "index.lock", "refs/heads/main.lock"])
+def test_created_pending_git_state_remains_non_green_without_mutation(installed, consumer, artifact):
+    git_artifact(installed, artifact)
+    before = snapshot(installed.kb.root)
+    if consumer == "doctor":
+        assert_read_only_failure(installed)
+        assert onboard._organization_probe(installed.manifest, installed.receipts())[0] is False
+    else:
+        report, _ = installed.kb.run()
+        assert report.exit_code() != 0, report.steps
+    assert snapshot(installed.kb.root) == before
+
+
+@pytest.mark.parametrize("consumer", ["doctor", "update"])
+@pytest.mark.parametrize("artifact", [".synthesis-index-fixture.recovery.json", "HEAD.lock", "index.lock", "refs/heads/main.lock"])
+def test_adopted_git_state_is_not_owned_or_changed(installed, consumer, artifact):
+    receipts = installed.receipts()
+    receipts.data["knowledge_repositories"].pop("knowledge")
+    receipts.record_knowledge_repository("knowledge", installed.kb.standard, installed.kb.url, "adopted")
+    git_artifact(installed, artifact)
+    before = snapshot(installed.kb.root)
+    if consumer == "doctor":
+        code, report = installed.doctor()
+        assert code == 0, report.steps
+    else:
+        report, _ = installed.kb.run()
+        assert report.exit_code() == 0, report.steps
+    assert snapshot(installed.kb.root) == before
+
+
+@pytest.mark.parametrize("consumer", ["doctor", "update"])
+def test_git_administrative_symlink_redirection_is_refused(installed, consumer):
+    kb = installed.kb
+    index = Path(kb.git("rev-parse", "--git-path", "index", cwd=kb.standard))
+    index = index if index.is_absolute() else kb.standard / index
+    destination = kb.root / "redirected-index"
+    destination.write_bytes(index.read_bytes())
+    index.unlink()
+    index.symlink_to(destination)
+    before = snapshot(kb.root)
+    if consumer == "doctor":
+        assert_read_only_failure(installed)
+    else:
+        report, _ = kb.run()
+        assert report.exit_code() != 0, report.steps
+    assert index.is_symlink()
+    assert snapshot(kb.root) == before
+
+
+@pytest.mark.parametrize("consumer", ["doctor", "update"])
+def test_git_paths_find_pending_state_after_administrative_directory_move(installed, consumer):
+    kb = installed.kb
+    admin = kb.root / "separate-git"
+    kb.git("init", "-q", "--separate-git-dir", str(admin), cwd=kb.standard)
+    assert (kb.standard / ".git").is_file()
+    artifact = git_artifact(installed, ".synthesis-index-fixture.recovery.json")
+    assert artifact.parent == admin
+    before = snapshot(kb.root)
+    if consumer == "doctor":
+        assert_read_only_failure(installed)
+    else:
+        report, _ = kb.run()
+        assert report.exit_code() != 0, report.steps
+    assert snapshot(kb.root) == before

--- a/skills/synthesis-onboarding/scripts/test_updater_doctor.py
+++ b/skills/synthesis-onboarding/scripts/test_updater_doctor.py
@@ -1,0 +1,165 @@
+"""Read-only doctor consumers for checkout ownership and instruction migration."""
+
+import hashlib
+from types import SimpleNamespace
+
+import pytest
+
+import onboard
+import system_contract as contract
+from test_kb_update_ownership import kb, snapshot  # noqa: F401
+
+
+@pytest.fixture
+def installed(kb, monkeypatch):
+    report, receipts = kb.run(enrolling=True)
+    assert report.exit_code() == 0, report.steps
+    public = kb.root / "public"
+    organization = kb.root / "organization"
+    public_relative = "skills/synthesis-onboarding/references/kernel.example.md"
+    organization_relative = ".agents/workspace-instructions.md"
+    for root, relative, content in (
+        (public, public_relative, "Public fixture instructions.\n"),
+        (organization, organization_relative, "Organization fixture instructions.\n"),
+    ):
+        path = root / relative
+        path.parent.mkdir(parents=True)
+        path.write_text(content)
+        kb.git("init", "-q", "-b", "main", cwd=root)
+        kb.git("add", ".", cwd=root)
+        kb.git("commit", "-q", "-m", "Seed fixture", cwd=root)
+    manifest = {**kb.manifest, "_path": str(organization / ".agents/onboarding.yaml"),
+                "skills_repos": [],
+                "instruction_sources": [{"path": organization_relative, "required": True}]}
+    workspace = kb.standard.parent
+    graph = {"schema_version": 1, "sources": [
+        {"role": "public", "path": public_relative, "required": True},
+        {"role": "organization", "path": organization_relative, "required": True}],
+        "output": "AGENTS.md", "claude_adapter": "CLAUDE.md"}
+    pair = contract.materialize_instruction_pair(graph,
+        {"public": public, "organization": organization}, workspace, generation=1)
+    receipts.data["instruction_receipt"] = pair
+    receipts.save()
+    real_receipts = onboard.Receipts
+    monkeypatch.setattr(onboard, "Receipts", lambda *a, **k: real_receipts(kb.receipts_path))
+    monkeypatch.setattr(onboard, "source_root", lambda: public)
+    # These cases exercise the actual organization and output doctor blocks;
+    # unrelated public-plugin and personal-layer selection has separate tests.
+    monkeypatch.setattr(onboard, "render_layer_doctor", lambda *a, **k: False)
+
+    def doctor():
+        report = onboard.Report(as_json=True)
+        code = onboard.doctor(report, manifest, [], onboard.normalize_policy("stable", None))
+        return code, report
+
+    def read_receipts():
+        return real_receipts(kb.receipts_path)
+
+    return SimpleNamespace(kb=kb, receipts=read_receipts, workspace=workspace,
+        manifest=manifest, pair=pair, doctor=doctor)
+
+
+def assert_read_only_failure(installed):
+    before = snapshot(installed.kb.root)
+    code, report = installed.doctor()
+    assert code == 1, report.steps
+    assert any(step["status"] == onboard.ERROR for step in report.steps)
+    assert snapshot(installed.kb.root) == before
+    return report
+
+
+def test_current_instruction_and_owned_checkout_doctor_passes_read_only(installed):
+    before = snapshot(installed.kb.root)
+    code, report = installed.doctor()
+    assert code == 0, report.steps
+    assert snapshot(installed.kb.root) == before
+    assert onboard._organization_probe(installed.manifest, installed.receipts())[0] is True
+    assert onboard._knowledge_probe(installed.manifest, installed.receipts())[0] is True
+
+
+@pytest.mark.parametrize("converted", [False, True], ids=["legacy-duplicate", "legacy-adapter"])
+def test_doctor_requires_migration_for_both_legacy_output_forms(installed, converted):
+    receipts = installed.receipts()
+    agents = (installed.workspace / "AGENTS.md").read_bytes()
+    receipts.data["instruction_receipt"]["outputs"]["CLAUDE.md"]["sha256"] = hashlib.sha256(agents).hexdigest()
+    if not converted:
+        (installed.workspace / "CLAUDE.md").write_bytes(agents)
+    receipts.save()
+    report = assert_read_only_failure(installed)
+    assert any(step["detail"].startswith("workspace instruction migration required")
+               for step in report.steps)
+
+
+@pytest.mark.parametrize("corruption", ["missing", "list", "sources-map", "sources-scalar",
+    "sources-null-entry", "sources-bad-role", "outputs-list", "output-null",
+    "different-workspace", "wrong-digest"])
+def test_doctor_handles_malformed_instruction_receipts_without_traceback(installed, corruption):
+    receipts = installed.receipts()
+    pair = receipts.data["instruction_receipt"]
+    if corruption == "missing":
+        del receipts.data["instruction_receipt"]
+    elif corruption == "list":
+        receipts.data["instruction_receipt"] = ["invalid"]
+    elif corruption == "sources-map":
+        pair["sources"] = {"public": {}}
+    elif corruption == "sources-scalar":
+        pair["sources"] = 17
+    elif corruption == "sources-null-entry":
+        pair["sources"] = [None]
+    elif corruption == "sources-bad-role":
+        pair["sources"][0]["role"] = []
+    elif corruption == "outputs-list":
+        pair["outputs"] = []
+    elif corruption == "output-null":
+        pair["outputs"]["CLAUDE.md"] = None
+    elif corruption == "different-workspace":
+        pair["outputs"]["CLAUDE.md"]["path"] = str(installed.kb.root / "other/CLAUDE.md")
+    else:
+        pair["outputs"]["CLAUDE.md"]["sha256"] = "a" * 64
+    receipts.save()
+    assert_read_only_failure(installed)
+
+
+def test_adopted_feature_branch_and_private_work_remain_unchanged_during_doctor(installed):
+    receipts = installed.receipts()
+    kb = installed.kb
+    receipts.data["knowledge_repositories"].pop("knowledge")
+    receipts.record_knowledge_repository("knowledge", kb.standard, kb.url, "adopted")
+    kb.git("checkout", "-q", "-b", "work/topic", cwd=kb.standard)
+    (kb.standard / "untracked.md").write_text("Uncommitted fixture content.\n")
+    before = snapshot(kb.root)
+    code, report = installed.doctor()
+    assert code == 0, report.steps
+    assert snapshot(kb.root) == before
+    assert onboard._organization_probe(installed.manifest, installed.receipts())[0] is True
+
+
+@pytest.mark.parametrize("corruption", ["unknown-ownership", "invalid-inventory", "invalid-adoption",
+    "invalid-entry", "wrong-path", "wrong-remote", "branch-drift", "upstream-drift", "dirty"])
+def test_doctor_and_both_probes_fail_closed_on_knowledge_ownership(installed, corruption):
+    receipts = installed.receipts()
+    kb = installed.kb
+    if corruption == "unknown-ownership":
+        receipts.data.pop("knowledge_repositories")
+    elif corruption == "invalid-inventory":
+        receipts.data["knowledge_repositories"] = []
+    elif corruption == "invalid-adoption":
+        receipts.data["adopted_repos"] = []
+    elif corruption == "invalid-entry":
+        receipts.data["knowledge_repositories"]["knowledge"] = None
+    elif corruption == "wrong-path":
+        receipts.data["knowledge_repositories"]["knowledge"]["path"] = str(kb.root / "elsewhere")
+    elif corruption == "wrong-remote":
+        kb.git("remote", "set-url", "origin", "https://example.test/wrong.git", cwd=kb.standard)
+    elif corruption == "branch-drift":
+        kb.git("checkout", "-q", "-b", "work/topic", "--track", "origin/main", cwd=kb.standard)
+    elif corruption == "upstream-drift":
+        kb.git("config", "branch.main.remote", ".", cwd=kb.standard)
+    else:
+        (kb.standard / "content.md").write_text("Work in progress.\n")
+    receipts.save()
+    assert_read_only_failure(installed)
+    before = snapshot(kb.root)
+    assert onboard._organization_probe(installed.manifest, installed.receipts())[0] is False
+    assert onboard._knowledge_probe(installed.manifest, installed.receipts())[0] is False
+    assert snapshot(kb.root) == before

--- a/skills/synthesis-onboarding/scripts/test_updater_doctor.py
+++ b/skills/synthesis-onboarding/scripts/test_updater_doctor.py
@@ -163,3 +163,34 @@ def test_doctor_and_both_probes_fail_closed_on_knowledge_ownership(installed, co
     assert onboard._organization_probe(installed.manifest, installed.receipts())[0] is False
     assert onboard._knowledge_probe(installed.manifest, installed.receipts())[0] is False
     assert snapshot(kb.root) == before
+
+
+@pytest.mark.parametrize("corruption", ["null", "list", "scalar", "entry-null",
+    "entry-list", "entry-empty", "repository-type", "digest-type", "path-relative"])
+def test_malformed_skill_copy_inventory_cannot_escape_doctor(installed, corruption):
+    receipts = installed.receipts()
+    path = str(installed.kb.workspaces.parent / ".agents/skills/example-skill")
+    metadata = {"repository": "https://example.test/skills.git", "commit": "a" * 40,
+                "sha256": "b" * 64}
+    value = {path: metadata}
+    if corruption == "null":
+        value = None
+    elif corruption == "list":
+        value = []
+    elif corruption == "scalar":
+        value = 17
+    elif corruption == "entry-null":
+        value[path] = None
+    elif corruption == "entry-list":
+        value[path] = []
+    elif corruption == "entry-empty":
+        value[path] = {}
+    elif corruption == "repository-type":
+        metadata["repository"] = []
+    elif corruption == "digest-type":
+        metadata["sha256"] = []
+    else:
+        value = {"relative-path": metadata}
+    receipts.data["org_skill_copies"] = value
+    receipts.save()
+    assert_read_only_failure(installed)


### PR DESCRIPTION
## Changes

- Record created versus adopted repository ownership and restrict managed updates to the recorded branch and upstream.
- Generate canonical instructions with a Claude import adapter and verify historical provenance before migration.
- Keep doctor and update non-green when owned Git recovery state needs attention; preserve user-owned checkouts.
- Include regression and adversarial controls plus a transaction-bound, closed acceptance manifest.

## Verification

All 459 onboarding tests passed, including 111 targeted ownership and doctor cases. Independent reviews exercised real Git concurrency and filesystem failures. Required release checks and CI are running; installation preservation and genuine client lifecycle acceptance remain separate gates.