### PR TITLE
Refuse edits that would fuse previously separate lines

### DIFF
--- a/skills/synthesis-context-lifecycle/SKILL.md
+++ b/skills/synthesis-context-lifecycle/SKILL.md
@@ -465,7 +465,14 @@ python3 scripts/context_edit.py insert-before --file sessions/2026-08.md \
 It refuses, without writing, when the anchor is absent, when it matches a
 different number of times than declared, when the replacement would leave the
 file byte-identical, when the result would exceed a stated line budget, or when
-the target is a symlink. It writes atomically and then re-reads the file to
+the target is a symlink. Line structure is protected the same way, because
+header fields, as-of markers, and every downstream line-anchored reader parse
+these records by line: an edit whose boundary would fuse previously separate
+lines is refused with the merge point named. `insert-before` requires an
+anchor that begins a line and text that ends with a newline; a `replace` may
+not drop the anchor's boundary newline against a surviving neighbor (interior
+restructuring of the replaced region stays legitimate, as do whole-line
+deletions). Nothing is normalized silently. It writes atomically and then re-reads the file to
 confirm the change is actually on disk. There is no flag that makes a missing
 anchor succeed. `--dry-run` previews without writing and still refuses a bad
 anchor. Import `replace_once` or `set_field` to use it from Python.

--- a/skills/synthesis-context-lifecycle/scripts/context_edit.py
+++ b/skills/synthesis-context-lifecycle/scripts/context_edit.py
@@ -14,6 +14,13 @@ matched the expected number of times, that content actually changed, and that
 the change is present in the file after writing. Anything else exits non-zero
 without writing. There is no flag to make a missing anchor succeed.
 
+Line structure is load-bearing: header fields, as-of markers, and every
+downstream line-anchored reader parse these records by line. An edit whose
+boundary would fuse previously separate lines — an insert-before whose text
+lacks a trailing newline, an anchor that begins mid-line, a replacement that
+drops the anchor's boundary newline against surviving neighbors — is refused
+with the merge point named, never normalized silently.
+
 Use it from any session or script that edits a durable context file, rather
 than reimplementing replacement logic per project.
 
@@ -286,6 +293,69 @@ def _atomic_write(path: Path, text: str) -> None:
         raise
 
 
