### PR TITLE
Update skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.95.3",
+  "version": "4.95.4",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.95.3",
+  "version": "4.95.4",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.95.4] - 2026-09-05
+
+**Reload guidance keeps existing conversations first.** Onboarding 2.3.3 uses
+one recovery contract across native installation, refresh, doctor and transaction
+output. Restart and reopen the existing conversation when supported, then verify
+genuine same-session startup evidence and loaded metadata. A new conversation
+is a fallback when recovery is unsupported or verification fails.
+
+Same-version installation no longer implies active-task acceptance. Doctor
+distinguishes client-session evidence from the invoking task, verified uninstall
+does not request a restart, and update hints use the stable public command.
+Repair, provenance and lifecycle verification remain fail-closed.
+
 ## [4.95.3] - 2026-09-05
 
 **Updates respect repository ownership and one instruction format.** Onboarding

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Continue the existing conversation after a verified reload (September 2026).**
+Release **4.95.4** gives consistent recovery advice across installation, update
+and diagnosis. A new conversation is a fallback, not the default. Installed
+currency and client-session evidence are not presented as proof that the
+invoking task reloaded; verified uninstall no longer requests a restart.
+
 **Updates respect existing work (September 2026).** Release **4.95.3** leaves
 adopted knowledge checkouts under their owner's control and binds managed
 updates to the original branch and upstream. Generated organization instructions

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,15 +1,15 @@
-# Transaction-bound acceptance for updater ownership and instruction convergence.
+# Transaction-bound acceptance for client reload guidance.
 schema: 2
-suite: updater-ownership-2026-09-05
+suite: reload-guidance-2026-09-05
 membership: closed
-production_entry_point: synthesis update and repair through the installed onboarding engine
+production_entry_point: synthesis setup, update, doctor, status and uninstall output through the public CLI and native onboarding engine
 enforcing_boundary: release.py consumes the exact base-to-head acceptance before publication and dual-client installation
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: source tests cover declared interleavings, not universal exclusion of uncooperating writers; installed personal-state preservation, historical archive restoration and genuine client lifecycle acceptance require separate live verification; no production deployment is authorized
+unverified_remainder: isolated tests verify output and lifecycle rejection controls, not actual client process restart; installed personal-state preservation, historical archive restoration and exact client-session acceptance require separate live verification; no site deployment is authorized
 changed_surfaces:
   - path: .claude-plugin/plugin.json
     cases: [release-contract]
@@ -20,29 +20,17 @@ changed_surfaces:
   - path: README.md
     cases: [release-contract]
   - path: skills/synthesis-onboarding/SKILL.md
-    cases: [engine-contract, instruction-fresh, kb-adopted]
-  - path: skills/synthesis-onboarding/references/org-manifest.md
-    cases: [instruction-fresh, kb-adopted, doctor-legacy]
+    cases: [engine-contract, doctor, native]
   - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [kb-adopted, kb-created, kb-binding, doctor-current, doctor-legacy, doctor-corrupt, doctor-ownership, doctor-public-commit, kb-symlink, kb-branch-race, kb-refmap, kb-native-locks, kb-partial-write, kb-recovery-index, kb-pending-state, kb-adopted-locks, kb-admin-paths]
+    cases: [native, no-refresh, update-hint, native-preservation]
   - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
-    cases: [engine-contract]
-  - path: skills/synthesis-onboarding/scripts/system_contract.py
-    cases: [instruction-fresh, instruction-legacy, instruction-proof, instruction-attacks, instruction-source-race, instruction-activation-race, instruction-staging, instruction-rollback, instruction-atime, doctor-public-commit]
-  - path: skills/synthesis-onboarding/scripts/test_additive_enrollment.py
-    cases: [enrollment-preservation]
+    cases: [doctor, partial, transaction, uninstall, scope, recorded-scope, observation-preservation, repair, provenance, engine-contract]
+  - path: skills/synthesis-onboarding/scripts/reload_guidance.py
+    cases: [doctor, partial, transaction, native, recorded-scope]
   - path: skills/synthesis-onboarding/scripts/test_onboard.py
-    cases: [engine-idempotence]
-  - path: skills/synthesis-onboarding/scripts/test_instruction_convergence.py
-    cases: [instruction-fresh, instruction-legacy]
-  - path: skills/synthesis-onboarding/scripts/test_instruction_adversarial.py
-    cases: [instruction-proof, instruction-attacks, instruction-source-race, instruction-activation-race, instruction-staging, instruction-rollback, instruction-atime, doctor-public-commit]
-  - path: skills/synthesis-onboarding/scripts/test_kb_update_ownership.py
-    cases: [kb-adopted, kb-created, kb-binding, fixture-maintenance]
-  - path: skills/synthesis-onboarding/scripts/test_kb_adversarial.py
-    cases: [kb-symlink, kb-branch-race, kb-refmap, kb-native-locks, kb-partial-write, kb-recovery-index]
-  - path: skills/synthesis-onboarding/scripts/test_updater_doctor.py
-    cases: [doctor-current, doctor-legacy, doctor-corrupt, doctor-ownership, kb-pending-state, kb-adopted-locks, kb-admin-paths]
+    cases: [native-preservation]
+  - path: skills/synthesis-onboarding/scripts/test_reload_guidance.py
+    cases: [doctor, partial, transaction, native, no-refresh, update-hint, uninstall, same-session, scope, recorded-scope, observation-preservation, rejection, repair, provenance]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [acceptance-self]
 cases:
@@ -58,119 +46,63 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_engine_versions_and_skill_contract_agree
     motivating_defect: engine-and-skill-versions-could-disagree
