### PR TITLE
Make checkpoint applicability consistent

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.96.5",
+  "version": "4.96.6",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.96.5",
+  "version": "4.96.6",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.96.6] - 2026-09-09
+
+Checkpoint commands and native discovery share an applicability rule. Registered
+ordinary projects that never adopted structured state report NOT_APPLICABLE,
+without creating state, issuing receipts or implying project health. Projects
+that adopted structured state retain their checkpoint obligations when that file
+is deleted, malformed or unsafe. Refresh inspection reports the same requirement.
+No project migration is performed by a checkpoint or refresh.
+
 ## [4.96.5] - 2026-09-09
 
 Board admission and record-repair consumers share one metadata conflict policy.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Checkpoint applicability (September 2026).** Release **4.96.6** distinguishes
+ordinary projects from projects that adopted structured state. Ordinary projects
+can finish checkpoint inspection without migration or a receipt; missing or
+invalid adopted state remains blocking. Native discovery and refresh use the
+same distinction, without treating non-applicability as project health.
+
 **Metadata ownership across linked worktrees (September 2026).** Release **4.96.5**
 uses one conflict policy for board admission and record-repair consumers. Claims
 on the same project metadata conflict across verified linked checkouts, while

--- a/skills/synthesis-checkpoint/SKILL.md
+++ b/skills/synthesis-checkpoint/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "1.7.1"
+  version: "1.7.2"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -215,7 +215,8 @@ Without admitted authority, report the exact blocking seat and preserve the work
 Under an accepted claim, make the verified correction, attribute it to this
 session and retain local continuity. Publish at the next authorized remote
 handoff or day-end. A missing structured-state file alone does not authorize a
-migration. Release claims acquired solely for the checkpoint before pausing;
+migration. Shared applicability distinguishes never-adopted ordinary projects
+from required state that is missing or unsafe. Release claims acquired solely for the checkpoint before pausing;
 narrow or release genuinely owned completed/paused work under the normal protocol.
 
 Before the checkpoint closes, ask: **What executable state or required input

--- a/skills/synthesis-checkpoint/references/refresh-and-report.md
+++ b/skills/synthesis-checkpoint/references/refresh-and-report.md
@@ -65,6 +65,13 @@ an event or relabel an installed tree as a live reload.
 
 ## Finishing inspection
 
+Structured-state input is optional only for a verified ordinary project that
+never adopted it. Refresh uses the shared checkpoint applicability decision;
+missing or unsafe adopted state remains required and reports failure. Explicit
+checkpoint/validation commands return `NOT_APPLICABLE` for ordinary projects,
+without state creation, a receipt or a health claim. No missing file authorizes
+migration. Existing native identity and pending-attribution checks still apply.
+
 For a structured project discovered from the working directory, the Stop gate
 can return `NOT_APPLICABLE` for an unclaimed session only after validating its
 native identity, checking exact-session pending edit

--- a/skills/synthesis-checkpoint/scripts/refresh.py
+++ b/skills/synthesis-checkpoint/scripts/refresh.py
@@ -291,11 +291,25 @@ def inspect(args, *, ignore_campaign: bool = False) -> tuple[dict, dict | None]:
             # conflict-to-recovered transition; selected checkout stays in
             # recovery evidence instead of silently changing the report key.
             checks["project_status"], state, invalid_state = selected_lifecycle(project, args.index.name, args.project_id)
+            structured_required = True
+            try:
+                applicability, _issues = project_state.checkpoint_applicability(project)
+                structured_required = applicability == "REQUIRED"
+                checks["structured_checkpoint"] = status(applicability, "STRUCTURED_CHECKPOINT_APPLICABILITY",
+                    checkpoint_accepted=False, no_receipt_issued=True)
+                if structured_required and not (project / project_state.STATE_FILE).is_file():
+                    invalid_state = True
+                    checks["structured_checkpoint"] = status("FAIL", "ADOPTED_STRUCTURED_STATE_MISSING",
+                        checkpoint_accepted=False, no_receipt_issued=True)
+            except (OSError, project_state.ProjectStateError):
+                invalid_state = True
+                checks["structured_checkpoint"] = status("UNKNOWN", "STRUCTURED_APPLICABILITY_UNVERIFIED",
+                    checkpoint_accepted=False, no_receipt_issued=True)
             if invalid_state:
                 checks["structured_hashes"] = status("FAIL", "STRUCTURED_STATE_INVALID")
             if "project_tiers" in requested:
                 targets = report["read_targets"]
-                targets.append(file_evidence(project / project_state.STATE_FILE, "structured_state", required=False))
+                targets.append(file_evidence(project / project_state.STATE_FILE, "structured_state", required=structured_required))
                 targets.append(file_evidence(project / "CONTEXT.md", "context"))
                 if targets[-1]["status"] == "PASS":
                     context = (project / "CONTEXT.md").read_text(encoding="utf-8")