+def _line_number(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _line_merge_refusals(text: str, anchor: str, replacement: str) -> list[str]:
+    """Boundary merges an edit would create: previously separate lines fused.
+
+    Interior restructuring of the replaced region is deliberate editing; these
+    refusals cover only the region's outer boundaries, where a dropped
+    separator silently rewrites a line the anchor never named. The effective
+    boundary character is what survives the edit — the replacement's edge when
+    it has one, the untouched neighbor otherwise — so whole-line deletions
+    (anchor ``"foo\\n"`` replaced by nothing) stay legitimate.
+    """
+    refusals: list[str] = []
+    offset = text.find(anchor)
+    while offset != -1:
+        end = offset + len(anchor)
+        if anchor.endswith("\n") and end < len(text):
+            last = (
+                replacement[-1:]
+                if replacement
+                else (text[offset - 1] if offset > 0 else "\n")
+            )
+            if last != "\n":
+                refusals.append(
+                    "the edited region leaves its last line unterminated, "
+                    f"fusing it with line {_line_number(text, end)}"
+                )
+        if anchor.startswith("\n") and offset > 0:
+            first = (
+                replacement[:1] if replacement else (text[end : end + 1] or "\n")
+            )
+            if first != "\n":
+                refusals.append(
+                    "the edited region drops the separator after line "
+                    f"{_line_number(text, offset)}, fusing it with what follows"
+                )
+        offset = text.find(anchor, end)
+    return refusals
+
+
+def _insert_refusals(text: str, anchor: str, inserted: str) -> list[str]:
+    """Insert-before is line-oriented: the anchor must start a line and the
+    inserted text must end one, or the splice corrupts an existing line."""
+    refusals: list[str] = []
+    if not inserted.endswith("\n"):
+        refusals.append(
+            "--text does not end with a newline, so its last line would fuse "
+            "with the anchor's line; end the text with a newline"
+        )
+    offset = text.find(anchor)
+    while offset != -1:
+        if offset > 0 and text[offset - 1] != "\n":
+            refusals.append(
+                f"the anchor begins mid-line (line {_line_number(text, offset)}); "
+                "inserting there would splice into an existing line — anchor "
+                "on the start of a line instead"
+            )
+        offset = text.find(anchor, offset + len(anchor))
+    return refusals
+
+
 def apply_replacement(
     text: str,
     anchor: str,
@@ -311,6 +381,15 @@ def apply_replacement(
         raise ContextEditError(
             f"anchor matched {found} time(s), expected {count}: {anchor[:80]!r}\n"
             "Narrow the anchor, or pass --count to confirm the intended number."
+        )
+
+    merges = _line_merge_refusals(text, anchor, replacement)
+    if merges:
+        raise ContextEditError(
+            "edit would merge previously separate lines: "
+            + "; ".join(merges)
+            + ".\nKeep the boundary newline in the replacement, or include "
+            "the neighboring line explicitly in both anchor and replacement."
         )
 
     edited = text.replace(anchor, replacement, count)
@@ -342,11 +421,19 @@ def replace_once(
     allow_header_lag: bool = False,
     allow_stale_body: bool = False,
     state_reviewed: bool = False,
+    inserted_text: str | None = None,
 ) -> dict:
     """Apply one verified replacement to a durable context file."""
     path = Path(path)
     original = _read(path)
     edited = apply_replacement(original, anchor, replacement, count=count)
+    if inserted_text is not None:
+        insert_problems = _insert_refusals(original, anchor, inserted_text)
+        if insert_problems:
+            raise ContextEditError(
+                "insert-before would corrupt line structure: "
+                + "; ".join(insert_problems)
+            )
     lines = _check_budget(edited, max_lines, path)
     note = _coherence_gate(
         path,
@@ -451,6 +538,11 @@ def insert_before(
     forgetting to do so deletes the very heading you anchored on. The edit
     still "succeeds", because content did change. This operation removes that
     footgun by construction: the anchor is never consumed.
+
+    The operation is line-oriented: the anchor must begin a line and the text
+    must end with a newline, or the splice fuses previously separate lines —
+    a corruption that once shipped through two commits while every gate
+    reported success. Violations are refused with the merge point named.
     """
     return replace_once(
         path,
@@ -461,6 +553,7 @@ def insert_before(
         allow_header_lag=allow_header_lag,
         allow_stale_body=allow_stale_body,
         state_reviewed=state_reviewed,
+        inserted_text=text,
     )
 
 

--- a/skills/synthesis-context-lifecycle/scripts/test_context_edit.py
+++ b/skills/synthesis-context-lifecycle/scripts/test_context_edit.py
@@ -352,3 +352,108 @@ def test_cli_success_reports_line_count(tmp_path: Path, capsys) -> None:
     assert code == 0
     assert "changed" in captured.out and "1 replacement(s)" in captured.out
     assert "**Status:** Complete" in path.read_text(encoding="utf-8")
+
+
+def test_insert_before_refuses_text_without_trailing_newline(
+    tmp_path: Path,
+) -> None:
+    """The 2026-09-01 corruption: an insert whose text lacked a trailing
+    newline fused three logical lines into one, every gate reported success,
+    and the damage shipped in two commits. The helper must refuse instead."""
+    path = record(tmp_path, "intro line\nParent seat: [x](y)\n")
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(ContextEditError, match="end the text with a newline"):
+        insert_before(
+            path, anchor="Parent seat:", text="(reader briefing sits alongside)"
+        )
+
+    assert path.read_text(encoding="utf-8") == before
+    assert "alongside)Parent" not in path.read_text(encoding="utf-8")
+
+
+def test_insert_before_refuses_a_mid_line_anchor(tmp_path: Path) -> None:
+    path = record(tmp_path, "prefix text Parent seat: [x](y)\n")
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(ContextEditError, match="begins mid-line \\(line 1\\)"):
+        insert_before(path, anchor="Parent seat:", text="new line\n")
+
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_insert_before_multi_line_text_succeeds_at_a_line_boundary(
+    tmp_path: Path,
+) -> None:
+    path = record(tmp_path, "intro line\nParent seat: [x](y)\n")
+
+    insert_before(
+        path, anchor="Parent seat:", text="Plan link:\n[p](q)\n(note)\n"
+    )
+
+    text = path.read_text(encoding="utf-8")
+    assert "(note)\nParent seat:" in text
+    assert text.count("\n") == 5
+
+
+def test_replace_refuses_dropping_a_boundary_newline(tmp_path: Path) -> None:
+    path = record(tmp_path, "keep\nfoo\nnext\n")
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(ContextEditError, match="fusing it with line 3"):
+        replace_once(path, anchor="foo\n", replacement="foo")
+
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_replace_refuses_deleting_a_leading_separator(tmp_path: Path) -> None:
+    path = record(tmp_path, "prev\nfoo more\n")
+    before = path.read_text(encoding="utf-8")
+
+    with pytest.raises(ContextEditError, match="separator after line 1"):
+        replace_once(path, anchor="\nfoo", replacement="")
+
+    assert path.read_text(encoding="utf-8") == before
+
+
+def test_replace_allows_whole_line_deletion(tmp_path: Path) -> None:
+    path = record(tmp_path, "keep\nfoo\nnext\n")
+
+    replace_once(path, anchor="foo\n", replacement="")
+
+    assert path.read_text(encoding="utf-8") == "keep\nnext\n"
+
+
+def test_replace_allows_collapsing_lines_inside_the_region(
+    tmp_path: Path,
+) -> None:
+    """Interior restructuring is deliberate editing; only the region's outer
+    boundaries are protected."""
+    path = record(tmp_path, "start\none\ntwo\nend\n")
+
+    replace_once(path, anchor="one\ntwo", replacement="one two")
+
+    assert path.read_text(encoding="utf-8") == "start\none two\nend\n"
+
+
+def test_cli_insert_refusal_exits_nonzero_without_success_output(
+    tmp_path: Path, capsys
+) -> None:
+    path = record(tmp_path, "intro line\nParent seat: [x](y)\n")
+
+    code = main(
+        [
+            "insert-before",
+            "--file",
+            str(path),
+            "--anchor",
+            "Parent seat:",
+            "--text",
+            "no trailing newline",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "corrupt line structure" in captured.err
+    assert "changed" not in captured.out


### PR DESCRIPTION
context_edit.py gains boundary line-merge refusals (insert-before without trailing newline, mid-line anchors, replacements dropping boundary newlines), each naming its merge point. 34 tests green. Landed per 2026-09-19 packet-2 flip ruling (context-edit DROP->LAND: replace-side engine + tests verified absent from main).