-  - id: instruction-fresh
+  - id: doctor
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_instruction_convergence.py::test_fresh_pair_is_canonical_content_and_literal_import
-    motivating_defect: duplicate-outputs-conflicted-with-the-client-import-contract
-  - id: instruction-legacy
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_doctor_emits_existing_conversation_recovery
+    motivating_defect: doctor-unconditionally-abandoned-existing-conversations
+  - id: partial
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_instruction_convergence.py::test_receipted_predecessor_converges_without_losing_archive
-    motivating_defect: exact-prior-adapter-transition-blocked-update
-  - id: instruction-proof
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_partial_doctor_only_requests_the_missing_client
+    motivating_defect: partial-evidence-needs-client-specific-recovery
+  - id: transaction
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_retained_immutable_release_proof_accepts_committed_org_update
-    motivating_defect: immutable-installed-source-needs-retained-release-proof
-  - id: instruction-attacks
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_setup_transaction_emits_the_recovery_ladder
+    motivating_defect: stored-and-rendered-guidance-lacked-evidence-based-recovery
+  - id: native
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_retained_immutable_release_proof_attacks
-    motivating_defect: corrupt-release-proof-could-escape-the-handled-error-boundary
-  - id: instruction-source-race
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_native_success_does_not_abandon_existing_conversations
+    motivating_defect: install-and-refresh-advice-mistook-installation-for-live-state
+  - id: no-refresh
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_source_resolution_cannot_hide_a_new_concurrent_instruction_edit
-    motivating_defect: source-resolution-window-could-overwrite-a-newer-target-edit
-  - id: instruction-activation-race
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_native_no_refresh_positive_control_does_not_launch_client
+    motivating_defect: current-install-must-remain-non-mutating
+  - id: update-hint
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_activation_or_rollback_never_clobbers_a_newer_output_edit
-    motivating_defect: rollback-could-restore-over-a-concurrent-edit
-  - id: instruction-staging
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_native_version_mismatch_uses_public_terminal_update_hint
+    motivating_defect: hint-exposed-internal-update-entrypoint
+  - id: uninstall
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_staged_candidate_must_still_match_the_verified_render
-    motivating_defect: modified-staged-payload-could-disagree-with-returned-receipt
-  - id: instruction-rollback
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_uninstall_not_applicable_never_requests_restart
+    motivating_defect: verified-removal-unconditionally-requested-a-restart
+  - id: same-session
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_failure_restoring_one_owned_output_does_not_skip_the_other
-    motivating_defect: one-restore-error-could-prevent-independent-output-recovery
-  - id: instruction-atime
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_genuine_same_uuid_event_is_accepted_without_a_new_conversation
+    motivating_defect: same-session-reload-must-not-require-new-identity
+  - id: scope
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_instruction_read_access_time_is_not_a_concurrent_content_edit
-    motivating_defect: normal-read-access-time-was-misclassified-as-drift
-  - id: kb-adopted
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_doctor_global_event_is_labelled_not_exact_invoking_task_acceptance
+    motivating_defect: client-evidence-could-be-mistaken-for-exact-task-acceptance
+  - id: rejection
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_kb_update_ownership.py::test_adopted_checkout_survives_enrollment_and_two_replays
-    motivating_defect: replayed-update-pulled-user-owned-checkouts
-  - id: kb-created
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_receipt_rejection_positive_control_remains_fail_closed
+    motivating_defect: wording-change-must-not-weaken-lifecycle-evidence
+  - id: recorded-scope
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_kb_update_ownership.py::test_created_checkout_records_tracking_and_fast_forwards
-    motivating_defect: managed-updates-lacked-durable-acquisition-binding
-  - id: kb-binding
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_retained_event_is_labelled_recorded_not_latest
+    motivating_defect: retained-session-evidence-must-not-be-described-as-latest
+  - id: observation-preservation
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_kb_update_ownership.py::test_managed_state_change_during_fetch_is_preserved
-    motivating_defect: fetch-window-could-invalidate-update-authority
-  - id: kb-symlink
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_scope_presentation_preserves_observation_and_outcome_bytes
+    motivating_defect: scope-labels-must-not-rewrite-hash-bound-observations
+  - id: repair
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_symlinked_parent_replacement_must_not_update_different_checkout
-    motivating_defect: symlinked-parent-could-redirect-an-update-to-a-user-checkout
-  - id: kb-branch-race
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_doctor_repair_precedes_reload_in_real_installed_failure
+    motivating_defect: restart-advice-must-not-hide-installation-defects
+  - id: provenance
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_peer_branch_change_after_final_verification_must_not_be_merged
-    motivating_defect: blind-merge-followed-a-concurrently-changed-head
-  - id: kb-refmap
+    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_doctor_provenance_repair_precedes_reload_and_installed_repair
+    motivating_defect: restart-advice-must-not-hide-source-drift
+  - id: native-preservation
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_fetch_must_not_apply_unrelated_configured_ref_mappings
-    motivating_defect: fetch-applied-extra-ref-mappings-outside-ownership
-  - id: doctor-current
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_current_instruction_and_owned_checkout_doctor_passes_read_only
-    motivating_defect: read-only-acceptance-needs-a-positive-control
-  - id: doctor-legacy
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_doctor_requires_migration_for_both_legacy_output_forms
-    motivating_defect: duplicate-output-receipt-was-incorrectly-green
-  - id: doctor-corrupt
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_doctor_handles_malformed_instruction_receipts_without_traceback
-    motivating_defect: malformed-receipts-caused-unhandled-diagnostic-failure
-  - id: doctor-ownership
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_doctor_and_both_probes_fail_closed_on_knowledge_ownership
-    motivating_defect: ownership-drift-was-not-consumed-by-doctor-or-layer-probes
-  - id: enrollment-preservation
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_additive_enrollment.py::test_real_engine_enroll_and_repair_preserve_personal_files_and_receipts
-    motivating_defect: reconciliation-must-preserve-independent-personal-layers
-  - id: engine-idempotence
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::EngineTests::test_install_then_idempotent_rerun
-    motivating_defect: current-output-contract-must-survive-full-engine-replay
-  - id: doctor-public-commit
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_instruction_adversarial.py::test_actual_doctor_rejects_forged_public_commit_in_current_receipt
-    motivating_defect: matching-public-source-bytes-did-not-prove-the-recorded-commit
-  - id: kb-native-locks
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_prepared_update_excludes_real_concurrent_git_writers
-    motivating_defect: a-separate-check-then-blind-merge-could-advance-a-peer-branch
-  - id: kb-partial-write
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_real_filesystem_checkout_failure_preserves_original_state
-    motivating_defect: failed-read-tree-could-partially-write-without-replacing-its-index
-  - id: kb-recovery-index
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_kb_adversarial.py::test_failed_index_activation_retains_new_index_and_recovery_identity
-    motivating_defect: index-activation-failure-could-delete-the-only-updated-index
-  - id: kb-pending-state
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_created_pending_git_state_remains_non_green_without_mutation
-    motivating_defect: retained-recovery-state-could-be-ignored-by-later-updates-or-doctor
-  - id: kb-adopted-locks
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_adopted_git_state_is_not_owned_or_changed
-    motivating_defect: adopted-checkout-locks-are-not-updater-owned-recovery-state
-  - id: kb-admin-paths
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_updater_doctor.py::test_git_paths_find_pending_state_after_administrative_directory_move
-    motivating_defect: separate-git-directories-could-hide-retained-update-state
-  - id: fixture-maintenance
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_kb_update_ownership.py::test_fixture_suppresses_automatic_maintenance_without_hiding_locks
-    motivating_defect: fixture-peer-commit-started-detached-maintenance-during-preservation-snapshots
+    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_install_does_not_replace_an_existing_live_plugin_cache
+    motivating_defect: install-must-not-refresh-an-active-cache-implicitly

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -31,6 +31,8 @@ changed_surfaces:
     cases: [native-preservation]
   - path: skills/synthesis-onboarding/scripts/test_reload_guidance.py
     cases: [doctor, partial, transaction, native, no-refresh, update-hint, uninstall, same-session, scope, recorded-scope, observation-preservation, rejection, repair, provenance]
