### PR TITLE
Allow clean project inspections to finish with explicit checkpoint scope

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.96.0",
+  "version": "4.96.1",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.96.0",
+  "version": "4.96.1",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.96.1] - 2026-09-06
+
+Unclaimed sessions can finish inspection of a clean project without claiming
+write ownership or issuing a checkpoint receipt. Native identity, exact-session
+pending attribution and Git subtree checks keep unresolved work explicit.
+Claimed sessions still require their normal checkpoint evidence.
+
+Checkpoint failures now explain the unresolved requirement on stderr. A repeated
+Claude Stop failure terminates the continuation with a visible failure reason
+instead of spending additional model turns on an unresolvable checkpoint.
+
 ## [4.96.0] - 2026-09-06
 
 Checkpoint refresh-and-report mode uses a deterministic local inspector and

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Project inspections finish without a write claim (September 2026).**
+Release **4.96.1** checks native identity, pending attribution and a clean project subtree
+before marking an unclaimed inspection's checkpoint not applicable. It grants no
+write authority or continuity receipt. Real checkpoint failures remain explicit;
+repeated Claude Stop failures end with a visible reason instead of a retry loop.
+
 **Refresh existing sessions with one skill (September 2026).** Release **4.96.0**
 adds refresh-and-report mode to synthesis-checkpoint, with local deterministic
 inspection, configurable campaigns and transactionally deduplicated feedback.

--- a/skills/synthesis-checkpoint/references/refresh-and-report.md
+++ b/skills/synthesis-checkpoint/references/refresh-and-report.md
@@ -63,6 +63,25 @@ does not prove a current native startup failed. If native evidence requires a
 real restart/resume, preserve the reason and stop dependent work; never fabricate
 an event or relabel an installed tree as a live reload.
 
+## Finishing inspection
+
+For a structured project discovered from the working directory, the Stop gate
+can return `NOT_APPLICABLE` for an unclaimed session only after validating its
+native identity, checking exact-session pending edit
+attribution and verifying a clean project Git subtree. It issues no checkpoint
+receipt and does not establish successful recovery, past read-only behavior or
+permission to execute project work. A clean project whose semantic state is
+stale can still be reported as stale. Pending edits or unverifiable evidence
+remain `UNKNOWN` or `FAIL`; a claimed record owner still follows normal closure.
+
+Checkpoint failures explain the unmet requirement on stderr. If verified Claude calls
+Stop again with `stop_hook_active=true` and the requirement is still unresolved,
+the hook terminates continued processing with a visible failure reason. This
+client-specific termination carries the failure verdict and grants no accepted
+checkpoint; it never converts failure into acceptance. Missing identity evidence
+remains blocking. Codex retains its own
+failure transport. Do not claim lifecycle success from a CLI exit code alone.
+
 ## Optional reusable campaign
 
 Default local configuration is `~/.synthesis/checkpoint/active-campaign.json`.

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,404 +1,194 @@
-# Release-specific acceptance. Exact Git change base: 2175b605e6f16c1da912a87bc0e1bbf575d90273.
-# The unchanged runner verifies closed membership against committed Git truth.
+# Release-specific acceptance. Exact change base: f1fcabac50cf70ee254d97128a4e74118dad879e.
 schema: 2
-suite: "single-mac-session-refresh-and-coordination-2026-09-06"
-membership: "closed"
-production_entry_point: "synthesis-checkpoint refresh.py inspect and explicit feedback; coordination.py lease_refresh used by status, resolve, inbox and native lifecycle consumers; release.py required-check dispatch"
-enforcing_boundary: "release.py derives exact Git base-to-head membership and consumes transaction-bound acceptance before publication and dual-client installation"
-receipt_consumer: "synthesis-skills-manager.release.consume-acceptance.v1"
-change_base_policy: "boundary-supplied-git-diff"
-expected_status: "pass"
-metadata_class: "acceptance-test"
+suite: native-observer-stop-completion-2026-09-06
+membership: closed
+production_entry_point: project_state.py hook through registered native Stop hooks
+enforcing_boundary: release.py derives exact Git base-to-head membership and consumes transaction-bound acceptance
+  before publication and dual-client installation
+receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
+change_base_policy: boundary-supplied-git-diff
+expected_status: pass
+metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: "Refresh fixtures use isolated homes and real local Git repositories, including an alternate selected worktree. Native receipt and transcript fixtures establish parsing and binding behavior; they do not prove genuine post-release execution in either installed client, enabled live registry state, full installed-tree parity, or that an agent read the indicated prose. Coordination race fixtures use real temporary local Git lease remotes and deterministic interleavings with a pre-fix positive control; they establish cooperating same-Mac serialization, not multi-computer readiness or safety against every uncoordinated writer. Explicit feedback may perform normal lease CAS writes even when duplicate content is not appended. Inspect does not repair projects or release claims; these fixtures do not make arbitrary project writes claim-gated or authenticate a principal authorization beyond the existing caller/reason rules. Release, installation, historical-cache preservation, current-global and exact-session dual-client acceptance require separate evidence. This manifest grants no publication, deployment, disclosure, policy, automation or administrative-release authority."
+unverified_remainder: Fixtures use isolated native-shaped transcripts, temporary homes and real local Git/lease
+  repositories. They verify native identity parsing, exact pending attribution, clean-project applicability, owned
+  checkpoint controls and actual CLI failure transport. They do not establish genuine installed native execution,
+  full skill/tier reading, multi-computer safety, or arbitrary write admission. NOT_APPLICABLE issues no checkpoint
+  receipt and is not recovery PASS or historical proof of read-only behavior. Generic events without a structured-project
+  context or known own pending evidence retain their existing non-project applicability. Claude terminal failure
+  control requires verified native Claude identity; Codex retains failure transport. Source publication, both-client
+  installation, retained-cache integrity, actual new native Stop behavior and exact/current-global startup evidence
+  require separate verification. This manifest grants no publication, deployment, policy, automation or administrative-release
+  authority.
 changed_surfaces:
