### PR TITLE
Update lifecycle validation

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.95.4",
+  "version": "4.95.5",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.95.4",
+  "version": "4.95.5",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.95.5] - 2026-09-05
+
+**Long conversations retain verifiable startup evidence.** Onboarding 2.3.4
+uses the shared structured transcript validator instead of a 64 MiB file-size
+limit and a UUID substring check. The validator bounds memory for both long
+histories and large individual message records, while the transcript digest
+is streamed. Canonical client-root paths and release-content checks remain
+required; malformed, ambiguous or conflicting identity fails closed.
+
+Doctor and status report eligible receipt-validation failures instead of
+silently discarding them and requesting another restart. Diagnostics stay
+outside immutable events and hash-bound observations. Existing conversation
+history, personal installation choices and organization enrollment are not
+rewritten by this correction.
+
 ## [4.95.4] - 2026-09-05
 
 **Reload guidance keeps existing conversations first.** Onboarding 2.3.3 uses

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Long conversations keep their startup evidence (September 2026).**
+Release **4.95.5** validates structured session identity with bounded memory, including
+large individual messages, and streams the full transcript digest. Doctor and
+status expose receipt-validation failures instead of sending an already
+reloaded conversation through another restart. Native history is retained;
+identity, client-root and release-content checks remain required.
+
 **Continue the existing conversation after a verified reload (September 2026).**
 Release **4.95.4** gives consistent recovery advice across installation, update
 and diagnosis. A new conversation is a fallback, not the default. Installed

--- a/skills/synthesis-agent-conformance/SKILL.md
+++ b/skills/synthesis-agent-conformance/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management", "synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "1.9.3"
+  version: "1.9.4"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -75,6 +75,14 @@ Preserved events are local runtime evidence and have no automatic age-based
 deletion. Exact-session checks waive only the 24-hour freshness limit; they
 still require the original client-owned transcript, matching session UUID,
 plugin version, and exact plugin root to validate.
+
+Transcript identity validation scans the first 1,000 physical JSONL lines,
+validates complete records within that window, and retains only bounded
+identity fields. Long histories and large message strings do not require
+whole-file or whole-record allocation. Malformed records, conflicting identity,
+duplicate identity keys and excessive nesting fail closed. This is a bounded
+startup-identity check, not a claim that every later transcript record was
+semantically validated. Onboarding separately streams the full-file digest.
 
 Use `--json` for a machine-readable report. Each check carries a plane and one
 of PASS, FAIL, WARN, UNKNOWN, or UNSUPPORTED. A required UNKNOWN fails the

--- a/skills/synthesis-agent-conformance/scripts/live_receipt.py
+++ b/skills/synthesis-agent-conformance/scripts/live_receipt.py
@@ -4,13 +4,209 @@
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TextIO
 
 
 MAX_BINDING_LINES = 1_000
+TRANSCRIPT_READ_CHARS = 64 * 1024
+MAX_PROJECTED_STRING_CHARS = 512
+MAX_TRANSCRIPT_JSON_DEPTH = 128
 RECEIPT_CLIENTS = {"claude", "codex"}
+
+_STRING_SPECIAL = re.compile(r'["\\\x00-\x1f]')
+_HORIZONTAL_SPACE = re.compile(r"[ \t\r]+")
+_DIGITS = re.compile(r"[0-9]+")
+_NON_STRING = object()
+_ROOT_PROJECTION = {
+    "type": True,
+    "sessionId": True,
+    "payload": {"id": True, "session_id": True},
+}
+
+
+class _InvalidTranscriptJSON(ValueError):
+    """A transcript record cannot safely supply identity evidence."""
+
+
+class _TranscriptJSON:
+    """Validate JSONL while retaining only the fixed identity projection.
+
+    ``readline`` and ``json.loads`` on a complete record both allocate in
+    proportion to an individual prompt or tool result. This parser instead
+    keeps one fixed input chunk and bounded strings for the handful of
+    projected keys/values. Discarded strings and numbers are validated in
+    chunks, and containers have a fixed nesting bound. Every inspected line
+    is parsed completely, so a large ignored value cannot hide a subsequent
+    identity declaration or malformed suffix.
+    """
+
+    def __init__(self, handle: TextIO):
+        self.handle = handle
+        self.buffer = ""
+        self.offset = 0
+
+    def peek(self) -> str:
+        if self.offset == len(self.buffer):
+            self.buffer = self.handle.read(TRANSCRIPT_READ_CHARS)
+            self.offset = 0
+        return self.buffer[self.offset : self.offset + 1]
+
+    def take(self) -> str:
+        value = self.peek()
+        self.offset += bool(value)
+        return value
+
+    def expect(self, wanted: str) -> None:
+        if self.take() != wanted:
+            raise _InvalidTranscriptJSON("unexpected JSON token")
+
+    def spaces(self) -> None:
+        while self.peek():
+            match = _HORIZONTAL_SPACE.match(self.buffer, self.offset)
+            if match is None:
+                return
+            self.offset = match.end()
+
+    def string(self, capture: bool) -> object:
+        self.expect('"')
+        fragments: list[str] = ['"'] if capture else []
+        retained = 1
+
+        def retain(fragment: str) -> None:
+            nonlocal capture, retained
+            if not capture:
+                return
+            retained += len(fragment)
+            if retained > MAX_PROJECTED_STRING_CHARS:
+                capture = False
+                fragments.clear()
+            else:
+                fragments.append(fragment)
+
+        while self.peek():
+            match = _STRING_SPECIAL.search(self.buffer, self.offset)
+            end = match.start() if match else len(self.buffer)
+            retain(self.buffer[self.offset:end])
+            self.offset = end
+            if match is None:
+                continue
+            special = self.take()
+            if special == '"':
+                retain('"')
+                # Only bounded, already validated strings reach json.loads;
+                # it supplies the standard escape and surrogate semantics.
+                return json.loads("".join(fragments)) if capture else _NON_STRING
+            if special != "\\":
+                raise _InvalidTranscriptJSON("unescaped JSON control character")
+            escaped = self.take()
+            if escaped and escaped in '"\\/bfnrt':
+                retain("\\" + escaped)
+            elif escaped == "u":
+                digits = "".join(self.take() for _ in range(4))
+                if len(digits) != 4 or any(c not in "0123456789abcdefABCDEF" for c in digits):
+                    raise _InvalidTranscriptJSON("invalid JSON unicode escape")
+                retain("\\u" + digits)
+            else:
+                raise _InvalidTranscriptJSON("invalid JSON escape")
+        raise _InvalidTranscriptJSON("unterminated JSON string")
+
+    def digits(self) -> None:
+        if not self.peek() or self.peek() not in "0123456789":
+            raise _InvalidTranscriptJSON("JSON number requires a digit")
+        while self.peek():
+            match = _DIGITS.match(self.buffer, self.offset)
+            if match is None:
+                return
+            self.offset = match.end()
+
+    def number(self) -> None:
+        if self.peek() == "-":
+            self.take()
+        if self.peek() == "0":
+            self.take()
+        elif self.peek() and self.peek() in "123456789":
+            self.digits()
+        else:
+            raise _InvalidTranscriptJSON("invalid JSON number")
+        if self.peek() == ".":
+            self.take()
+            self.digits()
+        if self.peek() and self.peek() in "eE":
+            self.take()
+            if self.peek() and self.peek() in "+-":
+                self.take()
+            self.digits()
+
+    def value(self, projection: object = None, depth: int = 0) -> object:
+        if depth > MAX_TRANSCRIPT_JSON_DEPTH:
+            raise _InvalidTranscriptJSON("JSON nesting exceeds the verification limit")
+        self.spaces()
+        token = self.peek()
+        if token == '"':
+            return self.string(capture=projection is not None)
+        if token == "{":
+            self.take()
+            wanted = projection if isinstance(projection, dict) else {}
+            result: dict[str, object] = {}
+            self.spaces()
+            if self.peek() == "}":
+                self.take()
+                return result if isinstance(projection, dict) else _NON_STRING
+            while True:
+                self.spaces()
+                key = self.string(capture=bool(wanted))
+                self.spaces()
+                self.expect(":")
+                selected = wanted.get(key)
+                if selected is not None and key in result:
+                    raise _InvalidTranscriptJSON("duplicate projected identity key")
+                value = self.value(selected, depth + 1)
+                if selected is not None:
+                    result[key] = value
+                self.spaces()
+                separator = self.take()
+                if separator == "}":
+                    return result if isinstance(projection, dict) else _NON_STRING
+                if separator != ",":
+                    raise _InvalidTranscriptJSON("invalid JSON object separator")
+        if token == "[":
+            self.take()
+            self.spaces()
+            if self.peek() == "]":
+                self.take()
+                return _NON_STRING
+            while True:
+                self.value(depth=depth + 1)
+                self.spaces()
+                separator = self.take()
+                if separator == "]":
+                    return _NON_STRING
+                if separator != ",":
+                    raise _InvalidTranscriptJSON("invalid JSON array separator")
+        if token and token in "-0123456789":
+            self.number()
+            return _NON_STRING
+        for literal in ("true", "false", "null"):
+            if token == literal[0]:
+                for character in literal:
+                    self.expect(character)
+                return None if literal == "null" else _NON_STRING
+        raise _InvalidTranscriptJSON("invalid JSON value")
+
+    def record(self) -> object:
+        self.spaces()
+        if self.peek() in {"", "\n"}:
+            self.take()
+            return None
+        value = self.value(_ROOT_PROJECTION)
+        self.spaces()
+        if self.take() not in {"", "\n"}:
+            raise _InvalidTranscriptJSON("JSONL record has trailing content")
+        return value
 
 
 def latest_receipt_paths(destination: Path, client: str) -> tuple[Path, Path]:
@@ -230,55 +426,101 @@ def claude_root_transcript_path(
     return True
 
 
+def client_root_transcript_path(
+    transcript: Path, client: str, session_id: str, transcript_root: Path
+) -> bool:
+    """Validate the configured native transcript root without reading history.
+
+    Claude requires its root-session filename and directory shape. Codex
+    retains the conformance contract of containment in its configured root;
+    the structured ``session_meta`` declaration supplies its session identity.
+    Missing Claude destinations may be valid at SessionStart, so file
+    existence/type is deliberately verified separately by the binding reader.
+    """
+    if client not in RECEIPT_CLIENTS or not transcript.is_absolute():
+        return False
+    try:
+        uuid.UUID(session_id)
+    except (ValueError, TypeError, AttributeError):
+        return False
+    root = transcript_root.expanduser().absolute()
+    candidate = transcript.expanduser().absolute()
+    try:
+        relative = candidate.relative_to(root)
+        if (
+            not relative.parts
+            or any(part in {".", ".."} for part in relative.parts)
+            or root.is_symlink()
+        ):
+            return False
+        current = root
+        for part in relative.parts:
+            current = current / part
+            if current.is_symlink():
+                return False
+        candidate.resolve(strict=False).relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    return client != "claude" or claude_root_transcript_path(
+        candidate, root, session_id
+    )
+
+
 def transcript_binding_state(
     transcript: Path, client: str, session_id: str
 ) -> str:
     """Return ``bound``, ``pending``, ``conflicting``, or ``invalid``.
 
     ``pending`` covers a transcript Claude has not created or populated yet.
-    Once a transcript declares any different session id, the state is
-    ``conflicting`` and must not be preserved as genuine evidence.
+    Once an inspected record declares any different session id, the state is
+    ``conflicting`` and must not be preserved as genuine evidence. The first
+    ``MAX_BINDING_LINES`` physical JSONL lines are inspected completely with
+    bounded memory, even when an individual line contains a large prompt.
+    Malformed or ambiguous records fail closed rather than being skipped:
+    a rejected record could otherwise conceal a contradictory declaration.
     """
+    if client not in RECEIPT_CLIENTS:
+        return "invalid"
+    try:
+        uuid.UUID(session_id)
+    except (ValueError, TypeError, AttributeError):
+        return "invalid"
     if not transcript.exists():
         return "pending"
     if transcript.is_symlink() or not transcript.is_file():
         return "invalid"
-    declared: set[str] = set()
+    matched = False
+    conflicting = False
     try:
         with transcript.open(encoding="utf-8") as handle:
-            for index, line in enumerate(handle):
-                if index >= MAX_BINDING_LINES:
+            parser = _TranscriptJSON(handle)
+            for _ in range(MAX_BINDING_LINES):
+                if not parser.peek():
                     break
-                try:
-                    payload = json.loads(line)
-                except (TypeError, ValueError):
-                    continue
+                payload = parser.record()
                 if not isinstance(payload, dict):
                     continue
+                declared: tuple[object, ...] = ()
                 if client == "codex":
                     metadata = payload.get("payload")
                     if payload.get("type") == "session_meta" and isinstance(
                         metadata, dict
                     ):
-                        declared.update(
-                            value
-                            for value in (
-                                str(metadata.get("id") or ""),
-                                str(metadata.get("session_id") or ""),
-                            )
-                            if value
-                        )
+                        declared = (metadata.get("id"), metadata.get("session_id"))
                 elif client == "claude":
-                    value = str(payload.get("sessionId") or "")
-                    if value:
-                        declared.add(value)
-    except (OSError, UnicodeError):
+                    declared = (payload.get("sessionId"),)
+                for value in declared:
+                    if value is None or value == "":
+                        continue
+                    if value == session_id:
+                        matched = True
+                    else:
+                        conflicting = True
+    except (OSError, UnicodeError, ValueError, RecursionError):
         return "invalid"
-    if declared == {session_id}:
-        return "bound"
-    if declared:
+    if conflicting:
         return "conflicting"
-    return "pending"
+    return "bound" if matched else "pending"
 
 
 def transcript_binds_session(
@@ -287,7 +529,9 @@ def transcript_binds_session(
     """Return whether a client transcript declares the claimed session id.
 
     Both clients write the binding at the start of their JSONL transcript.
-    The bounded scan fails closed on malformed or unexpectedly shaped files
-    without reading an arbitrarily large transcript during SessionStart.
+    The inspected prefix must contain a matching structured declaration and
+    no conflicting declaration or malformed JSON. Its memory use is bounded
+    independently of transcript length and individual record size; later
+    history beyond the line limit is not a new source of identity evidence.
     """
     return transcript_binding_state(transcript, client, session_id) == "bound"

--- a/skills/synthesis-agent-conformance/scripts/test_streaming_transcript.py
+++ b/skills/synthesis-agent-conformance/scripts/test_streaming_transcript.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Bounded-memory validation of native JSONL transcript identity evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tracemalloc
+from pathlib import Path
+
+import pytest
+
+
+SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+
+import live_receipt  # noqa: E402
+
+
+SESSION = "019fff79-5858-7993-a329-b301bccf5d31"
+OTHER = "019fff79-5858-7993-a329-b301bccf5d32"
+
+
+def _binding(client: str, session: str = SESSION) -> dict:
+    if client == "codex":
+        return {"type": "session_meta", "payload": {"id": session}}
+    return {"sessionId": session}
+
+
+def _write(path: Path, *records: object) -> Path:
+    path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records), encoding="utf-8"
+    )
+    return path
+
+
+def _digest(path: Path) -> str:
+    result = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            result.update(chunk)
+    return result.hexdigest()
+
+
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_large_single_record_binds_with_bounded_memory(tmp_path: Path, client: str) -> None:
+    """A valid identity after a >64 MiB string cannot require that allocation."""
+    path = tmp_path / "large.jsonl"
+    with path.open("wb") as handle:
+        handle.write(b'{"discarded":"')
+        for _ in range(1025):
+            handle.write(b"x" * (64 * 1024))
+        handle.write(b'",')
+        handle.write(json.dumps(_binding(client))[1:].encode("utf-8") + b"\n")
+    before = _digest(path)
+    assert path.stat().st_size > 64 * 1024 * 1024
+
+    tracemalloc.start()
+    try:
+        result = live_receipt.transcript_binding_state(path, client, SESSION)
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert result == "bound"
+    assert peak < 4 * 1024 * 1024, "binding retained an oversized transcript record"
+    assert _digest(path) == before
+
+
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_conflicting_declaration_after_large_discarded_string_is_rejected(
+    tmp_path: Path, client: str
+) -> None:
+    path = tmp_path / "conflicting.jsonl"
+    with path.open("wb") as handle:
+        handle.write(json.dumps(_binding(client)).encode("utf-8") + b"\n")
+        handle.write(b'{"discarded":"')
+        for _ in range(33):
+            handle.write(b"x" * (64 * 1024))
+        handle.write(b'",')
+        handle.write(json.dumps(_binding(client, OTHER))[1:].encode("utf-8") + b"\n")
+    assert live_receipt.transcript_binding_state(path, client, SESSION) == "conflicting"
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        '{"sessionId":"%s","sessionId":"%s"}' % (OTHER, SESSION),
+        '{"sessionId":"%s","sessionId":"%s"}' % (SESSION, OTHER),
+        '{"sessionId":"%s","discarded":"bad\\q"}' % SESSION,
+        '{"sessionId":"%s","discarded":01}' % SESSION,
+        '{"sessionId":"%s","discarded":NaN}' % SESSION,
+        '{"sessionId":"%s","discarded":[true,]}' % SESSION,
+        '{"sessionId":"%s","discarded":true} trailing' % SESSION,
+        '{"sessionId":"%s","discarded":' % SESSION,
+    ],
+    ids=["duplicate-before", "duplicate-after", "escape", "number", "nan", "array", "trailing", "partial"],
+)
+def test_malformed_or_ambiguous_record_cannot_supply_binding(tmp_path: Path, record: str) -> None:
+    path = tmp_path / "invalid.jsonl"
+    path.write_text(record + "\n", encoding="utf-8")
+    assert live_receipt.transcript_binding_state(path, "claude", SESSION) == "invalid"
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        '{"type":"message","type":"session_meta","payload":{"id":"%s"}}' % SESSION,
+        '{"type":"session_meta","payload":{"id":"%s","id":"%s"}}' % (OTHER, SESSION),
+        '{"type":"session_meta","payload":{"id":"%s"},"payload":{"id":"%s"}}' % (OTHER, SESSION),
+    ],
+)
+def test_codex_duplicate_identity_keys_fail_closed(tmp_path: Path, record: str) -> None:
+    path = tmp_path / "ambiguous.jsonl"
+    path.write_text(record + "\n", encoding="utf-8")
+    assert live_receipt.transcript_binding_state(path, "codex", SESSION) == "invalid"
+
+
+def test_malformed_record_after_positive_binding_fails_closed(tmp_path: Path) -> None:
+    path = _write(tmp_path / "invalid-after.jsonl", _binding("codex"))
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"type":"session_meta","payload":{"id":"%s"},broken}\n' % OTHER)
+    assert live_receipt.transcript_binding_state(path, "codex", SESSION) == "invalid"
+
+
+def test_nesting_exhaustion_is_a_verdict_not_a_recursion_error(tmp_path: Path) -> None:
+    path = tmp_path / "deep.jsonl"
+    path.write_text(
+        '{"sessionId":"%s","discarded":' % SESSION + "[" * 2048 + "0" + "]" * 2048 + "}\n",
+        encoding="utf-8",
+    )
+    assert live_receipt.transcript_binding_state(path, "claude", SESSION) == "invalid"
+
+
+def test_escaped_identity_keys_and_values_bind(tmp_path: Path) -> None:
+    path = tmp_path / "escaped.jsonl"
+    escaped_session = "".join("\\u%04x" % ord(character) for character in SESSION)
+    path.write_text('{"session\\u0049d":"%s"}\r\n' % escaped_session, encoding="utf-8")
+    assert live_receipt.transcript_binding_state(path, "claude", SESSION) == "bound"
+
+
+def test_uuid_in_ignored_strings_or_nested_objects_does_not_bind(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "not-identity.jsonl",
+        {"text": SESSION, "nested": {"sessionId": SESSION}},
+        {"type": "message", "payload": {"id": SESSION}},
+    )
+    for client in ("claude", "codex"):
+        assert live_receipt.transcript_binding_state(path, client, SESSION) == "pending"
+
+
+def test_scan_boundary_is_explicit_and_preserves_earlier_conflicts(tmp_path: Path) -> None:
+    path = tmp_path / "boundary.jsonl"
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(json.dumps(_binding("claude")) + "\n")
+        for _ in range(live_receipt.MAX_BINDING_LINES - 2):
+            handle.write('{}\n')
+        handle.write(json.dumps(_binding("claude", OTHER)) + "\n")
+    assert live_receipt.transcript_binding_state(path, "claude", SESSION) == "conflicting"
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(json.dumps(_binding("claude")) + "\n")
+        for _ in range(live_receipt.MAX_BINDING_LINES - 1):
+            handle.write('{}\n')
+        handle.write(json.dumps(_binding("claude", OTHER)) + "\n")
+    assert live_receipt.transcript_binding_state(path, "claude", SESSION) == "bound"
+
+
+def test_giant_unselected_key_and_scalar_are_not_retained(tmp_path: Path) -> None:
+    path = tmp_path / "wide.jsonl"
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write('{"' + "x" * (256 * 1024) + '":' + "7" * (256 * 1024))
+        handle.write(',"sessionId":"%s"}\n' % SESSION)
+    assert live_receipt.transcript_binding_state(path, "claude", SESSION) == "bound"
+
+
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_client_root_helper_accepts_only_the_configured_native_root(tmp_path: Path, client: str) -> None:
+    root = tmp_path / ("." + client)
+    relative = (
+        Path("projects") / "encoded" / (SESSION + ".jsonl")
+        if client == "claude" else Path("sessions") / "native.jsonl"
+    )
+    path = root / relative
+    path.parent.mkdir(parents=True)
+    _write(path, _binding(client))
+    helper = live_receipt.client_root_transcript_path
+    assert helper(path, client, SESSION, root)
+    assert not helper(tmp_path / "outside.jsonl", client, SESSION, root)
+    assert not helper(relative, client, SESSION, root)
+    assert not helper(root / "segment" / ".." / relative, client, SESSION, root)
+    assert not helper(path, "unknown", SESSION, root)
+    assert not helper(path, client, "not-a-uuid", root)
+
+
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_client_root_helper_rejects_symlinked_transcript_or_parent(tmp_path: Path, client: str) -> None:
+    root = tmp_path / ("." + client)
+    parent = root / ("projects" if client == "claude" else "sessions")
+    parent.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = _write(outside / (SESSION + ".jsonl"), _binding(client))
+    if client == "claude":
+        (parent / "encoded").symlink_to(outside, target_is_directory=True)
+        path = parent / "encoded" / target.name
+    else:
+        path = parent / target.name
+        path.symlink_to(target)
+    assert not live_receipt.client_root_transcript_path(path, client, SESSION, root)
+
+
+def test_claude_root_helper_rejects_subagent_and_wrong_filename(tmp_path: Path) -> None:
+    root = tmp_path / ".claude"
+    helper = live_receipt.client_root_transcript_path
+    assert not helper(root / "projects" / "encoded" / "other.jsonl", "claude", SESSION, root)
+    assert not helper(
+        root / "projects" / "encoded" / SESSION / "subagents" / "agent.jsonl",
+        "claude", SESSION, root,
+    )