+  - path: skills/synthesis-skills-manager/scripts/test_release.py
+    cases: [workspace-bootstrap-recovery]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [acceptance-self]
 cases:
@@ -106,3 +108,7 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_install_does_not_replace_an_existing_live_plugin_cache
     motivating_defect: install-must-not-refresh-an-active-cache-implicitly
+  - id: workspace-bootstrap-recovery
+    control_class: acceptance-test
+    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_quick_answers_self_bootstrap_release_contract_is_public_and_coherent
+    motivating_defect: historical-bootstrap-contract-required-unconditional-new-chat

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.3.2"
+  version: "2.3.3"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -293,9 +293,16 @@ required action, and `2` means ground truth could not be established.
 An update is the initiating task's last action before client restart. On
 machines with the durable historical-cache guardian, the update also verifies
 the exact historical root used by the invoking task before returning. Resume
-the same conversation only after a genuine fresh SessionStart receipt reports
-the installed release and loaded skills. Codex hook trust remains a human
-setting and is never auto-approved.
+the existing conversation when supported, but continue only after a genuine
+transcript-bound SessionStart for the same session UUID reports the installed
+version and enabled immutable plugin root, with matching loaded skill metadata.
+Use a new conversation when same-session recovery is unsupported or those checks
+fail; first-time users without an existing conversation can start one after
+restart. Installed currency alone does not establish active-session currency.
+Doctor and status label recorded selected-client evidence separately from acceptance
+of the initiating task. Verified uninstall requires no live client load.
+Codex hook trust remains a conditional human setting, is never auto-approved,
+and does not itself prove hook execution.
 
 ## Ownership boundaries
 

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -34,6 +34,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from reload_guidance import recovery_instruction
+
 from enrollment import (EnrollmentJournal, regular_tree, move_verified, engine_lock, engine_state_root,
                         recover_copy_transactions, organization_copy_transaction)
 
@@ -89,7 +91,7 @@ from whole_system import (
     validate_personal_policy,
 )
 
-ENGINE_VERSION = "2.3.2"
+ENGINE_VERSION = "2.3.3"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"
@@ -1283,7 +1285,7 @@ def phase_ecosystem(
                         (PLUGIN_NAME, name, before_version, expected),
                         hint=(
                             "Close other Claude Code and Codex sessions, then run "
-                            "onboard.py update as the invoking session's last action."
+                            "synthesis update as the invoking session's last action."
                         ),
                     )
                 else:
@@ -1375,17 +1377,18 @@ def phase_ecosystem(
                     hint=expectation_detail,
                 )
             elif after_version != before_version:
-                restart = "restart Claude Code" if name == "claude" else "restart Codex"
                 report.add(
                     "ecosystem", CHANGED,
-                    "%s plugin updated for %s: %s -> %s; %s, then start a new chat there" %
-                    (PLUGIN_NAME, name, before_version, after_version, restart),
+                    "%s plugin updated for %s: %s -> %s" %
+                    (PLUGIN_NAME, name, before_version, after_version),
+                    hint=recovery_instruction([name]),
                 )
             else:
                 report.add(
                     "ecosystem", OK,
-                    "%s plugin current for %s at %s; no new task needed" %
+                    "%s plugin current for %s at %s; installation currency does not verify the active conversation" %
                     (PLUGIN_NAME, name, after_version or "unknown version"),
+                    hint=recovery_instruction([name]),
                 )
             continue
         if no_plugin_cli:
@@ -1414,11 +1417,10 @@ def phase_ecosystem(
                 hint=expectation_detail,
             )
         elif success and after_state is True:
-            restart = "restart Claude Code" if name == "claude" else "restart Codex"
             report.add(
                 "ecosystem", CHANGED,
-                "%s: %s; %s, then start a new chat there" %
-                (name, detail, restart),
+                "%s: %s" % (name, detail),
+                hint=recovery_instruction([name], initial=True),
             )
         else:
             need_fallback = True
@@ -3344,7 +3346,7 @@ def doctor(report, manifest, clients_wanted, policy, desired_state=None):
                          policy_label(policy), target_version),
                         hint=(
                             "Close other Claude Code and Codex sessions, then run "
-                            "onboard.py update as the invoking session's last action."
+                            "synthesis update as the invoking session's last action."
                         ),
                     )
                 else:

--- a/skills/synthesis-onboarding/scripts/reload_guidance.py
+++ b/skills/synthesis-onboarding/scripts/reload_guidance.py
@@ -1,0 +1,33 @@
+"""Shared recovery wording; this module does not verify or mutate client state."""
+
+RECORDED_SESSION_SCOPE = "recorded-selected-client-sessions"
+RECORDED_SESSION_DETAIL = (
+    "Recorded selected-client session evidence, not acceptance of the invoking task."
+)
+
+
+def recovery_instruction(clients, *, initial=False):
+    """Prefer existing conversations, conditional on genuine lifecycle evidence."""
+    names = {"claude": "Claude Code", "codex": "Codex"}
+    selected = list(dict.fromkeys(clients))
+    steps = [
+        "restart %s and reopen the existing %s if supported"
+        % (names[client], "chat" if client == "claude" else "task")
+        for client in selected
+    ]
+    if not steps:
+        steps = ["restart selected clients and reopen the existing conversation if supported"]
+    advice = "; ".join(steps) + (
+        ". Continue only after a genuine transcript-bound SessionStart for the same "
+        "session UUID reports the installed version and enabled immutable plugin root, "
+        "and loaded skill metadata matches. If same-session recovery is unsupported "
+        "or those checks fail, start a new conversation and verify its fresh SessionStart."
+    )
+    if initial:
+        advice += " If there is no existing conversation, start one after restart."
+    if "codex" in selected:
+        advice += (
+            " If Codex shows pending hook review, approve the synthesis-skills hooks; "
+            "human trust is separate from evidence that the hooks executed."
+        )
+    return advice

--- a/skills/synthesis-onboarding/scripts/synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/synthesis_cli.py
@@ -18,6 +18,7 @@ from typing import Any, Callable
 
 import onboard
 import organization