-  - path: ".claude-plugin/plugin.json"
-    cases:
-      - "release-contract"
-  - path: ".codex-plugin/plugin.json"
-    cases:
-      - "release-contract"
-  - path: ".github/workflows/validate.yml"
-    cases:
-      - "release-ci-instruction-parity"
-      - "release-ci-required-groups"
-  - path: "AGENTS.md"
-    cases:
-      - "release-ci-instruction-parity"
-      - "release-ci-required-groups"
-  - path: "CHANGELOG.md"
-    cases:
-      - "release-contract"
-  - path: "README.md"
-    cases:
-      - "release-contract"
-  - path: "skills/synthesis-checkpoint/SKILL.md"
-    cases:
-      - "refresh-inspection-is-local-and-reports-exact-scope"
-      - "refresh-conflict-reads-no-project-prose"
-      - "refresh-optional-and-required-inputs-stay-separate"
-      - "refresh-archived-project-remains-blocked"
-      - "refresh-unverified-identity-cannot-send"
-      - "refresh-current-installed-and-stale-native-are-distinct"
-      - "refresh-campaign-is-declarative-and-strict"
-      - "refresh-concurrent-feedback-deduplicates-and-allocates-revision"
-      - "refresh-malformed-matching-report-prevents-append"
-      - "refresh-arbitrary-payload-is-omitted"
-      - "refresh-untracked-registry-is-refused"
-      - "refresh-malformed-state-reports-failure-without-repair"
-      - "refresh-feedback-refuses-receipt-changed-after-inspection"
-      - "refresh-recovery-only-campaign-still-checks-native-identity"
-      - "refresh-duplicate-json-keys-are-not-accepted"
-      - "refresh-failed-feedback-retains-complete-local-inspection"
-      - "refresh-no-campaign-does-not-send"
-      - "refresh-cli-no-campaign-ignores-invalid-optional-descriptor"
-      - "refresh-campaign-descriptor-change-delivers-next-revision"
-      - "refresh-unrelated-malformed-reports-are-counted-without-copying"
-      - "refresh-identifiable-malformed-matching-json-still-blocks"
-      - "refresh-claude-delivery-aliases-share-one-logical-report"
-      - "refresh-selected-descendant-archive-outweighs-canonical-active-registry"
-      - "refresh-selected-structured-archive-cannot-be-reported-active"
-      - "refresh-historical-archive-prose-does-not-override-active-current-status"
-  - path: "skills/synthesis-checkpoint/references/refresh-and-report.md"
-    cases:
-      - "refresh-inspection-is-local-and-reports-exact-scope"
-      - "refresh-conflict-reads-no-project-prose"
-      - "refresh-optional-and-required-inputs-stay-separate"
-      - "refresh-archived-project-remains-blocked"
-      - "refresh-unverified-identity-cannot-send"
-      - "refresh-current-installed-and-stale-native-are-distinct"
-      - "refresh-campaign-is-declarative-and-strict"
-      - "refresh-concurrent-feedback-deduplicates-and-allocates-revision"
-      - "refresh-malformed-matching-report-prevents-append"
-      - "refresh-arbitrary-payload-is-omitted"
-      - "refresh-untracked-registry-is-refused"
-      - "refresh-malformed-state-reports-failure-without-repair"
-      - "refresh-feedback-refuses-receipt-changed-after-inspection"
-      - "refresh-recovery-only-campaign-still-checks-native-identity"
-      - "refresh-duplicate-json-keys-are-not-accepted"
-      - "refresh-failed-feedback-retains-complete-local-inspection"
-      - "refresh-no-campaign-does-not-send"
-      - "refresh-cli-no-campaign-ignores-invalid-optional-descriptor"
-      - "refresh-campaign-descriptor-change-delivers-next-revision"
-      - "refresh-unrelated-malformed-reports-are-counted-without-copying"
-      - "refresh-identifiable-malformed-matching-json-still-blocks"
-      - "refresh-claude-delivery-aliases-share-one-logical-report"
-      - "refresh-selected-descendant-archive-outweighs-canonical-active-registry"
-      - "refresh-selected-structured-archive-cannot-be-reported-active"
-      - "refresh-historical-archive-prose-does-not-override-active-current-status"
-  - path: "skills/synthesis-checkpoint/scripts/refresh.py"
-    cases:
-      - "refresh-inspection-is-local-and-reports-exact-scope"
-      - "refresh-conflict-reads-no-project-prose"
-      - "refresh-optional-and-required-inputs-stay-separate"
-      - "refresh-archived-project-remains-blocked"
-      - "refresh-unverified-identity-cannot-send"
-      - "refresh-current-installed-and-stale-native-are-distinct"
-      - "refresh-campaign-is-declarative-and-strict"
-      - "refresh-concurrent-feedback-deduplicates-and-allocates-revision"
-      - "refresh-malformed-matching-report-prevents-append"
-      - "refresh-arbitrary-payload-is-omitted"
-      - "refresh-untracked-registry-is-refused"
-      - "refresh-malformed-state-reports-failure-without-repair"
-      - "refresh-feedback-refuses-receipt-changed-after-inspection"
-      - "refresh-recovery-only-campaign-still-checks-native-identity"
-      - "refresh-duplicate-json-keys-are-not-accepted"
-      - "refresh-failed-feedback-retains-complete-local-inspection"
-      - "refresh-no-campaign-does-not-send"
-      - "refresh-cli-no-campaign-ignores-invalid-optional-descriptor"
-      - "refresh-campaign-descriptor-change-delivers-next-revision"
-      - "refresh-unrelated-malformed-reports-are-counted-without-copying"
-      - "refresh-identifiable-malformed-matching-json-still-blocks"
-      - "refresh-claude-delivery-aliases-share-one-logical-report"
-      - "refresh-selected-descendant-archive-outweighs-canonical-active-registry"
-      - "refresh-selected-structured-archive-cannot-be-reported-active"
-      - "refresh-historical-archive-prose-does-not-override-active-current-status"
-  - path: "skills/synthesis-checkpoint/scripts/test_refresh.py"
-    cases:
-      - "refresh-inspection-is-local-and-reports-exact-scope"
-      - "refresh-conflict-reads-no-project-prose"
-      - "refresh-optional-and-required-inputs-stay-separate"
-      - "refresh-archived-project-remains-blocked"
-      - "refresh-unverified-identity-cannot-send"
-      - "refresh-current-installed-and-stale-native-are-distinct"
-      - "refresh-campaign-is-declarative-and-strict"
-      - "refresh-concurrent-feedback-deduplicates-and-allocates-revision"
-      - "refresh-malformed-matching-report-prevents-append"
-      - "refresh-arbitrary-payload-is-omitted"
-      - "refresh-untracked-registry-is-refused"
-      - "refresh-malformed-state-reports-failure-without-repair"
-      - "refresh-feedback-refuses-receipt-changed-after-inspection"
-      - "refresh-recovery-only-campaign-still-checks-native-identity"
-      - "refresh-duplicate-json-keys-are-not-accepted"
-      - "refresh-failed-feedback-retains-complete-local-inspection"
-      - "refresh-no-campaign-does-not-send"
-      - "refresh-cli-no-campaign-ignores-invalid-optional-descriptor"
-      - "refresh-campaign-descriptor-change-delivers-next-revision"
-      - "refresh-unrelated-malformed-reports-are-counted-without-copying"
-      - "refresh-identifiable-malformed-matching-json-still-blocks"
-      - "refresh-claude-delivery-aliases-share-one-logical-report"
-      - "refresh-selected-descendant-archive-outweighs-canonical-active-registry"
-      - "refresh-selected-structured-archive-cannot-be-reported-active"
-      - "refresh-historical-archive-prose-does-not-override-active-current-status"
-  - path: "skills/synthesis-context-lifecycle/SKILL.md"
-    cases:
-      - "refresh-conflict-reads-no-project-prose"
-      - "refresh-selected-descendant-archive-outweighs-canonical-active-registry"
-      - "refresh-inspection-is-local-and-reports-exact-scope"
-      - "coord-release-is-bound-to-the-claiming-harness-session"
-  - path: "skills/synthesis-implementation-integrity/acceptance-suite.yaml"
-    cases:
-      - "acceptance-self"
-      - "acceptance-omitted-path-refused"
-      - "acceptance-git-transaction-binding"
-  - path: "skills/synthesis-project-management/SKILL.md"
-    cases:
-      - "refresh-conflict-reads-no-project-prose"
-      - "refresh-selected-descendant-archive-outweighs-canonical-active-registry"
-      - "refresh-inspection-is-local-and-reports-exact-scope"
-      - "coord-release-is-bound-to-the-claiming-harness-session"
-  - path: "skills/synthesis-project-management/scripts/coordination.py"
-    cases:
-      - "coord-lease-refresh-cannot-restore-claims-after-same-machine-mutation"
-      - "coord-lease-refresh-without-configuration-preserves-local-board"
-      - "coord-lease-refresh-reads-configuration-under-mutation-lock"
-      - "coord-lease-refresh-reports-failure-preserves-board-and-releases-lock"
-      - "coord-lease-compare-and-swap-retries-after-concurrent-advance"
-      - "coord-lease-unreachable-remote-fails-closed"
-      - "coord-claim-conflict-message-heartbeat-and-release"
-      - "coord-release-is-bound-to-the-claiming-harness-session"
-      - "coord-cross-session-administrative-release-requires-and-records-a-reason"
-      - "coord-r4-lease-fence-cannot-resurrect-released-session"
-  - path: "skills/synthesis-project-management/scripts/test_coordination.py"
-    cases:
-      - "coord-lease-refresh-cannot-restore-claims-after-same-machine-mutation"
-      - "coord-lease-refresh-without-configuration-preserves-local-board"
-      - "coord-lease-refresh-reads-configuration-under-mutation-lock"
-      - "coord-lease-refresh-reports-failure-preserves-board-and-releases-lock"
-      - "coord-lease-compare-and-swap-retries-after-concurrent-advance"
-      - "coord-lease-unreachable-remote-fails-closed"
-      - "coord-claim-conflict-message-heartbeat-and-release"
-      - "coord-release-is-bound-to-the-claiming-harness-session"
-      - "coord-cross-session-administrative-release-requires-and-records-a-reason"
-      - "coord-r4-lease-fence-cannot-resurrect-released-session"
-  - path: "skills/synthesis-skills-manager/scripts/release.py"
-    cases:
-      - "release-ci-required-groups"
-      - "release-bound-receipt-consumed"
-      - "release-receipt-binding-mismatch-refused"
+- path: .claude-plugin/plugin.json
+  cases:
+  - release-contract
+- path: .codex-plugin/plugin.json
+  cases:
+  - release-contract
+- path: CHANGELOG.md
+  cases:
+  - release-contract
+- path: README.md
+  cases:
+  - release-contract
+- path: skills/synthesis-checkpoint/references/refresh-and-report.md
+  cases: &id001
+  - clean-native-observer-has-no-checkpoint-authority
+  - observer-dirty-project-remains-blocked
+  - exact-native-pending-attribution-blocks
+  - foreign-pending-and-unrelated-dirty-work-are-preserved
+  - known-native-pending-work-blocks-from-workspace-root
+  - nonproject-session-without-pending-work-retains-applicability
+  - observer-identity-is-native-and-fail-closed
+  - missing-native-validator-fails-closed
+  - foreign-ambient-identity-cannot-grant-checkpoint-authority
+  - empty-board-identity-does-not-bind-foreign-seat
+  - matching-native-reference-and-empty-optional-reference-are-safe
+  - owner-checkpoint-authority-is-preserved
+  - clean-stale-semantics-are-not-reported-as-recovery-pass
+  - clean-causal-conflict-can-finish-reporting-without-checkpoint
+  - unverifiable-project-git-state-cannot-exonerate-observer
+  - claude-reentrant-stop-terminates-with-blocked-verdict
+  - codex-never-consumes-claude-terminal-control
+  - real-hook-cli-uses-local-lease-and-actionable-failure
+- path: skills/synthesis-project-management/SKILL.md
+  cases: *id001
+- path: skills/synthesis-project-management/scripts/project_state.py
+  cases: *id001
+- path: skills/synthesis-project-management/scripts/test_checkpoint_observer.py
+  cases: *id001
+- path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
+  cases:
+  - release-contract
+  - release-bound-receipt-consumed
+  - release-receipt-binding-mismatch-refused
+  - acceptance-self
+  - acceptance-omitted-path-refused
+  - acceptance-git-transaction-binding
 cases:
