### PR TITLE
Stranded manifest entries, required repo-local delegate, 4.98.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.97.0",
+  "version": "4.98.0",
   "description": "Synthesis engineering workflows for durable human-agent work across Claude Code, ChatGPT, Codex, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synthesis-skills",
-  "version": "4.97.0",
+  "version": "4.98.0",
   "description": "Synthesis engineering workflows for durable human-agent work across ChatGPT, Codex, Claude Code, and other Agent Skills runtimes.",
   "author": {
     "name": "Rajiv Pant",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,7 +31,7 @@ jobs:
           SYNTHESIS_ACCEPTANCE_CHANGE_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: python skills/synthesis-skills-manager/scripts/release.py --repo-root . --acceptance-only
       - run: python -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
-      - run: python -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-bitbucket/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py skills/synthesis-slack-sync/scripts/test_*.py skills/synthesis-chief-of-staff/scripts/test_*.py -q
+      - run: python -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-bitbucket/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py skills/synthesis-slack-sync/scripts/test_*.py skills/synthesis-chief-of-staff/scripts/test_*.py skills/synthesis-repo-guard/test_*.py -q
       - run: python -m pytest skills/synthesis-onboarding/scripts/ -q
       - run: python skills/synthesis-onboarding/scripts/check_scaffolds.py .
       - run: python skills/synthesis-onboarding/scripts/check_capabilities.py .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ python3 -m pytest skills/synthesis-checkpoint/scripts/ -q
 python3 -m pytest skills/synthesis-promotion-gate/scripts/ -q
 python3 -m pytest skills/synthesis-context-lifecycle/scripts/ skills/synthesis-implementation-integrity/scripts/ -q
 python3 -m pytest skills/synthesis-kb-edit/scripts/test_*.py skills/synthesis-okf/scripts/test_*.py -q
-python3 -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-bitbucket/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py skills/synthesis-slack-sync/scripts/test_*.py skills/synthesis-chief-of-staff/scripts/test_*.py -q
+python3 -m pytest skills/synthesis-daily-rituals/scripts/test_*.py skills/synthesis-bitbucket/scripts/test_*.py skills/synthesis-message-guard/scripts/test_*.py skills/synthesis-git-hooks/scripts/test_*.py skills/synthesis-slack-sync/scripts/test_*.py skills/synthesis-chief-of-staff/scripts/test_*.py skills/synthesis-repo-guard/test_*.py -q
 python3 -m pytest skills/synthesis-onboarding/scripts/ -q
 python3 skills/synthesis-onboarding/scripts/check_scaffolds.py .
 python3 skills/synthesis-onboarding/scripts/check_capabilities.py .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Synthesis Skills are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow [Semantic Versioning](https://semver.org/).
 
+## [4.98.0] - 2026-09-11
+
+Pending manifests classify entries beneath a removed, unrecorded worktree as
+stranded, name the missing worktree root and the accepted remedy, and keep
+evaluating the other repositories. An operator-asserted `--drop-stranded`
+retires such entries only after an append-only ledger record carries the
+assertion, and every flush retires each published repository's entries, so
+long-lived manifests no longer accrete. The global pre-commit chain fails
+closed for repositories that declare `.githooks/required` when the delegate is
+missing or not executable; the doctor's `delegate-required` control agrees.
+
 ## [4.97.0] - 2026-09-10
 
 The pull-request queue scan dispatches by origin host: Bitbucket Cloud

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ the [runtime integration contract](docs/runtime-integration.md), and the
 
 ## What's new
 
+**Stranded manifests and required delegates (September 2026).** Release **4.98.0**
+classifies pending-manifest entries beneath a removed, unrecorded worktree as
+stranded, names the missing worktree root and the accepted remedy, and keeps
+evaluating the other repositories. An operator-asserted `--drop-stranded` retires
+such entries only after an append-only ledger record carries the assertion, and
+every flush retires each published repository's entries, so long-lived manifests
+no longer accrete. The global pre-commit chain fails closed for repositories that
+declare `.githooks/required` when the delegate is missing or not executable, and
+the doctor's `delegate-required` control reports the same verdict.
+
 **Bitbucket queues and shell-aware peer sends (September 2026).** Release **4.97.0**
 reads Bitbucket Cloud repositories in the pull-request queue scan through the
 synthesis-bitbucket helper; GitHub is unchanged and other hosts stay named as

--- a/skills/synthesis-git-hooks/SKILL.md
+++ b/skills/synthesis-git-hooks/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: ["synthesis-project-management"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.4.1"
+  version: "2.5.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -18,6 +18,23 @@ The engine is a Bash boundary plus standard-library Python sidecars. The policy
 is data — a YAML file at `~/.synthesis/git-hook-config.yaml` that anyone
 adopting synthesis engineering fills in with personal-remote patterns, client
 names, internal URLs, and optionally a coordination-board path.
+
+## v2.5.0 — Required repo-local delegate, fail closed
+
+Global `core.hooksPath` makes this chain the only path to a repository's own
+`.githooks/pre-commit`; an absent or mode-644 delegate used to be skipped
+silently, so a repository's own commit guards reported success while running
+nothing. Declaring `.githooks/required` opts in — declared means the marker
+is present in the working tree or listed in the index; content is ignored.
+With the declaration, a missing, non-regular, or non-executable delegate (a
+symlink is judged by its target) blocks the commit and names the remedy
+(`create .githooks/pre-commit` or `chmod +x .githooks/pre-commit`); without
+it nothing changes. Withdrawal is a staged `git rm .githooks/required` in a
+reviewed commit; an unstaged `rm` leaves the index entry, and the
+declaration, standing, unless the commit itself stages the removal
+(`git commit -a`, or a partial commit naming `.githooks/required`). The
+doctor's `delegate-required` control applies the same rule and reports the
+same verdict.
 
 ## v2.4.0 — Coordination claims at the commit boundary
 

--- a/skills/synthesis-git-hooks/scripts/_load_config.py
+++ b/skills/synthesis-git-hooks/scripts/_load_config.py
@@ -25,7 +25,11 @@ v2 design changes (fail-closed hardening):
 * **`--doctor`.** Self-check for rituals/bootstrap: config parses, every
   pattern compiles under both Python `re` and `grep -E`, core.hooksPath is
   wired, installed engine matches the skill source (drift detection), and
-  the cwd repo's classification + chained hook are reported. The drift
+  the cwd repo's classification + chained hook are reported, and the
+  `delegate-required` control asserts a repository that declares
+  `.githooks/required` (present in the working tree or listed in the
+  index) has a regular executable `.githooks/pre-commit` (the chain
+  fails closed on the same condition). The drift
   source resolves portably — `$SYNTHESIS_GIT_HOOKS_SOURCE` (authoritative;
   invalid values fail closed), else this script's own directory when it is
   not itself an installed copy, else documented install locations — never
@@ -55,7 +59,7 @@ import warnings
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
-SIDECAR_VERSION = "2.4.1"
+SIDECAR_VERSION = "2.5.0"
 REQUIRED_CONFIG_VERSION = 2
 
 DEFAULT_CONFIG = Path.home() / ".synthesis" / "git-hook-config.yaml"
@@ -654,6 +658,124 @@ def emit_shell_vars(config: dict) -> None:
     print("SYNTHESIS_SIDECAR_OK=1")
 
 
+# ─── delegate-required control ───────────────────────────────────────────
+#
+# Global core.hooksPath makes the installed pre-commit the only path to a
+# repository's own `.githooks/pre-commit`. The chain execs that delegate only
+# when it is present and executable; otherwise it exits 0, so a repository
+# whose commit-boundary guards live in the delegate can report success while
+# running nothing. A declared `.githooks/required` opts the repository in —
+# declared means present in the working tree OR listed in the index, so an
+# unstaged `rm` does not withdraw it while a staged `git rm` does; content
+# is ignored. The chain then fails closed on a missing, non-regular, or
+# non-executable delegate, and this control applies the same declaration
+# rule and reports the same verdict with the same remedy.
+
+DELEGATE_MARKER = ".githooks/required"
+DELEGATE_HOOK = ".githooks/pre-commit"
+
+
+def _worktree_root() -> str:
+    """Return the cwd's Git worktree root, or "" outside a worktree."""
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.strip()
+    except FileNotFoundError:
+        return ""
+
+
+def _marker_listed_in_index(repo_root: Path) -> bool:
+    """True when the index at `repo_root` lists the marker path, which
+    keeps the declaration standing through an unstaged `rm`; a staged
+    `git rm` clears the entry. Without a `git` binary nothing is listed."""
+    try:
+        return (
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo_root),
+                    "ls-files",
+                    "--error-unmatch",
+                    "--",
+                    DELEGATE_MARKER,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).returncode
+            == 0
+        )
+    except FileNotFoundError:
+        return False
+
+
+def delegate_required_control(repo_root: Path) -> Tuple[bool, str]:
+    """Evaluate the `delegate-required` doctor control for one worktree root.
+
+    Returns (healthy, report). The report always starts with
+    `delegate-required:`. The marker is declared when it is present in the
+    working tree or listed in the index — the pre-commit chain's rule.
+    `healthy` is False when the marker is declared and
+    the delegate is not a regular executable file — the exact state the
+    pre-commit chain refuses — and also when, without the marker, a delegate
+    exists that the chain would skip silently. Each unhealthy report names the
+    tested condition and the remedy.
+    """
+    marker = repo_root / DELEGATE_MARKER
+    delegate = repo_root / DELEGATE_HOOK
+    present = delegate.exists() or delegate.is_symlink()
+    runnable = delegate.is_file() and os.access(delegate, os.X_OK)
+    declared = (
+        marker.exists()
+        or marker.is_symlink()
+        or _marker_listed_in_index(repo_root)
+    )
+    if not declared:
+        prefix = (
+            f"delegate-required: not opted in ({DELEGATE_MARKER} is neither "
+            "in the working tree nor in the index)"
+        )
+        if not present:
+            return True, f"{prefix}; no repo-local hook to chain"
+        if runnable:
+            return True, f"{prefix}; chained repo-local hook: present, executable"
+        return False, (
+            f"{prefix}, yet {DELEGATE_HOOK} is present and not runnable, so "
+            "the chain skips it silently and every commit passes without "
+            f"it: chmod +x {DELEGATE_HOOK} (or replace it with an executable "
+            f"regular file), and declare {DELEGATE_MARKER} (add it to the "
+            "working tree or the index) so the chain fails closed on this "
+            "condition instead"
+        )
+    prefix = f"delegate-required: {DELEGATE_MARKER} is declared but"
+    if not present:
+        return False, (
+            f"{prefix} {DELEGATE_HOOK} is missing; the pre-commit chain "
+            f"refuses every commit here: create {DELEGATE_HOOK} (an "
+            "executable regular file) and track it beside the marker"
+        )
+    if not delegate.is_file():
+        return False, (
+            f"{prefix} {DELEGATE_HOOK} is not a regular file; the pre-commit "
+            f"chain refuses every commit here: replace {DELEGATE_HOOK} with "
+            "an executable regular file"
+        )
+    if not os.access(delegate, os.X_OK):
+        return False, (
+            f"{prefix} {DELEGATE_HOOK} is not executable; the pre-commit "
+            f"chain refuses every commit here: chmod +x {DELEGATE_HOOK}"
+        )
+    return True, (
+        f"delegate-required: opted in ({DELEGATE_MARKER} declared); "
+        f"{DELEGATE_HOOK} is a regular executable file and runs on every commit"
+    )
+
+
 # ─── doctor ──────────────────────────────────────────────────────────────
 
 def _grep_validates(pattern: str) -> Optional[str]:
@@ -987,23 +1109,20 @@ def run_doctor(config_path: Path) -> int:
             infos.append(
                 f"cwd repo class: {cls} ({len(push_urls)} push remotes)"
             )
-            try:
-                top = subprocess.run(
-                    ["git", "rev-parse", "--show-toplevel"],
-                    capture_output=True,
-                    text=True,
-                ).stdout.strip()
-            except FileNotFoundError:
-                top = ""
-            if top:
-                chained = Path(top) / ".githooks" / "pre-commit"
-                if chained.exists():
-                    if os.access(chained, os.X_OK):
-                        infos.append("chained repo-local hook: present, executable")
-                    else:
-                        problems.append(
-                            f"chained hook not executable: {chained}"
-                        )
+
+    # 7. delegate-required: the cwd repository's own declaration that its
+    # .githooks/pre-commit must run. A repository's opt-in is a fact about
+    # that repository, so this control runs whenever the cwd is a worktree,
+    # independent of config health or push remotes.
+    top = _worktree_root()
+    if top:
+        healthy, report = delegate_required_control(Path(top))
+        (infos if healthy else problems).append(report)
+    else:
+        infos.append(
+            "delegate-required: cwd is not inside a Git worktree "
+            "(control not evaluated)"
+        )
 
     print("synthesis-git-hooks doctor")
     for line in infos:
@@ -1053,7 +1172,7 @@ def main(argv: List[str]) -> int:
     mode.add_argument(
         "--doctor",
         action="store_true",
-        help="Self-check the protection chain: config, patterns, hooksPath wiring, source drift, cwd classification. Exit 0 = healthy.",
+        help="Self-check the protection chain: config, patterns, hooksPath wiring, source drift, cwd classification, delegate-required. Exit 0 = healthy.",
     )
     args = parser.parse_args(argv)
 

--- a/skills/synthesis-git-hooks/scripts/pre-commit
+++ b/skills/synthesis-git-hooks/scripts/pre-commit
@@ -85,6 +85,37 @@ EOF
     exit 1
 }
 
+delegate_refused() {
+    cat >&2 <<EOF
+
+==================================================================
+  X  COMMIT BLOCKED — required repo-local hook cannot run
+==================================================================
+
+This repository declares .githooks/required — the marker is present
+in the working tree or listed in the index — so its own pre-commit
+hook must run on every commit. Tested condition:
+
+  $1
+
+Remedy:  $2
+
+The chain FAILS CLOSED: while the declaration stands, no commit
+proceeds with the repository's own guards running nothing. Accepted
+form: .githooks/pre-commit as a regular, executable file (a symlink
+to one also qualifies). Withdrawing the declaration means staging
+the removal (git rm .githooks/required) in a reviewed change; an
+unstaged rm leaves the index entry, and the declaration, standing,
+unless the commit itself stages the removal (git commit -a, or a
+partial commit naming .githooks/required).
+
+Marker:     $REPO_HOOK_MARKER
+Delegate:   $REPO_HOOK
+Diagnose:   python3 $SIDECAR --doctor   (control: delegate-required)
+EOF
+    exit 1
+}
+
 [ -f "$CONFIG" ]  || fail_closed "Config not found at $CONFIG. Run the skill's install.sh to set it up."
 [ -f "$SIDECAR" ] || fail_closed "Sidecar not found at $SIDECAR."
 
@@ -103,6 +134,7 @@ eval "$SIDECAR_OUT"
 [ -n "${ACTIVE_REGEX:-}" ] || fail_closed "Active pattern set is empty — Tier 0 must never be empty in a valid config."
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || fail_closed "Cannot resolve the Git worktree root."
+[ -n "$REPO_ROOT" ] || fail_closed "Git worktree root resolved to an empty path."
 
 # A configured board promotes the advisory source-area claim to a commit
 # boundary. Without a configured board the content scanner still runs, but D6
@@ -398,12 +430,41 @@ fi
 # directory (v2.1+), driven by the same sidecar's CHECK_COMMIT_MSG flag.
 
 # Export class for any delegated per-repo hook, then chain.
+#
+# Global core.hooksPath makes this chain the only path to a repository's own
+# .githooks/pre-commit. The chain execs that delegate only when it is present
+# and executable; otherwise it exits 0 — so a repository whose commit-boundary
+# guards live in the delegate can report success while running nothing. A
+# declared .githooks/required opts the repository in — declared means present
+# in the working tree (-e or -L) OR listed in the index (git ls-files
+# --error-unmatch at the worktree root); content is ignored. Testing the
+# index too means an unstaged rm of the marker does not withdraw the
+# declaration; a staged git rm withdraws it in that commit, which is the
+# reviewed change the refusal text names. With the declaration, a missing,
+# non-regular, or non-executable delegate (a symlink is judged by its
+# target) blocks the commit and names the remedy. Without it the chain
+# behaves exactly as before. The doctor's delegate-required control applies
+# the same declaration rule and reports the same verdict.
 export SYNTHESIS_REPO_CLASS="$REPO_CLASS"
-if [ -n "$REPO_ROOT" ]; then
-    REPO_HOOK="$REPO_ROOT/.githooks/pre-commit"
-    if [ -f "$REPO_HOOK" ] && [ -x "$REPO_HOOK" ]; then
-        exec "$REPO_HOOK"
+REPO_HOOK="$REPO_ROOT/.githooks/pre-commit"
+REPO_HOOK_MARKER="$REPO_ROOT/.githooks/required"
+if [ -e "$REPO_HOOK_MARKER" ] || [ -L "$REPO_HOOK_MARKER" ] \
+    || git -C "$REPO_ROOT" ls-files --error-unmatch -- .githooks/required >/dev/null 2>&1; then
+    if [ ! -e "$REPO_HOOK" ] && [ ! -L "$REPO_HOOK" ]; then
+        delegate_refused ".githooks/pre-commit is missing." \
+            "create .githooks/pre-commit (an executable regular file) and track it beside .githooks/required"
+    elif [ ! -f "$REPO_HOOK" ]; then
+        delegate_refused ".githooks/pre-commit exists but is not a regular file." \
+            "replace .githooks/pre-commit with an executable regular file"
+    elif [ ! -x "$REPO_HOOK" ]; then
+        REPO_HOOK_MODE="$(ls -ldL -- "$REPO_HOOK" 2>/dev/null | cut -c1-10 || true)"
+        delegate_refused ".githooks/pre-commit exists but is not executable (mode ${REPO_HOOK_MODE:-unreadable})." \
+            "chmod +x .githooks/pre-commit"
     fi
+    echo "delegate-required: .githooks/required declared; chaining to .githooks/pre-commit" >&2
+fi
+if [ -f "$REPO_HOOK" ] && [ -x "$REPO_HOOK" ]; then
+    exec "$REPO_HOOK"
 fi
 
 exit 0

--- a/skills/synthesis-git-hooks/scripts/test_pre_commit.py
+++ b/skills/synthesis-git-hooks/scripts/test_pre_commit.py
@@ -738,14 +738,17 @@ def test_installed_copy_never_compares_against_itself(tmp_path, monkeypatch) -> 
     assert resolved == direct_copy
 
 
-def test_doctor_detects_drift_end_to_end(tmp_path: Path) -> None:
-    """Installed engine + discovered source, healthy then drifted."""
+def doctor_harness(tmp_path: Path) -> tuple[Path, Path, dict[str, str]]:
+    """An installed engine, a discoverable skill source, a policy, and a
+    global hooksPath under a private HOME — every doctor control healthy, so
+    a test can drift or opt in one thing and read that control's verdict.
+    Returns (installed engine dir, source dir, environment)."""
     home = tmp_path / "home"
     installed = home / ".synthesis" / "git-hooks"
     engine_copy(installed)
     source = home / ".claude" / "skills" / "synthesis-git-hooks" / "scripts"
     engine_copy(source)
-    config = tmp_path / "policy.yaml"
+    config = tmp_path / "doctor-policy.yaml"
     policy(config)
     (home / ".gitconfig").write_text(
         f"[core]\n\thooksPath = {installed}\n", encoding="utf-8"
@@ -760,23 +763,30 @@ def test_doctor_detects_drift_end_to_end(tmp_path: Path) -> None:
         "GIT_CONFIG_GLOBAL",
     ):
         environment.pop(variable, None)
+    return installed, source, environment
 