+from reload_guidance import RECORDED_SESSION_DETAIL, RECORDED_SESSION_SCOPE, recovery_instruction
 from enrollment import (EnrollmentJournal, recover_enrollments, require_settled_enrollments,
                         engine_lock, engine_state_root, recover_copy_transactions)
 from system_contract import (
@@ -42,7 +43,7 @@ from system_contract import (
 )
 
 
-ENGINE_VERSION = "2.3.2"
+ENGINE_VERSION = "2.3.3"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CLI_COMMANDS = (
     "setup",
@@ -324,6 +325,7 @@ def _current_planes(
         live = {"status": "restart-required", "detail": "no SessionStart receipt for this generation yet"}
     live = dict(live)
     live["missing_clients"] = missing
+    live["scope"] = RECORDED_SESSION_SCOPE
     planes["live-loaded"] = live
     return planes
 
@@ -340,15 +342,6 @@ def _non_green(planes: dict[str, Any], disabled: bool) -> bool:
     if disabled and planes["installed"].get("status") != "removed":
         return True
     return False
-
-
-def _restart_instruction(client: str) -> str:
-    if client == "claude":
-        return "restart Claude Code and start a new chat"
-    return (
-        "restart Codex and start a new thread; if Codex shows pending hook review, "
-        "approve the synthesis-skills hooks (Codex runs plugin hooks only after human trust)"
-    )
 
 
 def _next_action(
@@ -375,9 +368,9 @@ def _next_action(
     live = planes["live-loaded"]
     if live.get("status") != "verified":
         clients = live.get("missing_clients") or list(desired.get("clients") or [])
-        steps = "; ".join(_restart_instruction(client) for client in clients)
+        steps = recovery_instruction(clients)
         note = " (%s)" % promotion_note if promotion_note else ""
-        return "%s; then run synthesis doctor again%s" % (steps, note)
+        return "%s Then run synthesis doctor again%s." % (steps, note)
     if planes["outcome-verified"].get("status") in ("not-requested", "missing"):
         return (
             "Optional: synthesis outcome verify --task workspace-grounding-check "
@@ -411,6 +404,8 @@ def _plane_summary(name: str, plane: dict[str, Any]) -> str:
         for client in plane.get("missing_clients") or []:
             parts.append("%s missing" % client)
         detail = "; ".join(parts) or str(plane.get("detail") or "")
+        if plane.get("scope") == RECORDED_SESSION_SCOPE:
+            detail = "%s %s" % (detail, RECORDED_SESSION_DETAIL)
         return "%s%s" % (status, " — " + detail if detail else "")
     detail = plane.get("detail")
     return "%s%s" % (status, " — " + str(detail) if detail else "")
@@ -485,6 +480,8 @@ def _render_status(payload: dict[str, Any]) -> None:
             if not (isinstance(entry, dict) and entry.get("plugin_version") == recorded_version):
                 parts.append("%s missing" % client)
         print("  Live-loaded: %s%s" % (live.get("status"), " — " + "; ".join(parts) if parts else ""))
+        if live.get("status") != "not-applicable":
+            print("  Live scope:  %s" % RECORDED_SESSION_DETAIL)
     else:
         print("  Live-loaded: unknown")
     outcome = latest.get("outcome-verified") if latest else None
@@ -634,7 +631,7 @@ def _planes(
             "detail": (
                 "No client load is expected for a disabled installation."
                 if disabled
-                else "Start a fresh selected-client session to establish live-loaded state."
+                else recovery_instruction(desired.get("clients") or [], initial=command == "setup")
             ),
         },
         "outcome-verified": {"status": "not-applicable" if disabled else "not-requested"},
@@ -921,9 +918,12 @@ def _render(payload: dict[str, Any], as_json: bool) -> None:
         return
     if payload.get("transaction_id"):
         print(
-            "Synthesis generation %s %s. Restart selected clients before live verification."
+            "Synthesis generation %s %s."
             % (payload.get("generation"), payload.get("state"))
         )
+        live = payload.get("live-loaded") or {}
+        if live.get("status") == "restart-required":
+            print("Next action: %s" % live["detail"])
         retained = (payload.get("details") or {}).get("retained") or []
         if retained and not payload.get("purged"):
             print("Retained (not removed by uninstall):")
@@ -1492,6 +1492,12 @@ def main(
             promoted, _promotion_note = _promote_live_receipts(state)
             with state.locked():
                 payload = {"desired": state.read_desired(), "observed": state.read_observation()}
+                # Presentation metadata must not alter hash-bound observations.
+                if payload["desired"] and payload["desired"].get("enabled", True):
+                    payload["live_scope"] = {
+                        "scope": RECORDED_SESSION_SCOPE,
+                        "detail": RECORDED_SESSION_DETAIL,
+                    }
             payload["promoted"] = promoted
             _render(payload, args.json)
             return 0 if payload["desired"] is not None else 1

--- a/skills/synthesis-onboarding/scripts/test_onboard.py
+++ b/skills/synthesis-onboarding/scripts/test_onboard.py
@@ -719,7 +719,7 @@ class PluginTests(unittest.TestCase):
             )
         refresh.assert_not_called()
         self.assertEqual(report.steps[0]["status"], onboard.ACTION)
-        self.assertIn("onboard.py update", report.steps[0]["hint"])
+        self.assertIn("synthesis update", report.steps[0]["hint"])
 
     def test_update_refreshes_and_accepts_newer_version_from_old_plugin_cache(self):
         report = onboard.Report(as_json=True)

--- a/skills/synthesis-onboarding/scripts/test_reload_guidance.py
+++ b/skills/synthesis-onboarding/scripts/test_reload_guidance.py
@@ -270,12 +270,92 @@ def test_doctor_global_event_is_labelled_not_exact_invoking_task_acceptance(tmp_
     plane = payload["planes"]["live-loaded"]
     assert plane["status"] == "verified"
     assert plane["receipts"]["codex"]["session_id"] == event["session_id"]
-    assert plane["scope"] == "latest-selected-client-sessions"
+    assert plane["scope"] == "recorded-selected-client-sessions"
     assert synthesis_cli.main(
         ["doctor"], state=state, engine_runner=lambda _argv: _engine_result(),
     ) == 0
     human = capsys.readouterr().out.lower()
-    assert "latest" in human and "not" in human and "task" in human, human
+    assert "recorded" in human and "not" in human and "task" in human, human
+
+
+def _recorded_event_with_newer_candidate(tmp_path):
+    """A remains attached; independently prove that newer B is promotable."""
+    state, receipt = _state(tmp_path, ("codex",))
+    positive_control = system_contract.SystemState(home=tmp_path / "positive-control")
+    desired = state.read_desired()
+    positive_control.run_transaction("setup", desired, lambda _tx: {
+        "release": release_record(Path(receipt["plugin_root"])),
+        "source-provenance": {"status": "verified", "root": receipt["plugin_root"]},
+        "live-loaded": {"status": "restart-required"},
+    })
+    first = _fresh_event(state, receipt)
+    _registry_event(state.live_receipt_registry_root(), first, bound_at_record=True)
+    assert state.promote_live_receipts(binder=live_receipt.transcript_binds_session)
+    state.record_outcome({"status": "verified", "task": "fixture-outcome"})
+
+    newer = _fresh_event(state, receipt, session_id=str(uuid.uuid4()))
+    assert newer["recorded_at"] > first["recorded_at"]
+    for target in (state, positive_control):
+        _registry_event(target.live_receipt_registry_root(), newer, bound_at_record=True)
+    promoted = positive_control.promote_live_receipts(binder=live_receipt.transcript_binds_session)
+    assert [item["session_id"] for item in promoted] == [newer["session_id"]]
+    control = positive_control.read_observation()["transactions"][-1]["live-loaded"]
+    assert control["receipts"]["codex"]["receipt_event_id"] == newer["receipt_event_id"]
+    assert state.promote_live_receipts(binder=live_receipt.transcript_binds_session) == []
+    return state, first, newer
+
+
+@pytest.mark.parametrize("command", ["doctor", "status"])
+@pytest.mark.parametrize("as_json", [False, True], ids=["human", "json"])
+def test_retained_event_is_labelled_recorded_not_latest(tmp_path, capsys, command, as_json):
+    state, first, newer = _recorded_event_with_newer_candidate(tmp_path)
+    assert synthesis_cli.main(
+        [command] + (["--json"] if as_json else []),
+        state=state, engine_runner=lambda _argv: _engine_result(),
+    ) == 0
+    output = capsys.readouterr().out
+    stored = state.read_observation()["transactions"][-1]["live-loaded"]
+    assert stored["receipts"]["codex"]["receipt_event_id"] == first["receipt_event_id"]
+    assert first["receipt_event_id"] != newer["receipt_event_id"]
+    if as_json:
+        payload = json.loads(output)
+        if command == "doctor":
+            scope = payload["planes"]["live-loaded"]
+            assert scope["receipts"]["codex"]["receipt_event_id"] == first["receipt_event_id"]
+        else:
+            scope = payload["live_scope"]
+        assert scope["scope"] == "recorded-selected-client-sessions"
+    else:
+        lower = output.lower()
+        assert "recorded" in lower and "selected" in lower and "not" in lower and "task" in lower
+        assert "latest session" not in lower and "latest qualifying" not in lower
+
+
+@pytest.mark.parametrize("command", ["doctor", "status"])
+@pytest.mark.parametrize("as_json", [False, True], ids=["human", "json"])
+def test_scope_presentation_preserves_observation_and_outcome_bytes(tmp_path, capsys, command, as_json):
+    state, _, _ = _recorded_event_with_newer_candidate(tmp_path)
+    before = state.observation_path.read_bytes()
+    observed = json.loads(before)
+    latest = observed["transactions"][-1]
+    outcome = latest["outcome-verified"]
+    assert outcome["live_loaded_sha256"] == system_contract.json_digest(latest["live-loaded"])
+    assert synthesis_cli.main(
+        [command] + (["--json"] if as_json else []),
+        state=state, engine_runner=lambda _argv: _engine_result(),
+    ) == 0
+    output = capsys.readouterr().out
+    assert state.observation_path.read_bytes() == before
+    after = state.read_observation()["transactions"][-1]
+    assert after["outcome-verified"] == outcome
+    assert outcome["live_loaded_sha256"] == system_contract.json_digest(after["live-loaded"])
+    if as_json:
+        payload = json.loads(output)
+        if command == "status":
+            assert payload["observed"] == observed
+            assert payload["live_scope"]["scope"] == "recorded-selected-client-sessions"
+        else:
+            assert payload["planes"]["outcome-verified"] == outcome
 
 
 @pytest.mark.parametrize("defect", ["wrong-version", "missing-root", "wrong-digest", "unbound", "stale"])

--- a/skills/synthesis-onboarding/scripts/test_reload_guidance.py
+++ b/skills/synthesis-onboarding/scripts/test_reload_guidance.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""UX-001: exercise emitted recovery guidance without launching either client.
+
+The engine/client boundary is stubbed; the real report, CLI, transaction and
+receipt-verification producers run against isolated temporary state. Recovery
+text must not turn installed currency into exact-task lifecycle acceptance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+
+import onboard  # noqa: E402
+import synthesis_cli  # noqa: E402
+import system_contract  # noqa: E402
+from test_independent_review import (  # noqa: E402
+    _descriptor_file,
+    _engine_result,
+    _registry_event,
+    bootstrap,
+    live_receipt,
+)
+from test_synthesis_cli import verified_uninstall_engine  # noqa: E402
+from test_system_contract import (  # noqa: E402
+    live_receipt as receipt_fixture,
+    release_record,
+    release_repo,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_environment(monkeypatch, tmp_path):
+    """Neither an installed launcher nor the real receipt registry is an input."""
+    monkeypatch.delenv("SYNTHESIS_ACTIVE_DESCRIPTOR", raising=False)
+    monkeypatch.delenv("SYNTHESIS_RESOLVED_BOOTSTRAP", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+
+def _recovery_contract(text: str, clients: tuple[str, ...]) -> None:
+    """Assert the ordered recovery ladder, not a particular helper signature."""
+    lower = text.lower()
+    for client in clients:
+        assert "restart " + ("claude code" if client == "claude" else "codex") in lower
+    assert "existing" in lower, text
+    assert "reopen" in lower or "resume" in lower, text
+    assert lower.index("existing") < lower.index("new "), text
+    assert "sessionstart" in lower and "transcript" in lower, text
+    assert "same" in lower and ("uuid" in lower or "session" in lower), text
+    assert "version" in lower and "root" in lower, text
+    assert "metadata" in lower, text
+    assert "unsupported" in lower or "not support" in lower, text
+    assert "fail" in lower or "mismatch" in lower, text
+    if "codex" in clients:
+        assert "if" in lower and "hook" in lower and "trust" in lower, text
+
+
+def _state(tmp_path: Path, clients: tuple[str, ...]):
+    state = system_contract.SystemState(home=tmp_path / "home")
+    receipt = receipt_fixture(tmp_path, clients[0])
+    root = Path(receipt["plugin_root"])
+    desired = system_contract.default_desired_state("skills-only", list(clients), "stable")
+    planes = synthesis_cli._planes(desired, "setup")
+    planes.update({
+        "release": release_record(root),
+        "source-provenance": {"status": "verified", "root": str(root)},
+    })
+    state.run_transaction("setup", desired, lambda _tx: planes)
+    return state, receipt
+
+
+def _fresh_event(state, receipt, *, client=None, session_id=None):
+    event = dict(receipt)
+    event.update({
+        "client": client or receipt["client"],
+        "session_id": session_id or receipt["session_id"],
+        "receipt_event_id": str(uuid.uuid4()),
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+    })
+    event["provenance_env"] = event["client"] + "-transcript"
+    transcript = state.home / "transcripts" / (event["session_id"] + ".jsonl")
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    binding = (
+        {"type": "session_meta", "payload": {"id": event["session_id"]}}
+        if event["client"] == "codex" else {"sessionId": event["session_id"]}
+    )
+    transcript.write_text(json.dumps(binding) + "\n", encoding="utf-8")
+    event["transcript_path"] = str(transcript)
+    return event
+
+
+@pytest.mark.parametrize("clients", [("claude",), ("codex",), ("claude", "codex")])
+@pytest.mark.parametrize("as_json", [False, True], ids=["human", "json"])
+def test_doctor_emits_existing_conversation_recovery(tmp_path, capsys, clients, as_json):
+    state, _ = _state(tmp_path, clients)
+    assert synthesis_cli.main(
+        ["doctor"] + (["--json"] if as_json else []),
+        state=state, engine_runner=lambda _argv: _engine_result(),
+    ) == 1
+    output = capsys.readouterr().out
+    text = json.loads(output)["next_action"] if as_json else output
+    _recovery_contract(text, clients)
+
+
+@pytest.mark.parametrize("loaded,missing", [("claude", "codex"), ("codex", "claude")])
+def test_partial_doctor_only_requests_the_missing_client(tmp_path, capsys, loaded, missing):
+    state, receipt = _state(tmp_path, (loaded, missing))
+    assert state.record_live_load(receipt=_fresh_event(state, receipt))
+    assert synthesis_cli.main(
+        ["doctor", "--json"], state=state, engine_runner=lambda _argv: _engine_result(),
+    ) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["planes"]["live-loaded"]["missing_clients"] == [missing]
+    assert "restart " + ("claude code" if loaded == "claude" else "codex") not in payload["next_action"].lower()
+    _recovery_contract(payload["next_action"], (missing,))
+
+
+@pytest.mark.parametrize("as_json", [False, True], ids=["human", "json"])
+def test_setup_transaction_emits_the_recovery_ladder(tmp_path, capsys, as_json):
+    state = system_contract.SystemState(home=tmp_path / "home")
+    engine = _engine_result()
+    engine["effective_selection"] = {
+        "profile": "skills-only", "clients": ["claude", "codex"],
+        "personal_workspace": None, "personal_configuration": None,
+        "layers": system_contract.default_desired_state(
+            "skills-only", ["claude", "codex"], "stable"
+        )["layers"],
+    }
+    assert synthesis_cli.main(
+        ["setup", "--profile", "skills-only", "--clients", "claude,codex"]
+        + (["--json"] if as_json else []),
+        state=state, engine_runner=lambda _argv: engine,
+    ) == 0
+    output = capsys.readouterr().out
+    transaction = state.read_observation()["transactions"][-1]
+    assert transaction["live-loaded"]["status"] == "restart-required"
+    text = json.loads(output)["live-loaded"]["detail"] if as_json else output
+    _recovery_contract(text, ("claude", "codex"))
+    _recovery_contract(transaction["live-loaded"]["detail"], ("claude", "codex"))
+
+
+def _native_report(client, scenario, as_json, capsys):
+    before = "9.8.6" if scenario == "upgrade" else "9.8.7"
+    record = [(False, None), (True, "9.8.7")] if scenario == "initial" else [
+        (True, before), (True, "9.8.7"),
+    ]
+    report = onboard.Report(as_json=as_json)
+    with patch.object(onboard, "plugin_record", side_effect=record), \
+         patch.object(onboard, "expected_policy_version", return_value=("9.8.7", "fixture")), \
+         patch.object(onboard, "configured_marketplace_ref", return_value="main"), \
+         patch.object(onboard, "refresh_plugin", return_value=(True, "refreshed")) as refresh, \
+         patch.object(onboard, "install_plugin", return_value=(True, "installed")) as install, \
+         patch.object(onboard, "synchronize_codex_history", return_value=(True, "preserved")):
+        onboard.phase_ecosystem(
+            report, {client: "fixture-client"}, False, False,
+            {"channel": "stable", "version_pin": None}, refresh_native_plugins=True,
+        )
+    assert report.exit_code() == 0
+    (install if scenario == "initial" else refresh).assert_called_once()
+    (refresh if scenario == "initial" else install).assert_not_called()
+    onboard.finish(report, argparse.Namespace(json=as_json, dry_run=False), 0)
+    output = capsys.readouterr().out
+    if as_json:
+        output = " ".join(
+            str(step["detail"]) + " " + str(step.get("hint") or "")
+            for step in json.loads(output)["steps"]
+        )
+    return output, report
+
+
+@pytest.mark.parametrize("client", ["claude", "codex"])
+@pytest.mark.parametrize("scenario", ["upgrade", "initial", "same-version"])
+@pytest.mark.parametrize("as_json", [False, True], ids=["human", "json"])
+def test_native_success_does_not_abandon_existing_conversations(capsys, client, scenario, as_json):
+    text, report = _native_report(client, scenario, as_json, capsys)
+    if scenario == "same-version":
+        assert report.steps[0]["status"] == onboard.OK
+        assert "no new task needed" not in text.lower()
+    else:
+        assert report.steps[0]["status"] == onboard.CHANGED
+    _recovery_contract(text, (client,))
+    if scenario == "initial":
+        assert "none" in text.lower() or "no existing" in text.lower(), text
+
+
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_native_no_refresh_positive_control_does_not_launch_client(client):
+    report = onboard.Report(as_json=True)
+    with patch.object(onboard, "plugin_record", return_value=(True, "9.8.7")), \
+         patch.object(onboard, "expected_policy_version", return_value=("9.8.7", "fixture")), \
+         patch.object(onboard, "configured_marketplace_ref", return_value="stable"), \
+         patch.object(onboard, "refresh_plugin") as refresh, \
+         patch.object(onboard, "install_plugin") as install:
+        onboard.phase_ecosystem(
+            report, {client: "fixture-client"}, False, False,
+            {"channel": "stable", "version_pin": None}, refresh_native_plugins=True,
+        )
+    refresh.assert_not_called()
+    install.assert_not_called()
+    assert report.steps[0]["status"] == onboard.OK
+    assert "no refresh needed" in report.steps[0]["detail"]
+    assert "no new task needed" not in report.steps[0]["detail"]
+
+
+def test_native_version_mismatch_uses_public_terminal_update_hint():
+    report = onboard.Report(as_json=True)
+    with patch.object(onboard, "plugin_record", return_value=(True, "9.8.6")), \
+         patch.object(onboard, "expected_policy_version", return_value=("9.8.7", "fixture")), \
+         patch.object(onboard, "refresh_plugin") as refresh:
+        onboard.phase_ecosystem(
+            report, {"codex": "fixture-client"}, False, False,
+            {"channel": "stable", "version_pin": None}, refresh_native_plugins=False,
+        )
+    refresh.assert_not_called()
+    assert report.steps[0]["status"] == onboard.ACTION
+    hint = report.steps[0]["hint"]
+    assert "synthesis update" in hint and "last action" in hint
+    assert "onboard.py update" not in hint
+
+
+@pytest.mark.parametrize("as_json", [False, True], ids=["human", "json"])
+def test_uninstall_not_applicable_never_requests_restart(tmp_path, capsys, as_json):
+    state, _ = _state(tmp_path, ("claude", "codex"))
+    assert synthesis_cli.main(
+        ["uninstall"] + (["--json"] if as_json else []),
+        state=state, engine_runner=verified_uninstall_engine,
+    ) == 0
+    output = capsys.readouterr().out
+    transaction = state.read_observation()["transactions"][-1]
+    assert transaction["live-loaded"]["status"] == "not-applicable"
+    assert "restart" not in output.lower()
+    assert "fresh selected-client" not in output.lower()
+
+
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_genuine_same_uuid_event_is_accepted_without_a_new_conversation(tmp_path, client):
+    state, receipt = _state(tmp_path, (client,))
+    event = _fresh_event(state, receipt)
+    _registry_event(state.live_receipt_registry_root(), event, bound_at_record=True)
+    promoted = state.promote_live_receipts(binder=live_receipt.transcript_binds_session)
+    assert [(item["client"], item["session_id"]) for item in promoted] == [(client, receipt["session_id"])]
+    plane = state.read_observation()["transactions"][-1]["live-loaded"]
+    assert plane["status"] == "verified"
+    assert plane["receipts"][client]["receipt_event_id"] == event["receipt_event_id"]
+
+
+def test_doctor_global_event_is_labelled_not_exact_invoking_task_acceptance(tmp_path, monkeypatch, capsys):
+    state, receipt = _state(tmp_path, ("codex",))
+    invoking_session = str(uuid.uuid4())
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", "codex:" + invoking_session)
+    event = _fresh_event(state, receipt)
+    assert event["session_id"] != invoking_session
+    _registry_event(state.live_receipt_registry_root(), event, bound_at_record=True)
+    assert synthesis_cli.main(
+        ["doctor", "--json"], state=state, engine_runner=lambda _argv: _engine_result(),
+    ) == 0
+    payload = json.loads(capsys.readouterr().out)
+    plane = payload["planes"]["live-loaded"]
+    assert plane["status"] == "verified"
+    assert plane["receipts"]["codex"]["session_id"] == event["session_id"]
+    assert plane["scope"] == "latest-selected-client-sessions"
+    assert synthesis_cli.main(
+        ["doctor"], state=state, engine_runner=lambda _argv: _engine_result(),
+    ) == 0
+    human = capsys.readouterr().out.lower()
+    assert "latest" in human and "not" in human and "task" in human, human
+
+
+@pytest.mark.parametrize("defect", ["wrong-version", "missing-root", "wrong-digest", "unbound", "stale"])
+def test_receipt_rejection_positive_control_remains_fail_closed(tmp_path, defect):
+    state, receipt = _state(tmp_path, ("codex",))
+    event = _fresh_event(state, receipt)
+    if defect == "wrong-version":
+        event = receipt_fixture(tmp_path, "codex", "9.8.6")
+        assert state.record_live_load(receipt=event) is False
+    else:
+        match = {
+            "missing-root": "unavailable", "wrong-digest": "release digest",
+            "unbound": "transcript-bound", "stale": "freshness",
+        }[defect]
+        if defect == "missing-root":
+            event["plugin_root"] = str(tmp_path / "nonexistent")
+        elif defect == "wrong-digest":
+            loaded = tmp_path / "wrong-loaded-root"
+            shutil.copytree(event["plugin_root"], loaded)
+            (loaded / "hooks/hooks.json").write_text(
+                json.dumps({"hooks": {"SessionStart": [{"command": "altered"}]}}) + "\n",
+                encoding="utf-8",
+            )
+            event["plugin_root"] = str(loaded)
+        elif defect == "unbound":
+            event["transcript_bound_at_record"] = False
+        else:
+            event["recorded_at"] = "2020-01-01T00:00:00+00:00"
+        with pytest.raises(system_contract.ContractError, match=match):
+            state.record_live_load(receipt=event)
+    assert state.read_observation()["transactions"][-1]["live-loaded"]["status"] == "restart-required"
+    assert state.record_live_load(receipt=_fresh_event(state, receipt))
+    assert state.read_observation()["transactions"][-1]["live-loaded"]["status"] == "verified"
+
+
+def test_doctor_repair_precedes_reload_in_real_installed_failure(tmp_path, capsys):
+    state, _ = _state(tmp_path, ("codex",))
+    failing = _engine_result(1, steps=[{
+        "phase": "ecosystem", "status": "action-needed", "detail": "fixture install defect",
+    }])
+    assert synthesis_cli.main(
+        ["doctor", "--json"], state=state, engine_runner=lambda _argv: failing,
+    ) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["planes"]["installed"]["status"] == "defective"
+    assert payload["next_action"].startswith("Run synthesis repair")
+    assert "restart" not in payload["next_action"].lower()
+
+
+def test_doctor_provenance_repair_precedes_reload_and_installed_repair(tmp_path, monkeypatch, capsys):
+    checkout = release_repo(tmp_path)
+    root, descriptor = bootstrap.materialize_release(
+        checkout, tmp_path / "releases", channel="stable", ref="stable",
+        source_url="https://example.test/synthesis-skills.git",
+    )
+    active = _descriptor_file(tmp_path / "active.json", descriptor, root)
+    monkeypatch.setenv("SYNTHESIS_ACTIVE_DESCRIPTOR", str(active))
+    state = system_contract.SystemState(home=tmp_path / "home")
+    desired = system_contract.default_desired_state("skills-only", ["codex"], "stable")
+    state.run_transaction("setup", desired, lambda _tx: {
+        "release": descriptor,
+        "resolved": {"status": "verified", "release": descriptor},
+        "source-provenance": {"status": "verified", "root": str(root)},
+    })
+    target = root / ".codex-plugin/plugin.json"
+    os.chmod(target, 0o644)
+    target.write_text('{"name":"synthesis-skills","version":"9.8.7","altered":true}\n', encoding="utf-8")
+    assert synthesis_cli.main(
+        ["doctor", "--json"], state=state, engine_runner=lambda _argv: _engine_result(1),
+    ) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["planes"]["source-provenance"]["status"] == "drifted"
+    assert payload["planes"]["installed"]["status"] == "defective"
+    assert "content digest" in payload["next_action"]
+    assert "synthesis update" in payload["next_action"]
+    assert "restart" not in payload["next_action"].lower()

--- a/skills/synthesis-skills-manager/scripts/test_release.py
+++ b/skills/synthesis-skills-manager/scripts/test_release.py
@@ -900,14 +900,20 @@ def test_quick_answers_self_bootstrap_release_contract_is_public_and_coherent() 
     assert ".agents/workspace-AGENTS.md" in skill
     assert "AGENTS.md" in skill and "CLAUDE.md" in skill
     assert "synthesis-onboarding" in skill
-    # The receipt-verification sentence that reads as internal agent protocol
-    # to a human running the installer directly is gone from onboard.py's
-    # printed messages; the fuller protocol stays documented in this skill's
-    # own SKILL.md (a human never reads that file mid-install, only an agent
-    # consulting it as instructions does), so nothing about agent behavior
-    # regressed — only what a person sees in their own terminal changed.
+    # Native installation shares the existing-conversation recovery contract.
+    # A new chat is conditional, never the unconditional installation result.
+    # Producer/renderer and receipt rejection cases live in test_reload_guidance.
+    from reload_guidance import recovery_instruction
+
     assert "verify its exact current-plugin SessionStart receipt" not in onboard
-    assert "start a new chat there" in onboard
+    assert "start a new chat there" not in onboard
+    assert "hint=recovery_instruction([name]" in onboard
+    for client in ("claude", "codex"):
+        guidance = recovery_instruction([client], initial=True)
+        assert "reopen the existing" in guidance
+        assert "If same-session recovery is unsupported or those checks fail" in guidance
+        assert "start a new conversation" in guidance
+        assert "If there is no existing conversation" in guidance
 
 
 def test_main_carries_acceptance_authority_to_publish_boundary(


### PR DESCRIPTION
## Changes

Use one recovery message across installation, refresh, doctor, and transaction output. Prefer reopening an existing conversation after restart when genuine same-session evidence verifies the installed release; use a new conversation when recovery is unsupported or verification fails.

Label recorded client-session evidence separately from the invoking task in human and JSON diagnostics. Keep presentation metadata outside saved observations, preserve outcome evidence hashes, and avoid restart advice after verified uninstall. Repair and provenance failures retain precedence.

## Verification

- Regression fixtures committed before implementation: 25 failures and 12 passing controls.
- 45 recovery-guidance tests pass, including both clients and eight retained-evidence/preservation cases.
- Full onboarding suite: 505 passed.
- Independent review reproduced and verified both reporting corrections; no remaining finding in the changed behavior.
- Release acceptance maps all 11 changed paths to 18 named cases.

The gated release checks and repository CI remain required before publication. Actual client reload and installed-state preservation are separate acceptance checks; these tests do not claim them.