### PR TITLE
Conform checkpoint Stop output to native JSON contracts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.96.1",
+  "version": "4.96.2",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.96.1",
+  "version": "4.96.2",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.96.2] - 2026-09-06
+
+Checkpoint Stop output now uses the documented control fields accepted by both
+clients. The diagnostic verdict travels inside systemMessage, preserving the
+distinction between an accepted checkpoint, a checkpoint that does not apply,
+and blocked work. Strict Codex JSON validation no longer rejects that output.
+
 ## [4.96.1] - 2026-09-06
 
 Unclaimed sessions can finish inspection of a clean project without claiming

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Checkpoint output follows both native contracts (September 2026).**
+Release **4.96.2** carries diagnostic verdicts in the supported systemMessage field.
+Codex strict Stop validation and Claude completion use the same output format;
+checkpoint authority and failure checks retain their existing meaning.
+
 **Project inspections finish without a write claim (September 2026).**
 Release **4.96.1** checks native identity, pending attribution and a clean project subtree
 before marking an unclaimed inspection's checkpoint not applicable. It grants no

--- a/skills/synthesis-checkpoint/references/refresh-and-report.md
+++ b/skills/synthesis-checkpoint/references/refresh-and-report.md
@@ -80,7 +80,9 @@ the hook terminates continued processing with a visible failure reason. This
 client-specific termination carries the failure verdict and grants no accepted
 checkpoint; it never converts failure into acceptance. Missing identity evidence
 remains blocking. Codex retains its own
-failure transport. Do not claim lifecycle success from a CLI exit code alone.
+failure transport. Native Stop stdout contains only documented control fields;
+the diagnostic verdict and receipt distinction are carried in `systemMessage`.
+Do not claim lifecycle success from a CLI exit code alone.
 
 ## Optional reusable campaign
 

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,6 +1,6 @@
-# Release-specific fixture follow-up. Exact change base: c8a83de2c7afef1c1ba3823dff69d26151702bd6.
+# Release-specific native Stop wire contract. Base f6066def92f651b8c862483a655b6f94f448b0b0.
 schema: 2
-suite: native-owner-fixture-identity-2026-09-06
+suite: native-stop-json-contract-2026-09-06
 membership: closed
 production_entry_point: project_state.py hook through registered native Stop hooks
 enforcing_boundary: release.py derives exact Git base-to-head membership and consumes transaction-bound acceptance
@@ -19,16 +19,31 @@ unverified_remainder: Fixtures use isolated native-shaped transcripts, temporary
   control requires verified native Claude identity; Codex retains failure transport. Source publication, both-client
   installation, retained-cache integrity, actual new native Stop behavior and exact/current-global startup evidence
   require separate verification. This manifest grants no publication, deployment, policy, automation or administrative-release
-  authority. This follow-up changes only owner-fixture isolation and its closed acceptance manifest; it retains
-  execution of the complete observer acceptance suite and does not relax production identity checks.
+  authority. The embedded Codex 0.153.4 consumer schema is a deterministic format control; actual installed native
+  completion must be verified separately.
 changed_surfaces:
-- path: skills/synthesis-project-management/scripts/test_project_state.py
+- path: .claude-plugin/plugin.json
   cases:
-  - lifecycle-hook-issues-session-bound-clean-receipt
-  - lifecycle-hook-refuses-semantically-incomplete-stop
   - release-contract
-- path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
+  - native-stop-output-contract
+- path: .codex-plugin/plugin.json
   cases:
+  - release-contract
+  - native-stop-output-contract
+- path: CHANGELOG.md
+  cases:
+  - release-contract
+  - native-stop-output-contract
+- path: README.md
+  cases:
+  - release-contract
+  - native-stop-output-contract
+- path: skills/synthesis-checkpoint/references/refresh-and-report.md
+  cases:
+  - release-contract
+  - native-stop-output-contract
+- path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
+  cases: &id001
   - clean-native-observer-has-no-checkpoint-authority
   - observer-dirty-project-remains-blocked
   - exact-native-pending-attribution-blocks