-    def doctor():
-        return subprocess.run(
-            [sys.executable, str(installed / "_load_config.py"), "--doctor"],
-            cwd=tmp_path,
-            env=environment,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
 
-    healthy = doctor()
+def doctor(installed: Path, environment: dict[str, str], cwd: Path):
+    return subprocess.run(
+        [sys.executable, str(installed / "_load_config.py"), "--doctor"],
+        cwd=cwd,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_doctor_detects_drift_end_to_end(tmp_path: Path) -> None:
+    """Installed engine + discovered source, healthy then drifted."""
+    installed, source, environment = doctor_harness(tmp_path)
+
+    healthy = doctor(installed, environment, tmp_path)
     assert healthy.returncode == 0, healthy.stdout + healthy.stderr
     assert "no drift" in healthy.stdout
 
     (source / "pre-commit").write_bytes(b"#!/bin/bash\n# hotfixed\n")
-    drifted = doctor()
+    drifted = doctor(installed, environment, tmp_path)
     assert drifted.returncode == 1, drifted.stdout + drifted.stderr
     assert "DRIFT: installed pre-commit" in drifted.stdout
 
@@ -1065,3 +1075,367 @@ def test_r4_config_sidecar_emits_board_gate(tmp_path: Path) -> None:
     assert completed.returncode == 0, completed.stdout + completed.stderr
     assert "COORDINATION_CHECK_STAGED=1" in completed.stdout
     assert f"COORDINATION_BOARD={shlex.quote(str(board))}" in completed.stdout
+
+
+# ─── required repo-local delegate (fail closed) ──────────────────────────
+#
+# Global core.hooksPath makes the installed pre-commit the only path to a
+# repository's own `.githooks/pre-commit`. A declared `.githooks/required`
+# (present in the working tree or listed in the index) requires the delegate
+# to run on every commit; with the marker, a
+# missing or non-executable delegate blocks the commit and names the remedy.
+# Without the marker today's behavior stands: chain when runnable, else exit 0.
+
+
+DELEGATE_SCRIPT = """\
+#!/bin/bash
+# Repo-local pre-commit: leaves evidence that it ran, then exits 3 so the
+# chain's honoring of the delegate's exit status is observable.
+printf 'ran\\n' > "$(git rev-parse --show-toplevel)/delegate-ran"
+exit 3
+"""
+
+
+def delegate_repository(
+    tmp_path: Path, *, marker: bool, delegate: str | None
+) -> tuple[Path, dict[str, str]]:
+    """A staged, otherwise-clean repository with `.githooks/pre-commit` in
+    the requested state: None = absent, "644" = present but not executable,
+    "755" = executable, "dir" = a directory where the file should be,
+    "link644" = a symlink to a mode-644 regular file beside it."""
+    root, environment = repository(tmp_path)
+    hooks = root / ".githooks"
+    hooks.mkdir()
+    if marker:
+        (hooks / "required").write_text(
+            "This repository's own pre-commit hook must run on every commit.\n",
+            encoding="utf-8",
+        )
+    if delegate == "dir":
+        (hooks / "pre-commit").mkdir()
+    elif delegate == "link644":
+        target = hooks / "pre-commit.target"
+        target.write_text(DELEGATE_SCRIPT, encoding="utf-8")
+        target.chmod(0o644)
+        (hooks / "pre-commit").symlink_to("pre-commit.target")
+    elif delegate is not None:
+        script = hooks / "pre-commit"
+        script.write_text(DELEGATE_SCRIPT, encoding="utf-8")
+        script.chmod(0o755 if delegate == "755" else 0o644)
+    (root / "ordinary.md").write_text("ordinary content\n", encoding="utf-8")
+    assert run(root, "git", "add", "-A").returncode == 0
+    return root, environment
+
+
+def test_marker_with_missing_delegate_blocks_with_create_remedy(
+    tmp_path: Path,
+) -> None:
+    root, environment = delegate_repository(tmp_path, marker=True, delegate=None)
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "COMMIT BLOCKED" in completed.stderr
+    assert ".githooks/pre-commit is missing" in completed.stderr
+    assert "create .githooks/pre-commit" in completed.stderr
+    assert not (root / "delegate-ran").exists()
+
+
+def test_marker_with_non_executable_delegate_blocks_with_chmod_remedy(
+    tmp_path: Path,
+) -> None:
+    root, environment = delegate_repository(tmp_path, marker=True, delegate="644")
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "COMMIT BLOCKED" in completed.stderr
+    assert ".githooks/pre-commit exists but is not executable" in completed.stderr
+    assert "chmod +x .githooks/pre-commit" in completed.stderr
+    assert not (root / "delegate-ran").exists()
+
+
+def test_marker_with_directory_delegate_blocks_with_replace_remedy(
+    tmp_path: Path,
+) -> None:
+    root, environment = delegate_repository(tmp_path, marker=True, delegate="dir")
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "COMMIT BLOCKED" in completed.stderr
+    assert ".githooks/pre-commit exists but is not a regular file" in completed.stderr
+    assert (
+        "replace .githooks/pre-commit with an executable regular file"
+        in completed.stderr
+    )
+
+
+def test_marker_with_executable_delegate_runs_it_and_honors_its_exit(
+    tmp_path: Path,
+) -> None:
+    root, environment = delegate_repository(tmp_path, marker=True, delegate="755")
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert (root / "delegate-ran").read_text(encoding="utf-8") == "ran\n"
+    assert completed.returncode == 3, completed.stdout + completed.stderr
+    assert "COMMIT BLOCKED" not in completed.stderr
+
+
+def test_no_marker_with_non_executable_delegate_passes_unchanged(
+    tmp_path: Path,
+) -> None:
+    root, environment = delegate_repository(tmp_path, marker=False, delegate="644")
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "COMMIT BLOCKED" not in completed.stderr
+    assert "delegate-required" not in completed.stdout + completed.stderr
+    assert not (root / "delegate-ran").exists()
+
+
+def test_no_marker_with_executable_delegate_still_chains(tmp_path: Path) -> None:
+    root, environment = delegate_repository(tmp_path, marker=False, delegate="755")
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert (root / "delegate-ran").read_text(encoding="utf-8") == "ran\n"
+    assert completed.returncode == 3, completed.stdout + completed.stderr
+
+
+def test_doctor_delegate_required_reports_not_opted_in(tmp_path: Path) -> None:
+    installed, _, environment = doctor_harness(tmp_path)
+    root, _ = delegate_repository(tmp_path, marker=False, delegate=None)
+
+    completed = doctor(installed, environment, root)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "ok  delegate-required: not opted in" in completed.stdout
+    assert "HEALTHY: policy engine fully operational." in completed.stdout
+
+
+def test_doctor_delegate_required_healthy_with_executable_delegate(
+    tmp_path: Path,
+) -> None:
+    installed, _, environment = doctor_harness(tmp_path)
+    root, _ = delegate_repository(tmp_path, marker=True, delegate="755")
+
+    completed = doctor(installed, environment, root)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "ok  delegate-required: opted in" in completed.stdout
+    assert "regular executable file" in completed.stdout
+    assert "HEALTHY: policy engine fully operational." in completed.stdout
+
+
+def test_doctor_delegate_required_unhealthy_when_delegate_missing(
+    tmp_path: Path,
+) -> None:
+    installed, _, environment = doctor_harness(tmp_path)
+    root, _ = delegate_repository(tmp_path, marker=True, delegate=None)
+
+    completed = doctor(installed, environment, root)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "!!  delegate-required:" in completed.stdout
+    assert ".githooks/pre-commit is missing" in completed.stdout
+    assert "create .githooks/pre-commit" in completed.stdout
+    assert "UNHEALTHY" in completed.stdout
+
+
+def test_doctor_delegate_required_unhealthy_when_delegate_not_executable(
+    tmp_path: Path,
+) -> None:
+    installed, _, environment = doctor_harness(tmp_path)
+    root, _ = delegate_repository(tmp_path, marker=True, delegate="644")
+
+    completed = doctor(installed, environment, root)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "!!  delegate-required:" in completed.stdout
+    assert ".githooks/pre-commit is not executable" in completed.stdout
+    assert "chmod +x .githooks/pre-commit" in completed.stdout
+    assert "UNHEALTHY" in completed.stdout
+
+
+def test_doctor_delegate_required_unhealthy_when_delegate_not_a_file(
+    tmp_path: Path,
+) -> None:
+    installed, _, environment = doctor_harness(tmp_path)
+    root, _ = delegate_repository(tmp_path, marker=True, delegate="dir")
+
+    completed = doctor(installed, environment, root)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "!!  delegate-required:" in completed.stdout
+    assert ".githooks/pre-commit is not a regular file" in completed.stdout
+    assert (
+        "replace .githooks/pre-commit with an executable regular file"
+        in completed.stdout
+    )
+    assert "UNHEALTHY" in completed.stdout
+
+
+def test_doctor_not_opted_in_still_flags_a_silently_skipped_delegate(
+    tmp_path: Path,
+) -> None:
+    """Without the marker the chain exits 0 past a mode-644 delegate; the
+    doctor keeps naming that latent skip as a problem and points at the
+    opt-in that would turn it into a commit-boundary refusal."""
+    installed, _, environment = doctor_harness(tmp_path)
+    root, _ = delegate_repository(tmp_path, marker=False, delegate="644")
+
+    completed = doctor(installed, environment, root)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "!!  delegate-required: not opted in" in completed.stdout
+    assert "chmod +x .githooks/pre-commit" in completed.stdout
+    assert ".githooks/required" in completed.stdout
+    assert "UNHEALTHY" in completed.stdout
+
+
+# ─── declaration = working tree OR index ─────────────────────────────────
+#
+# The refusal text says withdrawing the declaration is a reviewed change, so
+# the declaration must not evaporate on an unstaged `rm`. The marker is
+# declared when `.githooks/required` is present in the working tree OR listed
+# in the index; a staged `git rm` withdraws it in that commit, an unstaged
+# `rm` does not. The doctor's delegate-required control uses the same rule.
+
+
+def committed_delegate_repository(
+    tmp_path: Path, *, delegate: str | None
+) -> tuple[Path, dict[str, str]]:
+    """`delegate_repository` with the marker and delegate COMMITTED (hooks
+    disabled for that commit) and a fresh ordinary change staged, so a test
+    can then remove the marker from the working tree alone (unstaged `rm`)
+    or from the index as well (staged `git rm`) and observe which of the two
+    withdraws the declaration."""
+    root, environment = delegate_repository(
+        tmp_path, marker=True, delegate=delegate
+    )
+    committed = run(
+        root, "git", "-c", "core.hooksPath=/dev/null", "commit", "-m", "Declare"
+    )
+    assert committed.returncode == 0, committed.stdout + committed.stderr
+    (root / "later.md").write_text("later content\n", encoding="utf-8")
+    assert run(root, "git", "add", "later.md").returncode == 0
+    return root, environment
+
+
+def marker_listed_in_index(root: Path) -> bool:
+    return (
+        run(root, "git", "ls-files", "--error-unmatch", "--", ".githooks/required")
+        .returncode
+        == 0
+    )
+
+
+def test_unstaged_rm_of_committed_marker_leaves_declaration_standing(
+    tmp_path: Path,
+) -> None:
+    """An unstaged `rm .githooks/required` leaves the index entry, so the
+    declaration stands and a mode-644 delegate is still refused with the
+    chmod remedy."""
+    root, environment = committed_delegate_repository(tmp_path, delegate="644")
+    (root / ".githooks" / "required").unlink()
+    assert marker_listed_in_index(root)
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "COMMIT BLOCKED" in completed.stderr
+    assert ".githooks/pre-commit exists but is not executable" in completed.stderr
+    assert "chmod +x .githooks/pre-commit" in completed.stderr
+    assert not (root / "delegate-ran").exists()
+
+
+def test_staged_git_rm_of_marker_withdraws_declaration_in_that_commit(
+    tmp_path: Path,
+) -> None:
+    """A staged `git rm .githooks/required` removes the index entry and the
+    working-tree file together: the commit that withdraws the declaration is
+    the first one a mode-644 delegate no longer blocks."""
+    root, environment = committed_delegate_repository(tmp_path, delegate="644")
+    removed = run(root, "git", "rm", "--quiet", "--", ".githooks/required")
+    assert removed.returncode == 0, removed.stdout + removed.stderr
+    assert not marker_listed_in_index(root)
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "COMMIT BLOCKED" not in completed.stderr
+    assert "delegate-required" not in completed.stdout + completed.stderr
+    assert not (root / "delegate-ran").exists()
+
+
+def test_marker_with_symlink_to_non_executable_target_reports_target_mode(
+    tmp_path: Path,
+) -> None:
+    """The refusal's mode parenthetical describes the file the chain would
+    exec — the symlink's target — not the link itself."""
+    root, environment = delegate_repository(
+        tmp_path, marker=True, delegate="link644"
+    )
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "COMMIT BLOCKED" in completed.stderr
+    assert "(mode -rw-r--r--)" in completed.stderr
+    assert "chmod +x .githooks/pre-commit" in completed.stderr
+    assert not (root / "delegate-ran").exists()
+
+
+def test_doctor_marker_in_index_only_still_evaluates_as_opted_in(
+    tmp_path: Path,
+) -> None:
+    """Doctor parity with the chain: a committed marker removed from the
+    working tree alone is still listed in the index, so the control reports
+    the repository as opted in."""
+    installed, _, environment = doctor_harness(tmp_path)
+    root, _ = committed_delegate_repository(tmp_path, delegate="755")
+    (root / ".githooks" / "required").unlink()
+    assert marker_listed_in_index(root)
+
+    completed = doctor(installed, environment, root)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "ok  delegate-required: opted in" in completed.stdout
+    assert "HEALTHY: policy engine fully operational." in completed.stdout
+
+
+def test_empty_worktree_root_fails_closed(tmp_path: Path) -> None:
+    """A Git that answers `rev-parse --show-toplevel` with an empty line and
+    exit 0 would make the chain probe `/.githooks/...` and ignore the
+    repository's own declaration; the root guard refuses instead. Real Git
+    never does this, so a PATH shim answers that one query and hands every
+    other call to the real binary."""
+    root, environment = delegate_repository(tmp_path, marker=True, delegate="644")
+    real_git = shutil.which("git")
+    assert real_git
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    shim = shim_dir / "git"
+    shim.write_text(
+        "#!/bin/bash\n"
+        'if [ "${1:-}" = rev-parse ] && [ "${2:-}" = --show-toplevel ]; then\n'
+        '  echo ""\n'
+        "  exit 0\n"
+        "fi\n"
+        f'exec "{real_git}" "$@"\n',
+        encoding="utf-8",
+    )
+    shim.chmod(0o755)
+    environment = dict(environment)
+    environment["PATH"] = f"{shim_dir}{os.pathsep}{environment['PATH']}"
+
+    completed = run(root, str(HOOK), env=environment)
+
+    assert completed.returncode == 1, completed.stdout + completed.stderr
+    assert "COMMIT BLOCKED" in completed.stderr
+    assert "Git worktree root resolved to an empty path." in completed.stderr
+    assert "delegate-required" not in completed.stderr
+    assert not (root / "delegate-ran").exists()

--- a/skills/synthesis-implementation-integrity/acceptance-suite.yaml
+++ b/skills/synthesis-implementation-integrity/acceptance-suite.yaml
@@ -1,8 +1,8 @@
 schema: 2
-suite: board-fixes-2026-09-10
+suite: stranded-and-required-delegate-2026-09-11
 membership: closed
-production_entry_point: pr_queue_scan.py scan and main, synthesis-bitbucket pr_queue.py list_open_prs and bkt_identity,
-  peer_send_gate.py --gate classify and message_body, retire_worktree.py --base validation
+production_entry_point: checkpoint_sync.py --hook, --flush-pending and --flush-session ID [--drop-stranded --assert TEXT],
+  the pre-commit chain's delegate step, and _load_config.py --doctor delegate-required control
 enforcing_boundary: release.py derives exact Git changed paths and consumes fresh transaction-bound acceptance
   before publication and both-client installation
 receipt_consumer: synthesis-skills-manager.release.consume-acceptance.v1
@@ -10,14 +10,22 @@ change_base_policy: boundary-supplied-git-diff
 expected_status: pass
 metadata_class: acceptance-test
 issues_authority_receipt: false
-unverified_remainder: Fixtures establish the host dispatch of the pull-request queue scan, the Bitbucket helper's
-  contract at the process boundary, the shell-aware peer-send parse, the retirement base refusal text, the
-  daily-rituals version record, the documented merge-claim rule, and one coherent release read from the actual
-  plugin manifests, CHANGELOG top heading and README release marker. They never reach gh or bkt, do not read the
-  body text of the 4.97.0 README note or CHANGELOG entry beyond that marker and heading, and no fixture reads
-  skills/synthesis-bitbucket/SKILL.md (its PR-queue section is bound to the helper cases that pin the contract
-  it documents). They do not establish native startup, complete agent reading, natural Stop, or multi-computer
-  readiness. Installed and genuine native acceptance are separate.
+unverified_remainder: Fixtures establish the stranded classification of manifest entries beneath a removed,
+  unrecorded worktree, the remedies named from retained intents and receipts, the operator-asserted drop with its
+  append-only ledger, per-repository retirement on flush, the failed-not-stranded verdict when git cannot answer,
+  the marker-gated delegate refusal in the pre-commit chain, the doctor's delegate-required control, and one
+  coherent release read from the actual plugin manifests, CHANGELOG top heading and README release marker. They
+  read skills/synthesis-repo-guard/SKILL.md and skills/synthesis-project-management/SKILL.md only for the
+  metadata version floor, the reference-link budget and the peer-resolution markers. No fixture in this suite
+  reads skills/synthesis-git-hooks/SKILL.md; its metadata version has no reliability floor, and within this suite
+  the file is bound only through the marker, no-marker, empty-root and doctor cases that pin the chain and
+  doctor it documents. No fixture
+  reads the body text of the 4.98.0 README note or CHANGELOG entry beyond that marker and heading, the stranded
+  section of skills/synthesis-repo-guard/SKILL.md, or the removed-worktree section of
+  checkpoint-closure-recovery.md (each is bound to the cases that pin the contract it documents). The coverage
+  coherence fixtures compare the pytest group lists in validate.yml, AGENTS.md and release.py; they do not
+  execute the group, which CI and the release gate run. They do not establish native startup, complete agent
+  reading, natural Stop, or multi-computer readiness. Installed and genuine native acceptance are separate.
 changed_surfaces:
 - path: .claude-plugin/plugin.json
   cases:
@@ -31,12 +39,11 @@ changed_surfaces:
   - release-contract-version
 - path: .github/workflows/validate.yml
   cases:
-  - release-contract-verification
-  - release-contract-required-checks
+  - ci-verification-coherence
+  - gate-covers-ci-groups
 - path: AGENTS.md
   cases:
-  - release-contract-verification
-  - release-contract-required-checks
+  - ci-verification-coherence
 - path: CHANGELOG.md
   cases:
   - release-contract
@@ -49,132 +56,50 @@ changed_surfaces:
   - release-surfaces-pinned
   - release-contract-version
   - public-surfaces
-- path: skills/synthesis-agent-conformance/scripts/test_conformance.py
+- path: skills/synthesis-git-hooks/SKILL.md
   cases:
-  - hook-live-receipt-selectors
-- path: skills/synthesis-bitbucket/SKILL.md
+  - marker-missing-delegate
+  - marker-non-executable-delegate
+  - marker-directory-delegate
+  - marker-executable-delegate-chains
+  - no-marker-unchanged
+  - doctor-delegate-not-opted-in
+  - doctor-delegate-healthy
+  - doctor-delegate-missing
+- path: skills/synthesis-git-hooks/scripts/_load_config.py
   cases:
-  - bitbucket-helper-module
-  - bkt-slug-alone
-  - bkt-identity-fields
-  - bkt-identity-required
-  - bkt-404-reason
-  - bkt-binary-missing
-- path: skills/synthesis-bitbucket/scripts/pr_queue.py
+  - doctor-delegate-not-opted-in
+  - doctor-delegate-healthy
+  - doctor-delegate-missing
+  - doctor-delegate-not-executable
+  - doctor-delegate-not-a-file
+  - doctor-silently-skipped-delegate
+  - doctor-drift-end-to-end
+- path: skills/synthesis-git-hooks/scripts/pre-commit
   cases:
-  - bitbucket-dispatch
-  - bkt-buckets-by-uuid
-  - bkt-account-id-match
-  - bkt-participants-fallback
-  - bkt-identity-required
-  - bkt-slug-alone
-  - bkt-rejects-owner-slash-name
-  - bkt-rejects-empty
-  - bkt-identity-fields
-  - bkt-identity-failure
-  - bkt-identity-resolved
-  - bkt-identity-unresolvable
-  - bkt-404-reason
-  - bkt-exit-code-named
-  - bkt-unparseable
-  - bkt-missing-key
-  - bkt-wrong-shape
-  - bkt-null-empty-queue
-  - bkt-empty-list-queue
-  - bkt-timeout
-  - bkt-binary-missing
-  - bkt-age-days
-- path: skills/synthesis-bitbucket/scripts/test_pr_queue.py
+  - marker-missing-delegate
+  - marker-non-executable-delegate
+  - marker-directory-delegate
+  - marker-executable-delegate-chains
+  - no-marker-unchanged
+  - no-marker-executable-chains
+  - empty-root-fails-closed
+- path: skills/synthesis-git-hooks/scripts/test_pre_commit.py
   cases:
-  - bkt-buckets-by-uuid
-  - bkt-account-id-match
-  - bkt-participants-fallback
-  - bkt-identity-required
-  - bkt-slug-alone
-  - bkt-rejects-owner-slash-name
-  - bkt-rejects-empty
-  - bkt-identity-fields
-  - bkt-identity-failure
-  - bkt-identity-resolved
-  - bkt-identity-unresolvable
-  - bkt-404-reason
-  - bkt-exit-code-named
-  - bkt-unparseable
-  - bkt-missing-key
-  - bkt-wrong-shape
-  - bkt-null-empty-queue
-  - bkt-empty-list-queue
-  - bkt-timeout
-  - bkt-binary-missing
-  - bkt-age-days
-- path: skills/synthesis-checkpoint/scripts/test_refresh.py
-  cases:
-  - optional-plan-absent
-- path: skills/synthesis-daily-rituals/SKILL.md
-  cases:
-  - version-record-labels
-  - version-record-declared
-  - version-record-newest
-  - version-record-labels-not-ahead
-  - bitbucket-dispatch
-  - unscanned-named
-  - remote-target-refusal
-- path: skills/synthesis-daily-rituals/references/version-history.md
-  cases:
-  - version-record-labels
-  - version-record-declared
-  - version-record-newest
-  - version-record-labels-not-ahead
-- path: skills/synthesis-daily-rituals/scripts/pr_queue_scan.py
-  cases:
-  - remote-target-hosts
-  - remote-target-refusal
-  - declared-target-manifest
-  - declared-target-unsupported-origin
-  - declared-target-git-fallback
-  - declared-target-missing-clone
-  - declared-target-unsupported-clone-origin
-  - unscanned-named
-  - scan-oldest-first
-  - bitbucket-helper-module
-  - bitbucket-dispatch
-  - bitbucket-identity-once
-  - bitbucket-404-unscanned
-  - bkt-missing
-  - bkt-unauthenticated
-  - gh-missing-bitbucket-scanned
-  - no-needless-host-cli
-  - main-gh-missing
-  - main-gh-unauthenticated
-  - main-both-hosts
-- path: skills/synthesis-daily-rituals/scripts/test_pr_queue_scan.py
-  cases:
-  - remote-target-hosts
-  - remote-target-refusal
-  - declared-target-manifest
-  - declared-target-unsupported-origin
-  - declared-target-git-fallback
-  - declared-target-missing-clone
-  - declared-target-unsupported-clone-origin
-  - unscanned-named
-  - scan-oldest-first
-  - bitbucket-helper-module
-  - bitbucket-dispatch
-  - bitbucket-identity-once
-  - bitbucket-404-unscanned
-  - bkt-missing
-  - bkt-unauthenticated
-  - gh-missing-bitbucket-scanned
-  - no-needless-host-cli
-  - main-gh-missing
-  - main-gh-unauthenticated
-  - main-both-hosts
-- path: skills/synthesis-daily-rituals/scripts/test_version_record.py
-  cases:
-  - version-record-labels
-  - version-record-declared
-  - version-record-newest
-  - version-record-labels-not-ahead
+  - marker-missing-delegate
+  - marker-non-executable-delegate
+  - marker-directory-delegate
+  - marker-executable-delegate-chains
+  - no-marker-unchanged
+  - no-marker-executable-chains
+  - empty-root-fails-closed
+  - doctor-delegate-not-opted-in
+  - doctor-delegate-healthy
+  - doctor-delegate-missing
+  - doctor-delegate-not-executable
+  - doctor-delegate-not-a-file
+  - doctor-silently-skipped-delegate
+  - doctor-drift-end-to-end
 - path: skills/synthesis-implementation-integrity/acceptance-suite.yaml
   cases:
   - manifest
@@ -182,71 +107,96 @@ changed_surfaces:
   - transaction-binding
 - path: skills/synthesis-project-management/SKILL.md
   cases:
-  - merge-claim-anchors
+  - release-contract
+  - reference-linked
   - public-surfaces
-- path: skills/synthesis-project-management/references/parallel-agent-protocol.md
+- path: skills/synthesis-project-management/references/checkpoint-closure-recovery.md
   cases:
-  - merge-claim-anchors
-  - shell-lane-boundary
-  - public-surfaces
-- path: skills/synthesis-project-management/scripts/peer_send_gate.py
+  - reference-linked
+  - stranded-reported-others-evaluated
+  - stranded-receipt-session-remedy
+  - stranded-intent-remedy
+  - stale-receipt-head-remedy
+  - drop-ledger-append-only
+  - drop-refuses-returned-root
+  - drop-blank-assertion
+  - drop-dry-run
+  - per-repository-retirement
+  - git-unavailable-failed
+  - visible-gitdir-not-stranded
+- path: skills/synthesis-repo-guard/SKILL.md
   cases:
-  - shell-lane-boundary
-  - heredoc-literal-not-a-send
-  - thread-values-as-data
-  - real-send-still-codex-lane
-  - nested-shell-send
-  - quoted-substitution-send
-  - unquoted-heredoc-expansion
-  - here-string-shell
-  - named-coprocess
-  - nesting-bound-fails-closed
-  - message-from-parsed-send
-  - nested-send-end-to-end
-  - unbalanced-quotes-raw-words
-  - gate-process-fails-closed
-- path: skills/synthesis-project-management/scripts/retire_worktree.py
+  - release-contract
+  - stranded-reported-others-evaluated
+  - stranded-receipt-session-remedy
+  - stranded-intent-remedy
+  - stale-receipt-head-remedy
+  - blocked-receipt-head-remedy
+  - drop-cli-combinations
+  - drop-blank-assertion
+  - drop-ledger-append-only
+  - drop-dry-run
+  - per-repository-retirement
+  - deleted-file-not-stranded
+  - git-unavailable-failed
+  - visible-gitdir-not-stranded
+- path: skills/synthesis-repo-guard/checkpoint_sync.py
   cases:
-  - base-refusal-names-form
-  - ambiguous-base-diagnosis
-  - revision-expression-base
-- path: skills/synthesis-project-management/scripts/test_coordination.py
+  - stranded-reported-others-evaluated
+  - stranded-receipt-session-remedy
+  - stranded-intent-remedy
+  - stop-records-stranded
+  - stop-preserves-receipt
+  - drop-blank-assertion
+  - drop-cli-combinations
+  - drop-refuses-returned-root
+  - drop-ledger-append-only
+  - drop-dry-run
+  - drop-all-stranded-manifest
+  - per-repository-retirement
+  - deleted-file-not-stranded
+  - nested-worktree-stays-failed
+  - git-unavailable-failed
+  - drop-never-drops-live-repository
+  - visible-gitdir-not-stranded
+  - stranded-needs-working-git
+  - stale-receipt-head-remedy
+  - blocked-receipt-head-remedy
+  - retirement-reconciles-manifest
+- path: skills/synthesis-repo-guard/test_checkpoint_sync.py
   cases:
-  - merge-claim-anchors
-- path: skills/synthesis-project-management/scripts/test_peer_send_gate.py
-  cases:
-  - shell-lane-boundary
-  - heredoc-literal-not-a-send
-  - thread-values-as-data
-  - real-send-still-codex-lane
-  - nested-shell-send
-  - quoted-substitution-send
-  - unquoted-heredoc-expansion
-  - here-string-shell
-  - named-coprocess
-  - nesting-bound-fails-closed
-  - message-from-parsed-send
-  - nested-send-end-to-end
-  - unbalanced-quotes-raw-words
-  - gate-process-fails-closed
-- path: skills/synthesis-project-management/scripts/test_project_applicability.py
-  cases:
-  - shallow-clone-applicability
-- path: skills/synthesis-project-management/scripts/test_retire_worktree.py
-  cases:
-  - base-refusal-names-form
-  - ambiguous-base-diagnosis
-  - revision-expression-base
+  - stranded-reported-others-evaluated
+  - stranded-receipt-session-remedy
+  - stranded-intent-remedy
+  - stop-records-stranded
+  - stop-preserves-receipt
+  - drop-blank-assertion
+  - drop-cli-combinations
+  - drop-refuses-returned-root
+  - drop-ledger-append-only
+  - drop-dry-run
+  - drop-all-stranded-manifest
+  - per-repository-retirement
+  - deleted-file-not-stranded
+  - nested-worktree-stays-failed
+  - git-unavailable-failed
+  - drop-never-drops-live-repository
+  - visible-gitdir-not-stranded
+  - stranded-needs-working-git
+  - stale-receipt-head-remedy
+  - blocked-receipt-head-remedy
 - path: skills/synthesis-skills-manager/scripts/release.py
   cases:
-  - release-contract-required-checks
+  - gate-covers-ci-groups
+  - gate-no-glob
 cases:
 - id: release-contract
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-project-management/scripts/test_project_state.py::test_project_state_reliability_release_contract_is_coherent
   motivating_defect: Release metadata must describe one coherent release read from the actual files; both
-    plugin versions agree, the CHANGELOG top heading carries that version, and README notes Release **version**.
+    plugin versions agree, the CHANGELOG top heading carries that version, README notes Release **version**,
+    and the repo-guard and project-management SKILL.md versions stay at or above the reliability floor.
 - id: release-surfaces-pinned
   control_class: acceptance-test
   expected_status: pass
@@ -258,385 +208,49 @@ cases:
   expected_status: pass
   fixture: ../synthesis-skills-manager/scripts/test_release.py::test_source_version_agrees
   motivating_defect: Both client manifests must agree on one version before a release is described; the
-    boundary reads that agreed version.
+    boundary reads that agreed version. This fixture exercises the boundary's parser on a synthetic
+    repository; the shipped files are read by release-contract and release-surfaces-pinned.
 - id: release-contract-changelog
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-skills-manager/scripts/test_release.py::test_changelog_top_version_parsed
   motivating_defect: The changelog's newest heading must parse as the version the boundary compares with
-    both manifests.
-- id: release-contract-verification
+    both manifests. This fixture exercises the boundary's parser on a synthetic repository; the shipped files
+    are read by release-contract and release-surfaces-pinned.
+- id: ci-verification-coherence
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-skills-manager/scripts/test_release.py::test_agents_verification_list_matches_ci_workflow
-  motivating_defect: The AGENTS.md verification fence and the CI conformance job drifted apart once; the
-    Bitbucket test group joins both together or the release fails.
-- id: release-contract-required-checks
+  motivating_defect: The AGENTS.md Verification fence and the validate.yml conformance job are held equal
+    step for step; the rituals-guard-hooks pytest group gained skills/synthesis-repo-guard/test_*.py in both,
+    so this release's core fixtures (test_checkpoint_sync.py, test_deleted_paths.py) run in CI and in the
+    documented local verification instead of in neither.
+- id: gate-covers-ci-groups
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-skills-manager/scripts/test_release.py::test_required_checks_cover_ci_pytest_groups
-  motivating_defect: The Bitbucket test group joined CI and AGENTS.md but not the release gate; every CI pytest
-    group must be covered by REQUIRED_CHECKS.
+  motivating_defect: Every pytest group the conformance job runs must be covered by a release.py
+    REQUIRED_CHECKS pytest command; skills/synthesis-repo-guard/ joined pytest.rituals-guard-hooks so the
+    release gate no longer publishes without running the tests this release depends on.
+- id: gate-no-glob
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-skills-manager/scripts/test_release.py::test_required_checks_do_not_depend_on_shell_glob_expansion
+  motivating_defect: release.py hands argv to subprocess without a shell, so the new repo-guard entry is the
+    directory skills/synthesis-repo-guard/ and never the test_*.py glob the workflow and AGENTS.md spell;
+    a glob there would run zero tests.
 - id: public-surfaces
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-project-management/scripts/test_coordination.py::test_peer_resolution_documented_on_public_surfaces
   motivating_defect: README, CHANGELOG and the coordination surfaces must keep documenting the peer-resolution
     mechanism after the release note and entry are added.
-- id: version-record-labels
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_version_record.py::test_every_labeled_version_has_a_record_entry
-  motivating_defect: A checklist step labeled v2.35.0 sent readers to a record whose newest entry was v2.34.0.
-- id: version-record-declared
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_version_record.py::test_declared_version_has_a_record_entry
-  motivating_defect: The frontmatter version had no heading in the release record.
-- id: version-record-newest
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_version_record.py::test_record_newest_entry_is_the_declared_version
-  motivating_defect: The record's newest entry trailed the declared version; the record is newest first and
-    every release adds its entry.
-- id: version-record-labels-not-ahead
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_version_record.py::test_no_label_runs_ahead_of_the_declared_version
-  motivating_defect: A step label named a version newer than the frontmatter declared.
-- id: remote-target-hosts
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_remote_target_parses_supported_remotes
-  motivating_defect: Bitbucket and GitHub origins in https, ssh and scp forms must resolve to host, owner and
-    name, keeping dots in the name.
-- id: remote-target-refusal
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_remote_target_refuses_to_guess_other_hosts
-  motivating_defect: A remote on neither supported host must yield nothing so the caller reports it unscanned
-    rather than guessing.
-- id: declared-target-manifest
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_declared_target_prefers_the_manifest_over_the_working_copy
-  motivating_defect: A declared repo with no local clone is still scannable on either host because the queue is
-    a remote fact.
-- id: declared-target-unsupported-origin
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_declared_target_names_an_unsupported_manifest_origin
-  motivating_defect: An unsupported manifest origin must be named in the unscanned reason.
-- id: declared-target-git-fallback
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_declared_target_falls_back_to_git_when_manifest_is_silent
-  motivating_defect: Git is consulted for the origin only when the manifest declares none.
-- id: declared-target-missing-clone
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_declared_target_names_a_missing_clone
-  motivating_defect: A missing clone and an unsupported origin must read differently in the unscanned reason.
-- id: declared-target-unsupported-clone-origin
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_declared_target_names_an_unsupported_working_copy_origin
-  motivating_defect: An unsupported working-copy origin must be named together with the clone it was read from.
-- id: unscanned-named
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_unscannable_repos_are_named_not_silently_dropped
-  motivating_defect: A repo the scan could not read must appear in unscanned with its reason and never
-    contribute to a clean-looking result.
-- id: scan-oldest-first
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_scan_sorts_oldest_first
-  motivating_defect: Oldest-first ordering and the login field must survive the dispatch by host.
-- id: bitbucket-helper-module
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_bitbucket_helper_is_the_sibling_skill_module
-  motivating_defect: The scan must load the sibling synthesis-bitbucket helper by path, once per process.
-- id: bitbucket-dispatch
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_scan_dispatches_bitbucket_origins_to_the_bitbucket_helper
-  motivating_defect: A bitbucket.org origin was reported unscanned on every run; it must be read through bkt,
-    bucketed by uuid, with the slug passed alone.
-- id: bitbucket-identity-once
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_scan_resolves_the_bitbucket_identity_once_for_many_repos
-  motivating_defect: The Bitbucket identity is resolved once for many repos, not once per repo.
-- id: bitbucket-404-unscanned
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_scan_reports_a_bitbucket_404_as_unscanned_not_empty
-  motivating_defect: A 404 from bkt must be an unscanned queue carrying the reason, never an empty one.
-- id: bkt-missing
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_scan_marks_bitbucket_repos_unscanned_when_bkt_is_missing
-  motivating_defect: A missing bkt binary marks only Bitbucket repos unscanned and never queries them.
-- id: bkt-unauthenticated
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_scan_marks_bitbucket_repos_unscanned_when_bkt_is_unauthenticated
-  motivating_defect: An unauthenticated bkt marks Bitbucket repos unscanned with bkt's own failure text.
-- id: gh-missing-bitbucket-scanned
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_scan_marks_github_repos_unscanned_when_gh_is_missing_and_still_scans_bitbucket
-  motivating_defect: One host's missing CLI must not hide the other host's queue.
-- id: no-needless-host-cli
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_scan_never_calls_a_host_cli_the_manifest_does_not_need
-  motivating_defect: A GitHub-only workspace must not touch bkt, and a --login override skips gh entirely.
-- id: main-gh-missing
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_missing_gh_exits_zero_and_names_each_github_repo_not_scanned
-  motivating_defect: A missing gh no longer aborts the whole scan; each GitHub repo is named not scanned and
-    the exit stays zero.
-- id: main-gh-unauthenticated
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_unauthenticated_gh_exits_zero_and_names_each_github_repo_not_scanned
-  motivating_defect: An unauthenticated gh names each GitHub repo not scanned and the exit stays zero.
-- id: main-both-hosts
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-daily-rituals/scripts/test_pr_queue_scan.py::test_main_prints_bitbucket_hits_and_json_carries_both_hosts
-  motivating_defect: The text and JSON reports carry hits and scanned repos from both hosts.
-- id: bkt-buckets-by-uuid
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_list_open_prs_buckets_by_uuid
-  motivating_defect: Open PRs are bucketed as awaiting your review, your own, and unreviewed by the
-    authenticated uuid.
-- id: bkt-account-id-match
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_list_open_prs_matches_identity_by_account_id_when_reviewer_has_no_uuid
-  motivating_defect: A reviewer record carrying only account_id must still match the identity.
-- id: bkt-participants-fallback
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_list_open_prs_reads_participants_when_reviewers_key_is_absent
-  motivating_defect: Reviewers are read from participants when the reviewers key is absent.
-- id: bkt-identity-required
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_list_open_prs_refuses_identity_without_uuid_or_account_id
-  motivating_defect: An identity with neither uuid nor account_id can bucket nothing and is refused.
-- id: bkt-slug-alone
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_list_open_prs_passes_workspace_and_slug_alone
-  motivating_defect: bkt receives the slug alone; the workspace/slug form is the one that 404s.
-- id: bkt-rejects-owner-slash-name
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_list_open_prs_rejects_owner_slash_name
-  motivating_defect: A workspace/slug repo argument is refused before bkt is called.
-- id: bkt-rejects-empty
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_list_open_prs_rejects_empty_workspace_or_slug
-  motivating_defect: An empty workspace or slug is refused before bkt is called.
-- id: bkt-identity-fields
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_bkt_identity_reads_uuid_account_id_and_username
-  motivating_defect: bkt api /user yields uuid, account_id and username.
-- id: bkt-identity-failure
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_bkt_identity_reports_failure_not_anonymous
-  motivating_defect: A failed identity call reports the failure instead of an anonymous user.
-- id: bkt-identity-resolved
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_list_open_prs_resolves_identity_when_none_is_given
-  motivating_defect: The helper resolves the identity itself when the caller passes none.
-- id: bkt-identity-unresolvable
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_list_open_prs_is_unscanned_when_identity_cannot_be_resolved
-  motivating_defect: An unresolvable identity makes the queue unscanned, not empty.
-- id: bkt-404-reason
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_404_is_unscanned_with_the_stderr_reason
-  motivating_defect: A 404 is unscanned with bkt's stderr as the reason.
-- id: bkt-exit-code-named
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_nonzero_exit_without_stderr_names_the_exit_code
-  motivating_defect: A silent non-zero exit names the exit code as the reason.
-- id: bkt-unparseable
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_unparseable_json_is_unscanned
-  motivating_defect: An unparseable body is unscanned.
-- id: bkt-missing-key
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_json_without_pull_requests_key_is_unscanned
-  motivating_defect: A body without pull_requests is unscanned.
-- id: bkt-wrong-shape
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_pull_requests_as_string_is_unscanned
-  motivating_defect: A pull_requests value of the wrong shape is unscanned.
-- id: bkt-null-empty-queue
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_null_pull_requests_is_a_scanned_empty_queue
-  motivating_defect: A null pull_requests is a scanned empty queue.
-- id: bkt-empty-list-queue
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_empty_pull_requests_list_is_a_scanned_empty_queue
-  motivating_defect: An empty pull_requests list is a scanned empty queue.
-- id: bkt-timeout
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_timeout_is_unscanned
-  motivating_defect: A timeout is unscanned with the reason.
-- id: bkt-binary-missing
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_missing_bkt_binary_is_unscanned
-  motivating_defect: A missing bkt binary is unscanned with the reason.
-- id: bkt-age-days
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-bitbucket/scripts/test_pr_queue.py::test_age_days_handles_bitbucket_timestamps
-  motivating_defect: Bitbucket's microsecond timestamps yield the same age computation the scan uses.
-- id: shell-lane-boundary
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_shell_lane_boundary_is_stated_in_the_protocol_and_the_gate
-  motivating_defect: The gate cannot see a send inside a script file or a program piped to a shell; the protocol
-    and the docstring must state both boundaries.
-- id: heredoc-literal-not-a-send
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_literal_codex_queue_in_a_heredoc_body_is_not_a_send
-  motivating_defect: Intake 2026-09-09, an inert heredoc body spelling the command was blocked as a send
-    lacking a thread.
-- id: thread-values-as-data
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_thread_values_carried_as_data_are_never_selected
-  motivating_defect: A thread value in a heredoc body or a quoted argument to another command is data and
-    selects no target.
-- id: real-send-still-codex-lane
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_a_real_send_with_a_thread_is_still_the_codex_lane
-  motivating_defect: A direct send, behind env, nice, timeout, time, command, exec or coproc, or after other
-    commands, is still the codex lane with its thread.
-- id: nested-shell-send
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_a_nested_shell_string_send_is_still_detected
-  motivating_defect: A send inside a bash -c, sh -c, zsh -c or eval string is still detected.
-- id: quoted-substitution-send
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_a_send_inside_a_quoted_command_substitution_is_still_detected
-  motivating_defect: A send inside a $(...) or backtick substitution in double quotes was lost as part of
-    the word.
-- id: unquoted-heredoc-expansion
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_an_unquoted_heredoc_body_runs_its_substitutions
-  motivating_defect: A substitution in an unquoted-tag heredoc body runs; a quoted tag keeps the body literal.
-- id: here-string-shell
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_a_here_string_handed_to_a_shell_is_nested_execution
-  motivating_defect: A shell given its program on a here-string runs that program from the tool call's own text.
-- id: named-coprocess
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_a_named_coprocess_runs_the_group_that_follows_its_name
-  motivating_defect: The gate stopped at the coproc name, so a send in the brace group on the same line was
-    invisible.
-- id: nesting-bound-fails-closed
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_nesting_past_the_bound_is_gated_on_the_raw_words_not_crashed
-  motivating_defect: Seven hundred nested evals raised RecursionError, which the hook turned into a
-    non-blocking exit.
-- id: message-from-parsed-send
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_message_is_read_from_the_parsed_send_only
-  motivating_defect: The message is read from the parsed send's own argv, not from the first --message in
-    the text.
-- id: nested-send-end-to-end
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_nested_send_passes_the_gate_end_to_end_with_a_receipt
-  motivating_defect: A nested send with a receipt passes the whole gate; a literal heredoc beside it is
-    not logged.
-- id: unbalanced-quotes-raw-words
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_unbalanced_quotes_fail_closed_on_the_raw_words
-  motivating_defect: Text the shell would reject has no structure to judge, so its raw words decide and the
-    gate fails closed.
-- id: gate-process-fails-closed
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_peer_send_gate.py::test_gate_process_fails_closed_when_the_call_cannot_be_evaluated
-  motivating_defect: A crash in evaluation exited 1, which does not block; whatever evaluation raises now
-    blocks with exit 2 and the reason.
-- id: base-refusal-names-form
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_retire_worktree.py::test_local_verification_base_is_rejected
-  motivating_defect: A refused base must name the accepted form, the value received and what it resolved to.
-- id: ambiguous-base-diagnosis
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_retire_worktree.py::test_ambiguous_short_base_refusal_carries_git_diagnosis
-  motivating_defect: A short name shadowed by a local branch is refused with git's own ambiguity diagnosis and
-    an example that is not the refused value.
-- id: revision-expression-base
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_retire_worktree.py::test_revision_expression_base_is_rejected
-  motivating_defect: A revision expression such as HEAD~0 resolves to a commit but to no single ref name and is
-    refused saying so.
-- id: hook-live-receipt-selectors
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-agent-conformance/scripts/test_conformance.py::test_receipt_selectors_are_optional_and_hook_live_only
-  motivating_defect: Receipt selectors parse in any combination for hook-live and are refused by name for all.
-- id: optional-plan-absent
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-checkpoint/scripts/test_refresh.py::test_explicit_no_plan_declaration_is_absent_not_invalid
-  motivating_defect: A CONTEXT.md declaring no active plan beside a checklist link is optional absence, not a
-    blocking declaration.
-- id: shallow-clone-applicability
-  control_class: acceptance-test
-  expected_status: pass
-  fixture: ../synthesis-project-management/scripts/test_project_applicability.py::test_shallow_clone_cannot_establish_not_applicable
-  motivating_defect: A depth-1 clone cannot prove that no ancestor adopted structured state; the full clone is
-    the positive control.
-- id: merge-claim-anchors
+- id: reference-linked
   control_class: acceptance-test
   expected_status: pass
   fixture: ../synthesis-project-management/scripts/test_coordination.py::test_skill_document_stays_within_repo_budget
-  motivating_defect: The rule that a merge request names the tested target head must live in SKILL.md and the
-    protocol reference within the line budget.
+  motivating_defect: SKILL.md must stay within the line budget, keep its load-bearing rules, and link every
+    reference, so the extended checkpoint-closure-recovery reference cannot become an orphan.
 - id: manifest
   control_class: acceptance-test
   expected_status: pass
@@ -652,3 +266,210 @@ cases:
   expected_status: pass
   fixture: ../synthesis-implementation-integrity/scripts/test_acceptance_suite.py::test_schema2_receipt_binds_transaction_and_git_state
   motivating_defect: Acceptance must bind the actual release transaction and Git state.
+- id: stranded-reported-others-evaluated
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_flush_reports_stranded_entry_and_still_evaluates_other_repositories
+  motivating_defect: A manifest entry beneath a removed, unrecorded worktree aborted the whole flush as a
+    missing-worktree error; it must be reported stranded, naming the missing worktree root, while the other
+    repositories are still evaluated.
+- id: stranded-receipt-session-remedy
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_stranded_entry_with_retained_receipt_names_session_reconcile_remedy
+  motivating_defect: When this session's LOCAL_READY receipt still binds the manifest digest, the remedy is the
+    session-bound reconcile, not a drop; evidence outranks assertion.
+- id: stranded-intent-remedy
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_stranded_entry_named_by_retirement_intent_points_at_the_intent
+  motivating_defect: When a retirement intent names the worktree, the remedy is completing that intent, not a
+    drop.
+- id: stop-records-stranded
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_local_handoff_records_stranded_entry_without_aborting_other_repositories
+  motivating_defect: Stop must record the stranded entry as a readiness blocker and still record the other
+    repositories' local handoff.
+- id: stop-preserves-receipt
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_local_handoff_preserves_receipt_that_retains_stranded_worktree_evidence
+  motivating_defect: Stop must leave a receipt that retains the stranded worktree's evidence unchanged, so the
+    evidence survives to drive the remedy.
+- id: drop-blank-assertion
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_drop_stranded_refuses_blank_assertion
+  motivating_defect: An assertion of whitespace or invisible format characters only is no assertion and is
+    refused before anything is dropped.
+- id: drop-cli-combinations
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_drop_stranded_cli_refuses_wrong_combinations
+  motivating_defect: --drop-stranded is valid only with --flush-session and --assert; every other combination
+    is refused naming the accepted form, and nothing is written.
+- id: drop-refuses-returned-root
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_drop_stranded_refuses_when_worktree_root_exists_at_drop_time
+  motivating_defect: The stranded set is recomputed at drop time; a worktree root that exists again makes the
+    entry live and the drop is refused.
+- id: drop-ledger-append-only
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_drop_stranded_writes_append_only_ledger_and_narrows_manifest
+  motivating_defect: The drop writes the ledger record (session, paths, ancestor, missing root, evidence
+    presence, tracking repositories, assertion, identity, timestamp) before the manifest is narrowed, and never
+    replaces an existing record.
+- id: drop-dry-run
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_drop_stranded_dry_run_reports_and_writes_nothing
+  motivating_defect: A dry run reports the drop it would make and writes neither ledger nor manifest.
+- id: drop-all-stranded-manifest
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_drop_stranded_cli_retires_an_all_stranded_manifest
+  motivating_defect: A manifest whose every entry is stranded is retired through the CLI once the drop is
+    recorded.
+- id: per-repository-retirement
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_flush_retires_published_repositories_and_keeps_blocked_entries
+  motivating_defect: A long-lived manifest accreted already-published work behind one blocked repository;
+    each flush now retires the published repositories' entries and keeps the blocked ones.
+- id: deleted-file-not-stranded
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_deleted_file_inside_existing_repository_is_deleted_or_missing_not_stranded
+  motivating_defect: A deleted file whose repository still resolves stays deleted-or-missing; it is never
+    stranded or drop-eligible.
+- id: nested-worktree-stays-failed
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_missing_registered_nested_worktree_stays_failed_not_stranded
+  motivating_defect: A missing worktree that git still registers keeps the existing failed handling; only an
+    unregistered, unrecorded root is stranded.
+- id: git-unavailable-failed
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_stop_reports_git_unavailability_as_failed_not_stranded
+  motivating_defect: When git cannot answer for the nearest existing ancestor the entry is failed as stranded
+    classification unavailable, never stranded.
+- id: drop-never-drops-live-repository
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_drop_stranded_never_drops_a_live_repository_when_git_is_unavailable
+  motivating_defect: A transient git failure must never make a live repository's pending attribution
+    drop-eligible.
+- id: visible-gitdir-not-stranded
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_visible_git_directory_keeps_a_refused_probe_out_of_stranded
+  motivating_defect: A .git entry visible in the ancestor chain keeps a repository git refuses out of stranded.
+- id: stranded-needs-working-git
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_genuine_missing_worktree_root_classifies_stranded_only_with_a_working_git
+  motivating_defect: The stranded verdict needs git's own answer; the same missing root is failed when git is
+    absent and stranded when git works.
+- id: stale-receipt-head-remedy
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_stranded_entry_with_stale_receipt_digest_names_a_head_remedy_that_runs
+  motivating_defect: A receipt the manifest outgrew names the receipt's own head through --retirement-head,
+    and that remedy runs, retiring only what the head proves.
+- id: blocked-receipt-head-remedy
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-repo-guard/test_checkpoint_sync.py::test_stranded_entry_with_blocked_receipt_names_the_head_remedy
+  motivating_defect: A receipt that is not LOCAL_READY cannot drive the session-bound reconcile; the head
+    remedy is named instead.
+- id: retirement-reconciles-manifest
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-project-management/scripts/test_retire_worktree.py::test_retirement_reconciles_session_manifest_and_invalidates_receipt
+  motivating_defect: Worktree retirement still reconciles the session manifest through checkpoint_sync.py
+    and invalidates the receipt; the recorded path the stranded classification defers to keeps working.
+- id: marker-missing-delegate
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_marker_with_missing_delegate_blocks_with_create_remedy
+  motivating_defect: With .githooks/required tracked, a missing .githooks/pre-commit was skipped silently and
+    the commit succeeded with the repository's own guards running nothing; it must block and name the create
+    remedy.
+- id: marker-non-executable-delegate
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_marker_with_non_executable_delegate_blocks_with_chmod_remedy
+  motivating_defect: With the marker, a mode-644 delegate must block and name chmod +x as the remedy.
+- id: marker-directory-delegate
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_marker_with_directory_delegate_blocks_with_replace_remedy
+  motivating_defect: With the marker, a delegate that is not a regular file must block and name the accepted
+    form.
+- id: marker-executable-delegate-chains
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_marker_with_executable_delegate_runs_it_and_honors_its_exit
+  motivating_defect: With the marker and an executable delegate, the chain runs it and returns its exit
+    status.
+- id: no-marker-unchanged
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_no_marker_with_non_executable_delegate_passes_unchanged
+  motivating_defect: Without the marker a non-executable delegate changes nothing; the chain exits 0 and says
+    nothing about delegate-required.
+- id: no-marker-executable-chains
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_no_marker_with_executable_delegate_still_chains
+  motivating_defect: Without the marker an executable delegate still chains exactly as before.
+- id: empty-root-fails-closed
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_empty_worktree_root_fails_closed
+  motivating_defect: A Git answering rev-parse --show-toplevel with an empty path and exit 0 would make the chain probe
+    /.githooks and ignore the repository's declaration; the root guard refuses instead, proven through a PATH shim.
+- id: doctor-delegate-not-opted-in
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_doctor_delegate_required_reports_not_opted_in
+  motivating_defect: The doctor's delegate-required control reports a repository without the marker as not
+    opted in.
+- id: doctor-delegate-healthy
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_doctor_delegate_required_healthy_with_executable_delegate
+  motivating_defect: The doctor reports an opted-in repository with an executable delegate as healthy.
+- id: doctor-delegate-missing
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_doctor_delegate_required_unhealthy_when_delegate_missing
+  motivating_defect: The doctor reports the same verdict the chain enforces when the delegate is missing.
+- id: doctor-delegate-not-executable
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_doctor_delegate_required_unhealthy_when_delegate_not_executable
+  motivating_defect: The doctor reports the same verdict the chain enforces when the delegate is not
+    executable.
+- id: doctor-delegate-not-a-file
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_doctor_delegate_required_unhealthy_when_delegate_not_a_file
+  motivating_defect: The doctor reports the same verdict the chain enforces when the delegate is not a regular
+    file.
+- id: doctor-silently-skipped-delegate
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_doctor_not_opted_in_still_flags_a_silently_skipped_delegate
+  motivating_defect: Without the marker the chain exits 0 past a mode-644 delegate; the doctor still names that
+    latent skip and points at the opt-in that turns it into a refusal.
+- id: doctor-drift-end-to-end
+  control_class: acceptance-test
+  expected_status: pass
+  fixture: ../synthesis-git-hooks/scripts/test_pre_commit.py::test_doctor_detects_drift_end_to_end
+  motivating_defect: The doctor's existing drift detection must keep working through the harness that now
+    also carries the delegate-required control.

--- a/skills/synthesis-project-management/SKILL.md
+++ b/skills/synthesis-project-management/SKILL.md
@@ -5,7 +5,7 @@ license: "CC0-1.0"
 depends_on: ["synthesis-context-lifecycle"]
 metadata:
   author: "Rajiv Pant"
-  version: "2.13.10"
+  version: "2.14.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---

--- a/skills/synthesis-project-management/references/checkpoint-closure-recovery.md
+++ b/skills/synthesis-project-management/references/checkpoint-closure-recovery.md
@@ -68,3 +68,42 @@ backfill it from assumptions, synthesize an approval, or delete the manifest
 to obtain a green Stop. Independently reconstructible historical evidence or
 an explicit administrative decision is required for such a case. Source
 repair does not itself authorize repairing existing native manifests.
+
+## A worktree removed before any record could name it
+
+When the worktree vanished before a retirement intent or a Stop receipt named
+it, no historical HEAD exists to verify. `checkpoint_sync.py` reports each
+such path as `stranded`, names the missing worktree root, and keeps
+evaluating the manifest's other repositories. A path whose repository still
+resolves is not stranded; it stays `deleted-or-missing`. When git cannot
+answer for the nearest existing ancestor (a timeout, a missing binary) the
+path is reported `failed` as `stranded classification unavailable` and stays
+on the manifest; a `.git` entry visible in the ancestor chain likewise keeps
+it out of `stranded` even when git refuses the repository.
+
+If an intent or this session's retained receipt does name the worktree, the
+report points at that evidence (`--complete-worktree-retirement`, or
+`--reconcile-retired-worktree ... --retirement-session`), and Stop leaves the
+receipt unchanged so the evidence survives. The session-bound form is named
+only while the receipt is LOCAL_READY and bound to the current manifest
+digest; a receipt the manifest outgrew names the receipt's own head through
+`--retirement-head`, which retires only what that head proves. Only when
+neither exists is the explicit administrative decision above expressed as:
+
+```
+checkpoint_sync.py --flush-session NATIVE_SESSION_ID --drop-stranded \
+  --assert "<why the work is known published>" --dry-run --json
+```
+
+Review the preview, then omit `--dry-run`. The drop recomputes the stranded
+set, refuses if the worktree root exists again, writes an append-only record
+under `~/.synthesis/repo-guard/retired-pending/` carrying the dropped paths,
+the nearest existing ancestor, the missing worktree root, whether any intent
+or receipt named it, any repository whose HEAD tracks the same relative path
+with its blob oid, the assertion, the acting identity and the timestamp, and
+only then rewrites the manifest without those entries. A blank assertion
+(whitespace or invisible format characters only) is refused; existing
+records are never replaced. The same flush retires the
+entries of every repository whose result proves publication and keeps the
+blocked repositories' entries, so a manifest no longer accretes published
+work behind one blocked repository.

--- a/skills/synthesis-repo-guard/SKILL.md
+++ b/skills/synthesis-repo-guard/SKILL.md
@@ -5,7 +5,7 @@ license: "Apache-2.0"
 depends_on: []
 metadata:
   author: "Rajiv Pant"
-  version: "2.4.2"
+  version: "2.5.0"
   source_repo: "github.com/synthesisengineering/synthesis-skills"
   source_type: "public"
 ---
@@ -87,7 +87,8 @@ Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`)
   one lifecycle lock. Retirement pins a freshly fetched remote-tracking
   commit, fsyncs a resumable intent before removal, invalidates old receipts,
   and completes idempotently after interruption. A missing worktree without
-  this proof remains a fail-closed Stop error. Deleted files and child
+  this proof is reported as a `stranded` entry that blocks readiness (see
+  below) rather than silently attributed elsewhere. Deleted files and child
   directories within a verified live repository are recorded as missing,
   without restoring them or discarding their pending attribution. Resolution
   refuses symlink ancestry, unavailable worktree inventory and a missing
@@ -104,6 +105,54 @@ Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`)
 - A successful edit leaves a manifest even if Stop never runs. Remote
   publication retains manifests until source and context paths are verified
   upstream-current.
+
+### Stranded entries and per-repository retirement
+
+A manifest entry is **stranded** when its path is missing, its nearest
+existing ancestor sits outside every git working tree, and so the first
+missing component beneath that ancestor is a worktree root that no longer
+exists — a worktree removed before any retirement intent or Stop receipt could
+name it. Stop and flush report it as `stranded`, name the missing worktree
+root, and name the one accepted remedy. Other repositories in the same
+manifest are still evaluated. A deleted file whose repository still resolves
+is not stranded; it stays `deleted-or-missing`. Classification needs git's
+answer: when `git rev-parse` cannot run for the nearest existing ancestor (a
+timeout, no binary) the entry is `failed` as `stranded classification
+unavailable`, never `stranded`, and nothing is drop-eligible; when git refuses
+a live repository (a safe.directory refusal, a damaged gitdir) the `.git`
+entry visible in the ancestor chain keeps the existing handling. A transient
+git failure never discards a live repository's pending attribution.
+
+- Evidence outranks assertion. When a retirement intent names the worktree,
+  the remedy is `--complete-worktree-retirement INTENT` (prepared) or the
+  intent's own verified head through `--reconcile-retired-worktree`
+  (completed). When this session's retained receipt names it with a
+  local-ready head, the remedy is `--reconcile-retired-worktree WORKTREE
+  --retirement-session ID` while that receipt is LOCAL_READY and still binds
+  the current manifest digest; a receipt the manifest outgrew (edits accreted
+  after Stop wrote it) names the receipt's own head through
+  `--retirement-head` instead, which retires only what that head proves.
+  Stop leaves that receipt unchanged so the evidence survives.
+- With neither, the entry is drop-eligible:
+  `--flush-session ID --drop-stranded --assert "<why the work is known published>"`.
+  The drop recomputes the stranded set at run time, refuses if the worktree
+  root exists again, writes an append-only record to
+  `~/.synthesis/repo-guard/retired-pending/<manifest>-stranded-<UTC>.json`
+  (session, dropped paths, nearest existing ancestor, missing worktree root,
+  whether an intent or receipt named it, any repository whose HEAD tracks the
+  same relative path with its blob oid, the assertion, the acting identity,
+  the timestamp), then rewrites the manifest without those entries and
+  continues the normal flush. A blank `--assert` (whitespace or invisible
+  format characters only) is refused. `--dry-run`
+  reports the drop and writes nothing. Existing ledger records are never
+  replaced.
+- Every flush that is not a dry run retires the entries of each repository
+  whose result is `clean`, `committed-pushed`, `pushed-stranded`
+  (earlier commits pushed now) or `source-remote-ready`, keeps the blocked
+  repositories' entries, and deletes the manifest only once it is empty. The
+  `retired-repositories` result names what was retired. A long-lived session
+  therefore stops accreting already-published work onto a manifest one
+  blocked repository keeps alive.
 
 ---
 
@@ -133,6 +182,9 @@ Config `~/.synthesis/checkpoint-sync.yaml` (copy `checkpoint-sync.example.yaml`)
 
 # Publish and retire one exact session without inspecting unrelated sessions
 ./checkpoint_sync.py --flush-session <session-id>
+
+# Drop stranded entries (removed worktree, no retained evidence) under a recorded assertion
+./checkpoint_sync.py --flush-session <session-id> --drop-stranded --assert "merged to main on 2026-08-31"
 ```
 
 ### Exit codes (both scripts)
@@ -232,7 +284,8 @@ repo_sync_check.py [--workspace W] [--max-depth N] [--quiet] [--json]
                    [--report-dir D] [--no-report]
 
 checkpoint_sync.py [--config C] [--repo PATH] [--hook] [--now]
-                   [--flush-pending | --flush-session SESSION_ID]
+                   [--flush-pending | --flush-session SESSION_ID
+                    [--drop-stranded --assert TEXT]]
                    [--no-throttle] [--dry-run]
                    [--prepare-worktree-retirement PATH
                     --retirement-repository REPO --retirement-head SHA
@@ -256,6 +309,10 @@ checkpoint_sync.py [--config C] [--repo PATH] [--hook] [--now]
   delete any other session manifest. Use it when unrelated pending work must
   remain recoverable while one fully published session transitions to
   `REMOTE_READY`.
+- `--drop-stranded --assert TEXT` is valid only with `--flush-session`. It
+  retires drop-eligible stranded entries after recording the operator's
+  assertion in the retired-pending ledger; see "Stranded entries and
+  per-repository retirement" above.
 - `--retirement-session` derives a removed worktree's historical head from
   this native session's retained local receipt. It verifies the manifest
   digest, attributed bytes/deletions and file modes, and remote ancestry;
@@ -279,6 +336,11 @@ checkpoint_sync.py [--config C] [--repo PATH] [--hook] [--now]
 
 ## Changelog
 
+- **2.5.0 (2026-09-11):** classifies manifest entries beneath a removed,
+  unrecorded worktree as `stranded` instead of aborting the whole manifest;
+  adds `--flush-session ID --drop-stranded --assert TEXT` with an append-only
+  retired-pending ledger; retires published repositories' entries per flush
+  so blocked repositories no longer keep already-published work pending.
 - **2.3.0 (2026-08-23):** adds a fail-closed exact-session remote handoff that
   retires one verified manifest without coupling it to unrelated pending
   sessions; preserves global flush behavior and fsyncs successful manifest

--- a/skills/synthesis-repo-guard/checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/checkpoint_sync.py
@@ -38,6 +38,7 @@ Examples:
   ./checkpoint_sync.py --repo ~/x/plan.md --now   # local producer receipt
   ./checkpoint_sync.py --flush-pending       # explicit remote handoff
   ./checkpoint_sync.py --flush-session ID    # exact-session remote handoff
+  ./checkpoint_sync.py --flush-session ID --drop-stranded --assert "why"  # drop stranded entries
   ./checkpoint_sync.py --dry-run             # preview remote handoff
 """
 
@@ -67,6 +68,20 @@ PENDING_DIR = STATE_DIR / "pending"
 LOCAL_HANDOFF_DIR = STATE_DIR / "local-handoff"
 REMOTE_HANDOFF_STATE = STATE_DIR / "remote-handoff-last.json"
 RETIREMENT_DIR = STATE_DIR / "retired-worktrees"
+RETIRED_PENDING_DIR = STATE_DIR / "retired-pending"
+DROP_STRANDED_FORM = '--drop-stranded --assert "<why the work is known published>"'
+# Result actions that prove an entry's work is published; their manifest
+# entries retire even while other repositories in the same manifest block.
+PUBLISHED_ACTIONS = frozenset(
+    {"clean", "committed-pushed", "pushed-stranded", "source-remote-ready"}
+)
+# Environment names that identify who performed an operator-asserted drop.
+ACTING_IDENTITY_ENV = (
+    "SYNTHESIS_COORDINATION_SESSION",
+    "CLAUDE_CODE_HOST_SESSION_ID",
+    "CLAUDE_CODE_SESSION_ID",
+    "SYNTHESIS_CLIENT_SESSION_REF",
+)
 LIFECYCLE_LOCK_FD_ENV = "SYNTHESIS_LIFECYCLE_LOCK_FD"
 _LIFECYCLE_LOCK_STATE = threading.local()
 
@@ -189,6 +204,34 @@ def atomic_json(path: Path, payload: dict) -> None:
         raise
 
 
+def append_only_json(path: Path, payload: dict) -> Path:
+    """Create a new ledger record; an existing record is never replaced.
+
+    Returns the path actually written: the requested one, or a numbered
+    sibling when that name already holds a record.
+    """
+    validate_state_paths(path.parent, path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    validate_state_paths(path.parent, path)
+    encoded = (json.dumps(payload, indent=2) + "\n").encode("utf-8")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    candidate = path
+    ordinal = 1
+    while True:
+        try:
+            descriptor = os.open(candidate, flags, 0o600)
+        except FileExistsError:
+            ordinal += 1
+            candidate = path.with_name(f"{path.stem}-{ordinal}{path.suffix}")
+            continue
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        fsync_directory(candidate.parent)
+        return candidate
+
+
 def lexical_absolute(path: Path) -> Path:
     return Path(os.path.abspath(os.path.expanduser(str(path))))
 
@@ -254,7 +297,8 @@ def lifecycle_lock():
 
     path = lifecycle_lock_path()
     validate_state_paths(
-        path.parent, path, PENDING_DIR, LOCAL_HANDOFF_DIR, RETIREMENT_DIR
+        path.parent, path, PENDING_DIR, LOCAL_HANDOFF_DIR, RETIREMENT_DIR,
+        RETIRED_PENDING_DIR,
     )
     inherited = inherited_lifecycle_lock_fd(path)
     descriptor = inherited if inherited is not None else open_lock_file(path)
@@ -1246,6 +1290,482 @@ def file_evidence(path: Path) -> dict[str, object]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Stranded entries — a manifest path beneath a worktree that vanished before
+# any retirement intent or local-handoff receipt could name it
+# ---------------------------------------------------------------------------
+
+def is_commit_hex(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) in {40, 64}
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def retirement_intents_by_worktree() -> dict[str, list[dict]]:
+    """Index every retirement intent by the worktree it names."""
+    validate_state_paths(RETIREMENT_DIR)
+    index: dict[str, list[dict]] = {}
+    if not RETIREMENT_DIR.is_dir():
+        return index
+    for intent in sorted(RETIREMENT_DIR.glob("*.json")):
+        if intent.is_symlink():
+            raise ValueError(f"retirement intent is a symlink: {intent}")
+        try:
+            data = json.loads(intent.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"retirement intent is unreadable: {intent}: {exc}") from exc
+        if not isinstance(data, dict) or not isinstance(data.get("worktree"), str):
+            continue
+        index.setdefault(data["worktree"], []).append(
+            {
+                "intent": str(intent),
+                "state": str(data.get("state")),
+                "repository": data["repository"] if isinstance(data.get("repository"), str) else None,
+                "head": data["head"] if is_commit_hex(data.get("head")) else None,
+                "base_ref": data["base_ref"] if isinstance(data.get("base_ref"), str) else None,
+            }
+        )
+    return index
+
+
+def retained_receipt_evidence(manifest: Path) -> dict:
+    """This session's own receipt, read as evidence for stranded entries.
+
+    ``heads`` maps each worktree root the receipt proves with a local-ready
+    head to that head. ``manifest_sha256`` and ``readiness`` decide whether
+    ``--retirement-session`` would accept the receipt as it stands: that form
+    requires a LOCAL_READY receipt bound to the current manifest digest, and a
+    manifest that accreted after the receipt was written no longer matches.
+    Only this session's receipt can feed that form; other sessions' receipts
+    cannot retire this manifest and are not consulted.
+    """
+    empty = {"heads": {}, "manifest_sha256": None, "readiness": None}
+    receipt = LOCAL_HANDOFF_DIR / manifest.name
+    validate_state_paths(receipt)
+    if receipt.is_symlink():
+        raise ValueError(f"local handoff receipt is a symlink: {receipt}")
+    if not receipt.is_file():
+        return empty
+    try:
+        data = json.loads(receipt.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"local handoff receipt is unreadable: {receipt}: {exc}") from exc
+    if not isinstance(data, dict):
+        return empty
+    results = data.get("results")
+    heads: dict[str, str] = {}
+    for item in results if isinstance(results, list) else []:
+        if (
+            isinstance(item, dict)
+            and item.get("action") == "local-ready"
+            and isinstance(item.get("repo"), str)
+            and is_commit_hex(item.get("head"))
+        ):
+            heads[item["repo"]] = item["head"]
+    digest = data.get("pending_manifest_sha256")
+    readiness = data.get("readiness")
+    return {
+        "heads": heads,
+        "manifest_sha256": digest if isinstance(digest, str) else None,
+        "readiness": readiness if isinstance(readiness, str) else None,
+    }
+
+
+class StrandedEvidence:
+    """Retirement intents and per-session retained receipts, read once per run."""
+
+    def __init__(self) -> None:
+        self._intents: dict[str, list[dict]] | None = None
+        self._receipts: dict[Path, dict] = {}
+
+    def intents_naming(self, worktree: Path) -> list[dict]:
+        if self._intents is None:
+            self._intents = retirement_intents_by_worktree()
+        return self._intents.get(str(worktree), [])
+
+    def receipt(self, manifest: Path) -> dict:
+        if manifest not in self._receipts:
+            self._receipts[manifest] = retained_receipt_evidence(manifest)
+        return self._receipts[manifest]
+
+    def forget_receipt(self, manifest: Path) -> None:
+        """Drop the cached receipt after the manifest and receipt were rewritten
+        under the manifest lock, so later classification reads the rebound digest."""
+        self._receipts.pop(manifest, None)
+
+
+def classify_stranded_entry(
+    path: Path, session_id: str, manifest: Path, evidence: StrandedEvidence
+) -> dict | None:
+    """Classify a manifest path that no available worktree resolves.
+
+    Stranded: the path is missing, its nearest existing ancestor carries no
+    symlink and sits outside every git working tree, so the first missing
+    component beneath that ancestor is a worktree root that no longer exists.
+    Returns None when the existing handling applies instead: the path exists
+    (a symlink or other refusal), or its nearest existing ancestor is inside a
+    working tree (deleted-or-missing evidence, or a registered nested worktree
+    that retirement reconciliation owns). "Inside a working tree" is decided
+    by git when it answers, and by a ``.git`` entry visible anywhere in the
+    ancestor chain when git refuses (a safe.directory refusal, a damaged
+    gitdir): a live repository's deleted file is never stranded.
+
+    Raises ValueError when git cannot answer at all (a timeout, no binary):
+    nothing has been learned about the ancestor, so the callers report the
+    entry as failed and it is never drop-eligible.
+
+    Drop-eligible: stranded, and neither a retirement intent nor this
+    session's retained receipt names that worktree root. Retained evidence
+    outranks an operator assertion, so those entries name the evidence-based
+    remedy instead: ``--retirement-session`` while the receipt is LOCAL_READY
+    and bound to the current manifest digest, otherwise the receipt's own
+    head through ``--retirement-head`` (later edits are not proved by it).
+    """
+    path = lexical_absolute(path)
+    if os.path.lexists(path):
+        return None
+    ancestor = path.parent
+    while not os.path.lexists(ancestor):
+        if ancestor == ancestor.parent:
+            return None
+        ancestor = ancestor.parent
+    if not ancestor.is_dir() or any(
+        part.is_symlink() for part in (ancestor, *ancestor.parents)
+    ):
+        return None
+    toplevel_rc, toplevel, toplevel_error = git(ancestor, "rev-parse", "--show-toplevel")
+    if toplevel_rc == -1:
+        # git() reports a timeout or a missing binary as -1; that is the
+        # absence of an answer, not an answer of "outside every working tree".
+        raise ValueError(f"git is unavailable for {ancestor}: {toplevel_error}")
+    if toplevel_rc == 0 and toplevel:
+        return None
+    if any(os.path.lexists(candidate / ".git") for candidate in (ancestor, *ancestor.parents)):
+        # A working tree or a registered nested worktree is present whatever
+        # git answered, so the deleted-or-missing and nested-worktree
+        # handling applies and nothing here may be dropped.
+        return None
+    missing_root = ancestor / path.relative_to(ancestor).parts[0]
+    intents = evidence.intents_naming(missing_root)
+    receipt = evidence.receipt(manifest)
+    receipt_head = receipt["heads"].get(str(missing_root))
+    if intents:
+        intent = intents[0]
+        condition = f"retirement intent {intent['intent']} names it in state {intent['state']}"
+        if intent["state"] == "prepared":
+            remedy = f"--complete-worktree-retirement {intent['intent']}"
+        else:
+            remedy = (
+                f"--reconcile-retired-worktree {missing_root} "
+                f"--retirement-repository {intent['repository'] or '<owning repository>'} "
+                f"--retirement-head {intent['head'] or '<verified head>'} "
+                f"--retirement-base {intent['base_ref'] or '<fetched remote ref such as origin/main>'}"
+            )
+    elif receipt_head is not None:
+        current_digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
+        if receipt["manifest_sha256"] != current_digest:
+            cause = "binds an older attribution digest, so later edits are not proved by that receipt"
+        elif receipt["readiness"] != "LOCAL_READY":
+            cause = (
+                f"records readiness {receipt['readiness'] or '<absent>'} rather than LOCAL_READY, "
+                "which --retirement-session refuses"
+            )
+        else:
+            cause = None
+        if cause is None:
+            condition = "this session's retained local-handoff receipt names it"
+            remedy = (
+                f"--reconcile-retired-worktree {missing_root} --retirement-session {session_id} "
+                "--retirement-repository <owning repository> "
+                "--retirement-base <fetched remote ref such as origin/main>"
+            )
+        else:
+            condition = (
+                f"this session's retained local-handoff receipt names it with head {receipt_head} "
+                f"but {cause}"
+            )
+            remedy = (
+                f"--reconcile-retired-worktree {missing_root} "
+                "--retirement-repository <owning repository> "
+                f"--retirement-head {receipt_head} "
+                "--retirement-base <fetched remote ref such as origin/main>"
+            )
+    else:
+        condition = "no retirement intent or retained local-handoff receipt names it"
+        remedy = f"--flush-session {session_id} {DROP_STRANDED_FORM}"
+    return {
+        "repo": str(path),
+        "name": "pending-session",
+        "action": "stranded",
+        "alert": (
+            f"pending path is beneath a removed worktree {missing_root} ({condition}); "
+            f"accepted form: {remedy}"
+        ),
+        "drop_eligible": not intents and receipt_head is None,
+        "remedy": remedy,
+        "evidence": {
+            "nearest_existing_ancestor": str(ancestor),
+            "missing_worktree_root": str(missing_root),
+            "retirement_intents": [item["intent"] for item in intents],
+            "local_handoff_receipt_named_worktree": receipt_head is not None,
+            "local_handoff_receipt_head": receipt_head,
+        },
+    }
+
+
+def canonical_copy_evidence(relative: str, repositories: list[Path]) -> dict | None:
+    """Informational: a repository whose HEAD tracks the same relative path."""
+    seen: set[Path] = set()
+    for repository in sorted(repositories, key=str):
+        identity = repository.resolve(strict=False)
+        if identity in seen or not identity.is_dir():
+            continue
+        seen.add(identity)
+        try:
+            listing = subprocess.run(
+                ["git", "-C", str(identity), "ls-tree", "-z", "HEAD", "--", f":(literal){relative}"],
+                capture_output=True, timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if listing.returncode or not listing.stdout:
+            continue
+        metadata = listing.stdout.split(b"\t", 1)[0].split()
+        if len(metadata) != 3 or metadata[1] != b"blob":
+            continue
+        head_rc, head, _ = git(identity, "rev-parse", "HEAD")
+        if head_rc != 0 or not head:
+            continue
+        return {
+            "repository": str(identity),
+            "head": head,
+            "relative_path": relative,
+            "git_mode": metadata[0].decode("ascii"),
+            "blob_oid": metadata[2].decode("ascii"),
+        }
+    return None
+
+
+def meaningful_assertion(text: object) -> bool:
+    """An operator assertion must carry at least one visible character.
+
+    Whitespace of every script and invisible format characters (zero-width
+    spaces and joiners, a byte order mark) are blank: a ledger record whose
+    assertion cannot be read carries no reason.
+    """
+    return isinstance(text, str) and any(
+        character.isprintable() and not character.isspace() for character in text
+    )
+
+
+def acting_identity() -> dict[str, str]:
+    return {
+        name: os.environ[name]
+        for name in ACTING_IDENTITY_ENV
+        if os.environ.get(name, "").strip()
+    }
+
+
+def rebind_receipt_digest(manifest: Path, before_digest: str, marker: dict) -> bool:
+    """Re-bind this session's receipt to a manifest narrowed to a subset of the
+    attribution it already proved. A receipt bound to any other manifest
+    digest is left untouched, so later edits never inherit older evidence."""
+    receipt = LOCAL_HANDOFF_DIR / manifest.name
+    validate_state_paths(receipt)
+    if receipt.is_symlink() or not receipt.is_file():
+        return False
+    try:
+        retained = json.loads(receipt.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if (
+        not isinstance(retained, dict)
+        or retained.get("pending_manifest") != str(manifest)
+        or retained.get("pending_manifest_sha256") != before_digest
+    ):
+        return False
+    retained["pending_manifest_sha256"] = hashlib.sha256(manifest.read_bytes()).hexdigest()
+    retained.update(marker)
+    atomic_json(receipt, retained)
+    return True
+
+
+def drop_stranded_entries(
+    manifest: Path,
+    data: dict,
+    cfg: dict,
+    *,
+    assertion: str,
+    dry_run: bool,
+    evidence: StrandedEvidence,
+    root_of,
+) -> tuple[dict, dict]:
+    """Retire drop-eligible stranded entries under a recorded operator assertion.
+
+    Order: recompute the stranded set now, refuse if any worktree root exists
+    again, write the append-only ledger record, then rewrite the manifest
+    without those entries. Returns the outcome record and the manifest data
+    the rest of the flush should evaluate.
+    """
+    session_id = data["session_id"]
+    summary = {"repo": str(manifest), "name": "pending-session", "alert": None}
+    candidates: list[tuple[str, Path, dict]] = []
+    repositories: set[Path] = set()
+    seen: set[str] = set()
+    for value in data["paths"]:
+        raw = str(value)
+        if raw in seen:
+            continue
+        seen.add(raw)
+        resolved = Path(raw).expanduser().resolve(strict=False)
+        root = root_of(resolved)
+        if root is not None:
+            repositories.add(root)
+            continue
+        record = classify_stranded_entry(resolved, session_id, manifest, evidence)
+        if record is None or not record["drop_eligible"]:
+            continue
+        candidates.append((raw, resolved, record))
+    if not candidates:
+        return {**summary, "action": "no-stranded-entries", "files": 0}, data
+    for _raw, _resolved, record in candidates:
+        missing_root = Path(record["evidence"]["missing_worktree_root"])
+        if os.path.lexists(missing_root):
+            return {
+                **summary,
+                "action": "failed",
+                "alert": (
+                    f"stranded worktree root exists now: {missing_root}; nothing was dropped; "
+                    f"accepted form: --flush-session {session_id} without --drop-stranded, "
+                    "so its entries are evaluated as live paths"
+                ),
+            }, data
+    dropped = [raw for raw, _resolved, _record in candidates]
+    dropped_set = set(dropped)
+    narrowed = dict(data)
+    narrowed["paths"] = [value for value in data["paths"] if str(value) not in dropped_set]
+    if "remote_paths" in data:
+        narrowed["remote_paths"] = [
+            value for value in data["remote_paths"] if str(value) not in dropped_set
+        ]
+    if dry_run:
+        return {
+            **summary,
+            "action": "would-drop-stranded",
+            "files": len(dropped),
+            "detail": summarize_paths(dropped),
+        }, narrowed
+    repositories.update(configured_repos(cfg))
+    now = time.gmtime()
+    dropped_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", now)
+    before_digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
+    ledger_record = {
+        "schema_version": 1,
+        "record": "stranded-drop",
+        "session_id": session_id,
+        "manifest": str(manifest),
+        "manifest_sha256_before": before_digest,
+        "dropped_paths": dropped,
+        "evidence": [
+            {
+                "path": raw,
+                "nearest_existing_ancestor": record["evidence"]["nearest_existing_ancestor"],
+                "missing_worktree_root": record["evidence"]["missing_worktree_root"],
+                "retirement_intent_named_worktree": bool(record["evidence"]["retirement_intents"]),
+                "local_handoff_receipt_named_worktree": record["evidence"]["local_handoff_receipt_named_worktree"],
+                "canonical_copy": canonical_copy_evidence(
+                    resolved.relative_to(Path(record["evidence"]["missing_worktree_root"])).as_posix(),
+                    sorted(repositories, key=str),
+                ),
+            }
+            for raw, resolved, record in candidates
+        ],
+        "assertion": assertion.strip(),
+        "acting_identity": acting_identity(),
+        "host": socket.gethostname(),
+        "dropped_at": dropped_at,
+    }
+    ledger = append_only_json(
+        RETIRED_PENDING_DIR
+        / f"{manifest.stem}-stranded-{time.strftime('%Y%m%dT%H%M%SZ', now)}.json",
+        ledger_record,
+    )
+    history = data.get("dropped_stranded")
+    narrowed["dropped_stranded"] = [
+        *(history if isinstance(history, list) else []),
+        {"ledger": str(ledger), "paths_dropped": len(dropped), "dropped_at": dropped_at},
+    ]
+    narrowed["updated_at"] = dropped_at
+    atomic_json(manifest, narrowed)
+    rebind_receipt_digest(manifest, before_digest, {"derived_from_stranded_drop": str(ledger)})
+    evidence.forget_receipt(manifest)
+    return {
+        **summary,
+        "action": "dropped-stranded",
+        "files": len(dropped),
+        "detail": summarize_paths(dropped),
+        "ledger": str(ledger),
+    }, narrowed
+
+
+def retire_published_entries(
+    manifest: Path,
+    data: dict,
+    entries: list[tuple[str, Path, bool]],
+    root_of,
+    context_results: dict[Path, dict],
+    source_results: dict[Path, dict],
+) -> list[dict]:
+    """Remove the entries whose repository result proves publication.
+
+    Blocked repositories keep their entries; the manifest is deleted only when
+    nothing remains. Called with the manifest lock held, never on a dry run.
+    """
+    retired_resolved: set[Path] = set()
+    retired_roots: set[str] = set()
+    for _raw, resolved, is_context in entries:
+        root = root_of(resolved)
+        if root is None:
+            continue
+        result = (context_results if is_context else source_results).get(root)
+        if result is not None and result["action"] in PUBLISHED_ACTIONS:
+            retired_resolved.add(resolved)
+            retired_roots.add(str(root))
+
+    def survives(value: object) -> bool:
+        return Path(str(value)).expanduser().resolve(strict=False) not in retired_resolved
+
+    kept = [value for value in data["paths"] if survives(value)]
+    removed = len(data["paths"]) - len(kept)
+    summary = {
+        "repo": str(manifest),
+        "name": "pending-session",
+        "action": "retired-repositories",
+        "retired_repositories": sorted(retired_roots),
+        "files": removed,
+        "alert": None,
+    }
+    if not kept:
+        manifest.unlink(missing_ok=True)
+        fsync_directory(manifest.parent)
+        return [{**summary, "manifest_removed": True}]
+    if not removed:
+        return []
+    before_digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    data["paths"] = kept
+    if "remote_paths" in data:
+        data["remote_paths"] = [value for value in data["remote_paths"] if survives(value)]
+    data["updated_at"] = stamp
+    atomic_json(manifest, data)
+    rebind_receipt_digest(
+        manifest, before_digest, {"derived_from_repository_retirement": stamp}
+    )
+    return [{**summary, "manifest_removed": False}]
+
+
 def _local_handoff_checkpoint_unlocked(
     payload: dict, cfg: dict
 ) -> tuple[list[dict], Path | None]:
@@ -1262,13 +1782,25 @@ def _local_handoff_checkpoint_unlocked(
     manifest_digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
 
     grouped: dict[Path, list[Path]] = {}
+    stranded: list[dict] = []
+    evidence = StrandedEvidence()
     for path in paths:
         root = repo_root_for_path(path)
-        if root is None:
+        if root is not None:
+            grouped.setdefault(root, []).append(path)
+            continue
+        try:
+            record = classify_stranded_entry(path, session_id, manifest, evidence)
+        except (OSError, ValueError, TypeError) as exc:
+            return [{"repo": str(path), "name": "pending-session", "action": "failed", "alert": f"stranded classification unavailable: {exc}"}], manifest
+        if record is None:
             return [{"repo": str(path), "name": "pending-session", "action": "failed", "alert": "pending path is not inside an available git worktree"}], manifest
-        grouped.setdefault(root, []).append(path)
+        if not record["drop_eligible"]:
+            record["receipt_preserved"] = True
+            record["alert"] += "; the retained local-handoff receipt is left unchanged so that evidence survives"
+        stranded.append(record)
 
-    results: list[dict] = []
+    results: list[dict] = list(stranded)
     for repo, repo_paths in sorted(grouped.items(), key=lambda item: str(item[0])):
         branch_rc, branch, _ = git(repo, "branch", "--show-current")
         head_rc, head, _ = git(repo, "rev-parse", "HEAD")
@@ -1296,6 +1828,10 @@ def _local_handoff_checkpoint_unlocked(
     receipt = LOCAL_HANDOFF_DIR / f"{hashlib.sha256(session_id.encode('utf-8')).hexdigest()}.json"
     if hashlib.sha256(manifest.read_bytes()).hexdigest() != manifest_digest:
         return [{"repo": str(manifest), "name": "pending-session", "action": "failed", "alert": "attribution changed while recording local evidence; retry this exact session"}], manifest
+    if any(item.get("receipt_preserved") for item in stranded):
+        # A fresh receipt would overwrite the retained head evidence that
+        # --retirement-session or a prepared intent still needs.
+        return results, manifest
     atomic_json(
         receipt,
         {
@@ -1318,13 +1854,17 @@ def local_handoff_checkpoint(payload: dict, cfg: dict) -> tuple[list[dict], Path
 
 
 def _flush_pending_manifests_unlocked(
-    cfg: dict, manifests: list[Path], *, dry_run: bool
+    cfg: dict,
+    manifests: list[Path],
+    *,
+    dry_run: bool,
+    drop_stranded: bool = False,
+    assertion: str | None = None,
 ) -> tuple[list[dict], list[Path]]:
-    """Publish and retire exactly the supplied pending manifests."""
-    all_paths: list[Path] = []
-    source_paths: list[Path] = []
-    valid_manifests: list[Path] = []
+    """Publish the supplied pending manifests and retire their published entries."""
+    loaded: list[tuple[Path, dict]] = []
     errors: list[dict] = []
+    drop_results: list[dict] = []
     locks = []
     try:
         for manifest in manifests:
@@ -1347,42 +1887,89 @@ def _flush_pending_manifests_unlocked(
                 session_id = data.get("session_id")
                 if not isinstance(session_id, str) or pending_manifest_path(session_id) != manifest:
                     raise ValueError("manifest filename or session mismatch")
-                remote_paths = data.get("remote_paths", data.get("paths"))
-                if not isinstance(remote_paths, list):
+                if not isinstance(data.get("remote_paths", data.get("paths")), list):
                     raise ValueError("remote_paths must be a list")
-                all_values = data.get("paths")
-                if not isinstance(all_values, list):
+                if not isinstance(data.get("paths"), list):
                     raise ValueError("paths must be a list")
-                remote_set = {
-                    Path(str(value)).expanduser().resolve(strict=False)
-                    for value in remote_paths
-                }
-                all_set = {
-                    Path(str(value)).expanduser().resolve(strict=False)
-                    for value in all_values
-                }
-                all_paths.extend(remote_set)
-                source_paths.extend(all_set - remote_set)
-                valid_manifests.append(manifest)
+                loaded.append((manifest, data))
             except (OSError, ValueError, TypeError) as exc:
                 errors.append({"repo": str(manifest), "name": "pending-session", "action": "failed", "alert": f"invalid pending manifest: {exc}"})
 
+        evidence = StrandedEvidence()
+        root_cache: dict[Path, Path | None] = {}
+
+        def root_of(resolved: Path) -> Path | None:
+            if resolved not in root_cache:
+                root_cache[resolved] = repo_root_for_path(resolved)
+            return root_cache[resolved]
+
+        if drop_stranded:
+            for index, (manifest, data) in enumerate(loaded):
+                try:
+                    outcome, data = drop_stranded_entries(
+                        manifest, data, cfg, assertion=assertion or "", dry_run=dry_run,
+                        evidence=evidence, root_of=root_of,
+                    )
+                except (OSError, ValueError, TypeError, subprocess.SubprocessError) as exc:
+                    outcome = {"repo": str(manifest), "name": "pending-session", "action": "failed", "alert": f"stranded drop failed: {exc}"}
+                drop_results.append(outcome)
+                loaded[index] = (manifest, data)
+
         grouped: dict[Path, list[Path]] = {}
-        for path in sorted(set(all_paths)):
-            root = repo_root_for_path(path)
-            if root is None:
-                errors.append({"repo": str(path), "name": "pending-session", "action": "failed", "alert": "pending path is not inside an available git worktree"})
-                continue
-            grouped.setdefault(root, []).append(path)
-        results = errors + source_paths_remote_ready(source_paths) + [
-            checkpoint_explicit_paths(repo, paths, cfg, dry_run=dry_run)
+        source_grouped: dict[Path, list[Path]] = {}
+        membership: list[tuple[Path, dict, list[tuple[str, Path, bool]]]] = []
+        for manifest, data in loaded:
+            remote_values = data.get("remote_paths", data["paths"])
+            remote_resolved = {
+                Path(str(value)).expanduser().resolve(strict=False) for value in remote_values
+            }
+            entries: list[tuple[str, Path, bool]] = []
+            evaluated: set[Path] = set()
+            for value in [*data["paths"], *[v for v in remote_values if v not in data["paths"]]]:
+                resolved = Path(str(value)).expanduser().resolve(strict=False)
+                is_context = resolved in remote_resolved
+                entries.append((str(value), resolved, is_context))
+                if resolved in evaluated:
+                    continue
+                evaluated.add(resolved)
+                root = root_of(resolved)
+                if root is None:
+                    try:
+                        record = classify_stranded_entry(resolved, data["session_id"], manifest, evidence)
+                    except (OSError, ValueError, TypeError) as exc:
+                        record = {"repo": str(resolved), "name": "pending-session", "action": "failed", "alert": f"stranded classification unavailable: {exc}"}
+                    if record is None:
+                        record = (
+                            {"repo": str(resolved), "name": "pending-session", "action": "failed", "alert": "pending path is not inside an available git worktree"}
+                            if is_context
+                            else {"repo": str(resolved), "name": "source-path", "action": "source-unavailable", "alert": "edited source path is not inside an available git worktree"}
+                        )
+                    errors.append(record)
+                    continue
+                bucket = (grouped if is_context else source_grouped).setdefault(root, [])
+                if resolved not in bucket:
+                    bucket.append(resolved)
+            membership.append((manifest, data, entries))
+
+        source_results = source_groups_remote_ready(source_grouped)
+        context_results = {
+            repo: checkpoint_explicit_paths(repo, paths, cfg, dry_run=dry_run)
             for repo, paths in sorted(grouped.items(), key=lambda item: str(item[0]))
-        ]
-        if not dry_run and valid_manifests and not any(result.get("alert") for result in results):
-            for manifest in valid_manifests:
-                manifest.unlink(missing_ok=True)
-            fsync_directory(PENDING_DIR)
-        return results, valid_manifests
+        }
+        results = (
+            drop_results
+            + errors
+            + [source_results[root] for root in sorted(source_results, key=str)]
+            + [context_results[root] for root in sorted(context_results, key=str)]
+        )
+        if not dry_run:
+            for manifest, data, entries in membership:
+                results.extend(
+                    retire_published_entries(
+                        manifest, data, entries, root_of, context_results, source_results
+                    )
+                )
+        return results, [manifest for manifest, _data in loaded]
     finally:
         for lock in reversed(locks):
             fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
@@ -1403,7 +1990,12 @@ def flush_all_pending(cfg: dict, *, dry_run: bool) -> tuple[list[dict], list[Pat
 
 
 def flush_pending_session(
-    cfg: dict, session_id: str, *, dry_run: bool
+    cfg: dict,
+    session_id: str,
+    *,
+    dry_run: bool,
+    drop_stranded: bool = False,
+    assertion: str | None = None,
 ) -> tuple[list[dict], list[Path]]:
     """Publish and retire one exact session without inspecting unrelated manifests."""
     if not isinstance(session_id, str) or not session_id.strip():
@@ -1424,6 +2016,31 @@ def flush_pending_session(
                 "name": "pending-session",
                 "action": "failed",
                 "alert": "session id contains unsafe characters or exceeds 512 bytes",
+            }
+        ], []
+    if drop_stranded and not meaningful_assertion(assertion):
+        return [
+            {
+                "repo": "unknown",
+                "name": "pending-session",
+                "action": "failed",
+                "alert": (
+                    "stranded drop requires a non-blank --assert TEXT stating why the "
+                    f"work is known published; accepted form: --flush-session {session_id} "
+                    f"{DROP_STRANDED_FORM}"
+                ),
+            }
+        ], []
+    if assertion is not None and not drop_stranded:
+        return [
+            {
+                "repo": "unknown",
+                "name": "pending-session",
+                "action": "failed",
+                "alert": (
+                    "an assertion is accepted only with --drop-stranded; accepted form: "
+                    f"--flush-session {session_id} {DROP_STRANDED_FORM}"
+                ),
             }
         ], []
     manifest = pending_manifest_path(session_id)
@@ -1447,123 +2064,98 @@ def flush_pending_session(
                     "alert": None,
                 }
             ], []
-        return _flush_pending_manifests_unlocked(cfg, [manifest], dry_run=dry_run)
+        return _flush_pending_manifests_unlocked(
+            cfg, [manifest], dry_run=dry_run, drop_stranded=drop_stranded, assertion=assertion
+        )
 
 
-def source_paths_remote_ready(paths: list[Path]) -> list[dict]:
-    """Verify source edits were published by their policy-owning workflow."""
-    grouped: dict[Path, list[Path]] = {}
-    results: list[dict] = []
-    for path in sorted(set(paths)):
-        root = repo_root_for_path(path)
-        if root is None:
-            results.append(
-                {
-                    "repo": str(path),
-                    "name": "source-path",
-                    "action": "source-unavailable",
-                    "alert": "edited source path is not inside an available git worktree",
-                }
-            )
-            continue
-        grouped.setdefault(root, []).append(path)
+def source_groups_remote_ready(grouped: dict[Path, list[Path]]) -> dict[Path, dict]:
+    """Verify source edits were published by their policy-owning workflow.
 
+    One result per repository root, so the flush can retire exactly the
+    entries whose repository proved publication.
+    """
+    results: dict[Path, dict] = {}
     for repo, repo_paths in sorted(grouped.items(), key=lambda item: str(item[0])):
         relative = [str(path.resolve(strict=False).relative_to(repo.resolve())) for path in repo_paths]
         status_rc, status, status_error = git(
             repo, "status", "--porcelain", "--", *relative, strip=False
         )
         if status_rc != 0:
-            results.append(
-                {
-                    "repo": str(repo),
-                    "name": repo.name,
-                    "action": "source-unverifiable",
-                    "alert": f"source status failed: {status_error}",
-                }
-            )
+            results[repo] = {
+                "repo": str(repo),
+                "name": repo.name,
+                "action": "source-unverifiable",
+                "alert": f"source status failed: {status_error}",
+            }
             continue
         if status.strip():
-            results.append(
-                {
-                    "repo": str(repo),
-                    "name": repo.name,
-                    "action": "source-local-only",
-                    "alert": "edited source paths remain uncommitted",
-                }
-            )
+            results[repo] = {
+                "repo": str(repo),
+                "name": repo.name,
+                "action": "source-local-only",
+                "alert": "edited source paths remain uncommitted",
+            }
             continue
         upstream_rc, upstream, _ = git(
             repo, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"
         )
         if upstream_rc != 0 or not upstream:
-            results.append(
-                {
-                    "repo": str(repo),
-                    "name": repo.name,
-                    "action": "source-local-only",
-                    "alert": "source branch has no upstream",
-                }
-            )
+            results[repo] = {
+                "repo": str(repo),
+                "name": repo.name,
+                "action": "source-local-only",
+                "alert": "source branch has no upstream",
+            }
             continue
         branch_rc, branch, _ = git(repo, "branch", "--show-current")
         remote_rc, remote, _ = git(
             repo, "config", "--get", f"branch.{branch}.remote"
         )
         if branch_rc != 0 or not branch or remote_rc != 0 or not remote or remote == ".":
-            results.append(
-                {
-                    "repo": str(repo),
-                    "name": repo.name,
-                    "action": "source-local-only",
-                    "alert": "source branch has no fetchable remote",
-                }
-            )
+            results[repo] = {
+                "repo": str(repo),
+                "name": repo.name,
+                "action": "source-local-only",
+                "alert": "source branch has no fetchable remote",
+            }
             continue
         fetch_rc, _, fetch_error = git(repo, "fetch", remote, timeout=120)
         if fetch_rc != 0:
-            results.append(
-                {
-                    "repo": str(repo),
-                    "name": repo.name,
-                    "action": "source-unverifiable",
-                    "alert": f"source fetch failed: {fetch_error}",
-                }
-            )
+            results[repo] = {
+                "repo": str(repo),
+                "name": repo.name,
+                "action": "source-unverifiable",
+                "alert": f"source fetch failed: {fetch_error}",
+            }
             continue
         counts_rc, counts, counts_error = git(
             repo, "rev-list", "--left-right", "--count", f"{upstream}...HEAD"
         )
         if counts_rc != 0 or len(counts.split()) != 2:
-            results.append(
-                {
-                    "repo": str(repo),
-                    "name": repo.name,
-                    "action": "source-unverifiable",
-                    "alert": f"source upstream comparison failed: {counts_error}",
-                }
-            )
+            results[repo] = {
+                "repo": str(repo),
+                "name": repo.name,
+                "action": "source-unverifiable",
+                "alert": f"source upstream comparison failed: {counts_error}",
+            }
             continue
         behind, ahead = (int(value) for value in counts.split())
         if behind or ahead:
-            results.append(
-                {
-                    "repo": str(repo),
-                    "name": repo.name,
-                    "action": "source-not-remote-ready",
-                    "alert": f"source branch is ahead {ahead}, behind {behind}",
-                }
-            )
-            continue
-        results.append(
-            {
+            results[repo] = {
                 "repo": str(repo),
                 "name": repo.name,
-                "action": "source-remote-ready",
-                "files": len(relative),
-                "alert": None,
+                "action": "source-not-remote-ready",
+                "alert": f"source branch is ahead {ahead}, behind {behind}",
             }
-        )
+            continue
+        results[repo] = {
+            "repo": str(repo),
+            "name": repo.name,
+            "action": "source-remote-ready",
+            "files": len(relative),
+            "alert": None,
+        }
     return results
 
 
@@ -1687,6 +2279,24 @@ def main() -> int:
         help="Commit, push, and retire one exact session manifest without inspecting other sessions",
     )
     ap.add_argument(
+        "--drop-stranded",
+        action="store_true",
+        help=(
+            "With --flush-session: retire stranded entries (a removed worktree that no "
+            "retirement intent or retained receipt names) under a recorded operator assertion"
+        ),
+    )
+    ap.add_argument(
+        "--assert",
+        dest="assertion",
+        default=None,
+        metavar="TEXT",
+        help=(
+            "Why the stranded entries' work is known published; required by --drop-stranded "
+            "and recorded in the retired-pending ledger"
+        ),
+    )
+    ap.add_argument(
         "--reconcile-retired-worktree",
         type=Path,
         default=None,
@@ -1765,6 +2375,29 @@ def main() -> int:
         if not args.quiet:
             print("checkpoint_sync: choose exactly one retirement mode", file=sys.stderr)
         return 2
+    drop_form = f"--flush-session SESSION_ID {DROP_STRANDED_FORM}"
+    if args.drop_stranded or args.assertion is not None:
+        if args.flush_session is None:
+            print(
+                "checkpoint_sync: --drop-stranded and --assert are valid only with "
+                f"--flush-session; accepted form: {drop_form}",
+                file=sys.stderr,
+            )
+            return 2
+        if not args.drop_stranded:
+            print(
+                "checkpoint_sync: --assert is accepted only with --drop-stranded; "
+                f"accepted form: {drop_form}",
+                file=sys.stderr,
+            )
+            return 2
+        if not meaningful_assertion(args.assertion):
+            print(
+                "checkpoint_sync: --drop-stranded requires a non-blank --assert TEXT stating "
+                f"why the work is known published; accepted form: {drop_form}",
+                file=sys.stderr,
+            )
+            return 2
     if args.retirement_session is not None and (args.reconcile_retired_worktree is None or args.retirement_head is not None
             or args.hook or args.repo is not None or args.flush_pending or args.no_throttle):
         print("checkpoint_sync: --retirement-session requires --reconcile-retired-worktree and derives --retirement-head from evidence", file=sys.stderr)
@@ -1866,7 +2499,11 @@ def main() -> int:
 
     if args.flush_session is not None:
         results, manifests = flush_pending_session(
-            cfg, args.flush_session, dry_run=args.dry_run
+            cfg,
+            args.flush_session,
+            dry_run=args.dry_run,
+            drop_stranded=args.drop_stranded,
+            assertion=args.assertion,
         )
         alerts = [result for result in results if result.get("alert")]
         readiness = (
@@ -1896,6 +2533,10 @@ def main() -> int:
                 print(f"session remote handoff: {readiness}")
                 for result in results:
                     line = f"{result['name']}: {result['action']}"
+                    if result.get("detail"):
+                        line += f" ({result['detail']})"
+                    if result.get("ledger"):
+                        line += f" -> {result['ledger']}"
                     if result.get("alert"):
                         line += f"  ⚠ {result['alert']}"
                     print(line)

--- a/skills/synthesis-repo-guard/test_checkpoint_sync.py
+++ b/skills/synthesis-repo-guard/test_checkpoint_sync.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import os
+import re
+import shutil
 import subprocess
 import sys
 import threading
@@ -32,6 +35,7 @@ def isolated_runtime(tmp_path: Path, monkeypatch):
         "REMOTE_HANDOFF_STATE": state / "remote-handoff-last.json", "RETIREMENT_DIR": state / "retired-worktrees",
     }.items():
         monkeypatch.setattr(MODULE, name, path)
+    monkeypatch.setattr(MODULE, "RETIRED_PENDING_DIR", state / "retired-pending")
 
 
 def command(*args: str, cwd: Path | None = None) -> str:
@@ -941,3 +945,645 @@ def test_flush_rejects_symlinked_manifest_lock(tmp_path: Path, monkeypatch) -> N
     assert observed == []
     assert results[0]["action"] == "failed"
     assert manifest.exists()
+
+
+# ---------------------------------------------------------------------------
+# Stranded entries: a manifest path beneath a worktree that vanished before any
+# retirement record or receipt existed. Regressions for the accreting-manifest
+# defect (session 2a0f680b…, 2026-09-11).
+# ---------------------------------------------------------------------------
+
+DROP_FORM = '--drop-stranded --assert "<why the work is known published>"'
+
+
+def write_manifest(
+    session_id: str, paths: list[str], remote_paths: list[str], extra: dict | None = None
+) -> Path:
+    manifest = MODULE.pending_manifest_path(session_id)
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 2,
+        "session_id": session_id,
+        "updated_at": "2026-08-31T00:00:00Z",
+        "paths": paths,
+        "remote_paths": remote_paths,
+        **(extra or {}),
+    }
+    manifest.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return manifest
+
+
+def stranded_state(tmp_path: Path) -> tuple[Path, Path]:
+    """A worktrees directory outside every git working tree, and a worktree
+    root beneath it that no longer exists."""
+    worktrees = tmp_path / ".worktrees"
+    worktrees.mkdir()
+    assert MODULE.git(worktrees, "rev-parse", "--show-toplevel")[0] != 0  # positive control
+    return worktrees, worktrees / "gone-20260831"
+
+
+def configured_repository(tmp_path: Path, name: str) -> tuple[Path, Path]:
+    remote = tmp_path / f"{name}-remote.git"
+    repo = tmp_path / name
+    command("git", "init", "--bare", "-q", "-b", "main", str(remote))
+    command("git", "clone", "-q", str(remote), str(repo))
+    command("git", "config", "core.hooksPath", str(tmp_path / "fixture-hooks"), cwd=repo)
+    command("git", "config", "user.name", "Test", cwd=repo)
+    command("git", "config", "user.email", "test@example.com", cwd=repo)
+    context = repo / "projects" / "alpha" / "CONTEXT.md"
+    context.parent.mkdir(parents=True)
+    context.write_text("one\n", encoding="utf-8")
+    command("git", "add", "projects/alpha/CONTEXT.md", cwd=repo)
+    command("git", "commit", "-qm", "seed", cwd=repo)
+    command("git", "push", "-qu", "origin", "main", cwd=repo)
+    return repo, remote
+
+
+def test_flush_reports_stranded_entry_and_still_evaluates_other_repositories(
+    tmp_path: Path,
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    context = repo / "projects" / "alpha" / "CONTEXT.md"
+    context.write_text("published\n", encoding="utf-8")
+    worktrees, missing_root = stranded_state(tmp_path)
+    stranded = missing_root / "lessons" / "note.md"
+    session = "session-stranded"
+    manifest = write_manifest(session, [str(context), str(stranded)], [str(context), str(stranded)])
+
+    results, observed = MODULE.flush_pending_session(cfg, session, dry_run=False)
+
+    assert observed == [manifest]
+    by_action = {result["action"]: result for result in results}
+    entry = by_action["stranded"]
+    assert entry["repo"] == str(stranded)
+    assert str(missing_root) in entry["alert"]
+    assert f"--flush-session {session} {DROP_FORM}" in entry["alert"]
+    assert entry["drop_eligible"] is True
+    assert entry["evidence"]["nearest_existing_ancestor"] == str(worktrees)
+    assert entry["evidence"]["missing_worktree_root"] == str(missing_root)
+    assert "failed" not in by_action
+    assert by_action["committed-pushed"]["repo"] == str(repo)
+    assert command("git", "show", "HEAD:projects/alpha/CONTEXT.md", cwd=repo) == "published"
+    # The published repository's entries retire; the stranded entry stays visible.
+    assert json.loads(manifest.read_text(encoding="utf-8"))["paths"] == [str(stranded)]
+
+
+def test_stranded_entry_with_retained_receipt_names_session_reconcile_remedy(
+    tmp_path: Path,
+) -> None:
+    _repo, _remote, cfg = repository(tmp_path)
+    _worktrees, missing_root = stranded_state(tmp_path)
+    stranded = missing_root / "projects" / "alpha" / "CONTEXT.md"
+    session = "018f0000-0000-7000-8000-00000000000a"
+    manifest = write_manifest(session, [str(stranded)], [str(stranded)])
+    receipt = MODULE.LOCAL_HANDOFF_DIR / manifest.name
+    receipt.parent.mkdir(parents=True)
+    receipt.write_text(json.dumps({
+        "schema_version": 1, "readiness": "LOCAL_READY", "session_id": session,
+        "pending_manifest": str(manifest),
+        "pending_manifest_sha256": hashlib.sha256(manifest.read_bytes()).hexdigest(),
+        "results": [{"repo": str(missing_root), "name": missing_root.name, "action": "local-ready",
+                     "branch": "feature/gone", "head": "a" * 40, "files": 1,
+                     "file_evidence": [], "alert": None}],
+    }), encoding="utf-8")
+    before = manifest.read_bytes(), receipt.read_bytes()
+
+    results, _ = MODULE.flush_pending_session(cfg, session, dry_run=False)
+
+    entry = next(result for result in results if result["action"] == "stranded")
+    assert entry["drop_eligible"] is False
+    assert f"--reconcile-retired-worktree {missing_root} --retirement-session {session}" in entry["alert"]
+    assert "--retirement-head" not in entry["alert"]
+    assert "--drop-stranded" not in entry["alert"]
+    assert entry["evidence"]["local_handoff_receipt_head"] == "a" * 40
+    # Retained evidence outranks an assertion: the drop leaves this entry alone.
+    dropped, _ = MODULE.flush_pending_session(
+        cfg, session, dry_run=False, drop_stranded=True, assertion="published elsewhere"
+    )
+    assert {result["action"] for result in dropped} == {"no-stranded-entries", "stranded"}
+    assert (manifest.read_bytes(), receipt.read_bytes()) == before
+    assert not MODULE.RETIRED_PENDING_DIR.exists()
+
+
+@pytest.mark.parametrize("state", ["prepared", "completed"])
+def test_stranded_entry_named_by_retirement_intent_points_at_the_intent(
+    tmp_path: Path, state: str
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    _worktrees, missing_root = stranded_state(tmp_path)
+    session = "session-intent"
+    manifest = write_manifest(session, [str(missing_root / "x.md")], [])
+    MODULE.RETIREMENT_DIR.mkdir(parents=True)
+    intent = MODULE.RETIREMENT_DIR / ("1" * 64 + ".json")
+    intent.write_text(json.dumps({
+        "schema_version": 2, "state": state, "worktree": str(missing_root), "repository": str(repo),
+        "head": "b" * 40, "base_ref": "refs/remotes/origin/main", "base_oid": "c" * 40,
+    }), encoding="utf-8")
+    before = manifest.read_bytes()
+
+    results, _ = MODULE.flush_pending_session(
+        cfg, session, dry_run=False, drop_stranded=True, assertion="known published"
+    )
+
+    entry = next(result for result in results if result["action"] == "stranded")
+    assert entry["drop_eligible"] is False
+    assert str(intent) in entry["alert"]
+    if state == "prepared":
+        assert f"--complete-worktree-retirement {intent}" in entry["alert"]
+    else:
+        assert (f"--reconcile-retired-worktree {missing_root} --retirement-repository {repo} "
+                f"--retirement-head {'b' * 40} --retirement-base refs/remotes/origin/main") in entry["alert"]
+    assert manifest.read_bytes() == before
+    assert not MODULE.RETIRED_PENDING_DIR.exists()
+
+
+def test_local_handoff_records_stranded_entry_without_aborting_other_repositories(
+    tmp_path: Path,
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    context = repo / "projects" / "alpha" / "CONTEXT.md"
+    context.write_text("local\n", encoding="utf-8")
+    _worktrees, missing_root = stranded_state(tmp_path)
+    session = "session-local-stranded"
+    manifest = write_manifest(session, [str(context), str(missing_root / "lessons" / "note.md")], [str(context)])
+
+    results, observed = MODULE.local_handoff_checkpoint({"session_id": session, "cwd": str(repo)}, cfg)
+
+    assert observed == manifest
+    assert [result["action"] for result in results] == ["stranded", "local-ready"]
+    assert results[0]["drop_eligible"] is True
+    assert results[1]["repo"] == str(repo) and results[1]["head"]
+    payload = json.loads((MODULE.LOCAL_HANDOFF_DIR / manifest.name).read_text(encoding="utf-8"))
+    assert payload["readiness"] == "BLOCKED"
+    assert [result["action"] for result in payload["results"]] == ["stranded", "local-ready"]
+
+
+def test_local_handoff_preserves_receipt_that_retains_stranded_worktree_evidence(
+    tmp_path: Path,
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    context = repo / "projects" / "alpha" / "CONTEXT.md"
+    context.write_text("local\n", encoding="utf-8")
+    _worktrees, missing_root = stranded_state(tmp_path)
+    session = "018f0000-0000-7000-8000-00000000000b"
+    manifest = write_manifest(session, [str(context), str(missing_root / "x.md")], [str(context)])
+    receipt = MODULE.LOCAL_HANDOFF_DIR / manifest.name
+    receipt.parent.mkdir(parents=True)
+    receipt.write_text(json.dumps({
+        "schema_version": 1, "readiness": "LOCAL_READY", "session_id": session,
+        "pending_manifest": str(manifest), "pending_manifest_sha256": "0" * 64,
+        "results": [{"repo": str(missing_root), "name": missing_root.name, "action": "local-ready",
+                     "branch": "feature/gone", "head": "a" * 40, "files": 1, "file_evidence": [], "alert": None}],
+    }), encoding="utf-8")
+    before = receipt.read_bytes()
+
+    results, _ = MODULE.local_handoff_checkpoint({"session_id": session, "cwd": str(repo)}, cfg)
+
+    assert [result["action"] for result in results] == ["stranded", "local-ready"]
+    assert results[0]["drop_eligible"] is False
+    assert "retained local-handoff receipt" in results[0]["alert"]
+    assert receipt.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    "assertion",
+    [None, "", "  \n\t", "\u00a0\u3000\u2028\u0085", "\u200b", "\u200b\u200c\u200d", "\ufeff"],
+)
+def test_drop_stranded_refuses_blank_assertion(tmp_path: Path, assertion: str | None) -> None:
+    _repo, _remote, cfg = repository(tmp_path)
+    _worktrees, missing_root = stranded_state(tmp_path)
+    session = "session-no-assert"
+    manifest = write_manifest(session, [str(missing_root / "x.md")], [])
+    before = manifest.read_bytes()
+
+    results, observed = MODULE.flush_pending_session(
+        cfg, session, dry_run=False, drop_stranded=True, assertion=assertion
+    )
+
+    assert observed == []
+    assert results[0]["action"] == "failed"
+    assert "non-blank --assert" in results[0]["alert"]
+    assert f"--flush-session {session} {DROP_FORM}" in results[0]["alert"]
+    assert manifest.read_bytes() == before
+    assert not MODULE.RETIRED_PENDING_DIR.exists()
+
+
+def test_drop_stranded_cli_refuses_wrong_combinations(tmp_path: Path, monkeypatch, capsys) -> None:
+    config = tmp_path / "config.yaml"
+    config.write_text("repos: []\n", encoding="utf-8")
+    base = [str(MODULE_PATH), "--config", str(config)]
+    for argv in (
+        [*base, "--flush-session", "s", "--drop-stranded"],
+        [*base, "--flush-session", "s", "--drop-stranded", "--assert", " "],
+        [*base, "--flush-session", "s", "--drop-stranded", "--assert", "\u200b"],
+        [*base, "--flush-session", "s", "--drop-stranded", "--assert", "\ufeff"],
+        [*base, "--flush-session", "s", "--assert", "x"],
+        [*base, "--flush-pending", "--drop-stranded", "--assert", "x"],
+        [*base, "--drop-stranded", "--assert", "x"],
+    ):
+        monkeypatch.setattr(sys, "argv", argv)
+        assert MODULE.main() == 2, argv
+        assert f"--flush-session SESSION_ID {DROP_FORM}" in capsys.readouterr().err, argv
+    assert not MODULE.RETIRED_PENDING_DIR.exists()
+    assert not MODULE.REMOTE_HANDOFF_STATE.exists()
+
+
+def test_drop_stranded_refuses_when_worktree_root_exists_at_drop_time(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _repo, _remote, cfg = repository(tmp_path)
+    _worktrees, missing_root = stranded_state(tmp_path)
+    session = "session-reappeared"
+    manifest = write_manifest(session, [str(missing_root / "x.md")], [])
+    before = manifest.read_bytes()
+    original = MODULE.classify_stranded_entry
+
+    def reappearing(*args, **kwargs):
+        record = original(*args, **kwargs)
+        if record is not None:
+            missing_root.mkdir(exist_ok=True)  # the worktree returns between classification and the drop
+        return record
+
+    monkeypatch.setattr(MODULE, "classify_stranded_entry", reappearing)
+
+    results, _ = MODULE.flush_pending_session(
+        cfg, session, dry_run=False, drop_stranded=True, assertion="known published"
+    )
+
+    failed = next(result for result in results if result["action"] == "failed")
+    assert str(missing_root) in failed["alert"] and "exists now" in failed["alert"]
+    assert manifest.read_bytes() == before
+    assert not MODULE.RETIRED_PENDING_DIR.exists()
+
+
+def test_drop_stranded_writes_append_only_ledger_and_narrows_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    source = repo / "src" / "feature.py"
+    source.parent.mkdir()
+    source.write_text("local only\n", encoding="utf-8")  # uncommitted source keeps the manifest blocked
+    worktrees, missing_root = stranded_state(tmp_path)
+    mirrored = missing_root / "projects" / "alpha" / "CONTEXT.md"  # tracked at HEAD of the configured repo
+    orphan = missing_root / "lessons" / "orphan.md"
+    session = "session-drop"
+    manifest = write_manifest(
+        session, [str(source), str(mirrored), str(orphan)], [str(mirrored)],
+        extra={"retired_worktrees": [{"note": "history"}]},
+    )
+    monkeypatch.setenv("SYNTHESIS_COORDINATION_SESSION", "s-test-seat")
+    monkeypatch.setenv("CLAUDE_CODE_HOST_SESSION_ID", "host-1234")
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    monkeypatch.delenv("SYNTHESIS_CLIENT_SESSION_REF", raising=False)
+    before_digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
+    assertion = "both files were merged to main on 2026-08-31"
+
+    results, observed = MODULE.flush_pending_session(
+        cfg, session, dry_run=False, drop_stranded=True, assertion=assertion
+    )
+
+    assert observed == [manifest]
+    by_action = {result["action"]: result for result in results}
+    assert by_action["dropped-stranded"]["files"] == 2
+    assert "source-local-only" in by_action
+    assert "stranded" not in by_action
+    ledger = Path(by_action["dropped-stranded"]["ledger"])
+    assert ledger.parent == MODULE.RETIRED_PENDING_DIR
+    assert re.fullmatch(rf"{manifest.stem}-stranded-\d{{8}}T\d{{6}}Z\.json", ledger.name)
+    record = json.loads(ledger.read_text(encoding="utf-8"))
+    assert record["schema_version"] == 1
+    assert record["session_id"] == session
+    assert record["manifest"] == str(manifest)
+    assert record["manifest_sha256_before"] == before_digest
+    assert record["dropped_paths"] == [str(mirrored), str(orphan)]
+    assert record["assertion"] == assertion
+    assert record["acting_identity"] == {
+        "SYNTHESIS_COORDINATION_SESSION": "s-test-seat",
+        "CLAUDE_CODE_HOST_SESSION_ID": "host-1234",
+    }
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", record["dropped_at"])
+    evidence = {item["path"]: item for item in record["evidence"]}
+    assert evidence[str(mirrored)]["nearest_existing_ancestor"] == str(worktrees)
+    assert evidence[str(mirrored)]["missing_worktree_root"] == str(missing_root)
+    assert evidence[str(mirrored)]["retirement_intent_named_worktree"] is False
+    assert evidence[str(mirrored)]["local_handoff_receipt_named_worktree"] is False
+    canonical = evidence[str(mirrored)]["canonical_copy"]
+    assert Path(canonical["repository"]).resolve() == repo.resolve()
+    assert canonical["relative_path"] == "projects/alpha/CONTEXT.md"
+    assert canonical["blob_oid"] == command("git", "rev-parse", "HEAD:projects/alpha/CONTEXT.md", cwd=repo)
+    assert canonical["head"] == command("git", "rev-parse", "HEAD", cwd=repo)
+    assert evidence[str(orphan)]["canonical_copy"] is None
+    narrowed = json.loads(manifest.read_text(encoding="utf-8"))
+    assert narrowed["paths"] == [str(source)]
+    assert narrowed["remote_paths"] == []
+    assert narrowed["session_id"] == session
+    assert narrowed["retired_worktrees"] == [{"note": "history"}]
+    assert narrowed["dropped_stranded"][0]["ledger"] == str(ledger)
+    # Append-only: a record path that already exists is never overwritten.
+    second = MODULE.append_only_json(ledger, {"probe": True})
+    assert second != ledger and second.parent == ledger.parent
+    assert json.loads(ledger.read_text(encoding="utf-8")) == record
+    assert json.loads(second.read_text(encoding="utf-8")) == {"probe": True}
+
+
+def test_drop_stranded_dry_run_reports_and_writes_nothing(tmp_path: Path) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    source = repo / "src" / "feature.py"
+    source.parent.mkdir()
+    source.write_text("local only\n", encoding="utf-8")
+    _worktrees, missing_root = stranded_state(tmp_path)
+    session = "session-dry-drop"
+    manifest = write_manifest(
+        session, [str(source), str(missing_root / "a.md"), str(missing_root / "b.md")], [str(missing_root / "a.md")]
+    )
+    before = manifest.read_bytes()
+
+    results, observed = MODULE.flush_pending_session(
+        cfg, session, dry_run=True, drop_stranded=True, assertion="known published"
+    )
+
+    assert observed == [manifest]
+    by_action = {result["action"]: result for result in results}
+    assert by_action["would-drop-stranded"]["files"] == 2
+    assert "stranded" not in by_action
+    assert "source-local-only" in by_action
+    assert manifest.read_bytes() == before
+    assert not MODULE.RETIRED_PENDING_DIR.exists()
+    assert not MODULE.LOCAL_HANDOFF_DIR.exists()
+
+
+def test_drop_stranded_cli_retires_an_all_stranded_manifest(tmp_path: Path, monkeypatch) -> None:
+    _worktrees, missing_root = stranded_state(tmp_path)
+    session = "session-cli-drop"
+    manifest = write_manifest(session, [str(missing_root / "a.md")], [str(missing_root / "a.md")])
+    config = tmp_path / "config.yaml"
+    config.write_text("repos: []\n", encoding="utf-8")
+    argv = [str(MODULE_PATH), "--config", str(config), "--flush-session", session,
+            "--drop-stranded", "--assert", "a.md is lessons/a.md at origin/main", "--json"]
+
+    monkeypatch.setattr(sys, "argv", [*argv, "--dry-run"])
+    assert MODULE.main() == 0
+    assert manifest.exists()
+    assert not MODULE.RETIRED_PENDING_DIR.exists()
+
+    monkeypatch.setattr(sys, "argv", argv)
+    assert MODULE.main() == 0
+    assert not manifest.exists()
+    assert len(list(MODULE.RETIRED_PENDING_DIR.glob("*.json"))) == 1
+    state = json.loads(MODULE.REMOTE_HANDOFF_STATE.read_text(encoding="utf-8"))
+    assert state["readiness"] == "REMOTE_READY"
+    assert state["session_id"] == session
+
+
+def test_flush_retires_published_repositories_and_keeps_blocked_entries(tmp_path: Path) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    second, second_remote = configured_repository(tmp_path, "second")
+    cfg = {**cfg, "repos": [str(repo), str(second)]}
+    published = repo / "projects" / "alpha" / "CONTEXT.md"
+    published.write_text("published\n", encoding="utf-8")
+    blocked = second / "projects" / "alpha" / "CONTEXT.md"
+    blocked.write_text("blocked\n", encoding="utf-8")
+    command("git", "remote", "set-url", "origin", str(second_remote) + "-missing", cwd=second)
+    session = "session-partial"
+    manifest = write_manifest(session, [str(published), str(blocked)], [str(published), str(blocked)])
+
+    results, _ = MODULE.flush_pending_session(cfg, session, dry_run=False)
+
+    by_repo = {result["repo"]: result for result in results if result["repo"] in {str(repo), str(second)}}
+    assert by_repo[str(repo)]["action"] == "committed-pushed"
+    assert by_repo[str(second)]["action"] == "committed-no-push"
+    summary = next(result for result in results if result["action"] == "retired-repositories")
+    assert summary["retired_repositories"] == [str(repo)]
+    assert summary["files"] == 1
+    assert summary["manifest_removed"] is False
+    assert summary["alert"] is None
+    narrowed = json.loads(manifest.read_text(encoding="utf-8"))
+    assert narrowed["paths"] == [str(blocked)]
+    assert narrowed["remote_paths"] == [str(blocked)]
+
+    command("git", "remote", "set-url", "origin", str(second_remote), cwd=second)
+    results, _ = MODULE.flush_pending_session(cfg, session, dry_run=False)
+
+    assert next(r for r in results if r["repo"] == str(second))["action"] == "pushed-stranded"
+    summary = next(result for result in results if result["action"] == "retired-repositories")
+    assert summary["retired_repositories"] == [str(second)]
+    assert summary["manifest_removed"] is True
+    assert not manifest.exists()
+    assert not any(result.get("alert") for result in results)
+
+
+def test_deleted_file_inside_existing_repository_is_deleted_or_missing_not_stranded(
+    tmp_path: Path,
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    removed = repo / "projects" / "alpha" / "removed" / "note.md"  # its directory is gone, its repository is not
+    session = "session-deleted"
+    manifest = write_manifest(session, [str(removed)], [str(removed)])
+
+    local, _ = MODULE.local_handoff_checkpoint({"session_id": session, "cwd": str(repo)}, cfg)
+    assert local[0]["action"] == "local-ready"
+    assert local[0]["file_evidence"] == [{"path": str(removed), "state": "deleted-or-missing"}]
+
+    results, _ = MODULE.flush_pending_session(cfg, session, dry_run=False)
+    assert [result["action"] for result in results] == ["clean", "retired-repositories"]
+    assert not manifest.exists()
+
+
+def test_missing_registered_nested_worktree_stays_failed_not_stranded(tmp_path: Path) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    nested = repo / "nested"
+    command("git", "worktree", "add", "-q", "--orphan", "-b", "nested", str(nested), cwd=repo)
+    assert nested.parent == repo and (nested / ".git").is_file()
+    shutil.rmtree(nested)  # interruption, not the sanctioned retirement workflow
+    session = "session-nested"
+    manifest = write_manifest(session, [str(nested / "file.md")], [str(nested / "file.md")])
+
+    results, _ = MODULE.flush_pending_session(cfg, session, dry_run=False)
+
+    assert results[0]["action"] == "failed"
+    assert "not inside an available git worktree" in results[0]["alert"]
+    assert manifest.exists()
+
+
+# ---------------------------------------------------------------------------
+# Repair round (2026-09-11): a git probe that cannot answer, or answers while
+# a .git entry is visible in the ancestor chain, must never make a live
+# repository's deleted file drop-eligible; a receipt bound to an older digest
+# must name a remedy that runs; an assertion of invisible characters is blank.
+# ---------------------------------------------------------------------------
+
+GIT_UNAVAILABLE = [(-1, "", "timeout"), (-1, "", "git not found")]
+
+
+def toplevel_probe_returning(monkeypatch, outcome: tuple[int, str, str]) -> None:
+    """Fail only ``git rev-parse --show-toplevel``; every other git call is real."""
+    original = MODULE.git
+
+    def patched(repo, *args, **kwargs):
+        if args[:2] == ("rev-parse", "--show-toplevel"):
+            return outcome
+        return original(repo, *args, **kwargs)
+
+    monkeypatch.setattr(MODULE, "git", patched)
+
+
+@pytest.mark.parametrize("outcome", GIT_UNAVAILABLE)
+def test_stop_reports_git_unavailability_as_failed_not_stranded(
+    tmp_path: Path, monkeypatch, outcome: tuple[int, str, str]
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    removed = repo / "projects" / "alpha" / "removed" / "note.md"  # directory gone, repository intact
+    session = "session-git-unavailable"
+    manifest = write_manifest(session, [str(removed)], [str(removed)])
+    toplevel_probe_returning(monkeypatch, outcome)
+
+    results, observed = MODULE.local_handoff_checkpoint({"session_id": session, "cwd": str(repo)}, cfg)
+
+    assert observed == manifest
+    assert [result["action"] for result in results] == ["failed"]
+    assert results[0]["alert"].startswith("stranded classification unavailable: ")
+    assert f"git is unavailable for {removed.parent.parent}: {outcome[2]}" in results[0]["alert"]
+    assert "--drop-stranded" not in results[0]["alert"]
+    assert not (MODULE.LOCAL_HANDOFF_DIR / manifest.name).exists()
+
+
+@pytest.mark.parametrize("outcome", GIT_UNAVAILABLE)
+def test_drop_stranded_never_drops_a_live_repository_when_git_is_unavailable(
+    tmp_path: Path, monkeypatch, outcome: tuple[int, str, str]
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    removed = repo / "projects" / "alpha" / "removed" / "note.md"
+    session = "session-git-unavailable-drop"
+    manifest = write_manifest(session, [str(removed)], [str(removed)])
+    before = manifest.read_bytes()
+    toplevel_probe_returning(monkeypatch, outcome)
+
+    results, observed = MODULE.flush_pending_session(
+        cfg, session, dry_run=False, drop_stranded=True, assertion="the note was merged on 2026-09-01"
+    )
+
+    assert observed == [manifest]
+    actions = [result["action"] for result in results]
+    assert set(actions) == {"failed"}, actions
+    assert all(f"git is unavailable for {removed.parent.parent}: {outcome[2]}" in result["alert"] for result in results)
+    assert manifest.read_bytes() == before
+    assert not MODULE.RETIRED_PENDING_DIR.exists()
+
+
+def test_visible_git_directory_keeps_a_refused_probe_out_of_stranded(tmp_path: Path, monkeypatch) -> None:
+    """git can refuse a live repository (safe.directory, a damaged gitdir) with a
+    non-zero status; the ancestor chain still shows repo/.git, so the existing
+    handling applies and nothing is drop-eligible."""
+    repo, _remote, cfg = repository(tmp_path)
+    removed = repo / "projects" / "alpha" / "removed" / "note.md"
+    session = "session-refused-probe"
+    manifest = write_manifest(session, [str(removed)], [str(removed)])
+    before = manifest.read_bytes()
+    assert (repo / ".git").is_dir()  # positive control for the ancestor-chain test
+    toplevel_probe_returning(monkeypatch, (128, "", "fatal: detected dubious ownership in repository"))
+
+    assert MODULE.classify_stranded_entry(removed, session, manifest, MODULE.StrandedEvidence()) is None
+    stop, _ = MODULE.local_handoff_checkpoint({"session_id": session, "cwd": str(repo)}, cfg)
+    assert [result["action"] for result in stop] == ["failed"]
+    assert "not inside an available git worktree" in stop[0]["alert"]
+    results, _ = MODULE.flush_pending_session(
+        cfg, session, dry_run=False, drop_stranded=True, assertion="known published"
+    )
+    assert {result["action"] for result in results} == {"no-stranded-entries", "failed"}
+    assert manifest.read_bytes() == before
+    assert not MODULE.RETIRED_PENDING_DIR.exists()
+
+
+@pytest.mark.parametrize("outcome", [None, *GIT_UNAVAILABLE])
+def test_genuine_missing_worktree_root_classifies_stranded_only_with_a_working_git(
+    tmp_path: Path, monkeypatch, outcome: tuple[int, str, str] | None
+) -> None:
+    worktrees, missing_root = stranded_state(tmp_path)
+    path = missing_root / "lessons" / "note.md"
+    session = "session-positive-control"
+    manifest = write_manifest(session, [str(path)], [str(path)])
+    assert not any((candidate / ".git").exists() for candidate in (worktrees, *worktrees.parents))
+    if outcome is None:
+        record = MODULE.classify_stranded_entry(path, session, manifest, MODULE.StrandedEvidence())
+        assert record["action"] == "stranded" and record["drop_eligible"] is True
+        assert record["evidence"]["missing_worktree_root"] == str(missing_root)
+        return
+    toplevel_probe_returning(monkeypatch, outcome)
+    with pytest.raises(ValueError, match=f"git is unavailable for {re.escape(str(worktrees))}: {outcome[2]}"):
+        MODULE.classify_stranded_entry(path, session, manifest, MODULE.StrandedEvidence())
+
+
+def test_stranded_entry_with_stale_receipt_digest_names_a_head_remedy_that_runs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    repo, _remote, cfg = repository(tmp_path)
+    worktree = tmp_path / "retired-worktree"
+    command("git", "worktree", "add", "-qb", "feature/retired", str(worktree), cwd=repo)
+    retired_path = worktree / "change.txt"
+    retired_path.write_text("change\n", encoding="utf-8")
+    command("git", "add", "change.txt", cwd=worktree)
+    command("git", "commit", "-qm", "change", cwd=worktree)
+    head = command("git", "rev-parse", "HEAD", cwd=worktree)
+    command("git", "merge", "-q", "--no-edit", "feature/retired", cwd=repo)
+    command("git", "push", "-q", "origin", "main", cwd=repo)
+    command("git", "worktree", "remove", str(worktree), cwd=repo)
+    session = "018f0000-0000-7000-8000-00000000000c"
+    survivor = repo / "projects" / "alpha" / "CONTEXT.md"
+    manifest = write_manifest(session, [str(retired_path), str(survivor)], [str(survivor)])
+    receipt = MODULE.LOCAL_HANDOFF_DIR / manifest.name
+    receipt.parent.mkdir(parents=True)
+    receipt.write_text(json.dumps({
+        "schema_version": 1, "readiness": "LOCAL_READY", "session_id": session,
+        "pending_manifest": str(manifest), "pending_manifest_sha256": "0" * 64,  # the manifest accreted since
+        "results": [{"repo": str(worktree), "name": worktree.name, "action": "local-ready",
+                     "branch": "feature/retired", "head": head, "files": 1, "file_evidence": [], "alert": None}],
+    }), encoding="utf-8")
+    head_form = (
+        f"--reconcile-retired-worktree {worktree} --retirement-repository <owning repository> "
+        f"--retirement-head {head} --retirement-base <fetched remote ref such as origin/main>"
+    )
+
+    results, _ = MODULE.flush_pending_session(cfg, session, dry_run=True)
+
+    entry = next(result for result in results if result["action"] == "stranded")
+    assert entry["drop_eligible"] is False
+    assert "binds an older attribution digest" in entry["alert"]
+    assert entry["remedy"] == head_form and f"accepted form: {head_form}" in entry["alert"]
+    assert "--retirement-session" not in entry["remedy"]
+    assert entry["evidence"]["local_handoff_receipt_head"] == head
+    # The session-bound form the alert no longer names is refused for this receipt ...
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", session)
+    monkeypatch.delenv("SYNTHESIS_CLIENT_SESSION_REF", raising=False)
+    refused, _ = MODULE.recover_retired_session(worktree, repo, session, "origin/main", dry_run=True)
+    assert "lacks current attribution-digest evidence" in refused[0]["alert"]
+    # ... and the named form runs.
+    reconciled, touched = MODULE.reconcile_retired_worktree(worktree, repo, head, "origin/main", dry_run=False)
+    assert reconciled[0]["alert"] is None
+    assert reconciled[0]["action"] == "retired-worktree-reconciled"
+    assert touched == [manifest]
+    assert json.loads(manifest.read_text(encoding="utf-8"))["paths"] == [str(survivor)]
+
+
+def test_stranded_entry_with_blocked_receipt_names_the_head_remedy(tmp_path: Path) -> None:
+    _repo, _remote, cfg = repository(tmp_path)
+    _worktrees, missing_root = stranded_state(tmp_path)
+    session = "018f0000-0000-7000-8000-00000000000d"
+    manifest = write_manifest(session, [str(missing_root / "x.md")], [])
+    receipt = MODULE.LOCAL_HANDOFF_DIR / manifest.name
+    receipt.parent.mkdir(parents=True)
+    receipt.write_text(json.dumps({
+        "schema_version": 1, "readiness": "BLOCKED", "session_id": session,
+        "pending_manifest": str(manifest),
+        "pending_manifest_sha256": hashlib.sha256(manifest.read_bytes()).hexdigest(),
+        "results": [{"repo": str(missing_root), "name": missing_root.name, "action": "local-ready",
+                     "branch": "feature/gone", "head": "d" * 40, "files": 1, "file_evidence": [], "alert": None}],
+    }), encoding="utf-8")
+
+    results, _ = MODULE.flush_pending_session(cfg, session, dry_run=True)
+
+    entry = next(result for result in results if result["action"] == "stranded")
+    assert entry["drop_eligible"] is False
+    assert "records readiness BLOCKED" in entry["alert"]
+    assert "--retirement-session" not in entry["remedy"]
+    assert f"--retirement-head {'d' * 40}" in entry["remedy"]
+    assert f"accepted form: {entry['remedy']}" in entry["alert"]

--- a/skills/synthesis-skills-manager/scripts/release.py
+++ b/skills/synthesis-skills-manager/scripts/release.py
@@ -133,7 +133,7 @@ REQUIRED_CHECKS: tuple[tuple[str, list[str]], ...] = (
     ("pytest.release", ["python3", "-m", "pytest", "skills/synthesis-skills-manager/scripts/test_release.py", "-q"]),
     ("meeting-transcripts.completeness", ["python3", "skills/synthesis-meeting-transcripts/test_verify_transcripts.py"]),
     ("meeting-transcripts.primary", ["python3", "skills/synthesis-meeting-transcripts/test_transcript_primary.py"]),
-    ("pytest.rituals-guard-hooks", ["python3", "-m", "pytest", "skills/synthesis-daily-rituals/scripts/", "skills/synthesis-bitbucket/scripts/", "skills/synthesis-message-guard/scripts/", "skills/synthesis-git-hooks/scripts/", "skills/synthesis-slack-sync/scripts/", "skills/synthesis-chief-of-staff/scripts/", "-q"]),
+    ("pytest.rituals-guard-hooks", ["python3", "-m", "pytest", "skills/synthesis-daily-rituals/scripts/", "skills/synthesis-bitbucket/scripts/", "skills/synthesis-message-guard/scripts/", "skills/synthesis-git-hooks/scripts/", "skills/synthesis-slack-sync/scripts/", "skills/synthesis-chief-of-staff/scripts/", "skills/synthesis-repo-guard/", "-q"]),
     ("pytest.kb-edit-okf", ["python3", "-m", "pytest", "skills/synthesis-kb-edit/scripts/", "skills/synthesis-okf/scripts/", "-q"]),
     ("compileall", ["python3", "-m", "compileall", "-q", "skills"]),
 )


### PR DESCRIPTION
## User outcome

A long-lived pending manifest stops accreting paths it can never publish. When a worktree was removed while the session that edited it was still open, its entries used to fail every flush of that session forever, so the manifest kept every later path too. The flush now classifies those entries as stranded, names the missing worktree root and the accepted remedy, keeps evaluating the other repositories, and retires each repository whose entries are published or clean. An operator can drop stranded entries with an assertion that an append-only ledger records. Separately, a repository can declare that its own pre-commit delegate must run: the global chain then blocks a commit when that delegate is missing or not executable instead of passing silently.

## Change

- `synthesis-repo-guard/checkpoint_sync.py`: `classify_stranded_entry` produces action `stranded` with remedies derived from retained retirement intents and receipts; `--drop-stranded --assert TEXT` is valid only with `--flush-session ID`, writes `<state>/retired-pending/<manifest-sha>-stranded-<UTC>.json` with `O_CREAT|O_EXCL` (never overwritten) before retiring the entries; every flush retires clean, committed-and-pushed and source-remote-ready repositories per repository; a git timeout is reported as a failed check, never as stranded. Skill metadata 2.5.0; `checkpoint-closure-recovery.md` documents the removed-worktree case.
- `synthesis-git-hooks/scripts/pre-commit` and `_load_config.py`: a repository that declares `.githooks/required` (present in the working tree or listed in the index) fails closed when `.githooks/pre-commit` is absent, not a regular file, or not executable, naming the tested condition and the remedy (`create`, `replace`, or `chmod +x .githooks/pre-commit`); a symlink is judged by its target and the mode string follows the link; an empty worktree root refuses. Repositories without the declaration behave exactly as before. The doctor gains the `delegate-required` control with the same rule. Skill metadata 2.5.0.
- Verification coverage: the repo-guard test files join the rituals, guard and hooks pytest group in the CI workflow, the AGENTS verification list and the release gate's required checks.
- Release: 4.98.0 in both plugin manifests, CHANGELOG and README; the closed acceptance manifest binds all 17 changed surfaces to 47 cases.

## Runtime impact

- Claude Code: the installed `checkpoint_sync.py` (checkpoint and Stop-side flushes) reports stranded entries with remedies and stops holding a whole session's manifest hostage to them; the global pre-commit chain enforces `.githooks/required` where a repository declares it.
- ChatGPT Codex desktop/CLI: same scripts, same behavior.
- Other clients: none.

## Evidence

- [x] Source conformance passes (207 checks, 0 required failures on the branch head)
- [x] Relevant unit and integration tests pass: every CI pytest group on the branch head (project-management 516, checkpoint 65, promotion-gate 33, context-lifecycle and implementation-integrity 288, kb-edit and okf 8, rituals-guard-hooks 386 including repo-guard 83 and git-hooks 54, release 84, onboarding 678); scaffold and capability checks pass; `compileall` clean. Each package wrote its failing regression before the fix (17 stranded fixtures, 17 delegate and doctor fixtures) and received one independent adversarial review with a repair round.
- [x] Installed evidence supplied or marked not applicable: not applicable until the gated release installs both clients
- [x] Live evidence supplied for runtime behavior, or the exact human/runtime gate is named: a real 130-path manifest with three stranded entries under two removed worktrees is the motivating case; the operator-asserted drop against it runs after the release installs, under the operator's instruction, and its ledger record is the live evidence
- [x] Destructive and failure paths were tested where applicable: the ledger refuses to overwrite; `--drop-stranded` without `--flush-session` or `--assert` is refused; git timeouts are failed checks; a directory, a broken symlink and a mode-644 delegate all block; an unstaged removal of the marker leaves the declaration standing while a staged `git rm` withdraws it

## Public boundary

- [x] No personal, client, or organization-specific names, paths, data, or configuration
- [x] No installed cache was edited as source
- [x] Documentation and release notes match the behavior

## Contributor credit

The accreting-manifest defect was reported by an operations session through the synthesis coordination board on September 11, 2026, and its fix was requested by the project owner the same day. The fail-open delegate finding came from a personal-project seat on the same board that evening, with the opt-in design agreed there. Implementation, independent adversarial review and integration ran under the ecosystem engineering project's September 11 cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