-  - id: "refresh-inspection-is-local-and-reports-exact-scope"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_inspection_is_local_and_reports_exact_scope"
-    motivating_defect: "A diagnostic refresh could fetch, change refs or publish lifecycle state while claiming no mutation; file inspection could be overstated as agent reading or runtime acceptance."
-  - id: "refresh-conflict-reads-no-project-prose"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_conflict_reads_no_project_prose"
-    motivating_defect: "Agents read or changed project prose after causal recovery returned conflict, failure or unknown."
-  - id: "refresh-optional-and-required-inputs-stay-separate"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_optional_and_required_inputs_stay_separate"
-    motivating_defect: "A missing declared plan could be hidden among optional inputs or promoted to a blanket successful refresh."
-  - id: "refresh-archived-project-remains-blocked"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_archived_project_remains_blocked"
-    motivating_defect: "A refresh could reactivate an archived predecessor instead of reporting its successor."
-  - id: "refresh-unverified-identity-cannot-send"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_unverified_identity_cannot_send"
-    motivating_defect: "Legacy seats, unknown identities or an unjoined desktop handle could be accepted as native feedback senders."
-  - id: "refresh-current-installed-and-stale-native-are-distinct"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_current_installed_and_stale_native_are_distinct"
-    motivating_defect: "Current installed files could conceal stale native startup, or stale currency could prevent an attributable blocked report."
-  - id: "refresh-campaign-is-declarative-and-strict"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_campaign_is_declarative_and_strict"
-    motivating_defect: "Campaign configuration could contain executable commands, duplicate checks, malformed versions or unsafe recipients."
-  - id: "refresh-concurrent-feedback-deduplicates-and-allocates-revision"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_concurrent_feedback_deduplicates_and_allocates_revision"
-    motivating_defect: "Parallel feedback could duplicate reports or allocate the same revision outside the board lock."
-  - id: "refresh-malformed-matching-report-prevents-append"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_malformed_matching_report_prevents_append"
-    motivating_defect: "Corrupt matching report metadata could permit duplicate revision allocation or silent history replacement."
-  - id: "refresh-arbitrary-payload-is-omitted"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_arbitrary_payload_is_omitted"
-    motivating_defect: "Private project prose, previous replies or arbitrary fields could be copied into the shared bus."
-  - id: "refresh-untracked-registry-is-refused"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_untracked_registry_is_refused"
-    motivating_defect: "An untracked registry could select project state without version-controlled discovery authority."
-  - id: "refresh-malformed-state-reports-failure-without-repair"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_malformed_state_reports_failure_without_repair"
-    motivating_defect: "Malformed state could be silently repaired by diagnostics or reported as recovered."
-  - id: "refresh-feedback-refuses-receipt-changed-after-inspection"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_feedback_refuses_receipt_changed_after_inspection"
-    motivating_defect: "A changed or foreign native receipt could replace sender evidence between inspection and reporting."
-  - id: "refresh-recovery-only-campaign-still-checks-native-identity"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_recovery_only_campaign_still_checks_native_identity"
-    motivating_defect: "Omitting native runtime from campaign checks could prevent feedback or permit an unverified sender."
-  - id: "refresh-duplicate-json-keys-are-not-accepted"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_duplicate_json_keys_are_not_accepted"
-    motivating_defect: "Duplicate JSON keys could overwrite contradictory campaign, state or native evidence."
-  - id: "refresh-failed-feedback-retains-complete-local-inspection"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_failed_feedback_retains_complete_local_inspection"
-    motivating_defect: "Transport refusal could erase completed inspection and lose the transcript fallback."
-  - id: "refresh-no-campaign-does-not-send"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_no_campaign_does_not_send"
-    motivating_defect: "An ordinary checkpoint without an opted-in campaign could send unsolicited feedback."
-  - id: "refresh-cli-no-campaign-ignores-invalid-optional-descriptor"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_cli_no_campaign_ignores_invalid_optional_descriptor"
-    motivating_defect: "Explicit no-campaign inspection could still load an unwanted malformed descriptor."
-  - id: "refresh-campaign-descriptor-change-delivers-next-revision"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_campaign_descriptor_change_delivers_next_revision"
-    motivating_defect: "Recipient, check selection or minimum-version changes under one campaign ID could be suppressed as already recorded."
-  - id: "refresh-unrelated-malformed-reports-are-counted-without-copying"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_unrelated_malformed_reports_are_counted_without_copying"
-    motivating_defect: "Unrelated malformed records could block every campaign or leak malformed private prose into reports."
-  - id: "refresh-identifiable-malformed-matching-json-still-blocks"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_identifiable_malformed_matching_json_still_blocks"
-    motivating_defect: "Quarantining unrelated malformed records could permit append through matching-key corruption."
-  - id: "refresh-claude-delivery-aliases-share-one-logical-report"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_claude_delivery_aliases_share_one_logical_report"
-    motivating_defect: "One native Claude session could produce duplicate logical reports through harness and desktop aliases."
-  - id: "refresh-selected-descendant-archive-outweighs-canonical-active-registry"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_selected_descendant_archive_outweighs_canonical_active_registry"
-    motivating_defect: "Selected descendant archive state could be ignored in favor of the stale input checkout registry."
-  - id: "refresh-selected-structured-archive-cannot-be-reported-active"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_selected_structured_archive_cannot_be_reported_active"
-    motivating_defect: "Archived selected structured state could be ignored while its registry still says active."
-  - id: "refresh-historical-archive-prose-does-not-override-active-current-status"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-checkpoint/scripts/test_refresh.py::test_historical_archive_prose_does_not_override_active_current_status"
-    motivating_defect: "Historical archive prose or status fields could override explicitly active current lifecycle."
-  - id: "coord-lease-refresh-cannot-restore-claims-after-same-machine-mutation"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_coordination.py::test_lease_refresh_cannot_restore_claims_after_same_machine_mutation"
-    motivating_defect: "An unlocked stale reader restored an old local claim after release and a new claim; the old-algorithm positive control must reproduce this race while serialized refresh preserves remote authority."
-  - id: "coord-lease-refresh-without-configuration-preserves-local-board"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_coordination.py::test_lease_refresh_without_configuration_preserves_local_board"
-    motivating_defect: "A board without lease configuration could fetch or change its contents."
-  - id: "coord-lease-refresh-reads-configuration-under-mutation-lock"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_coordination.py::test_lease_refresh_reads_configuration_under_mutation_lock"
-    motivating_defect: "Reading configuration outside the mutation lock could race reconfiguration before mirror publication."
-  - id: "coord-lease-refresh-reports-failure-preserves-board-and-releases-lock"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_coordination.py::test_lease_refresh_reports_failure_preserves_board_and_releases_lock"
-    motivating_defect: "Configuration, fetch or mirror failure could corrupt the board or leave its shared lock held."
-  - id: "coord-lease-compare-and-swap-retries-after-concurrent-advance"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_coordination.py::test_lease_compare_and_swap_retries_after_concurrent_advance"
-    motivating_defect: "Local serialization could weaken remote compare-and-swap authority protection."
-  - id: "coord-lease-unreachable-remote-fails-closed"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_coordination.py::test_lease_unreachable_remote_fails_closed"
-    motivating_defect: "An unreachable lease remote could permit local-only changes that later refresh discards."
-  - id: "coord-claim-conflict-message-heartbeat-and-release"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_coordination.py::test_claim_conflict_message_heartbeat_and_release"
-    motivating_defect: "Serialization changes could regress overlap refusal or the normal message, heartbeat and owner-release lifecycle."
-  - id: "coord-release-is-bound-to-the-claiming-harness-session"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_coordination.py::test_release_is_bound_to_the_claiming_harness_session"
-    motivating_defect: "A foreign harness could release a seat without owning it."
-  - id: "coord-cross-session-administrative-release-requires-and-records-a-reason"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_coordination.py::test_cross_session_administrative_release_requires_and_records_a_reason"
-    motivating_defect: "Administrative release could lose attributable caller and recorded reason boundaries."
-  - id: "coord-r4-lease-fence-cannot-resurrect-released-session"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_coordination.py::test_r4_lease_fence_cannot_resurrect_released_session"
-    motivating_defect: "The staged-write authority fence could regress while diagnostic mirror serialization is repaired."
-  - id: "release-contract"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent"
-    motivating_defect: "Plugin manifests, newest changelog, README and skill version floors could disagree."
-  - id: "release-ci-instruction-parity"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-skills-manager/scripts/test_release.py::test_agents_verification_list_matches_ci_workflow"
-    motivating_defect: "The documented verification sequence could diverge from required CI checks."
-  - id: "release-ci-required-groups"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-skills-manager/scripts/test_release.py::test_required_checks_cover_ci_pytest_groups"
-    motivating_defect: "CI could run checkpoint tests while the local publication gate omits them."
-  - id: "release-bound-receipt-consumed"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-skills-manager/scripts/test_release.py::test_release_boundary_consumes_fresh_bound_acceptance_receipt"
-    motivating_defect: "Required checks could finish without consuming fresh transaction-bound acceptance."
-  - id: "release-receipt-binding-mismatch-refused"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "../synthesis-skills-manager/scripts/test_release.py::test_release_receipt_validator_rejects_every_binding_mismatch"
-    motivating_defect: "A receipt from another transaction, commit, tree, manifest or change universe could authorize publication."
-  - id: "acceptance-self"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "scripts/test_acceptance_suite.py::test_shipped_manifest_validates"
-    motivating_defect: "The release manifest could contain invalid fields, unresolved fixtures or unmapped cases."
-  - id: "acceptance-omitted-path-refused"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "scripts/test_acceptance_suite.py::test_schema2_rejects_undeclared_git_changed_surface"
-    motivating_defect: "Schema validation could pass while actual Git changes include undeclared paths."
-  - id: "acceptance-git-transaction-binding"
-    control_class: "acceptance-test"
-    expected_status: "pass"
-    fixture: "scripts/test_acceptance_suite.py::test_schema2_receipt_binds_transaction_and_git_state"
-    motivating_defect: "Executed evidence could lack the boundary-selected Git and transaction binding."
+- id: clean-native-observer-has-no-checkpoint-authority
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_clean_native_observer_has_no_checkpoint_authority
+  motivating_defect: A clean native observer was forced to acquire write authority or repeatedly fail Stop.
+- id: observer-dirty-project-remains-blocked
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_observer_dirty_project_remains_blocked
+  motivating_defect: Absence of a claim or attribution could exonerate staged, unstaged, untracked or deleted project
+    work.
+- id: exact-native-pending-attribution-blocks
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_exact_native_pending_attribution_blocks
+  motivating_defect: Exact native pending work, including malformed evidence, could be ignored when no seat matches.
+- id: foreign-pending-and-unrelated-dirty-work-are-preserved
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_foreign_pending_and_unrelated_dirty_work_are_preserved
+  motivating_defect: Foreign evidence could be modified or misattributed to a clean observer.
+- id: known-native-pending-work-blocks-from-workspace-root
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_known_native_pending_work_blocks_from_workspace_root
+  motivating_defect: Known exact-session pending evidence could be skipped outside a structured project working
+    directory; ordinary unrelated events must retain their applicability.
+- id: nonproject-session-without-pending-work-retains-applicability
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_nonproject_session_without_pending_work_retains_applicability
+  motivating_defect: Known exact-session pending evidence could be skipped outside a structured project working
+    directory; ordinary unrelated events must retain their applicability.
+- id: observer-identity-is-native-and-fail-closed
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_observer_identity_is_native_and_fail_closed
+  motivating_defect: An invalid, foreign, missing or unsafe transcript could claim native observer status.
+- id: missing-native-validator-fails-closed
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_missing_native_validator_fails_closed
+  motivating_defect: Missing native evidence validation could skip the observer guard or suppress a failure.
+- id: foreign-ambient-identity-cannot-grant-checkpoint-authority
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_foreign_ambient_identity_cannot_grant_checkpoint_authority
+  motivating_defect: An inherited parent reference could select and checkpoint a foreign seat.
+- id: empty-board-identity-does-not-bind-foreign-seat
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_empty_board_identity_does_not_bind_foreign_seat
+  motivating_defect: Empty event fields could match an unbound foreign coordination row.
+- id: matching-native-reference-and-empty-optional-reference-are-safe
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_matching_native_reference_and_empty_optional_reference_are_safe
+  motivating_defect: Optional reference parsing could reject the actual native identity or manufacture another one.
+- id: owner-checkpoint-authority-is-preserved
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_owner_checkpoint_authority_is_preserved
+  motivating_defect: The observer exception could weaken the claimed owner's checkpoint obligations.
+- id: clean-stale-semantics-are-not-reported-as-recovery-pass
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_clean_stale_semantics_are_not_reported_as_recovery_pass
+  motivating_defect: Ending a stale-state report could falsely issue a healthy recovery or continuity receipt.
+- id: clean-causal-conflict-can-finish-reporting-without-checkpoint
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_clean_causal_conflict_can_finish_reporting_without_checkpoint
+  motivating_defect: A clean observer reporting a causal conflict could be forced to repeat without checkpoint authority.
+- id: unverifiable-project-git-state-cannot-exonerate-observer
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_unverifiable_project_git_state_cannot_exonerate_observer
+  motivating_defect: Unreadable Git state could be mistaken for a clean project.
+- id: claude-reentrant-stop-terminates-with-blocked-verdict
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_claude_reentrant_stop_terminates_with_blocked_verdict
+  motivating_defect: A failed Claude Stop with empty feedback caused repeated paid turns without repairing its obligation.
+- id: codex-never-consumes-claude-terminal-control
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_codex_never_consumes_claude_terminal_control
+  motivating_defect: Claude-only terminal JSON could be applied to another client, event, or an unverified invocation.
+- id: real-hook-cli-uses-local-lease-and-actionable-failure
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_real_hook_cli_uses_local_lease_and_actionable_failure
+  motivating_defect: Unit verdicts alone could pass while real CLI lease reads, exit statuses or stderr remain defective.
+- id: release-contract
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent
+  motivating_defect: Plugin manifests, newest changelog, README and skill version floors could disagree.
+- id: release-bound-receipt-consumed
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-skills-manager/scripts/test_release.py::test_release_boundary_consumes_fresh_bound_acceptance_receipt
+  motivating_defect: Required checks could finish without consuming fresh transaction-bound acceptance.
+- id: release-receipt-binding-mismatch-refused
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-skills-manager/scripts/test_release.py::test_release_receipt_validator_rejects_every_binding_mismatch
+  motivating_defect: A receipt from another transaction, commit, tree, manifest or change universe could authorize
+    publication.
+- id: acceptance-self
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: scripts/test_acceptance_suite.py::test_shipped_manifest_validates
+  motivating_defect: The release manifest could contain invalid fields, unresolved fixtures or unmapped cases.
+- id: acceptance-omitted-path-refused
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: scripts/test_acceptance_suite.py::test_schema2_rejects_undeclared_git_changed_surface
+  motivating_defect: Schema validation could pass while actual Git changes include undeclared paths.
+- id: acceptance-git-transaction-binding
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: scripts/test_acceptance_suite.py::test_schema2_receipt_binds_transaction_and_git_state
+  motivating_defect: Executed evidence could lack the boundary-selected Git and transaction binding.

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.13.3"
+  version: "2.13.4"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -227,6 +227,11 @@ For an explicitly requested refresh-and-report pass, use the current installed
 `synthesis-checkpoint` mode. It inspects and reports without project edits,
 state generation, activation or claim acquisition; normal record-owner closure
 above applies only to work actually written under accepted authority.
