### PR TITLE
Align metadata ownership across linked checkouts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.96.4",
+  "version": "4.96.5",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.96.4",
+  "version": "4.96.5",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.96.5] - 2026-09-09
+
+Board admission and record-repair consumers share one metadata conflict policy.
+The same project record in linked worktrees conflicts through verified Git
+repository identity. Disjoint metadata files and ordinary source branches remain
+independent; logical conflicts never grant permission to write another checkout.
+Relative metadata claims require unambiguous workspace context, and unresolved metadata
+identity refuses admission. Named resources retain their separate namespace.
+
+Standalone Git hooks and onboarding updates include the shared helper. Updates
+from an older bundle verify its released companion files before introducing the
+new dependency; missing, modified or unrelated origins remain blocked.
+
 ## [4.96.4] - 2026-09-09
 
 Refresh feedback follows explicit registry successor links to the current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ independent; logical conflicts never grant permission to write another checkout.
 Relative metadata claims require unambiguous workspace context, and unresolved metadata
 identity refuses admission. Named resources retain their separate namespace.
 
-Standalone Git hooks and onboarding updates include the shared helper. Updates
-from an older bundle verify its released companion files before introducing the
+Standalone Git hooks and onboarding updates include the shared helper. Onboarding
+updates from an older bundle verify its released companion files before introducing the
 new dependency; missing, modified or unrelated origins remain blocked.
 
 ## [4.96.4] - 2026-09-09

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Metadata ownership across linked worktrees (September 2026).** Release **4.96.5**
+uses one conflict policy for board admission and record-repair consumers. Claims
+on the same project metadata conflict across verified linked checkouts, while
+disjoint files and ordinary source branches remain independent. Write permission
+still requires the actor's exact checkout, branch and paths. Existing hook
+bundles receive the shared helper only after their installed origins are verified.
+
 **Successor feedback and session freshness (September 2026).** Release **4.96.4**
 routes reports through explicit registry successor links while preserving their
 source project and execution boundaries. Freshness checks use dated session

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 uses one conflict policy for board admission and record-repair consumers. Claims
 on the same project metadata conflict across verified linked checkouts, while
 disjoint files and ordinary source branches remain independent. Write permission
-still requires the actor's exact checkout, branch and paths. Existing hook
-bundles receive the shared helper only after their installed origins are verified.
+still requires the actor's exact checkout, branch and paths. Onboarding updates
+introduce the shared helper after verifying the installed bundle's origins.
 
 **Successor feedback and session freshness (September 2026).** Release **4.96.4**
 routes reports through explicit registry successor links while preserving their

--- a/skills/synthesis-agent-conformance/scripts/test_diagnostic_parity.py
+++ b/skills/synthesis-agent-conformance/scripts/test_diagnostic_parity.py
@@ -102,6 +102,7 @@ def inbox_project(tmp_path: Path, monkeypatch):
         return next(row for row in coordination.rows(board.read_text(encoding="utf-8"))
                     if row.project == project_name)
 