--- a/skills/synthesis-agent-conformance/scripts/test_streaming_transcript.py
+++ b/skills/synthesis-agent-conformance/scripts/test_streaming_transcript.py
@@ -218,3 +218,52 @@ def test_claude_root_helper_rejects_subagent_and_wrong_filename(tmp_path: Path) 
         root / "projects" / "encoded" / SESSION / "subagents" / "agent.jsonl",
         "claude", SESSION, root,
     )
+
+
+@pytest.mark.parametrize("read_chars", [1, 2, 3, 7])
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_chunk_boundaries_preserve_json_grammar_and_identity(
+    tmp_path: Path, monkeypatch, read_chars: int, client: str
+) -> None:
+    monkeypatch.setattr(live_receipt, "TRANSCRIPT_READ_CHARS", read_chars)
+    escaped_session = "".join("\\u%04x" % ord(character) for character in SESSION)
+    identity = (
+        '"t\\u0079pe":"session_meta","payload":{"i\\u0064":"%s"}'
+        if client == "codex" else '"session\\u0049d":"%s"'
+    ) % escaped_session
+    discarded = (
+        '"discarded":{"numbers":[-12.5e+2,0,1E-3],'
+        '"nested":[true,false,null,{"text":"snowman ☃ \\u2603 \\\\ \\""}]}'
+    )
+    path = tmp_path / "chunks.jsonl"
+    path.write_text("{" + discarded + "," + identity + "}\r\n", encoding="utf-8")
+    assert live_receipt.transcript_binding_state(path, client, SESSION) == "bound"
+    path.write_text(
+        "{" + identity + ',"discarded":"invalid\\u12z4"}\r\n', encoding="utf-8"
+    )
+    assert live_receipt.transcript_binding_state(path, client, SESSION) == "invalid"
+
+
+@pytest.mark.parametrize("ending", [b"\n", b"\r\n", b"\r"])
+def test_native_text_reader_preserves_universal_newline_boundaries(
+    tmp_path: Path, ending: bytes
+) -> None:
+    path = tmp_path / "newlines.jsonl"
+    path.write_bytes(json.dumps(_binding("claude")).encode("utf-8") + ending)
+    assert live_receipt.transcript_binding_state(path, "claude", SESSION) == "bound"
+    with path.open("ab") as handle:
+        handle.write(json.dumps(_binding("claude", OTHER)).encode("utf-8") + ending)
+    assert live_receipt.transcript_binding_state(path, "claude", SESSION) == "conflicting"
+
+
+@pytest.mark.parametrize("read_chars", [1, 7, 64 * 1024])
+def test_invalid_utf8_in_scanned_records_fails_closed(
+    tmp_path: Path, monkeypatch, read_chars: int
+) -> None:
+    monkeypatch.setattr(live_receipt, "TRANSCRIPT_READ_CHARS", read_chars)
+    path = tmp_path / "invalid-encoding.jsonl"
+    path.write_bytes(
+        json.dumps(_binding("codex")).encode("utf-8")
+        + b'\n{"discarded":"\xff"}\n'
+    )
+    assert live_receipt.transcript_binding_state(path, "codex", SESSION) == "invalid"

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,15 +1,16 @@
-# Transaction-bound acceptance for client reload guidance.
+# Transaction-bound acceptance for structured long-transcript validation.
+# Red fixture commits: bc532be (generation/CLI), 9bdf6cd (shared scanner).
 schema: 2