+An unclaimed session inspecting a discovered structured project, with valid
+native identity, no exact-session pending edits and a clean Git subtree, can finish with `NOT_APPLICABLE`; this
+issues no receipt and proves neither successful recovery nor execution authority.
+Unresolved evidence remains explicit; see the checkpoint refresh reference for
+failure termination and client-specific behavior.
 
 ### Cross-Agent Session Coordination
 

--- a/skills/synthesis-project-management/scripts/project_state.py
+++ b/skills/synthesis-project-management/scripts/project_state.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+import uuid
 from typing import Any, Iterable
 
 from plan_reference import PlanReference, resolve_plan_target
@@ -1136,8 +1137,14 @@ def _row_for_event(rows: list[dict[str, str]], payload: dict[str, Any]) -> dict[
     event_ids = {
         str(payload.get(key) or "").strip()
         for key in ("session_id", "root_task_uuid", "task_id")
-    }
+    } - {""}
     configured = os.environ.get("SYNTHESIS_CLIENT_SESSION_REF", "").strip()
+    native = payload.get("session_id")
+    if (
+        configured.startswith(("cc:", "codex:"))
+        and (not isinstance(native, str) or not native or configured.split(":", 1)[1] != native)
+    ):
+        raise ProjectStateError("native lifecycle identity conflicts with the configured client reference; refusing a foreign checkpoint")
     if configured:
         event_ids.update({configured, configured.rsplit(":", 1)[-1]})
     matches = []