@@ -55,6 +70,16 @@ changed_surfaces:
   - acceptance-git-transaction-binding
   - lifecycle-hook-issues-session-bound-clean-receipt
   - lifecycle-hook-refuses-semantically-incomplete-stop
+  - native-stop-output-contract
+  - native-consumer-rejects-old-output
+- path: skills/synthesis-project-management/SKILL.md
+  cases:
+  - release-contract
+  - native-stop-output-contract
+- path: skills/synthesis-project-management/scripts/project_state.py
+  cases: *id001
+- path: skills/synthesis-project-management/scripts/test_checkpoint_observer.py
+  cases: *id001
 cases:
 - id: clean-native-observer-has-no-checkpoint-authority
   control_class: acceptance-test
@@ -192,3 +217,13 @@ cases:
   fixture: ../synthesis-project-management/scripts/test_project_state.py::test_lifecycle_hook_refuses_semantically_incomplete_stop
   motivating_defect: An inherited foreign reference stopped the negative fixture at identity validation instead
     of exercising its required stale-state refusal.
+- id: native-stop-output-contract
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_stop_output_conforms_to_native_codex_consumer_schema
+  motivating_defect: Diagnostic top-level fields were rejected by the strict native Codex Stop output schema.
+- id: native-consumer-rejects-old-output
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_old_diagnostic_stdout_is_rejected_by_native_codex_schema
+  motivating_defect: A schema positive control must reproduce rejection of the released diagnostic shape.

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.13.4"
+  version: "2.13.5"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-project-management/scripts/project_state.py
+++ b/skills/synthesis-project-management/scripts/project_state.py
@@ -1346,9 +1346,13 @@ def checkpoint_hook(
 
 
 def _emit_checkpoint_hook(verdict: str, issues: list[str], payload: dict[str, Any]) -> int:
-    output = {"status": verdict, "issues": issues, "checkpoint_accepted": verdict == "PASS"}
+    report = {"status": verdict, "issues": issues, "checkpoint_accepted": verdict == "PASS"}
     if verdict == "NOT_APPLICABLE":
-        output["no_receipt_issued"] = True
+        report["no_receipt_issued"] = True
+    # Codex validates Stop stdout against an additionalProperties:false schema.
+    # Keep diagnostic fields inside the supported string, separate from native
+    # lifecycle control. Both clients can retain the exact verdict for review.
+    output = {"systemMessage": "PROJECT_CHECKPOINT_JSON: " + json.dumps(report, sort_keys=True)}
     if verdict in {"PASS", "NOT_APPLICABLE"}:
         print(json.dumps(output))
         return 0
@@ -1364,7 +1368,7 @@ def _emit_checkpoint_hook(verdict: str, issues: list[str], payload: dict[str, An
         except (OSError, ProjectStateError):
             client = None
         if client == "claude":
-            output.update({"continue": False, "stopReason": reason, "systemMessage": "Checkpoint blocked; no clean checkpoint was accepted."})
+            output.update({"continue": False, "stopReason": reason})
             print(json.dumps(output))
             print(reason, file=sys.stderr)
             return 0

--- a/skills/synthesis-project-management/scripts/test_checkpoint_observer.py
+++ b/skills/synthesis-project-management/scripts/test_checkpoint_observer.py
@@ -11,6 +11,7 @@ import sys
 from types import SimpleNamespace
 
 import pytest
+from jsonschema import Draft7Validator, ValidationError
 
 import coordination
 import project_state as state
@@ -19,6 +20,39 @@ from test_project_state import board, commit_version, init_repo, run
 
 NATIVE = "018f0000-0000-7000-8000-000000000002"
 FOREIGN = "018f0000-0000-7000-8000-000000000001"
+
+
+# Exact embedded stop.command.output schema from codex-cli 0.153.4.
+# Binary SHA-256: 4ca47945439f9251fe35f4cbe071369192cd9a6c5a3a17b75c7a11ad548a9c7f.
+# Source contract: https://learn.chatgpt.com/docs/hooks
+CODEX_STOP_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": False,
+    "definitions": {"BlockDecisionWire": {"enum": ["block"], "type": "string"}},
+    "properties": {
+        "continue": {"default": True, "type": "boolean"},
+        "decision": {"allOf": [{"$ref": "#/definitions/BlockDecisionWire"}], "default": None},
+        "reason": {
+            "default": None,
+            "description": "Claude requires `reason` when `decision` is `block`; we enforce that semantic rule during output parsing rather than in the JSON schema.",
+            "type": "string",
+        },
+        "stopReason": {"default": None, "type": "string"},
+        "suppressOutput": {"default": False, "type": "boolean"},
+        "systemMessage": {"default": None, "type": "string"},
+    },
+    "title": "stop.command.output",
+    "type": "object",
+}
+
+
+def native_output(text: str) -> tuple[dict, dict]:
+    """Validate the consumer wire format before inspecting Synthesis evidence."""
+    output = json.loads(text)
+    Draft7Validator(CODEX_STOP_SCHEMA).validate(output)
+    message = output["systemMessage"]
+    assert message.startswith("PROJECT_CHECKPOINT_JSON: ")
+    return output, json.loads(message.removeprefix("PROJECT_CHECKPOINT_JSON: "))
 
 
 @pytest.fixture
@@ -301,13 +335,14 @@ def test_claude_reentrant_stop_terminates_with_blocked_verdict(observer: SimpleN
     assert state._emit_checkpoint_hook(verdict, issues, payload) == 2
     first = capsys.readouterr()
     assert "remains UNKNOWN" in first.err and "Preserve retained work" in first.err
-    assert "continue" not in json.loads(first.out)
+    first_output, first_report = native_output(first.out)
+    assert "continue" not in first_output and first_report["status"] == "UNKNOWN"
     payload["stop_hook_active"] = True
     assert state._emit_checkpoint_hook(verdict, issues, payload) == 0
     repeated = capsys.readouterr()
-    terminal = json.loads(repeated.out)
-    assert terminal["status"] == "UNKNOWN" and terminal["continue"] is False
-    assert terminal["checkpoint_accepted"] is False
+    terminal, report = native_output(repeated.out)
+    assert report["status"] == "UNKNOWN" and terminal["continue"] is False
+    assert report["checkpoint_accepted"] is False
     assert "remains UNKNOWN" in terminal["stopReason"] and repeated.err
     assert_no_receipt(observer)
 
@@ -317,8 +352,9 @@ def test_codex_never_consumes_claude_terminal_control(observer: SimpleNamespace,
     payload = event(observer, client, stop_hook_active=active, hook_event_name=event_name)
     assert state._emit_checkpoint_hook("FAIL", ["retained owner obligation"], payload) == 2
     output = capsys.readouterr()
-    assert json.loads(output.out)["checkpoint_accepted"] is False
-    assert "continue" not in json.loads(output.out) and output.err
+    wire, report = native_output(output.out)
+    assert report["checkpoint_accepted"] is False
+    assert "continue" not in wire and output.err
     assert_no_receipt(observer)
 
 
@@ -339,16 +375,48 @@ def test_real_hook_cli_uses_local_lease_and_actionable_failure(observer: SimpleN
 
     clean = cli(event(observer))
     assert clean.returncode == 0, clean.stderr
-    assert json.loads(clean.stdout) == {"status": "NOT_APPLICABLE", "issues": inspect(observer)[1], "checkpoint_accepted": False, "no_receipt_issued": True}
+    _wire, report = native_output(clean.stdout)
+    assert report == {"status": "NOT_APPLICABLE", "issues": inspect(observer)[1], "checkpoint_accepted": False, "no_receipt_issued": True}
+    clean_codex = cli(event(observer, "codex"))
+    assert clean_codex.returncode == 0, clean_codex.stderr
+    assert native_output(clean_codex.stdout)[1] == report
     (observer.project / "REFERENCE.md").write_text("retained edit\n", encoding="utf-8")
     first = cli(event(observer))
     assert first.returncode == 2 and "remains UNKNOWN" in first.stderr
+    assert native_output(first.stdout)[1]["status"] == "UNKNOWN"
     repeated = cli(event(observer, stop_hook_active=True))
-    assert repeated.returncode == 0 and json.loads(repeated.stdout)["continue"] is False
-    assert json.loads(repeated.stdout)["status"] == "UNKNOWN"
+    wire, report = native_output(repeated.stdout)
+    assert repeated.returncode == 0 and wire["continue"] is False
+    assert report["status"] == "UNKNOWN"
     codex = cli(event(observer, "codex", stop_hook_active=True))
-    assert codex.returncode == 2 and "continue" not in json.loads(codex.stdout)
+    wire, report = native_output(codex.stdout)
+    assert codex.returncode == 2 and "continue" not in wire
+    assert report["status"] == "UNKNOWN" and not report["checkpoint_accepted"]
     malformed = cli([])
     assert malformed.returncode == 2 and "not an object" in malformed.stderr
+    assert native_output(malformed.stdout)[1]["status"] == "UNKNOWN"
     assert observer.board.read_bytes() == before
     assert_no_receipt(observer)
+
+
+@pytest.mark.parametrize("verdict", ["PASS", "NOT_APPLICABLE", "UNKNOWN", "FAIL", "LOCAL_RECOVERABLE"])
+def test_stop_output_conforms_to_native_codex_consumer_schema(observer: SimpleNamespace, capsys: pytest.CaptureFixture, verdict: str) -> None:
+    result = state._emit_checkpoint_hook(verdict, ["bounded fixture evidence"], event(observer, "codex"))
+    captured = capsys.readouterr()
+    wire, report = native_output(captured.out)
+    assert set(wire) == {"systemMessage"}
+    assert report["status"] == verdict
+    assert report["issues"] == ["bounded fixture evidence"]
+    assert report["checkpoint_accepted"] is (verdict == "PASS")
+    assert report.get("no_receipt_issued") is (True if verdict == "NOT_APPLICABLE" else None)
+    assert result == (0 if verdict in {"PASS", "NOT_APPLICABLE"} else 2)
+    assert bool(captured.err) is (result == 2)
+
+
+def test_old_diagnostic_stdout_is_rejected_by_native_codex_schema() -> None:
+    serialized = json.dumps(CODEX_STOP_SCHEMA, indent=2, sort_keys=True) + "\n"
+    assert hashlib.sha256(serialized.encode()).hexdigest() == "37679d1a933fdc3dc8cea5ff12d7d0e2dacfc036208d134aefc09247e1222d88"
+    Draft7Validator.check_schema(CODEX_STOP_SCHEMA)
+    old_output = {"status": "NOT_APPLICABLE", "issues": [], "checkpoint_accepted": False, "no_receipt_issued": True}
+    with pytest.raises(ValidationError, match="Additional properties are not allowed"):
+        Draft7Validator(CODEX_STOP_SCHEMA).validate(old_output)


### PR DESCRIPTION
A native Codex Stop hook rejects checkpoint diagnostic fields as unknown JSON properties, even when the checkpoint correctly reports that an unclaimed clean inspection needs no receipt. The hook now carries its diagnostic report in the documented systemMessage string, using only supported native control fields on stdout.

Identity validation, checkpoint authority, receipt behavior, nonzero failure transport and verified Claude reentrant termination are unchanged. This prepares release 4.96.2.

Validation: full project-management suite 373 passed in the real release environment; independent 11-case review passed; source conformance 207 and instruction checks 2 passed. Tests validate output against the exact Stop schema extracted from Codex CLI 0.153.4 and positively reproduce rejection of the former shape. Closed release acceptance covers nine changed paths and 28 fixture nodes. Installed native completion will be verified after the gated dual-client release.