+    (tmp_path / "sender-project").mkdir()
     sender = claim("sender-project", "codex:22222222-2222-4222-8222-222222222222")
     recipient = claim(project.name, SESSION_REF)
     for target, message in ((recipient.compact_id, DIRECT_MESSAGE),

--- a/skills/synthesis-git-hooks/SKILL.md
+++ b/skills/synthesis-git-hooks/SKILL.md
@@ -217,7 +217,7 @@ synthesis-git-hooks/
     └── per-repo-overrides.md         # delegation to repo-local .githooks
 ```
 
-The installer also copies `coordination.py`, `coordination_schema.py`,
+The installer also copies `coordination.py`, `claim_scope.py`, `coordination_schema.py`,
 `pointer_lock.py`, `peer_addressing.py`, and the versioned session-word asset from the declared
 `synthesis-project-management` dependency into the shared runtime. Their
 canonical source remains in that owning skill; the git-hooks doctor compares

--- a/skills/synthesis-git-hooks/SKILL.md
+++ b/skills/synthesis-git-hooks/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.4.0"
+  version: "2.4.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-git-hooks/scripts/_load_config.py
+++ b/skills/synthesis-git-hooks/scripts/_load_config.py
@@ -55,7 +55,7 @@ import warnings
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
-SIDECAR_VERSION = "2.4.0"
+SIDECAR_VERSION = "2.4.1"
 REQUIRED_CONFIG_VERSION = 2
 
 DEFAULT_CONFIG = Path.home() / ".synthesis" / "git-hook-config.yaml"

--- a/skills/synthesis-git-hooks/scripts/_load_config.py
+++ b/skills/synthesis-git-hooks/scripts/_load_config.py
@@ -67,6 +67,7 @@ DEFAULT_CONFIG = Path.home() / ".synthesis" / "git-hook-config.yaml"
 CORE_ENGINE_FILES = ("pre-commit", "commit-msg", "_load_config.py")
 COORDINATION_ENGINE_FILES = (
     "coordination.py",
+    "claim_scope.py",
     "coordination_schema.py",
     "pointer_lock.py",
     "peer_addressing.py",

--- a/skills/synthesis-git-hooks/scripts/install.sh
+++ b/skills/synthesis-git-hooks/scripts/install.sh
@@ -26,6 +26,7 @@ CONFIG_PATH="$HOME/.synthesis/git-hook-config.yaml"
 
 for source in \
     "$COORDINATION_SOURCE/coordination.py" \
+    "$COORDINATION_SOURCE/claim_scope.py" \
     "$COORDINATION_SOURCE/coordination_schema.py" \
     "$COORDINATION_SOURCE/pointer_lock.py" \
     "$COORDINATION_SOURCE/peer_addressing.py" \
@@ -45,6 +46,7 @@ cp -f "$SCRIPT_DIR/pre-commit" "$TARGET_DIR/pre-commit"
 cp -f "$SCRIPT_DIR/commit-msg" "$TARGET_DIR/commit-msg"
 cp -f "$SCRIPT_DIR/_load_config.py" "$TARGET_DIR/_load_config.py"
 cp -f "$COORDINATION_SOURCE/coordination.py" "$TARGET_DIR/coordination.py"
+cp -f "$COORDINATION_SOURCE/claim_scope.py" "$TARGET_DIR/claim_scope.py"
 cp -f "$COORDINATION_SOURCE/coordination_schema.py" "$TARGET_DIR/coordination_schema.py"
 cp -f "$COORDINATION_SOURCE/pointer_lock.py" "$TARGET_DIR/pointer_lock.py"
 cp -f "$COORDINATION_SOURCE/peer_addressing.py" "$TARGET_DIR/peer_addressing.py"
@@ -56,6 +58,7 @@ chmod +x \
     "$TARGET_DIR/commit-msg" \
     "$TARGET_DIR/_load_config.py" \
     "$TARGET_DIR/coordination.py" \
+    "$TARGET_DIR/claim_scope.py" \
     "$TARGET_DIR/coordination_schema.py" \
     "$TARGET_DIR/pointer_lock.py" \
     "$TARGET_DIR/peer_addressing.py"

--- a/skills/synthesis-git-hooks/scripts/pre-commit
+++ b/skills/synthesis-git-hooks/scripts/pre-commit
@@ -111,7 +111,7 @@ case "${COORDINATION_CHECK_STAGED:-}" in
     1)
         COORDINATION_RUNTIME="$HOOK_DIR/coordination.py"
         COORDINATION_ASSET="$HOOK_DIR/../references/session-words-v1.txt.zlib.b85"
-        for dependency in coordination.py coordination_schema.py pointer_lock.py; do
+        for dependency in coordination.py claim_scope.py coordination_schema.py pointer_lock.py; do
             [ -f "$HOOK_DIR/$dependency" ] || fail_closed "coordination runtime incomplete: missing $HOOK_DIR/$dependency."
         done
         [ -f "$COORDINATION_ASSET" ] || fail_closed "coordination runtime incomplete: missing $COORDINATION_ASSET."

--- a/skills/synthesis-git-hooks/scripts/test_pre_commit.py
+++ b/skills/synthesis-git-hooks/scripts/test_pre_commit.py
@@ -974,6 +974,7 @@ def test_r4_installer_copies_coordination_runtime(tmp_path: Path) -> None:
         "commit-msg",
         "_load_config.py",
         "coordination.py",
+        "claim_scope.py",
         "coordination_schema.py",
         "pointer_lock.py",
         "peer_addressing.py",

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,7 +1,7 @@
 schema: 2
-suite: successor-routing-freshness-2026-09-09
+suite: metadata-claim-agreement-2026-09-09
 membership: closed
-production_entry_point: Refresh feedback and opt-in report routing; context doctor dated-session evidence
+production_entry_point: Board claim admission, copied Git hooks and verified runtime update
 enforcing_boundary: release.py derives exact Git changed paths and consumes fresh transaction-bound acceptance
   before source publication and both-client installation
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
@@ -9,11 +9,10 @@ change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: Fixtures establish source behavior with isolated Git records, boards and native-evidence
-  fixtures. They do not prove actual native startup, agent adherence to prose, real recipient delivery,
-  multi-computer support or foreign project repair. Documentation receives manual review; installed bytes
-  and genuine native behavior require separate acceptance. No project activation, claim transfer, foreign
-  repair, deployment, automation or memory change is authorized by this suite.
+unverified_remainder: Fixtures prove source behavior and verified update mechanics. They do not establish
+  actual native startup, full agent instruction reads, natural Stop completion, multi-computer readiness
+  or foreign repair. Installed bytes and real native acceptance are verified separately. No row-level
+  registry authority is implemented.
 changed_surfaces:
 - path: .claude-plugin/plugin.json
   cases:
@@ -27,255 +26,309 @@ changed_surfaces:
 - path: README.md
   cases:
   - release-contract
-- path: skills/synthesis-checkpoint/SKILL.md
+- path: skills/synthesis-git-hooks/SKILL.md
   cases:
-  - successor-delivery
-  - invalid-route
-  - route-revision
-  - explicit-registry
-  - peer-delivery
-  - exact-address
-  - structural-route
-  - registry-layout
-  - no-free-fallback
-  - workday-publication
-  - session-mismatch
-  - ahead-record
-  - missing-evidence
-  - conflicting-caches
-  - invalid-date
-  - unreadable-log
-  - author-committer
-  - late-closure
-  - bulk-new-evidence
-  - dirty-new-evidence
-  - index-new-evidence
-  - changed-anchor
-  - review-positive
-  - review-expiry
-  - review-unresolvable
-- path: skills/synthesis-checkpoint/references/refresh-and-report.md
-  cases: &id001
-  - successor-delivery
-  - invalid-route
-  - route-revision
-  - explicit-registry
-  - peer-delivery
-  - exact-address
-  - structural-route
-  - registry-layout
-  - no-free-fallback
-- path: skills/synthesis-checkpoint/scripts/refresh.py
-  cases: *id001
-- path: skills/synthesis-checkpoint/scripts/test_refresh.py
-  cases: *id001
-- path: skills/synthesis-context-lifecycle/SKILL.md
-  cases: &id002
-  - workday-publication
-  - session-mismatch
-  - ahead-record
-  - missing-evidence
-  - conflicting-caches
-  - invalid-date
-  - unreadable-log
-  - author-committer
-  - late-closure
-  - bulk-new-evidence
-  - dirty-new-evidence
-  - index-new-evidence
-  - changed-anchor
-  - review-positive
-  - review-expiry
-  - review-unresolvable
-- path: skills/synthesis-context-lifecycle/scripts/context_doctor.py
-  cases: *id002
-- path: skills/synthesis-context-lifecycle/scripts/test_context_doctor.py
-  cases: *id002
-- path: skills/synthesis-daily-rituals/SKILL.md
-  cases: *id002
+  - standalone-bundle
+  - missing-runtime
+  - release-contract
+- path: skills/synthesis-git-hooks/scripts/_load_config.py
+  cases:
+  - standalone-bundle
+  - missing-runtime
+- path: skills/synthesis-git-hooks/scripts/install.sh
+  cases:
+  - standalone-bundle
+  - missing-runtime
+- path: skills/synthesis-git-hooks/scripts/pre-commit
+  cases:
+  - standalone-bundle
+  - missing-runtime
+- path: skills/synthesis-git-hooks/scripts/test_pre_commit.py
+  cases:
+  - standalone-bundle
+  - missing-runtime
 - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
   cases:
-  - successor-delivery
-  - invalid-route
-  - route-revision
-  - explicit-registry
-  - peer-delivery
-  - exact-address
-  - structural-route
-  - registry-layout
-  - no-free-fallback
-  - workday-publication
-  - session-mismatch
-  - ahead-record
-  - missing-evidence
-  - conflicting-caches
-  - invalid-date
-  - unreadable-log
-  - author-committer
-  - late-closure
-  - bulk-new-evidence
-  - dirty-new-evidence
-  - index-new-evidence
-  - changed-anchor
-  - review-positive
-  - review-expiry
-  - review-unresolvable
+  - metadata-admission
+  - scope-controls
+  - aliases
+  - unknown-identity
+  - repair-scope
+  - physical-delimiters
+  - relative-source
+  - actor-authority
+  - virtual-resource
+  - public-api
+  - git-root
+  - nonrepo-installation
+  - nonrepo-ancestor
+  - nonrepo-refusal
+  - nonrepo-files
+  - introduce-helper
+  - reject-unproven-bundle
+  - restore-failed-update
+  - standalone-bundle
+  - missing-runtime
+  - phase-update
   - release-contract
   - manifest
   - unlisted-path
   - transaction-binding
+- path: skills/synthesis-onboarding/SKILL.md
+  cases:
+  - introduce-helper
+  - reject-unproven-bundle
+  - restore-failed-update
+  - phase-update
+  - release-contract
+- path: skills/synthesis-onboarding/scripts/runtime_payload.py
+  cases:
+  - introduce-helper
+  - reject-unproven-bundle
+  - restore-failed-update
+  - phase-update
+- path: skills/synthesis-onboarding/scripts/test_runtime_integration.py
+  cases:
+  - introduce-helper
+  - reject-unproven-bundle
+  - restore-failed-update
+  - phase-update
+- path: skills/synthesis-onboarding/scripts/test_runtime_payload.py
+  cases:
+  - introduce-helper
+  - reject-unproven-bundle
+  - restore-failed-update
+  - phase-update
 - path: skills/synthesis-project-management/SKILL.md
   cases:
+  - metadata-admission
+  - scope-controls
+  - aliases
+  - unknown-identity
+  - repair-scope
+  - physical-delimiters
+  - relative-source
+  - actor-authority
+  - virtual-resource
+  - public-api
+  - git-root
+  - nonrepo-installation
+  - nonrepo-ancestor
+  - nonrepo-refusal
+  - nonrepo-files
   - release-contract
+- path: skills/synthesis-project-management/references/parallel-agent-protocol.md
+  cases:
+  - metadata-admission
+  - scope-controls
+  - aliases
+  - unknown-identity
+  - repair-scope
+  - physical-delimiters
+  - relative-source
+  - actor-authority
+  - virtual-resource
+  - public-api
+  - git-root
+  - nonrepo-installation
+  - nonrepo-ancestor
+  - nonrepo-refusal
+  - nonrepo-files
+- path: skills/synthesis-project-management/scripts/claim_scope.py
+  cases:
+  - metadata-admission
+  - scope-controls
+  - aliases
+  - unknown-identity
+  - repair-scope
+  - physical-delimiters
+  - relative-source
+  - actor-authority
+  - virtual-resource
+  - public-api
+  - git-root
+  - nonrepo-installation
+  - nonrepo-ancestor
+  - nonrepo-refusal
+  - nonrepo-files
 - path: skills/synthesis-project-management/scripts/coordination.py
-  cases: *id001
-- path: skills/synthesis-project-management/scripts/project_recipient.py
-  cases: *id001
+  cases:
+  - metadata-admission
+  - scope-controls
+  - aliases
+  - unknown-identity
+  - repair-scope
+  - physical-delimiters
+  - relative-source
+  - actor-authority
+  - virtual-resource
+  - public-api
+  - git-root
+  - nonrepo-installation
+  - nonrepo-ancestor
+  - nonrepo-refusal
+  - nonrepo-files
 - path: skills/synthesis-project-management/scripts/test_coordination.py
-  cases: *id001
+  cases:
+  - metadata-admission
+  - scope-controls
+  - aliases
+  - unknown-identity
+  - repair-scope
+  - physical-delimiters
+  - relative-source
+  - actor-authority
+  - virtual-resource
+  - public-api
+  - git-root
+  - nonrepo-installation
+  - nonrepo-ancestor
+  - nonrepo-refusal
+  - nonrepo-files
 cases:
-- id: successor-delivery
+- id: metadata-admission
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-checkpoint/scripts/test_refresh.py::test_successor_feedback_delivers_without_reactivating_source
-  motivating_defect: Archived report destinations lost feedback; rerouting must preserve source restrictions.
-- id: invalid-route
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_logical_metadata_claim_is_refused_before_board_admission
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: scope-controls
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-checkpoint/scripts/test_refresh.py::test_invalid_successor_route_preserves_board_and_local_report
-  motivating_defect: Ambiguous, missing or cyclic relationships must not misdeliver a report.
-- id: route-revision
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_shared_claim_scope_is_symmetric_and_preserves_disjoint_work
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: aliases
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-checkpoint/scripts/test_refresh.py::test_successor_route_change_is_a_new_revision
-  motivating_defect: Changed routing evidence must not be suppressed as an old duplicate.
-- id: explicit-registry
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_metadata_relative_and_symlink_spellings_use_verified_checkout
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: unknown-identity
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-checkpoint/scripts/test_refresh.py::test_explicit_recipient_registry_never_falls_back
-  motivating_defect: An unavailable explicit recipient registry must not choose another workspace.
-- id: peer-delivery
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_metadata_identity_failure_cannot_be_treated_as_disjoint
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: repair-scope
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_project_report_message_reaches_successor_inbox_without_claim_mutation
-  motivating_defect: Reports need actual peer-consumer delivery without altering ownership.
-- id: exact-address
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_possible_repair_scope_is_explicitly_broader_than_exact_resource_claims
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: physical-delimiters
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_report_exact_session_recipient_is_never_redirected
-  motivating_defect: Exact session addresses must not inherit project successor routes.
-- id: structural-route
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_shared_scope_preserves_physical_synthetic_paths_and_row_delimiters
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: relative-source
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_report_route_needs_unambiguous_structural_relationship
-  motivating_defect: Narrative, duplicate fields and unsupported syntax cannot authorize routing.
-- id: registry-layout
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_relative_source_scope_does_not_inherit_the_invoking_checkout
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: actor-authority
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_report_registry_supports_project_block_layouts_without_prose_inference
-  motivating_defect: Supported registry layouts must resolve literal relationships consistently.
-- id: no-free-fallback
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_logical_metadata_conflict_never_authorizes_sibling_checkout
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: virtual-resource
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_invalid_explicit_report_registry_cannot_use_free_address
-  motivating_defect: Explicit routing failure must not become an unregistered delivery.
-- id: workday-publication
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_virtual_resources_never_use_filesystem_identity
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: public-api
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_delayed_publication_preserves_recorded_workday
-  motivating_defect: Overnight and delayed publication timestamps falsely redefined workdays.
-- id: session-mismatch
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_public_overlap_api_uses_shared_logical_metadata_policy
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: git-root
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_session_mismatch_is_detected_without_a_newer_commit_date
-  motivating_defect: A backdated commit must not hide newer dated session evidence.
-- id: ahead-record
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_metadata_namespace_is_relative_to_git_root_not_ancestor_names
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: nonrepo-installation
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_cache_ahead_of_archive_is_a_mismatch_not_uncommitted_work
-  motivating_defect: A record ahead of its archive is not proof of uncommitted work.
-- id: missing-evidence
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_existing_nonrepo_runtime_scope_can_be_admitted_beside_metadata
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: nonrepo-ancestor
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_missing_log_is_explicit_and_cannot_make_commit_day_authoritative
-  motivating_defect: Missing dated evidence cannot be filled with commit dates.
-- id: conflicting-caches
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_nonrepo_ancestor_containing_linked_checkout_still_conflicts
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: nonrepo-refusal
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_missing_log_does_not_hide_disagreeing_cache_dates
-  motivating_defect: Missing archive coverage must not hide explicit field disagreement.
-- id: invalid-date
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_nonrepo_scope_exception_never_hides_unresolved_metadata_identity
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: nonrepo-files
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_invalid_log_date_is_unverifiable
-  motivating_defect: Invalid dates must not certify freshness.
-- id: unreadable-log
+  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_existing_nonrepo_runtime_files_are_disjoint_from_metadata
+  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
+    authority.
+- id: introduce-helper
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_unreadable_log_fails_closed_without_a_clean_report
-  motivating_defect: Unreadable session evidence must prevent a clean conclusion.
-- id: author-committer
+  fixture: ../synthesis-onboarding/scripts/test_runtime_payload.py::test_pre_helper_bundle_upgrade_proves_old_pointer_and_executes_new_closure
+  motivating_defect: The new helper must reach verified existing bundles without adopting unrelated or
+    damaged payloads.
+- id: reject-unproven-bundle
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_author_and_committer_dates_do_not_override_session_evidence
-  motivating_defect: Distinct author and committer times cannot override the workday.
-- id: late-closure
+  fixture: ../synthesis-onboarding/scripts/test_runtime_payload.py::test_claim_helper_introduction_requires_released_companion_anchors
+  motivating_defect: The new helper must reach verified existing bundles without adopting unrelated or
+    damaged payloads.
+- id: restore-failed-update
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_delayed_completion_commit_does_not_reopen_project
-  motivating_defect: Publishing closure later must not imply resumed work.
-- id: bulk-new-evidence
+  fixture: ../synthesis-onboarding/scripts/test_runtime_payload.py::test_failed_claim_helper_introduction_restores_old_bundle_and_absence
+  motivating_defect: The new helper must reach verified existing bundles without adopting unrelated or
+    damaged payloads.
+- id: standalone-bundle
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_post_completion_session_rearms_review_even_in_bulk_commit
-  motivating_defect: New session evidence in bulk commits must expire an old review.
-- id: dirty-new-evidence
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_installer_copies_coordination_runtime
+  motivating_defect: The copied runtime must contain and verify its actual import closure.
+- id: missing-runtime
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_uncommitted_post_completion_session_is_not_covered_by_review
-  motivating_defect: Pending dated evidence must not inherit an older review.
-- id: index-new-evidence
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_configured_hook_missing_runtime_fails_closed
+  motivating_defect: Missing ownership enforcement cannot permit a commit.
+- id: phase-update
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_index_only_session_change_cannot_inherit_project_review
-  motivating_defect: A new index session date must expire an old project-path acknowledgment.
-- id: changed-anchor
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::SessionEvidenceTests::test_changed_completion_anchor_cannot_inherit_project_review
-  motivating_defect: Changing the completion anchor must not inherit review of another dated claim.
-- id: review-positive
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::PostCloseAcknowledgmentTests::test_a_review_covering_every_commit_silences_it
-  motivating_defect: A review covering the actual dated evidence remains effective.
-- id: review-expiry
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::PostCloseAcknowledgmentTests::test_the_acknowledgment_re_arms_on_the_next_project_commit
-  motivating_defect: A later project snapshot must not inherit old review authority.
-- id: review-unresolvable
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-context-lifecycle/scripts/test_context_doctor.py::PostCloseAcknowledgmentTests::test_an_unresolvable_sha_is_a_defect_not_a_silent_pass
-  motivating_defect: Missing Git review evidence must fail visibly.
+  fixture: ../synthesis-onboarding/scripts/test_runtime_integration.py::test_public_update_refreshes_independently_wired_runtime_and_preserves_personal_state
+  motivating_defect: The real update phase must preserve settings while installing the selected runtime.
 - id: release-contract
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent
-  motivating_defect: Release manifests, changelog, README and skill versions must describe one release.
+  motivating_defect: Manifests and documentation must describe one release.
 - id: manifest
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-  motivating_defect: Closed membership and fixture paths must validate.
+  motivating_defect: The release boundary must consume fresh acceptance covering the exact changed file
+    universe.
 - id: unlisted-path
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_schema2_rejects_undeclared_git_changed_surface
-  motivating_defect: Changed files must not escape the acceptance universe.
+  motivating_defect: The release boundary must consume fresh acceptance covering the exact changed file
+    universe.
 - id: transaction-binding
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_schema2_receipt_binds_transaction_and_git_state
-  motivating_defect: A different source or transaction cannot reuse acceptance evidence.
+  motivating_defect: The release boundary must consume fresh acceptance covering the exact changed file
+    universe.

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -26,6 +26,9 @@ changed_surfaces:
 - path: README.md
   cases:
   - release-contract
+- path: skills/synthesis-agent-conformance/scripts/test_diagnostic_parity.py
+  cases:
+  - diagnostic-claim-fixture
 - path: skills/synthesis-git-hooks/SKILL.md
   cases:
   - standalone-bundle
@@ -74,6 +77,8 @@ changed_surfaces:
   - manifest
   - unlisted-path
   - transaction-binding
+  - engine-versions
+  - diagnostic-claim-fixture
 - path: skills/synthesis-onboarding/SKILL.md
   cases:
   - introduce-helper
@@ -81,12 +86,19 @@ changed_surfaces:
   - restore-failed-update
   - phase-update
   - release-contract
+  - engine-versions
+- path: skills/synthesis-onboarding/scripts/onboard.py
+  cases:
+  - engine-versions
 - path: skills/synthesis-onboarding/scripts/runtime_payload.py
   cases:
   - introduce-helper
   - reject-unproven-bundle
   - restore-failed-update
   - phase-update
+- path: skills/synthesis-onboarding/scripts/synthesis_cli.py
+  cases:
+  - engine-versions
 - path: skills/synthesis-onboarding/scripts/test_runtime_integration.py
   cases:
   - introduce-helper
@@ -332,3 +344,14 @@ cases:
   fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_schema2_receipt_binds_transaction_and_git_state
   motivating_defect: The release boundary must consume fresh acceptance covering the exact changed file
     universe.
+- id: engine-versions
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_engine_versions_and_skill_contract_agree
+  motivating_defect: Both executable version surfaces and their skill contract must agree.
+- id: diagnostic-claim-fixture
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-agent-conformance/scripts/test_diagnostic_parity.py::test_valid_active_pointer_reconciles_without_mutation
+  motivating_defect: The diagnostic fixture must supply an actual sender workspace before ownership can
+    be verified.

--- a/skills/synthesis-onboarding/SKILL.md
+++ b/skills/synthesis-onboarding/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.4.0"
+  version: "2.4.1"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-onboarding/scripts/onboard.py
+++ b/skills/synthesis-onboarding/scripts/onboard.py
@@ -94,7 +94,7 @@ from whole_system import (
     validate_personal_policy,
 )
 
-ENGINE_VERSION = "2.4.0"
+ENGINE_VERSION = "2.4.1"
 PUBLIC_REPO_HTTPS = "https://github.com/synthesisengineering/synthesis-skills.git"
 PUBLIC_MARKETPLACE_REF = "synthesisengineering/synthesis-skills"
 PLUGIN_NAME = "synthesis-skills"

--- a/skills/synthesis-onboarding/scripts/runtime_payload.py
+++ b/skills/synthesis-onboarding/scripts/runtime_payload.py
@@ -27,6 +27,10 @@ from system_contract import (
 
 COMPONENTS = frozenset({"git-hooks", "message-guard", "kernel", "day-end"})
 INTRODUCED_DEPENDENCIES = {
+    "skills/synthesis-project-management/scripts/claim_scope.py": (
+        "skills/synthesis-project-management/scripts/coordination.py",
+        "skills/synthesis-git-hooks/scripts/pre-commit",
+    ),
     "skills/synthesis-daily-rituals/scripts/ritual_state.py": (
         "skills/synthesis-daily-rituals/scripts/day-end",
         "skills/synthesis-daily-rituals/scripts/day-end-nudge.sh",
@@ -249,7 +253,12 @@ def _released_match(entry, before, historical):
         return True
     if entry.source_relative == "@git-hooks-source-path" and before[1] == entry.mode:
         required = {relative for component, relative, _, _ in _specs(entry.target.parents[2], entry.target.parent, {"git-hooks"})}
-        if required <= set(by_relative):
+        missing = required - set(by_relative)
+        # A historical bundle predates explicitly declared dependencies. Its
+        # old pointer still needs every other member and the released anchors
+        # that authorize introducing each absent dependency.
+        if (missing <= set(INTRODUCED_DEPENDENCIES)
+                and all(set(INTRODUCED_DEPENDENCIES[relative]) <= set(by_relative) for relative in missing)):
             return _pointer_matches(entry.target.read_bytes(), historical)
     return False
 
@@ -317,8 +326,8 @@ def plan(source_root, home, state_dir, components, receipt_data, *, legacy_relea
     Legacy descriptors identify explicit immutable roots. The optional local
     acquisition repository supplies older tagged blobs bound to the current
     source commit; this function never fetches, checks out or scans other roots.
-    Only the declared day-end helper may be newly introduced, and only when
-    both already-present launcher anchors have independent released-byte proof.
+    Only declared dependencies may be newly introduced, and only when their
+    already-present companion anchors have independent released-byte proof.
     """
     home, state_dir = Path(home), Path(state_dir)
     if pending(state_dir):
@@ -351,7 +360,7 @@ def plan(source_root, home, state_dir, components, receipt_data, *, legacy_relea
         for relative in INTRODUCED_DEPENDENCIES[accepted[position].source_relative]:
             anchor = by_relative.get(relative)
             if anchor is None or snapshots[anchor] is None:
-                raise ContractError("new runtime dependency requires both existing released day-end anchors")
+                raise ContractError("new runtime dependency requires its existing released companion anchors")
             required_anchors.add(anchor)
     needed = unresolved | (required_anchors - released)
 

--- a/skills/synthesis-onboarding/scripts/runtime_payload.py
+++ b/skills/synthesis-onboarding/scripts/runtime_payload.py
@@ -98,7 +98,7 @@ def _specs(home, state_dir, components):
         for name in ("pre-commit", "commit-msg", "_load_config.py"):
             result.append(("git-hooks", "skills/synthesis-git-hooks/scripts/" + name,
                            home / ".synthesis/git-hooks" / name, 0o755))
-        for name in ("coordination.py", "coordination_schema.py", "pointer_lock.py", "peer_addressing.py"):
+        for name in ("coordination.py", "claim_scope.py", "coordination_schema.py", "pointer_lock.py", "peer_addressing.py"):
             result.append(("git-hooks", "skills/synthesis-project-management/scripts/" + name,
                            home / ".synthesis/git-hooks" / name, 0o755))
         result.append(("git-hooks", "skills/synthesis-project-management/references/session-words-v1.txt.zlib.b85",

--- a/skills/synthesis-onboarding/scripts/synthesis_cli.py
+++ b/skills/synthesis-onboarding/scripts/synthesis_cli.py
@@ -43,7 +43,7 @@ from system_contract import (
 )
 
 
-ENGINE_VERSION = "2.4.0"
+ENGINE_VERSION = "2.4.1"
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CLI_COMMANDS = (
     "setup",

--- a/skills/synthesis-onboarding/scripts/test_runtime_integration.py
+++ b/skills/synthesis-onboarding/scripts/test_runtime_integration.py
@@ -199,7 +199,7 @@ def test_public_update_refreshes_independently_wired_runtime_and_preserves_perso
     assert receipt["layer_choices"] == machine.original_receipt["layer_choices"]
     assert receipt["component_choices"] == machine.original_receipt["component_choices"]
     assert receipt["generated_files"] == {}, "independent refresh must not invent uninstall ownership"
-    assert len(receipt["runtime_payloads"]["files"]) == 9
+    assert len(receipt["runtime_payloads"]["files"]) == 10
     assert onboard._protective_doctors({"git-hooks"})[0] is True
     assert phase(machine, verify_only=True).exit_code() == 0
 

--- a/skills/synthesis-onboarding/scripts/test_runtime_integration.py
+++ b/skills/synthesis-onboarding/scripts/test_runtime_integration.py
@@ -33,7 +33,7 @@ GIT_PAYLOADS = {
     **{"skills/synthesis-git-hooks/scripts/" + name: (".synthesis/git-hooks/" + name, 0o755)
        for name in ("pre-commit", "commit-msg", "_load_config.py")},
     **{"skills/synthesis-project-management/scripts/" + name: (".synthesis/git-hooks/" + name, 0o755)
-       for name in ("coordination.py", "coordination_schema.py", "pointer_lock.py", "peer_addressing.py")},
+       for name in ("coordination.py", "claim_scope.py", "coordination_schema.py", "pointer_lock.py", "peer_addressing.py")},
     "skills/synthesis-project-management/references/session-words-v1.txt.zlib.b85":
         (".synthesis/references/session-words-v1.txt.zlib.b85", 0o644),
 }

--- a/skills/synthesis-onboarding/scripts/test_runtime_payload.py
+++ b/skills/synthesis-onboarding/scripts/test_runtime_payload.py
@@ -763,3 +763,96 @@ def test_failed_dependency_introduction_restores_anchors_and_absence(day_end_his
     after = snapshot(machine.home)
     assert {path: after[path] for path in before} == before
     machine.receipts.assert_current()
+
+
+CLAIM_DEPENDENCY = "skills/synthesis-project-management/scripts/claim_scope.py"
+
+
+@pytest.fixture
+def pre_claim_bundle(tmp_path):
+    """A released standalone bundle whose installed closure predates the helper."""
+    from types import SimpleNamespace
+    old = tmp_path / "old"
+    descriptor = release(old, "1.0.0", omit=(CLAIM_DEPENDENCY,))
+    current = tmp_path / "current"
+    subprocess.run(["git", "clone", str(old), str(current)], check=True, capture_output=True)
+    fixture_git(current, "config", "user.name", "Fixture")
+    fixture_git(current, "config", "user.email", "fixture@example.invalid")
+    source = Path(runtime.__file__).resolve().parents[3]
+    for relative in SOURCE_FILES["git-hooks"]:
+        (current / relative).write_bytes((source / relative).read_bytes())
+    for client in ("claude", "codex"):
+        (current / ("." + client + "-plugin/plugin.json")).write_text(json.dumps({
+            "name": "synthesis-skills", "version": "1.0.1",
+        }))
+    fixture_git(current, "add", ".")
+    fixture_git(current, "commit", "-qm", "Fixture")
+    fixture_git(current, "tag", "v1.0.1")
+    home = tmp_path / "home"
+    state = home / ".local/state/synthesis"
+    for relative, (target, mode) in SOURCE_FILES["git-hooks"].items():
+        if relative == CLAIM_DEPENDENCY:
+            continue
+        path = home / target
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes((old / relative).read_bytes())
+        path.chmod(mode)
+    pointer = home / ".synthesis/git-hooks/source-path"
+    pointer.write_text(str(old / "skills/synthesis-git-hooks/scripts") + "\n")
+    pointer.chmod(0o644)
+    return SimpleNamespace(current=current, old=old, descriptor=descriptor, home=home,
+        state=state, receipts=Receipts(state / "receipts.json"), pointer=pointer,
+        helper=home / SOURCE_FILES["git-hooks"][CLAIM_DEPENDENCY][0])
+
+
+def claim_bundle_plan(machine, proof="descriptor"):
+    kwargs = {"legacy_releases": [(machine.old, machine.descriptor)]} if proof == "descriptor" else {
+        "legacy_git_root": machine.current,
+    }
+    return runtime.plan(machine.current, machine.home, machine.state, {"git-hooks"},
+                        machine.receipts.data, **kwargs)
+
+
+@pytest.mark.parametrize("proof", ["descriptor", "history"])
+def test_pre_helper_bundle_upgrade_proves_old_pointer_and_executes_new_closure(pre_claim_bundle, proof):
+    machine = pre_claim_bundle
+    assert not machine.helper.exists()
+    runtime.apply(claim_bundle_plan(machine, proof), machine.receipts)
+    assert machine.helper.read_bytes() == (machine.current / CLAIM_DEPENDENCY).read_bytes()
+    assert machine.helper.stat().st_mode & 0o777 == 0o755
+    assert machine.pointer.read_text().strip() == str(machine.current / "skills/synthesis-git-hooks/scripts")
+    result = subprocess.run([sys.executable, "-B", "-c",
+        "import coordination; assert coordination.overlaps('release-train:fixture', 'release-train:fixture')"],
+        cwd=machine.helper.parent, capture_output=True, text=True, timeout=15,
+        env={**os.environ, "HOME": str(machine.home)})
+    assert result.returncode == 0, result.stderr
+    assert all(row["status"] == "current" for row in runtime.verify(claim_bundle_plan(machine, proof)))
+
+
+@pytest.mark.parametrize("damage", ["missing-engine", "modified-engine", "missing-hook", "modified-hook", "unrelated-pointer"])
+def test_claim_helper_introduction_requires_released_companion_anchors(pre_claim_bundle, damage):
+    machine = pre_claim_bundle
+    if damage == "unrelated-pointer":
+        machine.pointer.write_text(str(machine.home / "unrelated/scripts") + "\n")
+    else:
+        target = machine.helper.with_name("coordination.py" if damage.endswith("engine") else "pre-commit")
+        if damage.startswith("missing"):
+            target.unlink()
+        else:
+            target.write_text("independent local changes\n")
+    before = snapshot(machine.home)
+    with pytest.raises(ContractError):
+        claim_bundle_plan(machine)
+    assert snapshot(machine.home) == before
+    assert not machine.helper.exists()
+
+
+def test_failed_claim_helper_introduction_restores_old_bundle_and_absence(pre_claim_bundle):
+    machine = pre_claim_bundle
+    before = snapshot(machine.home)
+    with pytest.raises(ContractError, match="doctor failed"):
+        runtime.apply(claim_bundle_plan(machine), machine.receipts, verify_after=lambda: False)
+    after = snapshot(machine.home)
+    assert {path: after[path] for path in before} == before
+    assert not machine.helper.exists()
+    machine.receipts.assert_current()

--- a/skills/synthesis-onboarding/scripts/test_runtime_payload.py
+++ b/skills/synthesis-onboarding/scripts/test_runtime_payload.py
@@ -23,7 +23,7 @@ SOURCE_FILES = {
         "skills/synthesis-git-hooks/scripts/_load_config.py": (".synthesis/git-hooks/_load_config.py", 0o755),
         **{"skills/synthesis-project-management/scripts/" + n:
            (".synthesis/git-hooks/" + n, 0o755) for n in
-           ("coordination.py", "coordination_schema.py", "pointer_lock.py", "peer_addressing.py")},
+           ("coordination.py", "claim_scope.py", "coordination_schema.py", "pointer_lock.py", "peer_addressing.py")},
         "skills/synthesis-project-management/references/session-words-v1.txt.zlib.b85":
             (".synthesis/references/session-words-v1.txt.zlib.b85", 0o644),
     },

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.13.7"
+  version: "2.13.8"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-project-management/references/parallel-agent-protocol.md
+++ b/skills/synthesis-project-management/references/parallel-agent-protocol.md
@@ -34,6 +34,21 @@ machine:
 
 ## Claim scope over the task lifecycle
 
+Claim admission uses the shared `scripts/claim_scope.py` conflict predicate.
+Besides physical overlap, the same `projects/` metadata path in registered Git
+worktrees conflicts when their verified Git common directory is identical.
+Disjoint exact files and segment globs remain independent; ordinary source
+paths outside `projects/` remain isolated by checkout. Relative metadata claims
+need one unambiguous workspace context, and missing or ambiguous Git evidence
+refuses a possible logical overlap. Named resources such as release-train claims
+remain a separate namespace, independent of filesystem paths.
+
+Conflict identity does not grant write authority. Check-staged still requires
+the actor's exact physical worktree, branch and staged paths. A currency guard
+may ask whether a claim intersects the broader possible repair area (the project
+subtree or registry); that is explicitly broader than comparing two exact edits
+and is never proof of ownership or permission to write another checkout.
+
 Claims reserve the smallest coherent area needed for the current authorized
 task. Use exact files for independent edits. A directory claim is appropriate
 when the task requires coordinated changes across that directory, such as a

--- a/skills/synthesis-project-management/scripts/claim_scope.py
+++ b/skills/synthesis-project-management/scripts/claim_scope.py
@@ -12,11 +12,16 @@ import fnmatch
 import os
 from pathlib import Path
 import re
+import stat
 import subprocess
 
 
 class ClaimIdentityError(ValueError):
     """A possible logical metadata conflict lacks unambiguous Git identity."""
+
+
+class _NoVerifiedCheckout(ClaimIdentityError):
+    """Git ran but could not identify a checkout at this path."""
 
 
 def plain(value: str) -> str:
@@ -141,10 +146,43 @@ def _mixed_paths_intersect(absolute: tuple[str, ...], relative: tuple[str, ...])
     return False
 
 
+def _ordinary_nonrepo_scope(pattern: str) -> bool:
+    """Prove a literal existing ordinary scope has no Git administrative ancestor.
+
+    Its descendants are checked separately against the other claim's verified
+    registered worktrees; absence of a local .git does not prove containment safe.
+    """
+    if pattern.endswith("/**"):
+        pattern = pattern[:-3]  # the same subtree reserved by a literal directory
+    if _hint(pattern) is not None or any(token in pattern for token in "*?["):
+        return False
+    path = Path(pattern)
+    try:
+        mode = path.stat().st_mode
+        if not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
+            return False
+        directory = path if stat.S_ISDIR(mode) else path.parent
+        for parent in (directory, *directory.parents):
+            try:
+                (parent / ".git").lstat()
+            except FileNotFoundError:
+                pass
+            else:
+                return False
+            if (parent / "HEAD").is_file() and (parent / "objects").is_dir():
+                return False  # a bare repository is not an ordinary directory
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise ClaimIdentityError("ordinary claim filesystem identity is unavailable") from exc
+    return True
+
+
 class ClaimScopeResolver:
     """One-operation identity cache; never retained across board transactions."""
     def __init__(self):
         self.identities = {}
+        self.registered = {}
 
     def _physical(self, claim: str, workspaces) -> str:
         raw = os.path.expanduser(plain(claim))
@@ -183,7 +221,7 @@ class ClaimScopeResolver:
             except (OSError, subprocess.SubprocessError) as exc:
                 raise ClaimIdentityError("metadata claim Git identity is unavailable") from exc
             if done.returncode:
-                raise ClaimIdentityError("metadata claim has no verified Git checkout")
+                raise _NoVerifiedCheckout("metadata claim has no verified Git checkout")
             return done.stdout
         lines = git("rev-parse", "--path-format=absolute", "--git-common-dir", "--show-toplevel").splitlines()
         if len(lines) != 2 or not all(Path(line).is_absolute() and Path(line).is_dir() for line in lines):
@@ -192,9 +230,18 @@ class ClaimScopeResolver:
         registered = [str(Path(item[len("worktree "):]).resolve()) for item in git("worktree", "list", "--porcelain", "-z").split("\0") if item.startswith("worktree ")]
         if registered.count(root) != 1:
             raise ClaimIdentityError("metadata claim checkout is not uniquely registered")
+        self.registered[common] = tuple(registered)
         result = (common, root)
         self.identities[key] = result
         return result
+
+    def _scope_identity(self, pattern: str):
+        try:
+            return self._identity(pattern)
+        except _NoVerifiedCheckout:
+            if _ordinary_nonrepo_scope(pattern):
+                return None
+            raise
 
     def conflicts(self, left: str, right: str, *, left_workspaces=(), right_workspaces=()) -> bool:
         raw_left, raw_right = plain(left), plain(right)
@@ -214,8 +261,8 @@ class ClaimScopeResolver:
             return _mixed_paths_intersect(absolute, relative)
         left_hint, right_hint = _hint(a), _hint(b)
         try:
-            left_common, left_root = self._identity(a)
-            right_common, right_root = self._identity(b)
+            left_identity = self._scope_identity(a)
+            right_identity = self._scope_identity(b)
         except ClaimIdentityError:
             # Synthetic, non-Git paths in one physical projects directory can
             # still prove disjointness. Never use an ancestor's directory name
@@ -233,6 +280,17 @@ class ClaimScopeResolver:
                 return _patterns_intersect(raw_a, raw_b)
             absolute, relative = (raw_a, raw_b) if Path(plain(left)).is_absolute() else (raw_b, raw_a)
             return _mixed_paths_intersect(absolute, relative)
+        if left_identity is None or right_identity is None:
+            if left_identity is None and right_identity is None:
+                return False
+            ordinary, metadata, identity = (a, b, right_identity) if left_identity is None else (b, a, left_identity)
+            common, root = identity
+            relative = Path(metadata).relative_to(root).as_posix()
+            if not _metadata_suffixes(_parts(relative)):
+                return False
+            return any(Path(checkout).is_relative_to(_prefix(ordinary)) for checkout in self.registered[common])
+        left_common, left_root = left_identity
+        right_common, right_root = right_identity
         if left_common != right_common:
             return False
         try:

--- a/skills/synthesis-project-management/scripts/claim_scope.py
+++ b/skills/synthesis-project-management/scripts/claim_scope.py
@@ -1,0 +1,248 @@
+"""Shared conflict detection, deliberately separate from write authorization.
+
+Physical claims conflict where their path patterns intersect. The projects/
+metadata namespace also conflicts at the same relative target in registered
+worktrees with one verified Git common directory. This never permits writing a
+sibling checkout. Missing identity is an error, not evidence of foreign work.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+import fnmatch
+import os
+from pathlib import Path
+import re
+import subprocess
+
+
+class ClaimIdentityError(ValueError):
+    """A possible logical metadata conflict lacks unambiguous Git identity."""
+
+
+def plain(value: str) -> str:
+    return re.sub(r"`(.+?)`", r"\1", re.sub(r"\*\*(.+?)\*\*", r"\1", value)).strip()
+
+
+def split_values(value: str) -> list[str]:
+    clean = plain(value)
+    if not clean or clean.lower().startswith("released"):
+        return []
+    return [part.strip() for part in re.split(r"[,;]|<br\s*/?>", clean) if part.strip()]
+
+
+def workspace_parts(workspace: str) -> tuple[str, str]:
+    return tuple(plain(part) for part in workspace.rsplit(" @ ", 1)) if " @ " in workspace else (plain(workspace), "unknown")
+
+
+def _prefix(pattern: str) -> str:
+    return re.split(r"[*?\[]", pattern, maxsplit=1)[0].rstrip("/")
+
+
+def _tokens(segment: str) -> tuple[str, ...]:
+    result = []
+    offset = 0
+    while offset < len(segment):
+        end = offset + 1
+        if segment[offset] == "[":
+            if end < len(segment) and segment[end] == "!":
+                end += 1
+            if end < len(segment) and segment[end] == "]":
+                end += 1
+            end = segment.find("]", end)
+            end = end + 1 if end >= 0 else offset + 1
+        result.append(segment[offset:end])
+        offset = end
+    return tuple(result)
+
+
+@lru_cache(maxsize=4096)
+def _segments_intersect(left: str, right: str) -> bool:
+    """Intersect glob NFAs using character-class boundary representatives."""
+    if not any(c in left + right for c in "*?["):
+        return left == right
+    a, b = _tokens(left), _tokens(right)
+    # Class predicates change only at literal/range boundaries. Adjacent code
+    # points plus a generic character cover positive and negated Unicode ranges.
+    points = {1, ord("_"), 0x10FFFF}
+    for character in left + right:
+        points.update(p for p in (ord(character) - 1, ord(character), ord(character) + 1) if 0 < p <= 0x10FFFF)
+    alphabet = [chr(p) for p in points if chr(p) != "/"]
+    pending = [(0, 0, False)]
+    seen = set()
+    while pending:
+        i, j, consumed = pending.pop()
+        if (i, j, consumed) in seen:
+            continue
+        seen.add((i, j, consumed))
+        if i == len(a) and j == len(b) and consumed:
+            return True
+        if i < len(a) and a[i] == "*":
+            pending.append((i + 1, j, consumed))
+        if j < len(b) and b[j] == "*":
+            pending.append((i, j + 1, consumed))
+        if i < len(a) and j < len(b) and any(fnmatch.fnmatchcase(c, a[i]) and fnmatch.fnmatchcase(c, b[j]) for c in alphabet):
+            pending.append((i if a[i] == "*" else i + 1, j if b[j] == "*" else j + 1, True))
+    return False
+
+
+def _parts(pattern: str) -> tuple[str, ...]:
+    parts = tuple(part for part in pattern.strip("/").split("/") if part and part != ".")
+    # Literal ancestor claims reserve their subtree; wildcard claims use exact
+    # segment semantics, including explicit ** for recursive descent.
+    return parts if any(c in pattern for c in "*?[") else (*parts, "**")
+
+
+@lru_cache(maxsize=4096)
+def _patterns_intersect(left: tuple[str, ...], right: tuple[str, ...]) -> bool:
+    pending = [(0, 0)]
+    seen = set()
+    while pending:
+        i, j = pending.pop()
+        if (i, j) in seen:
+            continue
+        seen.add((i, j))
+        if i == len(left) and j == len(right):
+            return True
+        if i < len(left) and left[i] == "**":
+            pending.append((i + 1, j))
+        if j < len(right) and right[j] == "**":
+            pending.append((i, j + 1))
+        if i < len(left) and j < len(right) and _segments_intersect("*" if left[i] == "**" else left[i], "*" if right[j] == "**" else right[j]):
+            pending.append((i if left[i] == "**" else i + 1, j if right[j] == "**" else j + 1))
+    return False
+
+
+def _metadata_suffixes(parts: tuple[str, ...]) -> list[tuple[str, ...]]:
+    suffixes = []
+    for i, part in enumerate(parts):
+        if part == "**":
+            suffixes.append(parts[i:])
+        elif fnmatch.fnmatchcase("projects", part):
+            suffixes.append(parts[i + 1:])
+        if part != "**":
+            break
+    return suffixes
+
+
+def _hint(pattern: str) -> tuple[str, ...] | None:
+    parts = _parts(pattern)
+    indices = [i for i, part in enumerate(parts) if part == "projects"]
+    return parts[indices[-1] + 1:] if indices else None
+
+
+class ClaimScopeResolver:
+    """One-operation identity cache; never retained across board transactions."""
+    def __init__(self):
+        self.identities = {}
+
+    def _physical(self, claim: str, workspaces) -> str:
+        raw = os.path.expanduser(plain(claim))
+        if not raw or "\x00" in raw:
+            raise ClaimIdentityError("claim path is empty or invalid")
+        if Path(raw).is_absolute():
+            return os.path.realpath(raw)
+        candidates = set()
+        for workspace in workspaces:
+            path, _ = workspace_parts(workspace)
+            base = Path(os.path.expanduser(path))
+            if not base.is_absolute():
+                continue
+            if Path(raw).parts and Path(raw).parts[0] == base.name:
+                base = base.parent
+            candidates.add(os.path.realpath(base / raw))
+        if len(candidates) != 1:
+            if _hint(raw) is not None:
+                raise ClaimIdentityError("relative metadata claim requires one exact checkout context")
+            return raw  # historical relative source claims retain lexical scope
+        return candidates.pop()
+
+    def _identity(self, pattern: str) -> tuple[str, str]:
+        prefix = Path(_prefix(pattern) or "/")
+        while not prefix.is_dir() and prefix != prefix.parent:
+            prefix = prefix.parent
+        key = str(prefix)
+        if key in self.identities:
+            return self.identities[key]
+        env = os.environ.copy()
+        for name in ("GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"):
+            env.pop(name, None)
+        def git(*args):
+            try:
+                done = subprocess.run(["git", "--no-optional-locks", "-C", key, *args], env=env, capture_output=True, text=True, timeout=10)
+            except (OSError, subprocess.SubprocessError) as exc:
+                raise ClaimIdentityError("metadata claim Git identity is unavailable") from exc
+            if done.returncode:
+                raise ClaimIdentityError("metadata claim has no verified Git checkout")
+            return done.stdout
+        lines = git("rev-parse", "--path-format=absolute", "--git-common-dir", "--show-toplevel").splitlines()
+        if len(lines) != 2 or not all(Path(line).is_absolute() and Path(line).is_dir() for line in lines):
+            raise ClaimIdentityError("metadata claim Git identity is ambiguous")
+        common, root = (str(Path(line).resolve()) for line in lines)
+        registered = [str(Path(item[len("worktree "):]).resolve()) for item in git("worktree", "list", "--porcelain", "-z").split("\0") if item.startswith("worktree ")]
+        if registered.count(root) != 1:
+            raise ClaimIdentityError("metadata claim checkout is not uniquely registered")
+        result = (common, root)
+        self.identities[key] = result
+        return result
+
+    def conflicts(self, left: str, right: str, *, left_workspaces=(), right_workspaces=()) -> bool:
+        raw_left, raw_right = plain(left), plain(right)
+        virtual_left = re.match(r"^[A-Za-z][A-Za-z0-9_-]*:", raw_left) is not None
+        virtual_right = re.match(r"^[A-Za-z][A-Za-z0-9_-]*:", raw_right) is not None
+        if virtual_left or virtual_right:
+            return virtual_left and virtual_right and _segments_intersect(raw_left, raw_right)
+        a, b = self._physical(left, left_workspaces), self._physical(right, right_workspaces)
+        if Path(a).is_absolute() == Path(b).is_absolute() and _patterns_intersect(_parts(a), _parts(b)):
+            return True
+        if not Path(a).is_absolute() or not Path(b).is_absolute():
+            # No absolute context was supplied for these ordinary source
+            # paths. The invoking process's checkout is not their identity.
+            if Path(a).is_absolute() == Path(b).is_absolute():
+                return False
+            absolute, relative = (_parts(a), _parts(b)) if Path(a).is_absolute() else (_parts(b), _parts(a))
+            return any(_patterns_intersect(absolute[i:], relative) for i in range(len(absolute)))
+        left_hint, right_hint = _hint(a), _hint(b)
+        if left_hint is not None and right_hint is not None and not _patterns_intersect(left_hint, right_hint):
+            return False
+        try:
+            left_common, left_root = self._identity(a)
+            right_common, right_root = self._identity(b)
+        except ClaimIdentityError:
+            if left_hint is not None or right_hint is not None:
+                raise
+            # No project metadata is implicated and no repository identity is
+            # available. Preserve physical/lexical source-path behavior only.
+            raw_a, raw_b = _parts(plain(left)), _parts(plain(right))
+            if Path(plain(left)).is_absolute() == Path(plain(right)).is_absolute():
+                return _patterns_intersect(raw_a, raw_b)
+            absolute, relative = (raw_a, raw_b) if Path(plain(left)).is_absolute() else (raw_b, raw_a)
+            return any(_patterns_intersect(absolute[i:], relative) for i in range(len(absolute)))
+        if left_common != right_common:
+            return False
+        try:
+            relative_a = Path(a).relative_to(left_root).as_posix()
+            relative_b = Path(b).relative_to(right_root).as_posix()
+        except ValueError as exc:
+            raise ClaimIdentityError("metadata claim escapes its verified checkout") from exc
+        return any(_patterns_intersect(x, y) for x in _metadata_suffixes(_parts(relative_a)) for y in _metadata_suffixes(_parts(relative_b)))
+
+
+def claim_conflicts(left: str, right: str, *, left_workspaces=(), right_workspaces=()) -> bool:
+    return ClaimScopeResolver().conflicts(left, right, left_workspaces=left_workspaces, right_workspaces=right_workspaces)
+
+
+def project_claim_overlap(project: Path, claim: str, workspaces=()) -> bool:
+    """Broad possible-repair scope, not an assertion that exact edits conflict.
+
+    Any project resource or its registry could need repair. Two disjoint exact
+    resource claims can therefore both intersect this broad target while they
+    remain independent under claim_conflicts. Native ownership is separate.
+    """
+    project = Path(project).expanduser()
+    if not project.is_absolute():
+        raise ClaimIdentityError("project repair scope requires an absolute path")
+    resolver = ClaimScopeResolver()
+    targets = [str(project / "**")]
+    if project.parent.name == "projects":
+        targets.append(str(project.parent / "index.yaml"))
+    return any(resolver.conflicts(target, claim, right_workspaces=workspaces) for target in targets)

--- a/skills/synthesis-project-management/scripts/claim_scope.py
+++ b/skills/synthesis-project-management/scripts/claim_scope.py
@@ -130,6 +130,17 @@ def _hint(pattern: str) -> tuple[str, ...] | None:
     return parts[indices[-1] + 1:] if indices else None
 
 
+def _mixed_paths_intersect(absolute: tuple[str, ...], relative: tuple[str, ...]) -> bool:
+    # Without a checkout context, align only against known directory names.
+    # A trailing ** cannot invent a new repository root for a relative claim.
+    for i, segment in enumerate(absolute):
+        if any(token in segment for token in "*?["):
+            break
+        if _patterns_intersect(absolute[i:], relative):
+            return True
+    return False
+
+
 class ClaimScopeResolver:
     """One-operation identity cache; never retained across board transactions."""
     def __init__(self):
@@ -200,14 +211,19 @@ class ClaimScopeResolver:
             if Path(a).is_absolute() == Path(b).is_absolute():
                 return False
             absolute, relative = (_parts(a), _parts(b)) if Path(a).is_absolute() else (_parts(b), _parts(a))
-            return any(_patterns_intersect(absolute[i:], relative) for i in range(len(absolute)))
+            return _mixed_paths_intersect(absolute, relative)
         left_hint, right_hint = _hint(a), _hint(b)
-        if left_hint is not None and right_hint is not None and not _patterns_intersect(left_hint, right_hint):
-            return False
         try:
             left_common, left_root = self._identity(a)
             right_common, right_root = self._identity(b)
         except ClaimIdentityError:
+            # Synthetic, non-Git paths in one physical projects directory can
+            # still prove disjointness. Never use an ancestor's directory name
+            # to decide the logical namespace of a verified Git checkout.
+            if (left_hint is not None and right_hint is not None
+                    and a.rsplit("/projects/", 1)[0] == b.rsplit("/projects/", 1)[0]
+                    and not _patterns_intersect(left_hint, right_hint)):
+                return False
             if left_hint is not None or right_hint is not None:
                 raise
             # No project metadata is implicated and no repository identity is
@@ -216,7 +232,7 @@ class ClaimScopeResolver:
             if Path(plain(left)).is_absolute() == Path(plain(right)).is_absolute():
                 return _patterns_intersect(raw_a, raw_b)
             absolute, relative = (raw_a, raw_b) if Path(plain(left)).is_absolute() else (raw_b, raw_a)
-            return any(_patterns_intersect(absolute[i:], relative) for i in range(len(absolute)))
+            return _mixed_paths_intersect(absolute, relative)
         if left_common != right_common:
             return False
         try:

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -244,53 +244,10 @@ def split_values(value: str) -> list[str]:
     return claim_scope.split_values(value)
 
 
-def claim_prefix(claim: str) -> str:
-    marker = len(claim)
-    for token in ("*", "?", "["):
-        position = claim.find(token)
-        if position >= 0:
-            marker = min(marker, position)
-    return claim[:marker].rstrip("/")
-
-
-def claim_segments(claim: str) -> tuple[bool, list[str]]:
-    prefix = claim_prefix(claim)
-    if not prefix:
-        return True, []
-    expanded = os.path.expanduser(prefix)
-    absolute = expanded.startswith("/")
-    segments = [part for part in expanded.strip("/").split("/") if part]
-    return absolute, segments
-
-
-def overlaps(left: str, right: str) -> bool:
-    """Conflict test for two claim globs.
-
-    Claims arrive in mixed spellings — absolute, ``~``-prefixed, and
-    repository-relative — and two spellings of one real path must still
-    conflict. Same-form claims overlap on segment-boundary containment.
-    A relative claim overlaps an absolute one when its segment run aligns
-    anywhere inside the absolute claim through the end of either claim;
-    that alignment can flag unrelated trees that share segment names, and
-    the protocol prefers that false conflict (resolved by re-scoping to
-    absolute claims) over silently missing a real one.
-    """
-    left_absolute, left_segments = claim_segments(left)
-    right_absolute, right_segments = claim_segments(right)
-    if not left_segments or not right_segments:
-        return True
-    if left_absolute == right_absolute:
-        shorter, longer = sorted(
-            (left_segments, right_segments), key=len
-        )
-        return longer[: len(shorter)] == shorter
-    absolute_segments = left_segments if left_absolute else right_segments
-    relative_segments = right_segments if left_absolute else left_segments
-    for start in range(len(absolute_segments)):
-        length = min(len(relative_segments), len(absolute_segments) - start)
-        if absolute_segments[start : start + length] == relative_segments[:length]:
-            return True
-    return False
+def overlaps(left: str, right: str, *, left_workspaces=(), right_workspaces=()) -> bool:
+    """Use the shared conflict policy without granting checkout authority."""
+    return claim_scope.claim_conflicts(left, right,
+        left_workspaces=left_workspaces, right_workspaces=right_workspaces)
 
 
 def workspace_parts(workspace: str) -> tuple[str, str]:

--- a/skills/synthesis-project-management/scripts/coordination.py
+++ b/skills/synthesis-project-management/scripts/coordination.py
@@ -25,6 +25,7 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from pointer_lock import locked_pointer
+import claim_scope
 from peer_addressing import (
     CLIENT_CODEX,
     SelfIdentity,
@@ -232,8 +233,7 @@ def template() -> str:
 
 
 def plain(value: str) -> str:
-    without_bold = re.sub(r"\*\*(.+?)\*\*", r"\1", value)
-    return re.sub(r"`(.+?)`", r"\1", without_bold).strip()
+    return claim_scope.plain(value)
 
 
 def sanitize(value: str) -> str:
@@ -241,17 +241,7 @@ def sanitize(value: str) -> str:
 
 
 def split_values(value: str) -> list[str]:
-    clean = plain(value)
-    if not clean or clean.lower().startswith("released"):
-        return []
-    # Semicolons appear in hand-migrated rows; treating them as content would
-    # fuse several claims into one unmatchable string and silently disable
-    # overlap detection for that row.
-    return [
-        item.strip()
-        for item in re.split(r"[,;]|<br\s*/?>", clean)
-        if item.strip()
-    ]
+    return claim_scope.split_values(value)
 
 
 def claim_prefix(claim: str) -> str:
@@ -304,10 +294,7 @@ def overlaps(left: str, right: str) -> bool:
 
 
 def workspace_parts(workspace: str) -> tuple[str, str]:
-    if " @ " not in workspace:
-        return plain(workspace), "unknown"
-    path, branch = workspace.rsplit(" @ ", 1)
-    return plain(path), plain(branch)
+    return claim_scope.workspace_parts(workspace)
 
 
 def workspace_conflict(left: str, right: str) -> bool:
@@ -1189,6 +1176,7 @@ def _check_staged_board_snapshot(board: Path) -> str | None:
 
 def validate_sessions(sessions: list[Session]) -> list[str]:
     problems: list[str] = []
+    scopes = claim_scope.ClaimScopeResolver()
     seen_selectors: dict[tuple[str, object], str] = {}
     for session in sessions:
         if session.session_uuid:
@@ -1232,7 +1220,13 @@ def validate_sessions(sessions: list[Session]) -> list[str]:
         for right in live[index + 1 :]:
             for left_claim in left.claims:
                 for right_claim in right.claims:
-                    if overlaps(left_claim, right_claim):
+                    try:
+                        conflict = scopes.conflicts(left_claim, right_claim,
+                            left_workspaces=left.workspaces, right_workspaces=right.workspaces)
+                    except claim_scope.ClaimIdentityError as exc:
+                        problems.append(f"{left.label} / {right.label}: unverifiable claim scope: {exc}")
+                        continue
+                    if conflict:
                         problems.append(
                             f"{left.label}:{left_claim} overlaps "
                             f"{right.label}:{right_claim}"

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -2601,10 +2601,13 @@ def test_metadata_namespace_is_relative_to_git_root_not_ancestor_names(tmp_path,
 
 
 @pytest.mark.parametrize("name", ["git-hooks", "agent-control"])
-def test_existing_nonrepo_runtime_scope_can_be_admitted_beside_metadata(metadata_worktrees, tmp_path, name):
+@pytest.mark.parametrize("recursive", [False, True])
+def test_existing_nonrepo_runtime_scope_can_be_admitted_beside_metadata(metadata_worktrees, tmp_path, name, recursive):
     root, _ = metadata_worktrees
     runtime = tmp_path / "home/.synthesis" / name
     runtime.mkdir(parents=True)
+    if recursive:
+        runtime /= "**"
     metadata = str(root / "projects/index.yaml")
     scope = scope_module()
     assert not scope.claim_conflicts(metadata, str(runtime))
@@ -2613,14 +2616,17 @@ def test_existing_nonrepo_runtime_scope_can_be_admitted_beside_metadata(metadata
     assert MODULE.command_claim(claim_args(board, session_id="A", project="first",
         workspace=f"{root} @ main", area=metadata)) == 0
     assert MODULE.command_claim(claim_args(board, session_id="B", project="runtime",
-        workspace=f"{root} @ main", area=str(runtime))) == 0
+        workspace=f"{tmp_path / 'home'} @ runtime", area=str(runtime))) == 0
 
 
-def test_nonrepo_ancestor_containing_linked_checkout_still_conflicts(metadata_worktrees, tmp_path):
+@pytest.mark.parametrize("recursive", [False, True])
+def test_nonrepo_ancestor_containing_linked_checkout_still_conflicts(metadata_worktrees, tmp_path, recursive):
     root, _ = metadata_worktrees
     ancestor = tmp_path / "installation-container"
     ancestor.mkdir()
     assert git(root, "worktree", "add", "-b", "nested", str(ancestor / "linked")).returncode == 0
+    if recursive:
+        ancestor /= "**"
     scope = scope_module()
     metadata = str(root / "projects/index.yaml")
     assert scope.claim_conflicts(metadata, str(ancestor))
@@ -2638,7 +2644,7 @@ def test_nonrepo_scope_exception_never_hides_unresolved_metadata_identity(metada
         area /= "projects/item"
         area.mkdir(parents=True)
     elif form == "glob":
-        area /= "**"
+        area /= "*/**"
     else:
         (area / ".git").write_text("gitdir: /missing-fixture-git\n")
     with pytest.raises(scope_module().ClaimIdentityError):

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -2633,6 +2633,17 @@ def test_nonrepo_ancestor_containing_linked_checkout_still_conflicts(metadata_wo
     assert scope.claim_conflicts(str(ancestor), metadata)
 
 
+@pytest.mark.parametrize("relative", [".gitconfig", ".codex/config.toml", ".synthesis/references/session-words.txt"])
+def test_existing_nonrepo_runtime_files_are_disjoint_from_metadata(metadata_worktrees, tmp_path, relative):
+    root, _ = metadata_worktrees
+    runtime = tmp_path / "home" / relative
+    runtime.parent.mkdir(parents=True, exist_ok=True)
+    runtime.write_text("test-owned runtime configuration\n")
+    metadata = str(root / "projects/index.yaml")
+    assert not scope_module().claim_conflicts(metadata, str(runtime))
+    assert not scope_module().claim_conflicts(str(runtime), metadata)
+
+
 @pytest.mark.parametrize("form", ["missing", "metadata", "glob", "broken-git"])
 def test_nonrepo_scope_exception_never_hides_unresolved_metadata_identity(metadata_worktrees, tmp_path, form):
     root, _ = metadata_worktrees

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -2537,6 +2537,12 @@ def test_shared_scope_preserves_physical_synthetic_paths_and_row_delimiters(tmp_
     assert scope.split_values("`one`; **two**<br>three, four") == ["one", "two", "three", "four"]
 
 
+def test_relative_source_scope_does_not_inherit_the_invoking_checkout():
+    scope = scope_module()
+    assert not scope.claim_conflicts("repo/src/a.py", "repo/src/b.py")
+    assert scope.claim_conflicts("repo/src/**", "repo/src/b.py")
+
+
 @pytest.mark.parametrize("register_sibling", [False, True])
 def test_logical_metadata_conflict_never_authorizes_sibling_checkout(metadata_worktrees, tmp_path, capsys, register_sibling):
     root, sibling = metadata_worktrees

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -2335,7 +2335,7 @@ def test_every_command_notes_a_newer_installed_engine(tmp_path):
     relative = Path("skills") / "synthesis-project-management" / "scripts"
     older = cache / "4.80.0" / relative
     older.mkdir(parents=True)
-    for name in ("coordination.py", "coordination_schema.py", "pointer_lock.py", "peer_addressing.py"):
+    for name in ("coordination.py", "claim_scope.py", "coordination_schema.py", "pointer_lock.py", "peer_addressing.py"):
         (older / name).write_bytes((MODULE_PATH.parent / name).read_bytes())
     newer = cache / "4.81.0" / relative
     newer.mkdir(parents=True)
@@ -2552,3 +2552,17 @@ def test_logical_metadata_conflict_never_authorizes_sibling_checkout(metadata_wo
     result = json.loads(capsys.readouterr().out)
     assert result["enforcement_outcome"] == ("refused-outside-claim" if register_sibling else "refused-unregistered-worktree")
     assert not result["issues_authority_receipt"]
+
+
+@pytest.mark.parametrize("second,expected", [("metadata", 0), ("release-train:other", 0), ("release-train:fixture", 10)])
+def test_virtual_resources_never_use_filesystem_identity(metadata_worktrees, tmp_path, second, expected):
+    root, sibling = metadata_worktrees
+    board = tmp_path / "board.md"
+    first = claim_args(board, session_id="A", project="first", workspace=f"{root} @ main", area="release-train:fixture")
+    area = str(sibling / "projects/index.yaml") if second == "metadata" else second
+    later = claim_args(board, session_id="B", project="second", workspace=f"{sibling} @ sibling", area=area)
+    assert MODULE.command_claim(first) == 0
+    assert MODULE.command_claim(later) == expected
+    scope = scope_module()
+    assert scope.claim_conflicts("release-train:fixture", area) is (expected == 10)
+    assert scope.claim_conflicts(area, "release-train:fixture") is (expected == 10)

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -2598,3 +2598,48 @@ def test_metadata_namespace_is_relative_to_git_root_not_ancestor_names(tmp_path,
     left, right = str(root / pattern), str(sibling / "projects/index.yaml")
     assert scope.claim_conflicts(left, right)
     assert scope.claim_conflicts(right, left)
+
+
+@pytest.mark.parametrize("name", ["git-hooks", "agent-control"])
+def test_existing_nonrepo_runtime_scope_can_be_admitted_beside_metadata(metadata_worktrees, tmp_path, name):
+    root, _ = metadata_worktrees
+    runtime = tmp_path / "home/.synthesis" / name
+    runtime.mkdir(parents=True)
+    metadata = str(root / "projects/index.yaml")
+    scope = scope_module()
+    assert not scope.claim_conflicts(metadata, str(runtime))
+    assert not scope.claim_conflicts(str(runtime), metadata)
+    board = tmp_path / "board.md"
+    assert MODULE.command_claim(claim_args(board, session_id="A", project="first",
+        workspace=f"{root} @ main", area=metadata)) == 0
+    assert MODULE.command_claim(claim_args(board, session_id="B", project="runtime",
+        workspace=f"{root} @ main", area=str(runtime))) == 0
+
+
+def test_nonrepo_ancestor_containing_linked_checkout_still_conflicts(metadata_worktrees, tmp_path):
+    root, _ = metadata_worktrees
+    ancestor = tmp_path / "installation-container"
+    ancestor.mkdir()
+    assert git(root, "worktree", "add", "-b", "nested", str(ancestor / "linked")).returncode == 0
+    scope = scope_module()
+    metadata = str(root / "projects/index.yaml")
+    assert scope.claim_conflicts(metadata, str(ancestor))
+    assert scope.claim_conflicts(str(ancestor), metadata)
+
+
+@pytest.mark.parametrize("form", ["missing", "metadata", "glob", "broken-git"])
+def test_nonrepo_scope_exception_never_hides_unresolved_metadata_identity(metadata_worktrees, tmp_path, form):
+    root, _ = metadata_worktrees
+    area = tmp_path / "ordinary"
+    area.mkdir()
+    if form == "missing":
+        area /= "missing"
+    elif form == "metadata":
+        area /= "projects/item"
+        area.mkdir(parents=True)
+    elif form == "glob":
+        area /= "**"
+    else:
+        (area / ".git").write_text("gitdir: /missing-fixture-git\n")
+    with pytest.raises(scope_module().ClaimIdentityError):
+        scope_module().claim_conflicts(str(root / "projects/index.yaml"), str(area))

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -2431,3 +2431,124 @@ def test_invalid_explicit_report_registry_cannot_use_free_address(tmp_path, caps
     assert MODULE.command_message(message) == 10
     assert board.read_bytes() == before
     assert "recipient" in capsys.readouterr().err
+
+
+@pytest.fixture
+def metadata_worktrees(tmp_path):
+    root = staged_repository(tmp_path)
+    for name in ("projects/index.yaml", "projects/item/CONTEXT.md", "projects/item/REFERENCE.md",
+                 "projects/item/CURRENT_STATE.json", "projects/item/resources/a.md", "src/main.py"):
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("Fixture\n")
+    assert git(root, "add", ".").returncode == 0
+    assert git(root, "commit", "-m", "Fixture").returncode == 0
+    sibling = tmp_path / "sibling"
+    assert git(root, "worktree", "add", "-b", "sibling", str(sibling)).returncode == 0
+    return root, sibling
+
+
+def scope_module():
+    import claim_scope
+    return claim_scope
+
+
+def test_logical_metadata_claim_is_refused_before_board_admission(metadata_worktrees, tmp_path):
+    root, sibling = metadata_worktrees
+    board = tmp_path / "board.md"
+    first = claim_args(board, session_id="A", project="first", workspace=f"{root} @ main", area=f"{root}/projects/index.yaml")
+    second = claim_args(board, session_id="B", project="second", workspace=f"{sibling} @ sibling", area=f"{sibling}/projects/index.yaml")
+    assert MODULE.command_claim(first) == 0
+    before = board.read_bytes()
+    assert MODULE.command_claim(second) == 10
+    assert board.read_bytes() == before
+
+
+@pytest.mark.parametrize("left,right,expected", [
+    ("projects/index.yaml", "projects/index.yaml", True),
+    ("projects/item/CONTEXT.md", "projects/item/CONTEXT.md", True),
+    ("projects/item/CURRENT_STATE.json", "projects/item/CURRENT_STATE.json", True),
+    ("projects/item/CONTEXT.md", "projects/item/REFERENCE.md", False),
+    ("projects/item/resources/a.md", "projects/item/resources/b.md", False),
+    ("projects/item/**", "projects/item/REFERENCE.md", True),
+    ("projects/**", "projects/index.yaml", True),
+    ("**", "projects/index.yaml", True),
+    ("projects/*/CONTEXT.md", "projects/item/REFERENCE.md", False),
+    ("projects/*/CONTEXT.md", "projects/item/CONTEXT.md", True),
+    ("projects/item/resources/*.md", "projects/item/resources/*.py", False),
+    ("projects/item/resources/[ab].md", "projects/item/resources/[bc].md", True),
+    ("projects/item/resources/[ab].md", "projects/item/resources/[cd].md", False),
+    ("projects/item/resources/*.md", "projects/item/resources/nested/a.md", False),
+    ("projects/item/resources/**/*.md", "projects/item/resources/nested/a.md", True),
+    ("projects/item", "projects/item-other/CONTEXT.md", False),
+    ("src/main.py", "src/main.py", False),
+    ("src/**", "src/**", False),
+])
+def test_shared_claim_scope_is_symmetric_and_preserves_disjoint_work(metadata_worktrees, left, right, expected):
+    root, sibling = metadata_worktrees
+    scope = scope_module()
+    left, right = str(root / left), str(sibling / right)
+    assert scope.claim_conflicts(left, right) is expected
+    assert scope.claim_conflicts(right, left) is expected
+
+
+def test_metadata_relative_and_symlink_spellings_use_verified_checkout(metadata_worktrees, tmp_path):
+    root, sibling = metadata_worktrees
+    scope = scope_module()
+    alias = tmp_path / "alias"
+    alias.symlink_to(sibling, target_is_directory=True)
+    assert scope.claim_conflicts("projects/index.yaml", str(alias / "projects/index.yaml"), left_workspaces=[f"{root} @ main"])
+    assert scope.claim_conflicts(f"{root.name}/projects/index.yaml", "projects/index.yaml",
+        left_workspaces=[f"{root} @ main"], right_workspaces=[f"{alias} @ sibling"])
+
+
+@pytest.mark.parametrize("kind", ["missing", "ambiguous", "forged"])
+def test_metadata_identity_failure_cannot_be_treated_as_disjoint(metadata_worktrees, tmp_path, kind):
+    root, sibling = metadata_worktrees
+    scope = scope_module()
+    claim = str(tmp_path / "missing/projects/index.yaml")
+    workspaces = []
+    if kind == "ambiguous":
+        claim = "projects/index.yaml"
+        workspaces = [f"{root} @ main", f"{sibling} @ sibling"]
+    elif kind == "forged":
+        fake = tmp_path / "forged"
+        fake.mkdir()
+        (fake / ".git").write_text(f"gitdir: {root / '.git'}\n")
+        claim = str(fake / "projects/index.yaml")
+    with pytest.raises(scope.ClaimIdentityError):
+        scope.claim_conflicts(str(root / "projects/index.yaml"), claim, right_workspaces=workspaces)
+
+
+def test_possible_repair_scope_is_explicitly_broader_than_exact_resource_claims(metadata_worktrees):
+    root, sibling = metadata_worktrees
+    scope = scope_module()
+    assert not scope.claim_conflicts(str(root / "projects/item/resources/a.md"), str(sibling / "projects/item/resources/b.md"))
+    assert scope.project_claim_overlap(root / "projects/item", str(sibling / "projects/item/resources/b.md"))
+    assert scope.project_claim_overlap(root / "projects/item", str(sibling / "projects/index.yaml"))
+    assert not scope.project_claim_overlap(root / "projects/item", str(sibling / "projects/another/CONTEXT.md"))
+
+
+def test_shared_scope_preserves_physical_synthetic_paths_and_row_delimiters(tmp_path):
+    scope = scope_module()
+    assert scope.claim_conflicts(str(tmp_path / "projects/item/**"), str(tmp_path / "projects/item/CONTEXT.md"))
+    assert not scope.claim_conflicts(str(tmp_path / "projects/first/CONTEXT.md"), str(tmp_path / "projects/second/CONTEXT.md"))
+    assert not scope.claim_conflicts("/missing/branch-a/src/**", "/missing/branch-b/src/**")
+    assert scope.split_values("`one`; **two**<br>three, four") == ["one", "two", "three", "four"]
+
+
+@pytest.mark.parametrize("register_sibling", [False, True])
+def test_logical_metadata_conflict_never_authorizes_sibling_checkout(metadata_worktrees, tmp_path, capsys, register_sibling):
+    root, sibling = metadata_worktrees
+    board = tmp_path / "board.md"
+    request = claim_args(board, session_id="A", project="item", workspace=f"{root} @ main", area=f"{root}/projects/item/CONTEXT.md")
+    if register_sibling:
+        request.workspace.append(f"{sibling} @ sibling")
+    assert MODULE.command_claim(request) == 0
+    (sibling / "projects/item/CONTEXT.md").write_text("Changed fixture\n")
+    assert git(sibling, "add", "projects/item/CONTEXT.md").returncode == 0
+    capsys.readouterr()
+    assert MODULE.command_check_staged(check_staged_args(board, sibling)) == 10
+    result = json.loads(capsys.readouterr().out)
+    assert result["enforcement_outcome"] == ("refused-outside-claim" if register_sibling else "refused-unregistered-worktree")
+    assert not result["issues_authority_receipt"]

--- a/skills/synthesis-project-management/scripts/test_coordination.py
+++ b/skills/synthesis-project-management/scripts/test_coordination.py
@@ -810,14 +810,17 @@ def test_overlap_detects_relative_and_absolute_spellings_of_one_path() -> None:
     assert MODULE.overlaps(
         "ai-knowledge-demo/projects/index.yaml",
         "/home/user/workspaces/demo/ai-knowledge-demo/projects/index.yaml",
+        left_workspaces=["/home/user/workspaces/demo/ai-knowledge-demo @ main"],
     )
     assert MODULE.overlaps(
         "/home/user/workspaces/demo/ai-knowledge-demo/projects/**",
         "ai-knowledge-demo/projects/index.yaml",
+        right_workspaces=["/home/user/workspaces/demo/ai-knowledge-demo @ main"],
     )
     assert MODULE.overlaps(
         "ai-knowledge-demo/projects/demo-project/sessions/2026-07.md",
         "/home/user/workspaces/demo/ai-knowledge-demo/projects/**",
+        left_workspaces=["/home/user/workspaces/demo/ai-knowledge-demo @ main"],
     )
 
 
@@ -2572,3 +2575,26 @@ def test_virtual_resources_never_use_filesystem_identity(metadata_worktrees, tmp
     scope = scope_module()
     assert scope.claim_conflicts("release-train:fixture", area) is (expected == 10)
     assert scope.claim_conflicts(area, "release-train:fixture") is (expected == 10)
+
+
+def test_public_overlap_api_uses_shared_logical_metadata_policy(metadata_worktrees):
+    root, sibling = metadata_worktrees
+    assert MODULE.overlaps(str(root / "projects/index.yaml"), str(sibling / "projects/index.yaml"))
+    assert not MODULE.overlaps(str(root / "src/main.py"), str(sibling / "src/main.py"))
+
+
+@pytest.mark.parametrize("pattern", ["**", "pr?jects/index.yaml", "projects/index.yaml"])
+def test_metadata_namespace_is_relative_to_git_root_not_ancestor_names(tmp_path, pattern):
+    parent = tmp_path / "projects" / "container"
+    parent.mkdir(parents=True)
+    root = staged_repository(parent)
+    (root / "projects").mkdir()
+    (root / "projects/index.yaml").write_text("projects: []\n")
+    assert git(root, "add", ".").returncode == 0
+    assert git(root, "commit", "-m", "Fixture").returncode == 0
+    sibling = tmp_path / "outside-linked"
+    assert git(root, "worktree", "add", "-b", "sibling", str(sibling)).returncode == 0
+    scope = scope_module()
+    left, right = str(root / pattern), str(sibling / "projects/index.yaml")
+    assert scope.claim_conflicts(left, right)
+    assert scope.claim_conflicts(right, left)


### PR DESCRIPTION
Claims for the same project metadata can no longer be admitted in linked checkouts while a downstream record guard treats them as conflicting. Board admission and repair consumers use one policy based on verified Git identity and declared paths. Disjoint files and ordinary source branches remain independent, and a logical conflict never grants write permission in another checkout.

The standalone Git-hook bundle includes the shared helper. Onboarding updates introduce that dependency only after proving their released companion files and source pointer; damaged or unrelated payloads stay blocked. Non-repository installation folders and files are admitted when they are proven disjoint, including a positive control for folders containing a registered linked checkout.

Validation: fixture-first regressions, independent policy and historical-update controls, final-head project-management tests, and a closed acceptance manifest covering all 22 changed files. Required CI and the gated release must pass before installed/native acceptance is recorded.