@@ -1146,9 +1153,9 @@ def _row_for_event(rows: list[dict[str, str]], payload: dict[str, Any]) -> dict[
             continue
         client_ref = row.get("client session ref", "")
         if (
-            client_ref in event_ids
-            or client_ref.rsplit(":", 1)[-1] in event_ids
-            or row.get("session uuid", "") in event_ids
+            (client_ref and client_ref in event_ids)
+            or (client_ref and client_ref.rsplit(":", 1)[-1] in event_ids)
+            or (row.get("session uuid") and row["session uuid"] in event_ids)
         ):
             matches.append(row)
     if len(matches) > 1:
@@ -1203,12 +1210,99 @@ def _live_source_heads(state: dict[str, Any]) -> dict[str, str]:
     return live
 
 
+def _observer_native_identity(payload: dict[str, Any]) -> tuple[str, str]:
+    """Verify an observer from native transcript evidence, not a read-only flag."""
+    native = payload.get("session_id")
+    try:
+        uuid.UUID(native)
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise ProjectStateError("observer Stop requires a valid native session UUID") from exc
+    raw = payload.get("transcript_path")
+    if not isinstance(raw, str) or not Path(raw).is_absolute():
+        raise ProjectStateError("observer Stop requires this native session's transcript path")
+    transcript = Path(raw)
+    if transcript.is_symlink() or not transcript.is_file():
+        raise ProjectStateError("observer native transcript is missing or unsafe")
+    scripts = Path(__file__).resolve().parents[2] / "synthesis-agent-conformance" / "scripts"
+    if str(scripts) not in sys.path:
+        sys.path.insert(0, str(scripts))
+    try:
+        from live_receipt import client_root_transcript_path, transcript_binds_session
+    except (ImportError, SyntaxError) as exc:
+        raise ProjectStateError("observer native transcript validator is unavailable") from exc
+    matches = []
+    for client, variable in (("claude", "CLAUDE_CONFIG_DIR"), ("codex", "CODEX_HOME")):
+        raw_home = os.environ.get(variable, str(Path.home() / f".{client}"))
+        if not raw_home.strip() or not Path(raw_home).expanduser().is_absolute():
+            continue
+        home = Path(raw_home).expanduser()
+        if not client_root_transcript_path(transcript, client, native, home):
+            continue
+        if transcript_binds_session(transcript, client, native):
+            matches.append(client)
+    if len(matches) != 1:
+        raise ProjectStateError("observer transcript does not unambiguously bind this native session")
+    return matches[0], native
+
+
+def _observer_git(project: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(project), *arguments], capture_output=True, text=True,
+        env={**os.environ, "GIT_OPTIONAL_LOCKS": "0"}, timeout=15,
+    )
+
+
+def _observer_project(cwd: Path) -> Path | None:
+    for candidate in (cwd, *cwd.parents):
+        if (candidate / STATE_FILE).exists() or (candidate / STATE_FILE).is_symlink():
+            return candidate
+        # A deleted tracked state file must remain an observable obligation.
+        tracked = _observer_git(candidate, "ls-files", "--error-unmatch", "--", f":(literal){STATE_FILE}")
+        if tracked.returncode == 0:
+            return candidate
+    return None
+
+
+def _observer_pending_scope(payload: dict[str, Any], repo_guard_root: Path) -> tuple[str, list[str]] | None:
+    """Known exact-session work remains an obligation regardless of cwd."""
+    native = payload.get("session_id")
+    if not isinstance(native, str) or not native:
+        return None
+    pending = repo_guard_root / "pending"
+    own = pending / (_sha_bytes(native.encode()) + ".json")
+    if repo_guard_root.is_symlink() or pending.is_symlink() or own.is_symlink():
+        raise ProjectStateError("observer attribution evidence crosses an unsafe symlink")
+    if pending.exists() and not pending.is_dir():
+        raise ProjectStateError("observer attribution directory is unreadable")
+    if own.exists():
+        _observer_native_identity(payload)
+        attribution = _load_json(own)
+        if attribution.get("session_id") != native or type(attribution.get("schema_version")) is not int or attribution.get("schema_version") not in {1, 2}:
+            raise ProjectStateError("exact native-session pending attribution is invalid; preserve its evidence")
+        paths = attribution.get("paths")
+        if not isinstance(paths, list) or not paths or any(not isinstance(path, str) or not Path(path).is_absolute() for path in paths):
+            raise ProjectStateError("exact native-session pending attribution has invalid paths")
+        return "UNKNOWN", [f"native session has attributed edits but no matching active claim; preserve {own} and recover its own claim/checkpoint authority"]
+    return None
+
+
+def _observer_checkpoint_scope(payload: dict[str, Any], project: Path) -> tuple[str, list[str]]:
+    _observer_native_identity(payload)
+    dirty = _observer_git(project, "status", "--porcelain=v1", "-z", "--untracked-files=all", "--", ".")
+    if dirty.returncode:
+        raise ProjectStateError("observer project Git state could not be verified")
+    if dirty.stdout:
+        return "UNKNOWN", ["unowned structured project has staged, unstaged or untracked changes; absence of native attribution does not prove read-only work"]
+    return "NOT_APPLICABLE", ["no active checkpoint ownership or native pending attribution; observed Git project subtree is clean; no checkpoint receipt issued and no recovery/state-health PASS implied"]
+
+
 def checkpoint_hook(
     payload: dict[str, Any],
     *,
     coordination_board: Path,
     receipt_root: Path,
     refresh_coordination: bool = True,
+    repo_guard_root: Path | None = None,
 ) -> tuple[str, list[str]]:
     """Bind a lifecycle event to its seat and issue an exact clean receipt."""
     try:
@@ -1218,10 +1312,14 @@ def checkpoint_hook(
                 return "FAIL", [refresh_issue]
         row = _row_for_event(_parse_board_rows(coordination_board.resolve()), payload)
         if row is None:
+            root = repo_guard_root or Path(os.environ.get("SYNTHESIS_HOME", str(Path.home() / ".synthesis"))) / "repo-guard"
+            pending_scope = _observer_pending_scope(payload, root)
+            if pending_scope is not None:
+                return pending_scope
             cwd = Path(str(payload.get("cwd") or ".")).resolve()
-            for candidate in (cwd, *cwd.parents):
-                if (candidate / STATE_FILE).is_file():
-                    return "UNKNOWN", ["structured project has no matching active coordination seat"]
+            project = _observer_project(cwd)
+            if project is not None:
+                return _observer_checkpoint_scope(payload, project)
             return "NOT_APPLICABLE", []
         project = _project_from_claim(row)
         if project is None:
@@ -1243,8 +1341,36 @@ def checkpoint_hook(
             receipt_root=receipt_root,
             source_heads=source_heads,
         )
-    except (OSError, ProjectStateError) as exc:
+    except (OSError, subprocess.SubprocessError, ProjectStateError) as exc:
         return "FAIL", [str(exc)]
+
+
+def _emit_checkpoint_hook(verdict: str, issues: list[str], payload: dict[str, Any]) -> int:
+    output = {"status": verdict, "issues": issues, "checkpoint_accepted": verdict == "PASS"}
+    if verdict == "NOT_APPLICABLE":
+        output["no_receipt_issued"] = True
+    if verdict in {"PASS", "NOT_APPLICABLE"}:
+        print(json.dumps(output))
+        return 0
+    reason = "Project checkpoint remains " + verdict + ": " + "; ".join(issues)
+    reason += ". Preserve retained work; resolve only this session's authorized checkpoint obligations. Do not create or release a foreign claim to silence this error."
+    # Claude ignores stdout on exit 2 and feeds stderr back to the model.
+    # A repeated Stop must end with an explicit blocked result rather than
+    # repeatedly spending model turns. continue:false is Claude's documented
+    # terminal control, not a PASS or a receipt; Codex retains nonzero failure.
+    if payload.get("hook_event_name") == "Stop" and payload.get("stop_hook_active") is True:
+        try:
+            client, _native = _observer_native_identity(payload)
+        except (OSError, ProjectStateError):
+            client = None
+        if client == "claude":
+            output.update({"continue": False, "stopReason": reason, "systemMessage": "Checkpoint blocked; no clean checkpoint was accepted."})
+            print(json.dumps(output))
+            print(reason, file=sys.stderr)
+            return 0
+    print(json.dumps(output))
+    print(reason, file=sys.stderr)
+    return 2
 
 
 def _source_head_args(values: list[str]) -> dict[str, str]:
@@ -1322,6 +1448,7 @@ def _parser() -> argparse.ArgumentParser:
         type=Path,
         default=Path.home() / ".synthesis" / "project-state" / "receipts",
     )
+    hook.add_argument("--repo-guard-root", type=Path)
     return parser
 
 
@@ -1386,15 +1513,14 @@ def main(argv: list[str] | None = None) -> int:
             if not isinstance(payload, dict):
                 raise ValueError("hook payload is not an object")
         except (json.JSONDecodeError, ValueError) as exc:
-            print(json.dumps({"status": "UNKNOWN", "issues": [str(exc)]}))
-            return 2
+            return _emit_checkpoint_hook("UNKNOWN", [str(exc)], {})
         verdict, issues = checkpoint_hook(
             payload,
             coordination_board=args.coordination_board,
             receipt_root=args.receipt_root,
+            repo_guard_root=args.repo_guard_root,
         )