--- a/skills/synthesis-checkpoint/scripts/test_refresh.py
+++ b/skills/synthesis-checkpoint/scripts/test_refresh.py
@@ -114,6 +114,27 @@ def test_inspection_is_local_and_reports_exact_scope(fixture, monkeypatch, tmp_p
     assert tree(tmp_path) == before
 
 
+@pytest.mark.parametrize("adopted", [False, True])
+def test_refresh_uses_structured_checkpoint_applicability(fixture, adopted):
+    args, project, _ = fixture
+    if adopted:
+        path = project / refresh.project_state.STATE_FILE
+        path.write_text('{}\n')
+        git(project.parent.parent, "add", "projects")
+        git(project.parent.parent, "commit", "-m", "Fixture")
+        path.unlink()
+        git(project.parent.parent, "add", "-u")
+        git(project.parent.parent, "commit", "-m", "Fixture")
+    report, _ = refresh.inspect(args)
+    target = next(row for row in report["read_targets"] if row["role"] == "structured_state")
+    assert target["required"] is adopted
+    if adopted:
+        assert report["checks"]["structured_checkpoint"]["status"] in {"FAIL", "UNKNOWN"}
+        assert report["overall"] != "READY"
+    else:
+        assert report["checks"]["structured_checkpoint"]["status"] == "NOT_APPLICABLE"
+
+
 @pytest.mark.parametrize("outcome", ["CONFLICT", "UNKNOWN", "FAIL"])
 def test_conflict_reads_no_project_prose(fixture, monkeypatch, outcome):
     args, project, _ = fixture

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -48,6 +48,9 @@ changed_surfaces:
   - native-pending
   - unknown-owned-project
   - registry-registration
+  - anonymous-nonsynthesis
+  - retained-adoption
+  - observer-dependencies
 - path: skills/synthesis-project-management/scripts/test_project_applicability.py
   cases:
   - ordinary-cli
@@ -89,6 +92,17 @@ changed_surfaces:
   - transaction-binding
   - unknown-owned-project
   - registry-registration
+  - anonymous-nonsynthesis
+  - retained-adoption
+  - observer-dependencies
+- path: skills/synthesis-project-management/scripts/test_checkpoint_observer.py
+  cases:
+  - anonymous-nonsynthesis
+  - retained-adoption
+  - observer-dependencies
+  - structured-positive
+  - observer-identity
+  - native-pending
 cases:
 - id: ordinary-cli
   control_class: acceptance-test
@@ -172,3 +186,19 @@ cases:
   expected_status: pass
   fixture: ../synthesis-project-management/scripts/test_project_applicability.py::test_narrative_registry_id_cannot_establish_checkpoint_applicability
   motivating_defect: Narrative text cannot establish a registered project for non-applicability.
+- id: anonymous-nonsynthesis
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_unrelated_projects_directory_does_not_require_synthesis_checkpoint
+  motivating_defect: Unrelated Git and non-Git projects directories must not acquire synthesis checkpoint
+    obligations.
+- id: retained-adoption
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_observer_retains_adoption_when_registry_and_state_are_deleted
+  motivating_defect: Deleted registry and state cannot erase established adoption.
+- id: observer-dependencies
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_observer_discovery_does_not_exonerate_unverifiable_dependencies
+  motivating_defect: Unreadable Git evidence or registry dependencies cannot prove that a project is unrelated.

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,18 +1,17 @@
 schema: 2
-suite: metadata-claim-agreement-2026-09-09
+suite: checkpoint-applicability-2026-09-09
 membership: closed
-production_entry_point: Board claim admission, copied Git hooks and verified runtime update
+production_entry_point: project_state.py checkpoint/validate/hook and refresh.py inspect
 enforcing_boundary: release.py derives exact Git changed paths and consumes fresh transaction-bound acceptance
-  before source publication and both-client installation
+  before publication and both-client installation
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
 change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: Fixtures prove source behavior and verified update mechanics. They do not establish
-  actual native startup, full agent instruction reads, natural Stop completion, multi-computer readiness
-  or foreign repair. Installed bytes and real native acceptance are verified separately. No row-level
-  registry authority is implemented.
+unverified_remainder: Fixtures establish scoped source applicability and preservation of checkpoint bindings.
+  They do not establish native startup, complete agent reading, natural Stop, project migration or multi-computer
+  readiness. Installed and genuine native acceptance are separate.
 changed_surfaces:
 - path: .claude-plugin/plugin.json
   cases:
@@ -26,332 +25,150 @@ changed_surfaces:
 - path: README.md
   cases:
   - release-contract
-- path: skills/synthesis-agent-conformance/scripts/test_diagnostic_parity.py
+- path: skills/synthesis-project-management/SKILL.md
   cases:
-  - diagnostic-claim-fixture
-- path: skills/synthesis-git-hooks/SKILL.md
+  - ordinary-cli
+  - lost-state
+- path: skills/synthesis-project-management/references/project-state-recovery.md
   cases:
-  - standalone-bundle
-  - missing-runtime
-  - release-contract
-- path: skills/synthesis-git-hooks/scripts/_load_config.py
+  - ordinary-cli
+  - receipt-api
+  - lost-state
+  - unknown-project
+- path: skills/synthesis-project-management/scripts/project_state.py
   cases:
-  - standalone-bundle
-  - missing-runtime
-- path: skills/synthesis-git-hooks/scripts/install.sh
+  - ordinary-cli
+  - receipt-api
+  - lost-state
+  - native-discovery
+  - unknown-project
+  - unknown-history
+  - structured-positive
+  - observer-identity
+  - native-pending
+  - unknown-owned-project
+  - registry-registration
+- path: skills/synthesis-project-management/scripts/test_project_applicability.py
   cases:
-  - standalone-bundle
-  - missing-runtime
-- path: skills/synthesis-git-hooks/scripts/pre-commit
+  - ordinary-cli
+  - receipt-api
+  - lost-state
+  - native-discovery
+  - unknown-project
+  - unknown-history
+  - unknown-owned-project
+  - registry-registration
+- path: skills/synthesis-checkpoint/SKILL.md
   cases:
-  - standalone-bundle
-  - missing-runtime
-- path: skills/synthesis-git-hooks/scripts/test_pre_commit.py
+  - refresh-agreement
+- path: skills/synthesis-checkpoint/references/refresh-and-report.md
   cases:
-  - standalone-bundle
-  - missing-runtime
+  - refresh-agreement
+  - ordinary-cli
+- path: skills/synthesis-checkpoint/scripts/refresh.py
+  cases:
+  - refresh-agreement
+- path: skills/synthesis-checkpoint/scripts/test_refresh.py
+  cases:
+  - refresh-agreement
 - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
   cases:
-  - metadata-admission
-  - scope-controls
-  - aliases
-  - unknown-identity
-  - repair-scope
-  - physical-delimiters
-  - relative-source
-  - actor-authority
-  - virtual-resource
-  - public-api
-  - git-root
-  - nonrepo-installation
-  - nonrepo-ancestor
-  - nonrepo-refusal
-  - nonrepo-files
-  - introduce-helper
-  - reject-unproven-bundle
-  - restore-failed-update
-  - standalone-bundle
-  - missing-runtime
-  - phase-update
+  - ordinary-cli
+  - receipt-api
+  - lost-state
+  - native-discovery
+  - unknown-project
+  - unknown-history
+  - refresh-agreement
+  - structured-positive
+  - observer-identity
+  - native-pending
   - release-contract
   - manifest
   - unlisted-path
   - transaction-binding
-  - engine-versions
-  - diagnostic-claim-fixture
-- path: skills/synthesis-onboarding/SKILL.md
-  cases:
-  - introduce-helper
-  - reject-unproven-bundle
-  - restore-failed-update
-  - phase-update
-  - release-contract
-  - engine-versions
-- path: skills/synthesis-onboarding/scripts/onboard.py
-  cases:
-  - engine-versions
-- path: skills/synthesis-onboarding/scripts/runtime_payload.py
-  cases:
-  - introduce-helper
-  - reject-unproven-bundle
-  - restore-failed-update
-  - phase-update
-- path: skills/synthesis-onboarding/scripts/synthesis_cli.py
-  cases:
-  - engine-versions
-- path: skills/synthesis-onboarding/scripts/test_runtime_integration.py
-  cases:
-  - introduce-helper
-  - reject-unproven-bundle
-  - restore-failed-update
-  - phase-update
-- path: skills/synthesis-onboarding/scripts/test_runtime_payload.py
-  cases:
-  - introduce-helper
-  - reject-unproven-bundle
-  - restore-failed-update
-  - phase-update
-- path: skills/synthesis-project-management/SKILL.md
-  cases:
-  - metadata-admission
-  - scope-controls
-  - aliases
-  - unknown-identity
-  - repair-scope
-  - physical-delimiters
-  - relative-source
-  - actor-authority
-  - virtual-resource
-  - public-api
-  - git-root
-  - nonrepo-installation
-  - nonrepo-ancestor
-  - nonrepo-refusal
-  - nonrepo-files
-  - release-contract
-- path: skills/synthesis-project-management/references/parallel-agent-protocol.md
-  cases:
-  - metadata-admission
-  - scope-controls
-  - aliases
-  - unknown-identity
-  - repair-scope
-  - physical-delimiters
-  - relative-source
-  - actor-authority
-  - virtual-resource
-  - public-api
-  - git-root
-  - nonrepo-installation
-  - nonrepo-ancestor
-  - nonrepo-refusal
-  - nonrepo-files
-- path: skills/synthesis-project-management/scripts/claim_scope.py
-  cases:
-  - metadata-admission
-  - scope-controls
-  - aliases
-  - unknown-identity
-  - repair-scope
-  - physical-delimiters
-  - relative-source
-  - actor-authority
-  - virtual-resource
-  - public-api
-  - git-root
-  - nonrepo-installation
-  - nonrepo-ancestor
-  - nonrepo-refusal
-  - nonrepo-files
-- path: skills/synthesis-project-management/scripts/coordination.py
-  cases:
-  - metadata-admission
-  - scope-controls
-  - aliases
-  - unknown-identity
-  - repair-scope
-  - physical-delimiters
-  - relative-source
-  - actor-authority
-  - virtual-resource
-  - public-api
-  - git-root
-  - nonrepo-installation
-  - nonrepo-ancestor
-  - nonrepo-refusal
-  - nonrepo-files
-- path: skills/synthesis-project-management/scripts/test_coordination.py
-  cases:
-  - metadata-admission
-  - scope-controls
-  - aliases
-  - unknown-identity
-  - repair-scope
-  - physical-delimiters
-  - relative-source
-  - actor-authority
-  - virtual-resource
-  - public-api
-  - git-root
-  - nonrepo-installation
-  - nonrepo-ancestor
-  - nonrepo-refusal
-  - nonrepo-files
+  - unknown-owned-project
+  - registry-registration
 cases:
-- id: metadata-admission
+- id: ordinary-cli
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_logical_metadata_claim_is_refused_before_board_admission
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: scope-controls
+  fixture: ../synthesis-project-management/scripts/test_project_applicability.py::test_ordinary_registered_project_cli_is_explicitly_not_applicable
+  motivating_defect: Never-adopted ordinary projects must finish inspection without migration or a false
+    receipt.
+- id: receipt-api
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_shared_claim_scope_is_symmetric_and_preserves_disjoint_work
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: aliases
+  fixture: ../synthesis-project-management/scripts/test_project_applicability.py::test_direct_checkpoint_api_remains_receipt_only
+  motivating_defect: A non-applicable inspection must not manufacture a structured receipt.
+- id: lost-state
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_metadata_relative_and_symlink_spellings_use_verified_checkout
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: unknown-identity
+  fixture: ../synthesis-project-management/scripts/test_project_applicability.py::test_adopted_or_unsafe_state_never_becomes_not_applicable
+  motivating_defect: Deleting or damaging adopted state must retain checkpoint obligations.
+- id: native-discovery
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_metadata_identity_failure_cannot_be_treated_as_disjoint
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: repair-scope
+  fixture: ../synthesis-project-management/scripts/test_project_applicability.py::test_owned_hook_and_observer_discovery_keep_adoption_obligations
+  motivating_defect: Owned native discovery must not ignore deleted structured state.
+- id: unknown-project
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_possible_repair_scope_is_explicitly_broader_than_exact_resource_claims
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: physical-delimiters
+  fixture: ../synthesis-project-management/scripts/test_project_applicability.py::test_unknown_project_is_not_an_ordinary_project
+  motivating_defect: A typo or missing registration cannot establish non-applicability.
+- id: unknown-history
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_shared_scope_preserves_physical_synthetic_paths_and_row_delimiters
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: relative-source
+  fixture: ../synthesis-project-management/scripts/test_project_applicability.py::test_unverifiable_adoption_history_refuses_applicability
+  motivating_defect: Unreadable adoption evidence must fail closed.
+- id: refresh-agreement
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_relative_source_scope_does_not_inherit_the_invoking_checkout
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: actor-authority
+  fixture: ../synthesis-checkpoint/scripts/test_refresh.py::test_refresh_uses_structured_checkpoint_applicability
+  motivating_defect: Refresh optionality must agree with checkpoint applicability.
+- id: structured-positive
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_logical_metadata_conflict_never_authorizes_sibling_checkout
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: virtual-resource
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_owner_checkpoint_authority_is_preserved
+  motivating_defect: Valid adopted checkpoints retain their complete authority binding.
+- id: observer-identity
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_virtual_resources_never_use_filesystem_identity
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: public-api
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_observer_identity_is_native_and_fail_closed
+  motivating_defect: Missing native identity must never grant checkpoint authority.
+- id: native-pending
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_public_overlap_api_uses_shared_logical_metadata_policy
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: git-root
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_metadata_namespace_is_relative_to_git_root_not_ancestor_names
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: nonrepo-installation
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_existing_nonrepo_runtime_scope_can_be_admitted_beside_metadata
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: nonrepo-ancestor
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_nonrepo_ancestor_containing_linked_checkout_still_conflicts
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: nonrepo-refusal
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_nonrepo_scope_exception_never_hides_unresolved_metadata_identity
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: nonrepo-files
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_coordination.py::test_existing_nonrepo_runtime_files_are_disjoint_from_metadata
-  motivating_defect: Board admission and consumers must agree on declared scope without widening actor
-    authority.
-- id: introduce-helper
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-onboarding/scripts/test_runtime_payload.py::test_pre_helper_bundle_upgrade_proves_old_pointer_and_executes_new_closure
-  motivating_defect: The new helper must reach verified existing bundles without adopting unrelated or
-    damaged payloads.
-- id: reject-unproven-bundle
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-onboarding/scripts/test_runtime_payload.py::test_claim_helper_introduction_requires_released_companion_anchors
-  motivating_defect: The new helper must reach verified existing bundles without adopting unrelated or
-    damaged payloads.
-- id: restore-failed-update
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-onboarding/scripts/test_runtime_payload.py::test_failed_claim_helper_introduction_restores_old_bundle_and_absence
-  motivating_defect: The new helper must reach verified existing bundles without adopting unrelated or
-    damaged payloads.
-- id: standalone-bundle
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_installer_copies_coordination_runtime
-  motivating_defect: The copied runtime must contain and verify its actual import closure.
-- id: missing-runtime
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_r4_configured_hook_missing_runtime_fails_closed
-  motivating_defect: Missing ownership enforcement cannot permit a commit.
-- id: phase-update
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-onboarding/scripts/test_runtime_integration.py::test_public_update_refreshes_independently_wired_runtime_and_preserves_personal_state
-  motivating_defect: The real update phase must preserve settings while installing the selected runtime.
+  fixture: ../synthesis-project-management/scripts/test_checkpoint_observer.py::test_known_native_pending_work_blocks_from_workspace_root
+  motivating_defect: Changing cwd must not hide exact-session pending work.
 - id: release-contract
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent
-  motivating_defect: Manifests and documentation must describe one release.
+  motivating_defect: Release metadata must describe one coherent release.
 - id: manifest
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_shipped_manifest_validates
-  motivating_defect: The release boundary must consume fresh acceptance covering the exact changed file
-    universe.
+  motivating_defect: The declared acceptance universe must validate.
 - id: unlisted-path
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_schema2_rejects_undeclared_git_changed_surface
-  motivating_defect: The release boundary must consume fresh acceptance covering the exact changed file
-    universe.
+  motivating_defect: The release boundary must reject an undeclared changed surface.
 - id: transaction-binding
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_schema2_receipt_binds_transaction_and_git_state
-  motivating_defect: The release boundary must consume fresh acceptance covering the exact changed file
-    universe.
-- id: engine-versions
+  motivating_defect: Acceptance must bind the actual release transaction and Git state.
+- id: unknown-owned-project
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-onboarding/scripts/test_synthesis_cli.py::test_engine_versions_and_skill_contract_agree
-  motivating_defect: Both executable version surfaces and their skill contract must agree.
-- id: diagnostic-claim-fixture
+  fixture: ../synthesis-project-management/scripts/test_project_applicability.py::test_owned_hook_unknown_project_cannot_be_not_applicable
+  motivating_defect: An explicitly claimed missing or unregistered project must not disappear from native
+    checkpoint obligations.
+- id: registry-registration
   control_class: acceptance-test
   expected_status: pass
-  fixture: ../synthesis-agent-conformance/scripts/test_diagnostic_parity.py::test_valid_active_pointer_reconciles_without_mutation
-  motivating_defect: The diagnostic fixture must supply an actual sender workspace before ownership can
-    be verified.
+  fixture: ../synthesis-project-management/scripts/test_project_applicability.py::test_narrative_registry_id_cannot_establish_checkpoint_applicability
+  motivating_defect: Narrative text cannot establish a registered project for non-applicability.

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.13.8"
+  version: "2.13.9"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -216,7 +216,7 @@ Complete task → Update CONTEXT.md → local receipt → Next task
 2. **Archive if needed** — Move old sessions to sessions/, stable facts to REFERENCE.md
 3. **Attribute if warranted** — If multiple agents/models contributed materially, end the session-log entry with Attribution line(s) (see Agent Attribution)
 4. **Refresh adopted structured state** — For a project already using `CURRENT_STATE.json`, regenerate it and its compiled block after each meaningful source phase.
-   Prose-only projects retain their context protocol; do not invoke the structured checkpoint CLI on an absent file.
+   Prose-only projects retain their context protocol; checkpoint commands report non-applicability only after verifying state was never adopted.
 5. **Verify local continuity** — Confirm this native session's attributed state is readable and its local handoff is ready.
    Structured projects additionally require their session- and claim-bound Stop receipt. `NOT_APPLICABLE` does not certify pending edits.
    Do not create a commit or network push solely because the user is switching clients on this machine.

--- a/skills/synthesis-project-management/references/project-state-recovery.md
+++ b/skills/synthesis-project-management/references/project-state-recovery.md
@@ -20,6 +20,22 @@ untracked path would be overwritten, and the selected project still exists
 after the move. Otherwise the resolver reports the exact fresher source without
 mutating unrelated state.
 
+## Checkpoint applicability
+
+The checkpoint CLI, validation, native project discovery and refresh inspection
+share the structured-state applicability decision. A verified registered ordinary
+project that never adopted structured state returns `NOT_APPLICABLE`,
+`checkpoint_accepted: false` and `no_receipt_issued: true`, with successful command
+completion. This is neither project health nor a recovery/authority receipt.
+Ordinary context, session records and normal continuity obligations still apply.
+
+Existing state, compiled state markers and verified Git adoption evidence retain
+the structured obligation. Deleted, malformed, unreadable or unsafe state remains
+blocking. Missing project paths, missing registration or unverifiable evidence
+cannot establish non-applicability. Removing the state file is not a migration.
+The direct `checkpoint_project` function is a receipt-only API for adopted state;
+command and hook callers establish applicability before requesting a receipt.
+
 Structured projects store mutable operational truth in `CURRENT_STATE.json`:
 phase, status, accepted baseline, controlling plan, next actions, last session,
 owning coordination session, repository/project identity, durable Markdown

--- a/skills/synthesis-project-management/scripts/project_state.py
+++ b/skills/synthesis-project-management/scripts/project_state.py
@@ -1356,8 +1356,58 @@ def _observer_native_identity(payload: dict[str, Any]) -> tuple[str, str]:
 def _observer_git(project: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", "-C", str(project), *arguments], capture_output=True, text=True,
-        env={**os.environ, "GIT_OPTIONAL_LOCKS": "0"}, timeout=15,
+        env={**os.environ, "GIT_OPTIONAL_LOCKS": "0", "LC_ALL": "C"}, timeout=15,
     )
+
+
+def _observer_synthesis_evidence(project: Path) -> bool:
+    """A directory named projects is not itself evidence of Synthesis adoption.
+
+    Anonymous discovery needs a real registry entry or retained adoption
+    evidence. Explicit CLI and claim paths still use strict applicability.
+    """
+    try:
+        from project_recipient import registry_entries
+    except (ImportError, SyntaxError) as exc:
+        raise ProjectStateError("observer project registry reader is unavailable") from exc
+
+    def registered(text: str) -> bool:
+        try:
+            return project.name in registry_entries(text)
+        except ValueError:
+            return False
+
+    index = project.parent / "index.yaml"
+    if index.is_file() and not index.is_symlink():
+        if registered(index.read_text(encoding="utf-8")):
+            return True
+    context = project / "CONTEXT.md"
+    if context.is_file() and not context.is_symlink():
+        if "<!-- synthesis-current-state:" in context.read_text(encoding="utf-8"):
+            return True
+    identity = _observer_git(project, "rev-parse", "--show-toplevel")
+    if identity.returncode:
+        administrative = any((parent / ".git").exists() or (parent / ".git").is_symlink()
+            for parent in (project, *project.parents))
+        if identity.returncode == 128 and "not a git repository" in identity.stderr.lower() and not administrative:
+            return False
+        raise ProjectStateError("observer project Git identity could not be verified")
+    repo = Path(identity.stdout.strip()).resolve()
+    if project.parent != repo / "projects":
+        return False
+    relative = str((project / STATE_FILE).relative_to(repo))
+    if _run(repo, "ls-files", "--stage", "--", f":(literal){relative}").stdout.strip():
+        return True
+    if _run(repo, "log", "--all", "--reflog", "-1", "--format=%H", "--", f":(literal){relative}").stdout.strip():
+        return True
+    # A deleted registry still identifies an ordinary Synthesis project. Read
+    # the last retained registry blob, never infer registration from its name.
+    revision = _run(repo, "log", "--all", "--reflog", "-1", "--diff-filter=AM", "--format=%H",
+        "--", ":(literal)projects/index.yaml").stdout.strip()
+    if revision:
+        previous = _run(repo, "show", f"{revision}:projects/index.yaml")
+        return registered(previous.stdout)
+    return False
 
 
 def _observer_project(cwd: Path) -> Path | None:
@@ -1368,7 +1418,7 @@ def _observer_project(cwd: Path) -> Path | None:
             except (OSError, ProjectStateError) as exc:
                 raise ProjectStateError(f"observer project Git state or applicability could not be verified: {exc}") from exc
             return candidate
-        if candidate.parent.name == "projects":
+        if candidate.parent.name == "projects" and _observer_synthesis_evidence(candidate):
             applicability, _issues = checkpoint_applicability(candidate)
             if applicability == "REQUIRED":
                 return candidate

--- a/skills/synthesis-project-management/scripts/project_state.py
+++ b/skills/synthesis-project-management/scripts/project_state.py
@@ -16,6 +16,7 @@ import json
 import os
 from pathlib import Path
 import re
+import stat
 import subprocess
 import sys
 import uuid
@@ -96,9 +97,19 @@ def _atomic_text(path: Path, value: str) -> None:
 
 
 def _load_json(path: Path) -> dict[str, Any]:
+    def unique_pairs(pairs):
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON field: {key}")
+            result[key] = value
+        return result
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        if path.name == STATE_FILE and (path.is_symlink() or not stat.S_ISREG(path.stat().st_mode)):
+            raise ValueError("structured state must be a regular nonsymlink file")
+        payload = json.loads(path.read_text(encoding="utf-8"),
+            **({"object_pairs_hook": unique_pairs} if path.name == STATE_FILE else {}))
+    except (OSError, ValueError) as exc:
         raise ProjectStateError(f"unreadable JSON evidence {path}: {exc}") from exc
     if not isinstance(payload, dict):
         raise ProjectStateError(f"JSON evidence is not an object: {path}")
@@ -125,6 +136,62 @@ def _index_entry(text: str, project_id: str) -> str:
     following = re.search(r"(?m)^\s*-?\s*id:\s*", text[matches[0].end() :])
     end = matches[0].end() + following.start() if following else len(text)
     return text[start:end]
+
+
+def checkpoint_applicability(project: Path) -> tuple[str, list[str]]:
+    """Determine structured adoption without issuing a receipt or health verdict.
+
+    Absence alone is insufficient: current index entries, complete local Git
+    history and compiled project records retain adoption after deletion.
+    Callers must keep unknown applicability non-green. checkpoint_project is
+    receipt-only; CLI and lifecycle callers handle NOT_APPLICABLE explicitly.
+    """
+    project = Path(project).absolute()
+    if project.parent.name != "projects" or not project.is_dir():
+        raise ProjectStateError("checkpoint requires an existing registered project directory")
+    repo = _repository_root(project)
+    if project.parent != repo / "projects":
+        raise ProjectStateError("project registry is not at the verified repository root")
+    index = project.parent / "index.yaml"
+    for path in (project, project.parent, index):
+        if path.is_symlink():
+            raise ProjectStateError("checkpoint project or registry crosses an unsafe symlink")
+    tracked = _run(repo, "ls-files", "--error-unmatch", "--", ":(literal)projects/index.yaml")
+    if not tracked.stdout.strip():
+        raise ProjectStateError("checkpoint project registry is not tracked")
+    try:
+        from project_recipient import registry_entries
+        entries = registry_entries(index.read_text(encoding="utf-8"))
+    except (ImportError, SyntaxError, ValueError) as exc:
+        raise ProjectStateError("checkpoint registry collection cannot be verified") from exc
+    if project.name not in entries:
+        raise ProjectStateError("checkpoint project is not registered in the project collection")
+    context = project / "CONTEXT.md"
+    if context.is_symlink() or not context.is_file():
+        raise ProjectStateError("checkpoint project context is missing or unsafe")
+    state_path = project / STATE_FILE
+    if state_path.exists() or state_path.is_symlink():
+        value = _load_json(state_path)
+        if type(value.get("schema_version")) is not int or value["schema_version"] != STATE_SCHEMA or value.get("project_id") != project.name:
+            raise ProjectStateError("current operational state schema or project identity is invalid")
+        return "REQUIRED", ["structured state is present"]
+    relative = str(state_path.relative_to(repo))
+    if "<!-- synthesis-current-state:" in context.read_text(encoding="utf-8"):
+        return "REQUIRED", ["compiled project context records structured-state adoption"]
+    for worktree, _head, _branch in _worktrees(repo):
+        candidate = worktree / relative
+        if candidate.exists() or candidate.is_symlink():
+            return "REQUIRED", ["a registered checkout retains structured state"]
+        indexed = _run(worktree, "ls-files", "--stage", "--", f":(literal){relative}")
+        if indexed.stdout.strip():
+            return "REQUIRED", ["Git index records structured-state adoption"]
+    historical = _run(repo, "log", "--all", "--reflog", "-1", "--format=%H", "--", f":(literal){relative}")
+    if historical.stdout.strip():
+        return "REQUIRED", ["Git history records structured-state adoption"]
+    shallow = _run(repo, "rev-parse", "--is-shallow-repository").stdout.strip()
+    if shallow != "false":
+        raise ProjectStateError("complete local adoption history cannot be verified")
+    return "NOT_APPLICABLE", ["registered project has no structured-state adoption evidence; no checkpoint receipt issued and no recovery/state-health PASS implied"]
 
 
 def _latest_session_date(project: Path) -> str | None:
@@ -1047,7 +1114,10 @@ def checkpoint_project(
     receipt_root: Path,
     source_heads: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Issue a clean checkpoint only when state, claim, Git, and hashes bind."""
+    """Receipt-only API: require adopted state, claim, Git, and hash bindings."""
+    applicability, issues = checkpoint_applicability(project)
+    if applicability == "NOT_APPLICABLE":
+        raise ProjectStateError("structured checkpoint is not applicable: " + "; ".join(issues))
     project = project.resolve()
     state = _load_json(project / STATE_FILE)
     project_id = str(state.get("project_id") or "")
@@ -1095,10 +1165,13 @@ def validate_checkpoint(
     source_heads: dict[str, str] | None = None,
 ) -> tuple[str, list[str]]:
     """Validate an outgoing receipt without turning missing evidence green."""
-    project = project.resolve()
     try:
+        applicability, issues = checkpoint_applicability(project)
+        if applicability == "NOT_APPLICABLE":
+            return applicability, issues
+        project = project.resolve()
         state = _load_json(project / STATE_FILE)
-    except ProjectStateError as exc:
+    except (OSError, ProjectStateError) as exc:
         return "UNKNOWN", [str(exc)]
     project_id = str(state.get("project_id") or "")
     path = _receipt_path(receipt_root.resolve(), session_id, project_id)
@@ -1197,6 +1270,7 @@ def _project_from_claim(row: dict[str, str]) -> Path | None:
     if not project_id:
         return None
     paths: list[Path] = []
+    explicit: set[Path] = set()
     cells = (
         row.get("claimed areas (advisory lock)", "")
         + ","
@@ -1211,10 +1285,13 @@ def _project_from_claim(row: dict[str, str]) -> Path | None:
         parts = path.parts
         for index in range(len(parts) - 1):
             if tuple(parts[index : index + 2]) == marker:
-                paths.append(Path(*parts[: index + 2]))
+                direct = Path(*parts[: index + 2])
+                paths.append(direct)
+                explicit.add(direct)
         paths.append(path / "projects" / project_id)
     existing = sorted(
-        {path.resolve() for path in paths if (path / STATE_FILE).is_file()},
+        {path.resolve() for path in paths if path.parent.name == "projects"
+         and (path.is_dir() or path in explicit or (path.parent / "index.yaml").exists())},
         key=lambda item: (len(str(item)), str(item)),
     )
     if len(existing) > 1:
@@ -1227,7 +1304,9 @@ def _project_from_claim(row: dict[str, str]) -> Path | None:
                 continue
         if len(matching) == 1:
             return matching[0]
-        raise ProjectStateError("active claim names multiple structured project states")
+        raise ProjectStateError("active claim names multiple project directories")
+    if existing:
+        checkpoint_applicability(existing[0])
     return existing[0] if existing else None
 
 
@@ -1284,11 +1363,15 @@ def _observer_git(project: Path, *arguments: str) -> subprocess.CompletedProcess
 def _observer_project(cwd: Path) -> Path | None:
     for candidate in (cwd, *cwd.parents):
         if (candidate / STATE_FILE).exists() or (candidate / STATE_FILE).is_symlink():
+            try:
+                checkpoint_applicability(candidate)
+            except (OSError, ProjectStateError) as exc:
+                raise ProjectStateError(f"observer project Git state or applicability could not be verified: {exc}") from exc
             return candidate
-        # A deleted tracked state file must remain an observable obligation.
-        tracked = _observer_git(candidate, "ls-files", "--error-unmatch", "--", f":(literal){STATE_FILE}")
-        if tracked.returncode == 0:
-            return candidate
+        if candidate.parent.name == "projects":
+            applicability, _issues = checkpoint_applicability(candidate)
+            if applicability == "REQUIRED":
+                return candidate
     return None
 
 
@@ -1325,11 +1408,13 @@ def _observer_pending_scope(payload: dict[str, Any], repo_guard_root: Path) -> t
 
 def _observer_checkpoint_scope(payload: dict[str, Any], project: Path) -> tuple[str, list[str]]:
     _observer_native_identity(payload)
+    checkpoint_applicability(project)
     dirty = _observer_git(project, "status", "--porcelain=v1", "-z", "--untracked-files=all", "--", ".")
     if dirty.returncode:
         raise ProjectStateError("observer project Git state could not be verified")
     if dirty.stdout:
         return "UNKNOWN", ["unowned structured project has staged, unstaged or untracked changes; absence of native attribution does not prove read-only work"]
+    _load_json(project / STATE_FILE)  # a clean Git deletion is still missing evidence
     return "NOT_APPLICABLE", ["no active checkpoint ownership or native pending attribution; observed Git project subtree is clean; no checkpoint receipt issued and no recovery/state-health PASS implied"]
 
 
@@ -1361,6 +1446,9 @@ def checkpoint_hook(
         project = _project_from_claim(row)
         if project is None:
             return "NOT_APPLICABLE", []
+        applicability, issues = checkpoint_applicability(project)
+        if applicability == "NOT_APPLICABLE":
+            return applicability, issues
         state = _load_json(project / STATE_FILE)
         session_id = row.get("session uuid", "")
         source_heads = _live_source_heads(state)
@@ -1536,6 +1624,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.command == "checkpoint":
         try:
+            applicability, issues = checkpoint_applicability(args.project)
+            if applicability == "NOT_APPLICABLE":
+                print(json.dumps({"status": applicability, "issues": issues,
+                    "checkpoint_accepted": False, "no_receipt_issued": True}, indent=2))
+                return 0
             payload = checkpoint_project(
                 args.project,
                 session_id=args.session_id,
@@ -1569,8 +1662,11 @@ def main(argv: list[str] | None = None) -> int:
         receipt_root=args.receipt_root,
         source_heads=_source_head_args(args.source_head),
     )
-    print(json.dumps({"status": verdict, "issues": issues}, indent=2))
-    return 0 if verdict == "PASS" else 1
+    report = {"status": verdict, "issues": issues, "checkpoint_accepted": verdict == "PASS"}
+    if verdict == "NOT_APPLICABLE":
+        report["no_receipt_issued"] = True
+    print(json.dumps(report, indent=2))
+    return 0 if verdict in {"PASS", "NOT_APPLICABLE"} else 1
 
 
 if __name__ == "__main__":

--- a/skills/synthesis-project-management/scripts/test_checkpoint_observer.py
+++ b/skills/synthesis-project-management/scripts/test_checkpoint_observer.py
@@ -111,6 +111,44 @@ def assert_no_receipt(fixture: SimpleNamespace) -> None:
 
 
 @pytest.mark.parametrize("client", ["claude", "codex"])
+@pytest.mark.parametrize("git_repository", [False, True])
+@pytest.mark.parametrize("ordinary_index", [False, True])
+def test_unrelated_projects_directory_does_not_require_synthesis_checkpoint(observer, client, git_repository, ordinary_index):
+    root = observer.root / "ordinary-code"
+    project = root / "projects" / "app"
+    project.mkdir(parents=True)
+    (project / "main.py").write_text("print('fixture')\n")
+    if ordinary_index:
+        (project.parent / "index.yaml").write_text("application_modules:\n  - app\n")
+    if git_repository:
+        run("git", "init", "-b", "main", cwd=root)
+        run("git", "config", "user.name", "Fixture", cwd=root)
+        run("git", "config", "user.email", "fixture@example.invalid", cwd=root)
+        run("git", "add", ".", cwd=root)
+        run("git", "commit", "-m", "Fixture", cwd=root)
+    assert state._observer_project(project) is None
+    assert inspect(observer, event(observer, client, cwd=str(project))) == ("NOT_APPLICABLE", [])
+    assert not (project / state.STATE_FILE).exists()
+    assert_no_receipt(observer)
+
+
+@pytest.mark.parametrize("deletion", ["unstaged", "staged", "committed"])
+@pytest.mark.parametrize("client", ["claude", "codex"])
+def test_observer_retains_adoption_when_registry_and_state_are_deleted(observer, deletion, client):
+    (observer.project / state.STATE_FILE).unlink()
+    (observer.project.parent / "index.yaml").unlink()
+    # Exercise retained Git evidence without relying on a compiled marker.
+    (observer.project / "CONTEXT.md").write_text("# Context\n")
+    if deletion in {"staged", "committed"}:
+        run("git", "add", "-u", cwd=observer.repo)
+    if deletion == "committed":
+        run("git", "commit", "-m", "Fixture", cwd=observer.repo)
+    verdict, _issues = inspect(observer, event(observer, client))
+    assert verdict not in {"PASS", "NOT_APPLICABLE"}
+    assert_no_receipt(observer)
+
+
+@pytest.mark.parametrize("client", ["claude", "codex"])
 def test_clean_native_observer_has_no_checkpoint_authority(observer: SimpleNamespace, client: str, monkeypatch: pytest.MonkeyPatch) -> None:
     before = {path: path.read_bytes() for path in observer.project.rglob("*") if path.is_file()}
     board_before = observer.board.read_bytes()

--- a/skills/synthesis-project-management/scripts/test_checkpoint_observer.py
+++ b/skills/synthesis-project-management/scripts/test_checkpoint_observer.py
@@ -148,6 +148,25 @@ def test_observer_retains_adoption_when_registry_and_state_are_deleted(observer,
     assert_no_receipt(observer)
 
 
+@pytest.mark.parametrize("dependency", ["git-config", "registry-reader"])
+def test_observer_discovery_does_not_exonerate_unverifiable_dependencies(observer, monkeypatch, dependency):
+    (observer.project / state.STATE_FILE).unlink()
+    (observer.project.parent / "index.yaml").unlink()
+    (observer.project / "CONTEXT.md").write_text("# Context\n")
+    if dependency == "git-config":
+        (observer.repo / ".git/config").write_text("[broken configuration\n")
+    else:
+        original = builtins.__import__
+        def unavailable(name, *args, **kwargs):
+            if name == "project_recipient":
+                raise ImportError("fixture registry reader unavailable")
+            return original(name, *args, **kwargs)
+        monkeypatch.setattr(builtins, "__import__", unavailable)
+    verdict, _issues = inspect(observer)
+    assert verdict == "FAIL"
+    assert_no_receipt(observer)
+
+
 @pytest.mark.parametrize("client", ["claude", "codex"])
 def test_clean_native_observer_has_no_checkpoint_authority(observer: SimpleNamespace, client: str, monkeypatch: pytest.MonkeyPatch) -> None:
     before = {path: path.read_bytes() for path in observer.project.rglob("*") if path.is_file()}

--- a/skills/synthesis-project-management/scripts/test_project_applicability.py
+++ b/skills/synthesis-project-management/scripts/test_project_applicability.py
@@ -143,3 +143,25 @@ def test_unverifiable_adoption_history_refuses_applicability(machine, monkeypatc
     monkeypatch.setattr(state, "_run", unavailable)
     result, report = cli(machine, "checkpoint", capsys)
     assert result != 0 and report["status"] not in {"PASS", "NOT_APPLICABLE"}
+
+
+@pytest.mark.parametrize("missing", [True, False])
+def test_owned_hook_unknown_project_cannot_be_not_applicable(machine, monkeypatch, tmp_path, missing):
+    repo, project, claims, receipts = machine
+    unknown = project.parent / "typo"
+    if not missing:
+        unknown.mkdir()
+    claims.write_text(claims.read_text().replace("alpha", "typo").replace(f"tool:{SESSION}", f"codex:{SESSION}"))
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", f"codex:{SESSION}")
+    payload = native_hook_fixture(tmp_path, monkeypatch, "codex", SESSION, repo)
+    verdict, _ = state.checkpoint_hook(payload, coordination_board=claims, receipt_root=receipts,
+        refresh_coordination=False, repo_guard_root=tmp_path / "repo-guard")
+    assert verdict not in {"PASS", "NOT_APPLICABLE"}
+    assert not receipts.exists()
+
+
+def test_narrative_registry_id_cannot_establish_checkpoint_applicability(machine, capsys):
+    repo, _, _, _ = machine
+    (repo / "projects/index.yaml").write_text("notes: |\n  id: alpha\nprojects:\n  - id: beta\n")
+    result, report = cli(machine, "checkpoint", capsys)
+    assert result != 0 and report["status"] not in {"PASS", "NOT_APPLICABLE"}

--- a/skills/synthesis-project-management/scripts/test_project_applicability.py
+++ b/skills/synthesis-project-management/scripts/test_project_applicability.py
@@ -1,0 +1,145 @@
+"""Applicability never turns lost structured state into a clean checkpoint."""
+import json
+from pathlib import Path
+
+import pytest
+
+import project_state as state
+from test_project_state import board, init_repo, native_hook_fixture, run
+
+SESSION = "018f0000-0000-7000-8000-000000000001"
+
+
+@pytest.fixture
+def machine(tmp_path):
+    repo, project = init_repo(tmp_path)
+    claims = board(tmp_path / "board.md", [(SESSION, "s-abcd-efgh-jkmn", "alpha", str(repo))])
+    return repo, project, claims, tmp_path / "receipts"
+
+
+def adopted(machine):
+    repo, project, _, _ = machine
+    state.build_operational_state(project, project_id="alpha", phase="release 1.0.0",
+        status="active", controlling_plan="resources/artifacts/plan.md", accepted_baseline="1.0.0",
+        next_actions=["finish"], last_session="2026-09-03", session_id=SESSION)
+    run("git", "add", "projects", cwd=repo)
+    run("git", "commit", "-m", "Fixture", cwd=repo)
+
+
+def cli(machine, command, capsys, project=None):
+    _, selected, claims, receipts = machine
+    result = state.main([command, "--project", str(project or selected), "--session-id", SESSION,
+        "--coordination-board", str(claims), "--receipt-root", str(receipts)])
+    return result, json.loads(capsys.readouterr().out)
+
+
+@pytest.mark.parametrize("command", ["checkpoint", "validate"])
+@pytest.mark.parametrize("dirty", [False, True])
+def test_ordinary_registered_project_cli_is_explicitly_not_applicable(machine, capsys, command, dirty):
+    repo, project, _, receipts = machine
+    if dirty:
+        (project / "new-notes.md").write_text("Retained ordinary work\n")
+    before = run("git", "status", "--porcelain=v1", cwd=repo)
+    result, report = cli(machine, command, capsys)
+    assert result == 0
+    assert report["status"] == "NOT_APPLICABLE"
+    assert report["checkpoint_accepted"] is False
+    assert report["no_receipt_issued"] is True
+    assert "receipt" not in report
+    assert not receipts.exists() and not (project / state.STATE_FILE).exists()
+    assert run("git", "status", "--porcelain=v1", cwd=repo) == before
+
+
+def test_direct_checkpoint_api_remains_receipt_only(machine):
+    _, project, claims, receipts = machine
+    with pytest.raises(state.ProjectStateError):
+        state.checkpoint_project(project, session_id=SESSION, coordination_board=claims, receipt_root=receipts)
+    assert state.validate_checkpoint(project, session_id=SESSION, coordination_board=claims,
+        receipt_root=receipts)[0] == "NOT_APPLICABLE"
+    assert not receipts.exists()
+
+
+@pytest.mark.parametrize("command", ["checkpoint", "validate"])
+@pytest.mark.parametrize("change", ["unstaged", "staged", "committed", "marker-only", "malformed", "symlink", "duplicate", "unsupported"])
+def test_adopted_or_unsafe_state_never_becomes_not_applicable(machine, capsys, command, change, tmp_path):
+    repo, project, _, receipts = machine
+    adopted(machine)
+    path = project / state.STATE_FILE
+    if change in {"unstaged", "staged", "committed", "marker-only"}:
+        if change == "marker-only":
+            run("git", "reset", "--soft", "HEAD^", cwd=repo)
+            run("git", "reset", "HEAD", "--", f"projects/alpha/{state.STATE_FILE}", cwd=repo)
+        path.unlink()
+        if change in {"staged", "committed"}:
+            run("git", "add", "-u", cwd=repo)
+        if change == "committed":
+            run("git", "commit", "-m", "Fixture", cwd=repo)
+    elif change == "symlink":
+        target = tmp_path / "state-target.json"
+        target.write_bytes(path.read_bytes())
+        path.unlink()
+        path.symlink_to(target)
+    elif change == "duplicate":
+        path.write_text(path.read_text().replace('{', '{"project_id":"alpha",', 1))
+    elif change == "unsupported":
+        value = json.loads(path.read_text())
+        value["schema_version"] = 999
+        path.write_text(json.dumps(value))
+    else:
+        path.write_text("{")
+    result, report = cli(machine, command, capsys)
+    assert result != 0 and report["status"] not in {"PASS", "NOT_APPLICABLE"}
+    assert not receipts.exists()
+
+
+@pytest.mark.parametrize("client", ["cc", "codex"])
+@pytest.mark.parametrize("change", ["ordinary", "unstaged", "staged", "committed"])
+def test_owned_hook_and_observer_discovery_keep_adoption_obligations(machine, monkeypatch, tmp_path, client, change):
+    repo, project, claims, receipts = machine
+    if change != "ordinary":
+        adopted(machine)
+        (project / state.STATE_FILE).unlink()
+        if change in {"staged", "committed"}:
+            run("git", "add", "-u", cwd=repo)
+        if change == "committed":
+            run("git", "commit", "-m", "Fixture", cwd=repo)
+    monkeypatch.setenv("SYNTHESIS_CLIENT_SESSION_REF", f"{client}:{SESSION}")
+    claims.write_text(claims.read_text().replace(f"tool:{SESSION}", f"{client}:{SESSION}"))
+    payload = native_hook_fixture(tmp_path, monkeypatch, client, SESSION, project)
+    verdict, _ = state.checkpoint_hook(payload, coordination_board=claims, receipt_root=receipts,
+        refresh_coordination=False, repo_guard_root=tmp_path / "repo-guard")
+    if change == "ordinary":
+        assert verdict == "NOT_APPLICABLE"
+    else:
+        assert verdict not in {"PASS", "NOT_APPLICABLE"}
+        assert state._observer_project(project) == project
+        claims.write_text(claims.read_text().replace("| active |", "| released |"))
+        observed, _ = state.checkpoint_hook(payload, coordination_board=claims, receipt_root=receipts,
+            refresh_coordination=False, repo_guard_root=tmp_path / "repo-guard")
+        assert observed not in {"PASS", "NOT_APPLICABLE"}
+    assert not receipts.exists()
+
+
+@pytest.mark.parametrize("command", ["checkpoint", "validate"])
+@pytest.mark.parametrize("kind", ["missing", "unregistered", "nonproject"])
+def test_unknown_project_is_not_an_ordinary_project(machine, capsys, command, kind):
+    repo, project, _, _ = machine
+    target = repo / "projects" / "typo"
+    if kind == "unregistered":
+        target.mkdir()
+        (target / "CONTEXT.md").write_text("# Unknown\n")
+    elif kind == "nonproject":
+        target = repo
+    result, report = cli(machine, command, capsys, project=target)
+    assert result != 0 and report["status"] not in {"PASS", "NOT_APPLICABLE"}
+
+
+def test_unverifiable_adoption_history_refuses_applicability(machine, monkeypatch, capsys):
+    original = state._run
+    def unavailable(repo, *args, **kwargs):
+        if args[0] == "log":
+            raise state.ProjectStateError("fixture history unavailable")
+        return original(repo, *args, **kwargs)
+    monkeypatch.setattr(state, "_run", unavailable)
+    result, report = cli(machine, "checkpoint", capsys)
+    assert result != 0 and report["status"] not in {"PASS", "NOT_APPLICABLE"}


### PR DESCRIPTION
Projects that never adopted structured state now return explicit NOT_APPLICABLE for checkpoint inspection without creating state, receipts or a health claim. Checkpoint, validation and refresh share one applicability policy; adopted projects retain obligations when state is deleted, damaged or unverifiable. Anonymous discovery ignores unrelated code directories while preserving known adoption and dependency failures.

Validation:563 project-management/checkpoint tests passed,207 source checks and2 instruction checks passed; independent21-scenario matrix and16 new observer/dependency controls passed. The closed release manifest binds all14 changed surfaces to19 cases. Native installation and genuine both-client lifecycle acceptance follow the gated release.