-suite: reload-guidance-2026-09-05
+suite: long-transcript-2026-09-05
 membership: closed
-production_entry_point: synthesis setup, update, doctor, status and uninstall output through the public CLI and native onboarding engine
+production_entry_point: native SessionStart identity binding and synthesis doctor/status generation receipt attachment
 enforcing_boundary: release.py consumes the exact base-to-head acceptance before publication and dual-client installation
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: isolated tests verify output and lifecycle rejection controls, not actual client process restart; installed personal-state preservation, historical archive restoration and exact client-session acceptance require separate live verification; no site deployment is authorized
+unverified_remainder: structured identity scans the first 1000 physical JSONL lines, not later transcript semantics; fixture tests do not establish actual client restart or current-task loaded metadata; installed preservation and genuine exact-session acceptance require separate live checks; no site deployment is part of this release
 changed_surfaces:
   - path: .claude-plugin/plugin.json
     cases: [release-contract]
@@ -19,27 +20,35 @@ changed_surfaces:
     cases: [release-contract]
   - path: README.md
     cases: [release-contract]
+  - path: skills/synthesis-agent-conformance/SKILL.md
+    cases: [streaming]
+  - path: skills/synthesis-agent-conformance/scripts/live_receipt.py
+    cases: [streaming, malformed, long-transcript]
+  - path: skills/synthesis-agent-conformance/scripts/test_streaming_transcript.py
+    cases: [streaming, malformed]
   - path: skills/synthesis-onboarding/SKILL.md
-    cases: [engine-contract, doctor, native]
+    cases: [engine-contract, long-transcript]
   - path: skills/synthesis-onboarding/scripts/onboard.py
-    cases: [native, no-refresh, update-hint, native-preservation]
+    cases: [engine-contract]
   - path: skills/synthesis-onboarding/scripts/synthesis_cli.py
-    cases: [doctor, partial, transaction, uninstall, scope, recorded-scope, observation-preservation, repair, provenance, engine-contract]
-  - path: skills/synthesis-onboarding/scripts/reload_guidance.py
-    cases: [doctor, partial, transaction, native, recorded-scope]
-  - path: skills/synthesis-onboarding/scripts/test_onboard.py
-    cases: [native-preservation]
+    cases: [engine-contract, long-transcript, diagnostics, recovery-guidance]
+  - path: skills/synthesis-onboarding/scripts/system_contract.py
+    cases: [long-transcript, identity-rejection, root-rejection, diagnostics, generation-contract]
+  - path: skills/synthesis-onboarding/scripts/test_long_transcript.py
+    cases: [long-transcript, identity-rejection, root-rejection, diagnostics]
+  - path: skills/synthesis-onboarding/scripts/test_system_contract.py
+    cases: [generation-contract]
   - path: skills/synthesis-onboarding/scripts/test_reload_guidance.py
-    cases: [doctor, partial, transaction, native, no-refresh, update-hint, uninstall, same-session, scope, recorded-scope, observation-preservation, rejection, repair, provenance]
-  - path: skills/synthesis-skills-manager/scripts/test_release.py
-    cases: [workspace-bootstrap-recovery]
+    cases: [recovery-guidance]
+  - path: skills/synthesis-onboarding/scripts/test_independent_review.py
+    cases: [promotion-contract]
   - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
     cases: [acceptance-self]
 cases:
   - id: acceptance-self
     control_class: acceptance-test
     fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-    motivating_defect: closed-manifest-must-cover-the-current-transaction
+    motivating_defect: release-manifest-must-cover-the-exact-change-universe
   - id: release-contract
     control_class: acceptance-test
     fixture: ../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent
@@ -48,67 +57,39 @@ cases:
     control_class: acceptance-test
     fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_engine_versions_and_skill_contract_agree
     motivating_defect: engine-and-skill-versions-could-disagree
-  - id: doctor
+  - id: streaming
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_doctor_emits_existing_conversation_recovery
-    motivating_defect: doctor-unconditionally-abandoned-existing-conversations
-  - id: partial
+    fixture: ../synthesis-agent-conformance/scripts/test_streaming_transcript.py::test_large_single_record_binds_with_bounded_memory
+    motivating_defect: line-count-bounds-did-not-bound-memory-or-reject-ambiguous-identity
+  - id: long-transcript
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_partial_doctor_only_requests_the_missing_client
-    motivating_defect: partial-evidence-needs-client-specific-recovery
-  - id: transaction
+    fixture: ../synthesis-onboarding/scripts/test_long_transcript.py::test_long_native_transcript_is_accepted_with_bounded_memory
+    motivating_defect: long-native-history-was-rejected-and-promotion-failures-were-hidden
+  - id: generation-contract
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_setup_transaction_emits_the_recovery_ladder
-    motivating_defect: stored-and-rendered-guidance-lacked-evidence-based-recovery
-  - id: native
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_native_success_does_not_abandon_existing_conversations
-    motivating_defect: install-and-refresh-advice-mistook-installation-for-live-state
-  - id: no-refresh
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_native_no_refresh_positive_control_does_not_launch_client
-    motivating_defect: current-install-must-remain-non-mutating
-  - id: update-hint
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_native_version_mismatch_uses_public_terminal_update_hint
-    motivating_defect: hint-exposed-internal-update-entrypoint
-  - id: uninstall
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_uninstall_not_applicable_never_requests_restart
-    motivating_defect: verified-removal-unconditionally-requested-a-restart
-  - id: same-session
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_genuine_same_uuid_event_is_accepted_without_a_new_conversation
-    motivating_defect: same-session-reload-must-not-require-new-identity
-  - id: scope
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_doctor_global_event_is_labelled_not_exact_invoking_task_acceptance
-    motivating_defect: client-evidence-could-be-mistaken-for-exact-task-acceptance
-  - id: rejection
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_receipt_rejection_positive_control_remains_fail_closed
-    motivating_defect: wording-change-must-not-weaken-lifecycle-evidence
-  - id: recorded-scope
-    control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_retained_event_is_labelled_recorded_not_latest
-    motivating_defect: retained-session-evidence-must-not-be-described-as-latest
-  - id: observation-preservation
+    fixture: ../synthesis-onboarding/scripts/test_system_contract.py::test_sessionstart_receipts_complete_live_loaded_plane
+    motivating_defect: generation-validator-used-quoted-UUIDs-instead-of-native-identity
+  - id: recovery-guidance
     control_class: acceptance-test
     fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_scope_presentation_preserves_observation_and_outcome_bytes
-    motivating_defect: scope-labels-must-not-rewrite-hash-bound-observations
-  - id: repair
+    motivating_defect: stronger-validation-must-preserve-truthful-reload-and-outcome-contracts
+  - id: promotion-contract
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_doctor_repair_precedes_reload_in_real_installed_failure
-    motivating_defect: restart-advice-must-not-hide-installation-defects
-  - id: provenance
+    fixture: ../synthesis-onboarding/scripts/test_independent_review.py::test_pending_claude_receipt_is_promoted_once_its_transcript_binds
+    motivating_defect: pending-Claude-startup-must-attach-only-after-genuine-binding
+  - id: malformed
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_reload_guidance.py::test_doctor_provenance_repair_precedes_reload_and_installed_repair
-    motivating_defect: restart-advice-must-not-hide-source-drift
-  - id: native-preservation
+    fixture: ../synthesis-agent-conformance/scripts/test_streaming_transcript.py::test_malformed_or_ambiguous_record_cannot_supply_binding
+    motivating_defect: malformed-or-duplicate-identity-could-hide-a-contradiction
+  - id: identity-rejection
     control_class: acceptance-test
-    fixture: ../synthesis-onboarding/scripts/test_onboard.py::PluginTests::test_install_does_not_replace_an_existing_live_plugin_cache
-    motivating_defect: install-must-not-refresh-an-active-cache-implicitly
-  - id: workspace-bootstrap-recovery
+    fixture: ../synthesis-onboarding/scripts/test_long_transcript.py::test_structured_identity_is_required_without_mutating_state
+    motivating_defect: quoted-or-contradictory-UUIDs-could-enter-generation-state
+  - id: root-rejection
     control_class: acceptance-test
-    fixture: ../synthesis-skills-manager/scripts/test_release.py::test_quick_answers_self_bootstrap_release_contract_is_public_and_coherent
-    motivating_defect: historical-bootstrap-contract-required-unconditional-new-chat
+    fixture: ../synthesis-onboarding/scripts/test_long_transcript.py::test_live_load_preserves_path_time_and_payload_rejection
+    motivating_defect: transcript-path-provenance-and-payload-digest-must-be-rechecked
+  - id: diagnostics
+    control_class: acceptance-test
+    fixture: ../synthesis-onboarding/scripts/test_long_transcript.py::test_rejected_candidate_surfaces_reason_without_restart_loop
+    motivating_defect: eligible-receipt-rejection-was-hidden-behind-another-restart

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.3.3"
+  version: "2.3.4"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -279,6 +279,16 @@ reports six planes independently:
 4. source provenance
 5. live loaded
 6. outcome verified