-        print(json.dumps({"status": verdict, "issues": issues}))
-        return 0 if verdict in {"PASS", "NOT_APPLICABLE"} else 2
+        return _emit_checkpoint_hook(verdict, issues, payload)
     verdict, issues = validate_checkpoint(
         args.project,
         session_id=args.session_id,

--- a/skills/synthesis-project-management/scripts/test_checkpoint_observer.py
+++ b/skills/synthesis-project-management/scripts/test_checkpoint_observer.py
@@ -1,0 +1,354 @@
+"""Native observer completion and owned checkpoint obligations are distinct."""
+from __future__ import annotations
+
+import builtins
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+import coordination
+import project_state as state
+from test_project_state import board, commit_version, init_repo, run
+
+
+NATIVE = "018f0000-0000-7000-8000-000000000002"
+FOREIGN = "018f0000-0000-7000-8000-000000000001"
+
+
+@pytest.fixture
+def observer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    for key in ("SYNTHESIS_CLIENT_SESSION_REF", "CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_HOST_SESSION_ID", "CLAUDECODE"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("SYNTHESIS_HOME", str(tmp_path / ".synthesis"))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / ".claude"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    repo, project = init_repo(tmp_path)
+    state.build_operational_state(
+        project, project_id="alpha", phase="release 1.0.0", status="active",
+        controlling_plan="resources/artifacts/plan.md", accepted_baseline="1.0.0",
+        next_actions=["finish"], last_session="2026-09-03", session_id=FOREIGN,
+    )
+    run("git", "add", "projects", cwd=repo)
+    run("git", "commit", "-m", "Record structured state", cwd=repo)
+    transcripts = {
+        "claude": tmp_path / ".claude" / "projects" / "fixture-workspace" / f"{NATIVE}.jsonl",
+        "codex": tmp_path / ".codex" / "sessions" / "fixture.jsonl",
+    }
+    for client, path in transcripts.items():
+        path.parent.mkdir(parents=True)
+        record = {"type": "user", "sessionId": NATIVE} if client == "claude" else {"type": "session_meta", "payload": {"id": NATIVE}}
+        path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+    claims = board(tmp_path / "board.md", [])
+    return SimpleNamespace(
+        root=tmp_path, repo=repo, project=project, board=claims,
+        receipts=tmp_path / "receipts", guard=tmp_path / ".synthesis" / "repo-guard",
+        transcripts=transcripts,
+    )
+
+
+def event(fixture: SimpleNamespace, client: str = "claude", **changes: object) -> dict:
+    return {"session_id": NATIVE, "cwd": str(fixture.project),
+            "transcript_path": str(fixture.transcripts[client]),
+            "hook_event_name": "Stop", "stop_hook_active": False, **changes}
+
+
+def inspect(fixture: SimpleNamespace, payload: dict | None = None) -> tuple[str, list[str]]:
+    return state.checkpoint_hook(
+        event(fixture) if payload is None else payload,
+        coordination_board=fixture.board, receipt_root=fixture.receipts,
+        repo_guard_root=fixture.guard, refresh_coordination=False,
+    )
+
+
+def assert_no_receipt(fixture: SimpleNamespace) -> None:
+    assert not fixture.receipts.exists()
+
+
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_clean_native_observer_has_no_checkpoint_authority(observer: SimpleNamespace, client: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    before = {path: path.read_bytes() for path in observer.project.rglob("*") if path.is_file()}
+    board_before = observer.board.read_bytes()
+    calls = []
+    original = state._observer_git
+
+    def guarded_git(project: Path, *arguments: str):
+        calls.append(arguments)
+        assert arguments[0] in {"ls-files", "status"}
+        return original(project, *arguments)
+
+    monkeypatch.setattr(state, "_observer_git", guarded_git)
+    monkeypatch.setattr(state, "checkpoint_project", lambda *_a, **_k: pytest.fail("observer cannot checkpoint"))
+    verdict, issues = inspect(observer, event(observer, client))
+    assert verdict == "NOT_APPLICABLE"
+    assert "no recovery/state-health PASS" in " ".join(issues)
+    assert calls and observer.board.read_bytes() == board_before
+    assert {path: path.read_bytes() for path in before} == before
+    assert not observer.guard.exists()
+    assert_no_receipt(observer)
+
+
+@pytest.mark.parametrize("mutation", ["edit", "delete", "staged", "untracked", "deleted_state"])
+def test_observer_dirty_project_remains_blocked(observer: SimpleNamespace, mutation: str) -> None:
+    target = observer.project / "REFERENCE.md"
+    if mutation in {"edit", "staged"}:
+        target.write_text("retained edit\n", encoding="utf-8")
+        if mutation == "staged":
+            run("git", "add", str(target), cwd=observer.repo)
+    elif mutation == "delete":
+        target.unlink()
+    elif mutation == "deleted_state":
+        (observer.project / state.STATE_FILE).unlink()
+    else:
+        (observer.project / "retained.txt").write_text("retained\n", encoding="utf-8")
+    before = run("git", "status", "--porcelain=v1", cwd=observer.repo)
+    verdict, issues = inspect(observer)
+    assert verdict == "UNKNOWN" and "changes" in " ".join(issues)
+    assert run("git", "status", "--porcelain=v1", cwd=observer.repo) == before
+    assert_no_receipt(observer)
+
+
+@pytest.mark.parametrize("kind", ["valid", "malformed", "wrong_session", "bad_schema", "empty_paths", "relative_path", "symlink"])
+def test_exact_native_pending_attribution_blocks(observer: SimpleNamespace, kind: str) -> None:
+    pending = observer.guard / "pending"
+    pending.mkdir(parents=True)
+    own = pending / (hashlib.sha256(NATIVE.encode()).hexdigest() + ".json")
+    data = {"schema_version": 2, "session_id": NATIVE, "paths": [str(observer.project / "REFERENCE.md")]}
+    if kind == "wrong_session":
+        data["session_id"] = FOREIGN
+    elif kind == "bad_schema":
+        data["schema_version"] = True
+    elif kind == "empty_paths":
+        data["paths"] = []
+    elif kind == "relative_path":
+        data["paths"] = ["REFERENCE.md"]
+    if kind == "symlink":
+        target = observer.root / "retained.json"
+        target.write_text(json.dumps(data), encoding="utf-8")
+        own.symlink_to(target)
+    else:
+        own.write_text("{" if kind == "malformed" else json.dumps(data), encoding="utf-8")
+    before = own.read_bytes()
+    verdict, _issues = inspect(observer)
+    assert verdict == ("UNKNOWN" if kind == "valid" else "FAIL")
+    assert own.read_bytes() == before
+    assert_no_receipt(observer)
+
+
+def test_foreign_pending_and_unrelated_dirty_work_are_preserved(observer: SimpleNamespace) -> None:
+    pending = observer.guard / "pending"
+    pending.mkdir(parents=True)
+    foreign = pending / (hashlib.sha256(FOREIGN.encode()).hexdigest() + ".json")
+    foreign.write_text("malformed retained foreign evidence {", encoding="utf-8")
+    unrelated = observer.repo / "projects" / "beta"
+    unrelated.mkdir()
+    retained = unrelated / "notes.md"
+    retained.write_text("foreign work\n", encoding="utf-8")
+    run("git", "add", str(retained), cwd=observer.repo)
+    before = foreign.read_bytes(), retained.read_bytes(), run("git", "diff", "--cached", cwd=observer.repo)
+    assert inspect(observer)[0] == "NOT_APPLICABLE"
+    assert (foreign.read_bytes(), retained.read_bytes(), run("git", "diff", "--cached", cwd=observer.repo)) == before
+    assert_no_receipt(observer)
+
+
+@pytest.mark.parametrize("malformed", [False, True])
+def test_known_native_pending_work_blocks_from_workspace_root(observer: SimpleNamespace, malformed: bool) -> None:
+    pending = observer.guard / "pending"
+    pending.mkdir(parents=True)
+    own = pending / (hashlib.sha256(NATIVE.encode()).hexdigest() + ".json")
+    data = {"schema_version": 2, "session_id": NATIVE, "paths": [str(observer.project / "REFERENCE.md")]}
+    own.write_text("{" if malformed else json.dumps(data), encoding="utf-8")
+    before = own.read_bytes()
+    verdict, _issues = inspect(observer, event(observer, cwd=str(observer.root)))
+    assert verdict == ("FAIL" if malformed else "UNKNOWN")
+    assert own.read_bytes() == before
+    assert_no_receipt(observer)
+
+
+def test_nonproject_session_without_pending_work_retains_applicability(observer: SimpleNamespace) -> None:
+    assert inspect(observer, {"cwd": str(observer.root), "session_id": "legacy-session"}) == ("NOT_APPLICABLE", [])
+    assert_no_receipt(observer)
+
+
+@pytest.mark.parametrize("defect", ["missing_uuid", "invalid_uuid", "missing_transcript", "foreign_binding", "outside_root", "symlink", "parent_symlink", "empty_home", "relative_home"])
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_observer_identity_is_native_and_fail_closed(observer: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, client: str, defect: str) -> None:
+    payload = event(observer, client)
+    path = observer.transcripts[client]
+    if defect == "missing_uuid":
+        payload.pop("session_id")
+    elif defect == "invalid_uuid":
+        payload["session_id"] = "legacy-session"
+    elif defect == "missing_transcript":
+        payload.pop("transcript_path")
+    elif defect == "foreign_binding":
+        path.write_text(path.read_text().replace(NATIVE, FOREIGN), encoding="utf-8")
+    elif defect == "outside_root":
+        outside = observer.root / "untrusted.jsonl"
+        outside.write_bytes(path.read_bytes())
+        payload["transcript_path"] = str(outside)
+    elif defect == "symlink":
+        target = path.with_suffix(".saved")
+        path.rename(target)
+        path.symlink_to(target)
+    elif defect == "parent_symlink":
+        parent = path.parent
+        target = parent.with_name(parent.name + "-saved")
+        parent.rename(target)
+        parent.symlink_to(target, target_is_directory=True)
+    else:
+        variable = "CLAUDE_CONFIG_DIR" if client == "claude" else "CODEX_HOME"
+        monkeypatch.setenv(variable, "" if defect == "empty_home" else "relative/home")
+    assert inspect(observer, payload)[0] == "FAIL"
+    assert_no_receipt(observer)
+
+
+def test_missing_native_validator_fails_closed(observer: SimpleNamespace, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture) -> None:
+    original = builtins.__import__
+
+    def missing(name, *args, **kwargs):
+        if name == "live_receipt":
+            raise ImportError("fixture missing installed dependency")
+        return original(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing)
+    verdict, issues = inspect(observer)
+    assert verdict == "FAIL" and "validator is unavailable" in " ".join(issues)
+    assert state._emit_checkpoint_hook(verdict, issues, event(observer)) == 2
+    assert "remains FAIL" in capsys.readouterr().err
+    assert_no_receipt(observer)
+
+
+def test_foreign_ambient_identity_cannot_grant_checkpoint_authority(observer: SimpleNamespace, monkeypatch: pytest.MonkeyPatch) -> None:
+    board(observer.board, [(FOREIGN, "s-abcd-efgh-jkmn", "alpha", str(observer.repo))])
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", f"codex:{FOREIGN}")
+    verdict, issues = inspect(observer, event(observer, "codex"))
+    assert verdict == "FAIL" and "foreign checkpoint" in " ".join(issues)
+    assert_no_receipt(observer)
+
+
+def test_empty_board_identity_does_not_bind_foreign_seat(observer: SimpleNamespace) -> None:
+    row = {"status": "active", "client session ref": "", "session uuid": FOREIGN}
+    assert state._row_for_event([row], event(observer)) is None
+    row["session uuid"] = ""
+    assert state._row_for_event([row], event(observer)) is None
+    assert state._row_for_event([row], {}) is None
+
+
+def test_matching_native_reference_and_empty_optional_reference_are_safe(observer: SimpleNamespace, monkeypatch: pytest.MonkeyPatch) -> None:
+    for value in ("", f"cc:{NATIVE}"):
+        monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", value)
+        assert inspect(observer)[0] == "NOT_APPLICABLE"
+    assert_no_receipt(observer)
+
+
+def test_owner_checkpoint_authority_is_preserved(observer: SimpleNamespace) -> None:
+    board(observer.board, [(FOREIGN, "s-abcd-efgh-jkmn", "alpha", str(observer.repo))])
+    payload = {"session_id": FOREIGN, "cwd": str(observer.project)}
+    assert inspect(observer, payload) == ("PASS", [])
+    receipt_path = next(observer.receipts.glob("*.json"))
+    receipt = json.loads(receipt_path.read_text())
+    assert receipt["session_id"] == FOREIGN and receipt["project_id"] == "alpha"
+    accepted = receipt_path.read_bytes()
+    (observer.project / "CONTEXT.md").write_text("uncheckpointed owner edit\n", encoding="utf-8")
+    verdict, issues = inspect(observer, payload)
+    assert verdict == "FAIL" and any("changed" in issue for issue in issues)
+    assert receipt_path.read_bytes() == accepted
+
+
+def test_clean_stale_semantics_are_not_reported_as_recovery_pass(observer: SimpleNamespace) -> None:
+    (observer.project / "resources" / "artifacts" / "plan.md").write_text("# Changed plan\n", encoding="utf-8")
+    run("git", "add", "projects", cwd=observer.repo)
+    run("git", "commit", "-m", "Record plan change", cwd=observer.repo)
+    assert state.semantic_issues(observer.project)
+    verdict, issues = inspect(observer)
+    assert verdict == "NOT_APPLICABLE" and "no recovery/state-health PASS" in " ".join(issues)
+    assert_no_receipt(observer)
+
+
+def test_clean_causal_conflict_can_finish_reporting_without_checkpoint(observer: SimpleNamespace) -> None:
+    run("git", "checkout", "-b", "feature/a", cwd=observer.repo)
+    commit_version(observer.repo, observer.project, "2.0.0")
+    run("git", "checkout", "main", cwd=observer.repo)
+    commit_version(observer.repo, observer.project, "3.0.0")
+    recovery = state.resolve_project("alpha", observer.repo / "projects" / "index.yaml", fetch=False)
+    assert recovery.status == "CONFLICT"
+    assert inspect(observer)[0] == "NOT_APPLICABLE"
+    assert_no_receipt(observer)
+
+
+def test_unverifiable_project_git_state_cannot_exonerate_observer(observer: SimpleNamespace) -> None:
+    outside = observer.root / "not-a-repository"
+    outside.mkdir()
+    (outside / state.STATE_FILE).write_text("{}", encoding="utf-8")
+    verdict, issues = inspect(observer, event(observer, cwd=str(outside)))
+    assert verdict == "FAIL" and "Git state" in " ".join(issues)
+    assert_no_receipt(observer)
+
+
+def test_claude_reentrant_stop_terminates_with_blocked_verdict(observer: SimpleNamespace, capsys: pytest.CaptureFixture) -> None:
+    (observer.project / "REFERENCE.md").write_text("unattributed edit\n", encoding="utf-8")
+    payload = event(observer)
+    verdict, issues = inspect(observer, payload)
+    assert state._emit_checkpoint_hook(verdict, issues, payload) == 2
+    first = capsys.readouterr()
+    assert "remains UNKNOWN" in first.err and "Preserve retained work" in first.err
+    assert "continue" not in json.loads(first.out)
+    payload["stop_hook_active"] = True
+    assert state._emit_checkpoint_hook(verdict, issues, payload) == 0
+    repeated = capsys.readouterr()
+    terminal = json.loads(repeated.out)
+    assert terminal["status"] == "UNKNOWN" and terminal["continue"] is False
+    assert terminal["checkpoint_accepted"] is False
+    assert "remains UNKNOWN" in terminal["stopReason"] and repeated.err
+    assert_no_receipt(observer)
+
+
+@pytest.mark.parametrize("client,active,event_name", [("codex", True, "Stop"), ("claude", "true", "Stop"), ("claude", True, "PreCompact")])
+def test_codex_never_consumes_claude_terminal_control(observer: SimpleNamespace, capsys: pytest.CaptureFixture, client: str, active: object, event_name: str) -> None:
+    payload = event(observer, client, stop_hook_active=active, hook_event_name=event_name)
+    assert state._emit_checkpoint_hook("FAIL", ["retained owner obligation"], payload) == 2
+    output = capsys.readouterr()
+    assert json.loads(output.out)["checkpoint_accepted"] is False
+    assert "continue" not in json.loads(output.out) and output.err
+    assert_no_receipt(observer)
+
+
+def test_real_hook_cli_uses_local_lease_and_actionable_failure(observer: SimpleNamespace) -> None:
+    remote = observer.root / "coordination.git"
+    run("git", "init", "--bare", str(remote), cwd=observer.root)
+    (observer.root / "lease.json").write_text(json.dumps({"remote": str(remote)}), encoding="utf-8")
+    observer.board.write_text(coordination.template(), encoding="utf-8")
+    coordination.locked_update(observer.board, lambda content: content)
+    before = observer.board.read_bytes()
+
+    def cli(payload: object) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, "-B", str(Path(state.__file__)), "hook", "--coordination-board", str(observer.board),
+             "--receipt-root", str(observer.receipts), "--repo-guard-root", str(observer.guard)],
+            input=json.dumps(payload), capture_output=True, text=True, timeout=30,
+        )
+
+    clean = cli(event(observer))
+    assert clean.returncode == 0, clean.stderr
+    assert json.loads(clean.stdout) == {"status": "NOT_APPLICABLE", "issues": inspect(observer)[1], "checkpoint_accepted": False, "no_receipt_issued": True}
+    (observer.project / "REFERENCE.md").write_text("retained edit\n", encoding="utf-8")
+    first = cli(event(observer))
+    assert first.returncode == 2 and "remains UNKNOWN" in first.stderr
+    repeated = cli(event(observer, stop_hook_active=True))
+    assert repeated.returncode == 0 and json.loads(repeated.stdout)["continue"] is False
+    assert json.loads(repeated.stdout)["status"] == "UNKNOWN"
+    codex = cli(event(observer, "codex", stop_hook_active=True))
+    assert codex.returncode == 2 and "continue" not in json.loads(codex.stdout)
+    malformed = cli([])
+    assert malformed.returncode == 2 and "not an object" in malformed.stderr
+    assert observer.board.read_bytes() == before
+    assert_no_receipt(observer)


### PR DESCRIPTION
Reading a structured project without owning a write claim could finish recovery successfully and then repeatedly fail the Stop checkpoint gate. Validate native identity, exact pending attribution and clean Git state before marking an observer checkpoint not applicable; retain the owned checkpoint path and issue no observer receipt.

Make real failures actionable on stderr. A verified repeated Claude Stop failure ends continued processing with an explicit failure reason; other clients retain their failure transport. Guard empty or inherited identity references against foreign-seat matches.

Validation: observer/owner, identity, pending-work, dirty-state and real CLI fixtures; original-behavior positive control; source and instruction conformance; release-specific closed acceptance manifest. Genuine installed native acceptance follows the gated release.
