### PR TITLE
Isolate native identities in lifecycle fixtures

### DIFF
--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,6 +1,6 @@
-# Release-specific acceptance. Exact change base: f1fcabac50cf70ee254d97128a4e74118dad879e.
+# Release-specific fixture follow-up. Exact change base: c8a83de2c7afef1c1ba3823dff69d26151702bd6.
 schema: 2
-suite: native-observer-stop-completion-2026-09-06
+suite: native-owner-fixture-identity-2026-09-06
 membership: closed
 production_entry_point: project_state.py hook through registered native Stop hooks
 enforcing_boundary: release.py derives exact Git base-to-head membership and consumes transaction-bound acceptance
@@ -19,22 +19,16 @@ unverified_remainder: Fixtures use isolated native-shaped transcripts, temporary
   control requires verified native Claude identity; Codex retains failure transport. Source publication, both-client
   installation, retained-cache integrity, actual new native Stop behavior and exact/current-global startup evidence
   require separate verification. This manifest grants no publication, deployment, policy, automation or administrative-release
-  authority.
+  authority. This follow-up changes only owner-fixture isolation and its closed acceptance manifest; it retains
+  execution of the complete observer acceptance suite and does not relax production identity checks.
 changed_surfaces:
-- path: .claude-plugin/plugin.json
+- path: skills/synthesis-project-management/scripts/test_project_state.py
   cases:
+  - lifecycle-hook-issues-session-bound-clean-receipt
+  - lifecycle-hook-refuses-semantically-incomplete-stop
   - release-contract
-- path: .codex-plugin/plugin.json
+- path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
   cases:
-  - release-contract
-- path: CHANGELOG.md
-  cases:
-  - release-contract
-- path: README.md
-  cases:
-  - release-contract
-- path: skills/synthesis-checkpoint/references/refresh-and-report.md
-  cases: &id001
   - clean-native-observer-has-no-checkpoint-authority
   - observer-dirty-project-remains-blocked
   - exact-native-pending-attribution-blocks
@@ -53,20 +47,14 @@ changed_surfaces:
   - claude-reentrant-stop-terminates-with-blocked-verdict
   - codex-never-consumes-claude-terminal-control
   - real-hook-cli-uses-local-lease-and-actionable-failure
-- path: skills/synthesis-project-management/SKILL.md
-  cases: *id001
-- path: skills/synthesis-project-management/scripts/project_state.py
-  cases: *id001
-- path: skills/synthesis-project-management/scripts/test_checkpoint_observer.py
-  cases: *id001
-- path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
-  cases:
   - release-contract
   - release-bound-receipt-consumed
   - release-receipt-binding-mismatch-refused
   - acceptance-self
   - acceptance-omitted-path-refused
   - acceptance-git-transaction-binding
+  - lifecycle-hook-issues-session-bound-clean-receipt
+  - lifecycle-hook-refuses-semantically-incomplete-stop
 cases:
 - id: clean-native-observer-has-no-checkpoint-authority
   control_class: acceptance-test
@@ -192,3 +180,15 @@ cases:
   expected_status: pass
   fixture: scripts/test_acceptance_suite.py::test_schema2_receipt_binds_transaction_and_git_state
   motivating_defect: Executed evidence could lack the boundary-selected Git and transaction binding.
+- id: lifecycle-hook-issues-session-bound-clean-receipt
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_project_state.py::test_lifecycle_hook_issues_session_bound_clean_receipt
+  motivating_defect: A live release caller reference leaked into a synthetic owner fixture, hiding the real positive
+    owner-checkpoint control.
+- id: lifecycle-hook-refuses-semantically-incomplete-stop
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_project_state.py::test_lifecycle_hook_refuses_semantically_incomplete_stop
+  motivating_defect: An inherited foreign reference stopped the negative fixture at identity validation instead
+    of exercising its required stale-state refusal.

--- a/skills/synthesis-project-management/scripts/test_project_state.py
+++ b/skills/synthesis-project-management/scripts/test_project_state.py
@@ -718,9 +718,13 @@ def test_cross_project_plan_change_invalidates_clean_checkpoint(tmp_path: Path, 
     assert any("plan" in issue or "durable project files" in issue for issue in issues)
 
 
-def test_lifecycle_hook_issues_session_bound_clean_receipt(tmp_path: Path) -> None:
+@pytest.mark.parametrize("client", ["cc", "codex"])
+def test_lifecycle_hook_issues_session_bound_clean_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client: str
+) -> None:
     repo, project = init_repo(tmp_path)
     session = "018f0000-0000-7000-8000-000000000001"
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", f"{client}:{session}")
     claims = board(tmp_path / "board.md", [(session, "s-abcd-efgh-jkmn", "alpha", str(repo))])
     receipts = tmp_path / "receipts"
     state.build_operational_state(
@@ -746,9 +750,13 @@ def test_lifecycle_hook_issues_session_bound_clean_receipt(tmp_path: Path) -> No
     assert receipt["project_id"] == "alpha"
 
 
-def test_lifecycle_hook_refuses_semantically_incomplete_stop(tmp_path: Path) -> None:
+@pytest.mark.parametrize("client", ["cc", "codex"])
+def test_lifecycle_hook_refuses_semantically_incomplete_stop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, client: str
+) -> None:
     repo, project = init_repo(tmp_path)
     session = "018f0000-0000-7000-8000-000000000001"
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", f"{client}:{session}")
     claims = board(tmp_path / "board.md", [(session, "s-abcd-efgh-jkmn", "alpha", str(repo))])
     state.build_operational_state(
         project,


### PR DESCRIPTION
Owner checkpoint fixtures inherited the release caller's native identity, so a real session correctly triggered the foreign-identity guard before the fixtures reached their intended assertions. Bind each fixture to its own synthetic identity for both clients, keeping the production guard and original acceptance assertions unchanged.

Validation: targeted owner and opposing-identity cases with a foreign ambient identity; full project-management suite with the real release environment; closed two-path acceptance manifest retaining the observer and release-boundary cases. The 4.96.1 release remains pending its gated checks.