+
+Transcript length is not a reason to discard or replace a conversation. Hook,
+conformance and generation attachment share structured identity validation of
+the first 1,000 JSONL lines with bounded memory, including large message records.
+The full transcript digest is streamed. Only canonical client-owned root-session
+paths qualify; quoted UUIDs, conflicting identity, malformed evidence and
+payload drift cannot establish a live-loaded generation. Doctor and status
+expose rejected eligible receipts without changing the original event or
+hash-bound observations. Resolve the reported validation failure before
+rechecking; another restart is not a repair for invalid evidence.
 
 A plugin version, directory, or generated instruction file proves only its own
 plane. `live-loaded` requires a fresh client lifecycle receipt after restart.

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -91,7 +91,7 @@ from whole_system import (
     validate_personal_policy,
 )
 
-ENGINE_VERSION = "2.3.3"
+ENGINE_VERSION = "2.3.4"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"

--- a/skills/synthesis-onboarding/scripts/synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/synthesis_cli.py
@@ -43,7 +43,7 @@ from system_contract import (
 )
 
 
-ENGINE_VERSION = "2.3.3"
+ENGINE_VERSION = "2.3.4"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CLI_COMMANDS = (
     "setup",
@@ -187,7 +187,10 @@ def _transcript_binder() -> Callable[[Path, str, str], bool]:
 def _promote_live_receipts(state: SystemState) -> tuple[list[dict[str, Any]], str | None]:
     """Attach fresh client SessionStart receipts that bind their transcript now."""
     try:
-        return state.promote_live_receipts(binder=_transcript_binder()), None
+        rejections: list[dict[str, str]] = []
+        promoted = state.promote_live_receipts(binder=_transcript_binder(), rejections=rejections)
+        note = "; ".join("%s: %s" % (item["client"], item["reason"]) for item in rejections)
+        return promoted, note or None
     except ContractError as exc:
         return [], str(exc)
 
@@ -367,10 +370,16 @@ def _next_action(
         return "Run synthesis repair; the engine reported: %s" % planes["installed"].get("detail")
     live = planes["live-loaded"]
     if live.get("status") != "verified":
+        if promotion_note:
+            return (
+                "SessionStart evidence could not be attached: %s. "
+                "Inspect the rejected receipt and its client-owned transcript; "
+                "preserve both and resolve the reported validation failure before "
+                "running synthesis doctor again."
+            ) % promotion_note
         clients = live.get("missing_clients") or list(desired.get("clients") or [])
         steps = recovery_instruction(clients)
-        note = " (%s)" % promotion_note if promotion_note else ""
-        return "%s Then run synthesis doctor again%s." % (steps, note)
+        return "%s Then run synthesis doctor again." % steps
     if planes["outcome-verified"].get("status") in ("not-requested", "missing"):
         return (
             "Optional: synthesis outcome verify --task workspace-grounding-check "
@@ -486,6 +495,8 @@ def _render_status(payload: dict[str, Any]) -> None:
         print("  Live-loaded: unknown")
     outcome = latest.get("outcome-verified") if latest else None
     print("  Outcome:     %s" % (outcome.get("status") if isinstance(outcome, dict) else "unknown"))
+    if payload.get("promotion_note"):
+        print("  Receipt validation: %s" % payload["promotion_note"])
     if payload.get("promoted"):
         print("  Attached fresh SessionStart evidence for: %s" % ", ".join(
             item["client"] for item in payload["promoted"]
@@ -1489,7 +1500,7 @@ def main(
             return 0
 
         if args.command == "status":
-            promoted, _promotion_note = _promote_live_receipts(state)
+            promoted, promotion_note = _promote_live_receipts(state)
             with state.locked():
                 payload = {"desired": state.read_desired(), "observed": state.read_observation()}
                 # Presentation metadata must not alter hash-bound observations.
@@ -1499,6 +1510,8 @@ def main(
                         "detail": RECORDED_SESSION_DETAIL,
                     }
             payload["promoted"] = promoted
+            if promotion_note:
+                payload["promotion_note"] = promotion_note
             _render(payload, args.json)
             return 0 if payload["desired"] is not None else 1
 

--- a/skills/synthesis-onboarding/scripts/system_contract.py
+++ b/skills/synthesis-onboarding/scripts/system_contract.py
@@ -17,6 +17,7 @@ import re
 import shlex
 import stat
 import subprocess
+import sys
 import tempfile
 import uuid
 from datetime import datetime, timezone
@@ -97,6 +98,18 @@ def file_digest(path: Path) -> str:
         for chunk in iter(lambda: stream.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _live_receipt_validator():
+    """Load the shared identity contract from this release's skill tree."""
+    scripts = Path(__file__).resolve().parents[2] / "synthesis-agent-conformance" / "scripts"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    try:
+        import live_receipt
+    except ImportError as exc:
+        raise ContractError("live-load transcript validator is unavailable") from exc
+    return live_receipt
 
 
 def _fsync_directory(path: Path) -> None:
@@ -1457,6 +1470,7 @@ class SystemState:
         *,
         binder: Callable[[Path, str, str], bool],
         registry_root: Path | None = None,
+        rejections: list[dict[str, str]] | None = None,
     ) -> list[dict[str, Any]]:
         """Attach registry SessionStart events whose transcripts bind now.
 
@@ -1537,27 +1551,56 @@ class SystemState:
                             continue
                         candidates.append((recorded, client, event))
         promoted: list[dict[str, Any]] = []
+        rejected: dict[str, dict[str, str]] = {}
+
+        def reject(client: str, event: dict[str, Any], reason: str) -> None:
+            # Retain the newest eligible failure per client, not every event
+            # in a long-lived registry. A valid alternative clears the failure.
+            rejected.setdefault(client, {
+                "client": client, "session_id": str(event["session_id"]), "reason": reason,
+            })
+
         for recorded, client, event in sorted(candidates, key=lambda item: item[0], reverse=True):
             if any(item["client"] == client for item in promoted):
                 continue
             transcript_value = event.get("transcript_path")
             if not isinstance(transcript_value, str) or not transcript_value:
+                reject(client, event, "live-load receipt has no transcript path")
                 continue
             try:
                 bound = bool(
                     binder(Path(transcript_value).expanduser(), client, str(event["session_id"]))
                 )
             except Exception:  # a binder failure is never promotion evidence
-                bound = False
+                reject(client, event, "live-load transcript validator could not run")
+                continue
             if not bound:
+                try:
+                    binding = _live_receipt_validator().transcript_binding_state(
+                        Path(transcript_value).expanduser(), client, str(event["session_id"]),
+                    )
+                    reason = "live-load transcript binding is %s" % binding
+                    if binding == "pending":
+                        reason += "; wait for the client to finish writing its transcript and recheck"
+                    elif binding == "bound":
+                        reason = "live-load transcript validators disagree; evidence was not accepted"
+                except ContractError as exc:
+                    reason = str(exc)
+                reject(client, event, reason)
                 continue
             receipt = dict(event)
             receipt["transcript_bound_at_promotion"] = True
             try:
                 if self.record_live_load(receipt=receipt, promotion=True):
                     promoted.append({"client": client, "session_id": str(event["session_id"])})
-            except ContractError:
+                    rejected.pop(client, None)
+                else:
+                    reject(client, event, "live-load receipt no longer matches an enabled selected-client generation")
+            except ContractError as exc:
+                reject(client, event, str(exc))
                 continue
+        if rejections is not None:
+            rejections.extend(rejected.values())
         return promoted
 
     def record_live_load(
@@ -1634,14 +1677,19 @@ class SystemState:
             raise ContractError("live-load transcript is unavailable: %s" % exc)
         if stat.S_ISLNK(transcript_meta.st_mode) or not stat.S_ISREG(transcript_meta.st_mode):
             raise ContractError("live-load transcript must be a regular file")
-        if transcript_meta.st_size > 64 * 1024 * 1024:
-            raise ContractError("live-load transcript exceeds the verification size limit")
-        try:
-            transcript_text = transcript.read_text(encoding="utf-8", errors="replace")
-        except OSError as exc:
-            raise ContractError("live-load transcript is unreadable: %s" % exc)
-        if str(session_id) not in transcript_text:
-            raise ContractError("live-load transcript does not bind the session identifier")
+        # Use the same structured, bounded-memory identity proof as the hook
+        # and conformance. History length is not a provenance failure, and a
+        # UUID quoted in ordinary message text is not session metadata.
+        validator = _live_receipt_validator()
+        transcript_root = Path(os.environ.get(
+            "CODEX_HOME" if client == "codex" else "CLAUDE_CONFIG_DIR",
+            str(self.home / (".codex" if client == "codex" else ".claude")),
+        )).expanduser()
+        if not validator.client_root_transcript_path(transcript, client, str(session_id), transcript_root):
+            raise ContractError("live-load transcript is not a canonical client root-session path")
+        binding = validator.transcript_binding_state(transcript, client, str(session_id))
+        if binding != "bound":
+            raise ContractError("live-load transcript binding is %s, not bound" % binding)
         if not self.desired_path.is_file() or not self.observation_path.is_file():
             return False
         with self.locked():
@@ -1654,6 +1702,8 @@ class SystemState:
             if desired is None or not committed:
                 return False
             if not desired.get("enabled", True):
+                return False
+            if client not in (desired.get("clients") or []):
                 return False
             transaction = committed[-1]
             release = transaction.get("release")

--- a/skills/synthesis-onboarding/scripts/test_independent_review.py
+++ b/skills/synthesis-onboarding/scripts/test_independent_review.py
@@ -41,6 +41,12 @@ from test_onboard import Sandbox  # noqa: E402
 from test_system_contract import git, live_receipt as receipt_fixture, release_record, release_repo  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def isolated_native_roots(monkeypatch):
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
@@ -251,7 +257,8 @@ def test_pending_claude_receipt_is_promoted_once_its_transcript_binds(tmp_path: 
         },
     )
     registry = tmp_path / "registry"
-    transcript = tmp_path / "pending.jsonl"
+    transcript = Path(fixture["transcript_path"])
+    transcript.unlink()  # The isolated pending-at-hook fixture has not been created yet.
     pending = dict(fixture, transcript_path=str(transcript))
     pending["recorded_at"] = datetime.now(timezone.utc).isoformat()
     _registry_event(registry, pending, bound_at_record=False)
@@ -286,8 +293,7 @@ def test_promotion_ignores_receipts_that_predate_the_generation(tmp_path: Path) 
     fixture = receipt_fixture(tmp_path, "claude")
     root = Path(fixture["plugin_root"])
     registry = tmp_path / "registry"
-    transcript = tmp_path / "old.jsonl"
-    transcript.write_text(json.dumps({"sessionId": fixture["session_id"]}) + "\n", encoding="utf-8")
+    transcript = Path(fixture["transcript_path"])
     old = dict(fixture, transcript_path=str(transcript))
     old["recorded_at"] = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
     _registry_event(registry, old, bound_at_record=False)
@@ -310,7 +316,7 @@ def test_promotion_ignores_receipts_that_predate_the_generation(tmp_path: Path) 
 def test_doctor_promotes_a_fresh_claude_receipt_from_the_registry(tmp_path: Path, capsys) -> None:
     home = tmp_path / "home"
     state = system_contract.SystemState(home=home)
-    fixture = receipt_fixture(tmp_path, "claude")
+    fixture = receipt_fixture(tmp_path, "claude", home=home)
     root = Path(fixture["plugin_root"])
     desired = system_contract.default_desired_state("skills-only", ["claude"], "stable")
     state.run_transaction(
@@ -321,9 +327,7 @@ def test_doctor_promotes_a_fresh_claude_receipt_from_the_registry(tmp_path: Path
             "source-provenance": {"status": "verified", "root": str(root)},
         },
     )
-    transcript = home / ".claude" / "projects" / "encoded" / (fixture["session_id"] + ".jsonl")
-    transcript.parent.mkdir(parents=True)
-    transcript.write_text(json.dumps({"sessionId": fixture["session_id"]}) + "\n", encoding="utf-8")
+    transcript = Path(fixture["transcript_path"])
     pending = dict(fixture, transcript_path=str(transcript))
     pending["recorded_at"] = datetime.now(timezone.utc).isoformat()
     _registry_event(state.live_receipt_registry_root(), pending, bound_at_record=False)
@@ -483,7 +487,7 @@ def test_currency_cache_lives_under_the_engine_state_root(tmp_path: Path, monkey
 
 def test_status_and_doctor_render_human_summaries_with_a_next_action(tmp_path: Path, capsys) -> None:
     state = system_contract.SystemState(home=tmp_path / "home")
-    fixture = receipt_fixture(tmp_path, "claude")
+    fixture = receipt_fixture(tmp_path, "claude", home=state.home)
     root = Path(fixture["plugin_root"])
     desired = system_contract.default_desired_state("skills-only", ["claude", "codex"], "stable")
     state.run_transaction(

--- a/skills/synthesis-onboarding/scripts/test_long_transcript.py
+++ b/skills/synthesis-onboarding/scripts/test_long_transcript.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""LIFECYCLE-001: long native history remains valid without unbounded reads.
+
+All files are generated in temporary homes. The transcript contents, receipt
+registry and generation are real inputs to the production verifier; none of
+its binding, digest, persistence or promotion operations is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tracemalloc
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent
+CONFORMANCE_SCRIPTS = SCRIPTS.parents[1] / "synthesis-agent-conformance" / "scripts"
+for directory in (SCRIPTS, CONFORMANCE_SCRIPTS):
+    if str(directory) not in sys.path:
+        sys.path.insert(0, str(directory))
+
+import live_receipt  # noqa: E402
+import synthesis_cli  # noqa: E402
+import system_contract  # noqa: E402
+from test_system_contract import live_receipt as receipt_fixture, release_record  # noqa: E402
+
+
+MIB = 1024 * 1024
+HISTORICAL_LIMIT = 64 * MIB
+PEAK_MEMORY_LIMIT = 16 * MIB
+
+
+@pytest.fixture(autouse=True)
+def isolated_environment(monkeypatch, tmp_path):
+    monkeypatch.delenv("SYNTHESIS_ACTIVE_DESCRIPTOR", raising=False)
+    monkeypatch.delenv("SYNTHESIS_RESOLVED_BOOTSTRAP", raising=False)
+    monkeypatch.delenv("SYNTHESIS_PUBLIC_SESSIONSTART_RECEIPT", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+
+def _binding(client: str, session_id: str) -> dict:
+    if client == "codex":
+        return {
+            "type": "session_meta",
+            "payload": {"id": session_id, "cwd": "/workspace/example"},
+        }
+    return {"type": "user", "sessionId": session_id, "message": {"role": "user"}}
+
+
+def _case(tmp_path: Path, client: str):
+    state = system_contract.SystemState(tmp_path / "home")
+    receipt = receipt_fixture(tmp_path, client)
+    session_id = receipt["session_id"]
+    if client == "codex":
+        transcript = (
+            state.home / ".codex" / "sessions" / "2030" / "01" / "02"
+            / ("rollout-2030-01-02T03-04-05-" + session_id + ".jsonl")
+        )
+    else:
+        transcript = state.home / ".claude" / "projects" / "-workspace-example" / (session_id + ".jsonl")
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text(json.dumps(_binding(client, session_id)) + "\n", encoding="utf-8")
+    receipt["transcript_path"] = str(transcript)
+    root = Path(receipt["plugin_root"])
+    desired = system_contract.default_desired_state("skills-only", [client], "stable")
+    state.run_transaction(
+        "setup", desired,
+        lambda _tx: {
+            "release": release_record(root),
+            "source-provenance": {"status": "verified", "root": str(root)},
+            "live-loaded": {"status": "restart-required"},
+        },
+    )
+    receipt["recorded_at"] = datetime.now(timezone.utc).isoformat()
+    return state, receipt, transcript
+
+
+def _write_long_transcript(transcript: Path, client: str, session_id: str, shape: str) -> None:
+    """Write actual JSONL bytes, including a native-shaped very large record."""
+    block = "x" * (64 * 1024)
+    with transcript.open("w", encoding="utf-8") as handle:
+        handle.write(json.dumps(_binding(client, session_id)) + "\n")
+        if shape == "many-records":
+            record = (
+                {"type": "event_msg", "payload": {"type": "agent_message", "message": block}}
+                if client == "codex"
+                else {"type": "assistant", "sessionId": session_id,
+                      "message": {"role": "assistant", "content": [{"type": "text", "text": block}]}}
+            )
+            line = json.dumps(record) + "\n"
+            for _ in range(1041):
+                handle.write(line)
+        else:
+            if client == "codex":
+                handle.write('{"type":"event_msg","payload":{"type":"agent_message","message":"')
+            else:
+                handle.write('{"type":"assistant","sessionId":' + json.dumps(session_id)
+                             + ',"message":{"role":"assistant","content":[{"type":"text","text":"')
+            for _ in range(1041):
+                handle.write(block)
+            handle.write('"}}\n' if client == "codex" else '"}]}}\n')
+    assert transcript.stat().st_size > HISTORICAL_LIMIT
+
+
+def _registry_event(tmp_path: Path, receipt: dict, *, registry: Path | None = None) -> tuple[Path, Path]:
+    registry = registry if registry is not None else tmp_path / "registry"
+    path = registry / receipt["client"] / receipt["session_id"] / (receipt["receipt_event_id"] + ".json")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Promotion is the real pending-at-hook path, not an invented direct proof.
+    path.write_text(json.dumps(dict(receipt, transcript_bound_at_record=False)) + "\n", encoding="utf-8")
+    return registry, path
+
+
+@pytest.mark.parametrize("client", ["codex", "claude"])
+@pytest.mark.parametrize("shape", ["many-records", "large-record"])
+@pytest.mark.parametrize("route", ["direct", "promotion"])
+def test_long_native_transcript_is_accepted_with_bounded_memory(tmp_path, client, shape, route):
+    state, receipt, transcript = _case(tmp_path, client)
+    _write_long_transcript(transcript, client, receipt["session_id"], shape)
+    transcript_digest = system_contract.file_digest(transcript)
+    desired_before = state.desired_path.read_bytes()
+    registry, event_path = _registry_event(tmp_path, receipt)
+    event_before = event_path.read_bytes()
+
+    tracemalloc.start()
+    try:
+        if route == "direct":
+            accepted = state.record_live_load(receipt=receipt)
+        else:
+            accepted = state.promote_live_receipts(
+                binder=live_receipt.transcript_binds_session, registry_root=registry,
+            )
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert accepted, "a genuine long conversation must attach to its matching generation"
+    assert peak < PEAK_MEMORY_LIMIT, f"verification allocated {peak} bytes for a streamed transcript"
+    live = state.read_observation()["transactions"][-1]["live-loaded"]
+    assert live["status"] == "verified"
+    recorded = live["receipts"][client]
+    assert recorded["session_id"] == receipt["session_id"]
+    assert recorded["receipt_event_id"] == receipt["receipt_event_id"]
+    assert recorded["transcript_sha256"] == transcript_digest
+    assert recorded["transcript_bound_at_promotion"] is (route == "promotion")
+    assert system_contract.file_digest(transcript) == transcript_digest
+    assert state.desired_path.read_bytes() == desired_before
+    assert event_path.read_bytes() == event_before
+    if route == "promotion":
+        observation_before = state.observation_path.read_bytes()
+        assert state.promote_live_receipts(
+            binder=live_receipt.transcript_binds_session, registry_root=registry,
+        ) == []
+        assert state.observation_path.read_bytes() == observation_before
+
+
+@pytest.mark.parametrize("client", ["codex", "claude"])
+@pytest.mark.parametrize("shape", ["quoted-only", "conflicting", "wrong-client", "malformed"])
+@pytest.mark.parametrize("route", ["direct", "promotion"])
+def test_structured_identity_is_required_without_mutating_state(tmp_path, client, shape, route):
+    state, receipt, transcript = _case(tmp_path, client)
+    session_id = receipt["session_id"]
+    if shape == "quoted-only":
+        text = json.dumps({"type": "message", "text": "quoted session " + session_id}) + "\n"
+    elif shape == "conflicting":
+        text = json.dumps(_binding(client, session_id)) + "\n"
+        text += json.dumps(_binding(client, str(uuid.uuid4()))) + "\n"
+    elif shape == "wrong-client":
+        text = json.dumps(_binding("claude" if client == "codex" else "codex", session_id)) + "\n"
+    else:
+        text = '{"sessionId": "' + session_id + '"\n'
+    transcript.write_text(text, encoding="utf-8")
+    registry, _ = _registry_event(tmp_path, receipt)
+    desired_before = state.desired_path.read_bytes()
+    observation_before = state.observation_path.read_bytes()
+    if route == "direct":
+        with pytest.raises(system_contract.ContractError, match="transcript"):
+            state.record_live_load(receipt=receipt)
+    else:
+        assert state.promote_live_receipts(
+            binder=live_receipt.transcript_binds_session, registry_root=registry,
+        ) == []
+    assert state.desired_path.read_bytes() == desired_before
+    assert state.observation_path.read_bytes() == observation_before
+
+
+@pytest.mark.parametrize("client", ["codex", "claude"])
+@pytest.mark.parametrize("fault", ["symlink-file", "symlink-parent", "stale", "wrong-root"])
+def test_live_load_preserves_path_time_and_payload_rejection(tmp_path, client, fault):
+    state, receipt, transcript = _case(tmp_path, client)
+    if fault == "symlink-file":
+        alias = tmp_path / "alias.jsonl"
+        alias.symlink_to(transcript)
+        receipt["transcript_path"] = str(alias)
+    elif fault == "symlink-parent":
+        alias = tmp_path / "alias-directory"
+        alias.symlink_to(transcript.parent, target_is_directory=True)
+        receipt["transcript_path"] = str(alias / transcript.name)
+    elif fault == "stale":
+        receipt["recorded_at"] = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    else:
+        foreign_root = tmp_path / "different-plugin"
+        shutil.copytree(Path(receipt["plugin_root"]), foreign_root)
+        (foreign_root / "hooks" / "hooks.json").write_text(
+            json.dumps({"hooks": {"SessionStart": [{"command": "different"}]}}) + "\n",
+            encoding="utf-8",
+        )
+        receipt["plugin_root"] = str(foreign_root)
+    desired_before = state.desired_path.read_bytes()
+    observation_before = state.observation_path.read_bytes()
+    with pytest.raises(system_contract.ContractError):
+        state.record_live_load(receipt=receipt)
+    assert state.desired_path.read_bytes() == desired_before
+    assert state.observation_path.read_bytes() == observation_before
+
+
+@pytest.mark.parametrize("client", ["codex", "claude"])
+def test_short_structured_transcript_positive_control(tmp_path, client):
+    state, receipt, _ = _case(tmp_path, client)
+    assert state.record_live_load(receipt=receipt)
+    assert state.read_observation()["transactions"][-1]["live-loaded"]["status"] == "verified"
+
+
+@pytest.mark.parametrize("client", ["codex", "claude"])
+def test_transcript_outside_client_root_is_rejected(tmp_path, client):
+    state, receipt, transcript = _case(tmp_path, client)
+    outside = state.home / "unowned-transcript.jsonl"
+    shutil.copyfile(transcript, outside)
+    receipt["transcript_path"] = str(outside)
+    before = state.observation_path.read_bytes()
+    with pytest.raises(system_contract.ContractError, match="transcript"):
+        state.record_live_load(receipt=receipt)
+    assert state.observation_path.read_bytes() == before
+
+
+def test_claude_subagent_transcript_cannot_prove_the_parent_session(tmp_path):
+    state, receipt, transcript = _case(tmp_path, "claude")
+    subagent = transcript.parent / receipt["session_id"] / "subagents" / "agent-fixture.jsonl"
+    subagent.parent.mkdir(parents=True)
+    shutil.copyfile(transcript, subagent)
+    receipt["transcript_path"] = str(subagent)
+    before = state.observation_path.read_bytes()
+    with pytest.raises(system_contract.ContractError, match="transcript"):
+        state.record_live_load(receipt=receipt)
+    assert state.observation_path.read_bytes() == before
+
+
+def _different_plugin(tmp_path: Path, receipt: dict) -> str:
+    root = tmp_path / "different-plugin"
+    shutil.copytree(Path(receipt["plugin_root"]), root)
+    (root / "hooks" / "hooks.json").write_text(
+        json.dumps({"hooks": {"SessionStart": [{"command": "different"}]}}) + "\n",
+        encoding="utf-8",
+    )
+    return str(root)
+
+
+def _healthy_engine(_args):
+    """Only external client execution is substituted; CLI and validation run."""
+    return {"engine": "fixture", "counts": {"ok": 1}, "steps": [], "exit": 0}
+
+
+@pytest.mark.parametrize("client", ["codex", "claude"])
+@pytest.mark.parametrize("command", ["doctor", "status"])
+@pytest.mark.parametrize("as_json", [True, False], ids=["json", "human"])
+@pytest.mark.parametrize("fault,reason", [("identity", "transcript"), ("payload", "digest")])
+def test_rejected_candidate_surfaces_reason_without_restart_loop(
+    tmp_path, capsys, client, command, as_json, fault, reason,
+):
+    state, receipt, transcript = _case(tmp_path, client)
+    if fault == "identity":
+        transcript.write_text(json.dumps(_binding(client, str(uuid.uuid4()))) + "\n", encoding="utf-8")
+    else:
+        receipt["plugin_root"] = _different_plugin(tmp_path, receipt)
+    _, event = _registry_event(tmp_path, receipt, registry=state.live_receipt_registry_root())
+    event_before = event.read_bytes()
+    desired_before = state.desired_path.read_bytes()
+    observation_before = state.observation_path.read_bytes()
+
+    result = synthesis_cli.main(
+        [command] + (["--json"] if as_json else []), state=state, engine_runner=_healthy_engine,
+    )
+    assert result == (1 if command == "doctor" else 0)
+    output = capsys.readouterr().out
+    payload = json.loads(output) if as_json else None
+    note = payload.get("promotion_note", "") if payload else output
+    assert reason in note.lower(), "the actual receipt rejection must reach the user"
+    assert client in note.lower()
+    if command == "doctor":
+        action = payload["next_action"] if payload else output
+        assert "restart " not in action.lower(), "validation failure is not missing SessionStart evidence"
+    assert event.read_bytes() == event_before
+    assert state.desired_path.read_bytes() == desired_before
+    assert state.observation_path.read_bytes() == observation_before
+
+
+@pytest.mark.parametrize("client", ["codex", "claude"])
+@pytest.mark.parametrize("command", ["doctor", "status"])
+def test_accepted_candidate_suppresses_another_candidate_rejection(tmp_path, capsys, client, command):
+    state, receipt, _ = _case(tmp_path, client)
+    registry = state.live_receipt_registry_root()
+    _registry_event(tmp_path, receipt, registry=registry)
+    rejected = dict(
+        receipt, plugin_root=_different_plugin(tmp_path, receipt),
+        receipt_event_id=str(uuid.uuid4()), recorded_at=datetime.now(timezone.utc).isoformat(),
+    )
+    _registry_event(tmp_path, rejected, registry=registry)
+
+    assert synthesis_cli.main(
+        [command, "--json"], state=state, engine_runner=_healthy_engine,
+    ) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert not payload.get("promotion_note")
+    assert payload["promoted"] == [{"client": client, "session_id": receipt["session_id"]}]
+    live = state.read_observation()["transactions"][-1]["live-loaded"]
+    assert live["status"] == "verified"
+    assert live["receipts"][client]["receipt_event_id"] == receipt["receipt_event_id"]

--- a/skills/synthesis-onboarding/scripts/test_reload_guidance.py
+++ b/skills/synthesis-onboarding/scripts/test_reload_guidance.py
@@ -36,6 +36,7 @@ from test_independent_review import (  # noqa: E402
 from test_synthesis_cli import verified_uninstall_engine  # noqa: E402
 from test_system_contract import (  # noqa: E402
     live_receipt as receipt_fixture,
+    native_transcript,
     release_record,
     release_repo,
 )
@@ -46,6 +47,8 @@ def isolated_environment(monkeypatch, tmp_path):
     """Neither an installed launcher nor the real receipt registry is an input."""
     monkeypatch.delenv("SYNTHESIS_ACTIVE_DESCRIPTOR", raising=False)
     monkeypatch.delenv("SYNTHESIS_RESOLVED_BOOTSTRAP", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
 
 
@@ -69,7 +72,7 @@ def _recovery_contract(text: str, clients: tuple[str, ...]) -> None:
 
 def _state(tmp_path: Path, clients: tuple[str, ...]):
     state = system_contract.SystemState(home=tmp_path / "home")
-    receipt = receipt_fixture(tmp_path, clients[0])
+    receipt = receipt_fixture(tmp_path, clients[0], home=state.home)
     root = Path(receipt["plugin_root"])
     desired = system_contract.default_desired_state("skills-only", list(clients), "stable")
     planes = synthesis_cli._planes(desired, "setup")
@@ -90,13 +93,7 @@ def _fresh_event(state, receipt, *, client=None, session_id=None):
         "recorded_at": datetime.now(timezone.utc).isoformat(),
     })
     event["provenance_env"] = event["client"] + "-transcript"
-    transcript = state.home / "transcripts" / (event["session_id"] + ".jsonl")
-    transcript.parent.mkdir(parents=True, exist_ok=True)
-    binding = (
-        {"type": "session_meta", "payload": {"id": event["session_id"]}}
-        if event["client"] == "codex" else {"sessionId": event["session_id"]}
-    )
-    transcript.write_text(json.dumps(binding) + "\n", encoding="utf-8")
+    transcript = native_transcript(state.home, event["client"], event["session_id"])
     event["transcript_path"] = str(transcript)
     return event
 
@@ -296,7 +293,11 @@ def _recorded_event_with_newer_candidate(tmp_path):
     newer = _fresh_event(state, receipt, session_id=str(uuid.uuid4()))
     assert newer["recorded_at"] > first["recorded_at"]
     for target in (state, positive_control):
-        _registry_event(target.live_receipt_registry_root(), newer, bound_at_record=True)
+        target_event = dict(newer)
+        target_event["transcript_path"] = str(native_transcript(
+            target.home, newer["client"], newer["session_id"],
+        ))
+        _registry_event(target.live_receipt_registry_root(), target_event, bound_at_record=True)
     promoted = positive_control.promote_live_receipts(binder=live_receipt.transcript_binds_session)
     assert [item["session_id"] for item in promoted] == [newer["session_id"]]
     control = positive_control.read_observation()["transactions"][-1]["live-loaded"]
@@ -363,7 +364,7 @@ def test_receipt_rejection_positive_control_remains_fail_closed(tmp_path, defect
     state, receipt = _state(tmp_path, ("codex",))
     event = _fresh_event(state, receipt)
     if defect == "wrong-version":
-        event = receipt_fixture(tmp_path, "codex", "9.8.6")
+        event = receipt_fixture(tmp_path, "codex", "9.8.6", home=state.home)
         assert state.record_live_load(receipt=event) is False
     else:
         match = {

--- a/skills/synthesis-onboarding/scripts/test_system_contract.py
+++ b/skills/synthesis-onboarding/scripts/test_system_contract.py
@@ -24,6 +24,12 @@ sys.path.insert(0, str(SCRIPTS))
 import system_contract  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def isolated_native_roots(monkeypatch):
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+
 def git(path: Path, *args: str) -> str:
     env = dict(os.environ)
     env.update(
@@ -76,7 +82,27 @@ def release_repo(tmp_path: Path, version: str = "9.8.7") -> Path:
     return root
 
 
-def live_receipt(tmp_path: Path, client: str, version: str = "9.8.7") -> dict:
+def native_transcript(home: Path, client: str, session_id: str) -> Path:
+    """Create client-owned structured evidence outside the immutable plugin."""
+    if client == "codex":
+        transcript = (
+            home / ".codex" / "sessions" / "2030" / "01" / "02"
+            / ("rollout-" + session_id + ".jsonl")
+        )
+        binding = {"type": "session_meta", "payload": {"id": session_id}}
+    else:
+        transcript = (
+            home / ".claude" / "projects" / "-workspace-example" / (session_id + ".jsonl")
+        )
+        binding = {"sessionId": session_id}
+    transcript.parent.mkdir(parents=True, exist_ok=True)
+    transcript.write_text(json.dumps(binding) + "\n", encoding="utf-8")
+    return transcript
+
+
+def live_receipt(
+    tmp_path: Path, client: str, version: str = "9.8.7", *, home: Path | None = None,
+) -> dict:
     root = tmp_path / ("%s-%s-plugin" % (client, version))
     (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
     (root / ".codex-plugin").mkdir(exist_ok=True)
@@ -89,8 +115,7 @@ def live_receipt(tmp_path: Path, client: str, version: str = "9.8.7") -> dict:
         encoding="utf-8",
     )
     session_id = str(uuid.uuid4())
-    transcript = root / (client + ".jsonl")
-    transcript.write_text(json.dumps({"session_id": session_id}) + "\n", encoding="utf-8")
+    transcript = native_transcript(home if home is not None else tmp_path, client, session_id)
     return {
         "receipt_schema": 2,
         "receipt_event_id": str(uuid.uuid4()),
@@ -391,8 +416,7 @@ def test_sessionstart_receipts_complete_live_loaded_plane(tmp_path: Path) -> Non
     claude["provenance_env"] = "claude-transcript"
     claude["receipt_event_id"] = str(uuid.uuid4())
     claude["session_id"] = str(uuid.uuid4())
-    claude_transcript = tmp_path / "claude.jsonl"
-    claude_transcript.write_text(claude["session_id"] + "\n", encoding="utf-8")
+    claude_transcript = native_transcript(state.home, "claude", claude["session_id"])
     claude["transcript_path"] = str(claude_transcript)
     assert state.record_live_load(receipt=claude)
     current = state.read_observation()["transactions"][-1]


### PR DESCRIPTION
## Summary

- Share bounded-memory structured JSONL identity validation between native lifecycle evidence and generation attachment, including large individual messages.
- Stream the complete transcript digest, enforce canonical client-root paths, and retain release-content and freshness checks.
- Surface eligible receipt-validation failures in doctor and status without rewriting immutable events or hash-bound observations.

## Verification

- Red regression commits precede the implementation.
- 562 onboarding tests and 202 conformance tests pass, including large-history, malformed identity, path, digest, and diagnostic controls.
- Independent parser and integration review completed; its acceptance-manifest finding was corrected.
- Transaction-bound release checks and CI must pass before merge. Publication and dual-client installation use the gated release manager.

## Verification boundary

The identity scan covers the first 1,000 JSONL lines; the full file is hashed separately. Tests do not establish an actual client restart or the loaded metadata of a running conversation. This change does not deploy a website or reinitialize personal installation choices.